### PR TITLE
move admin batcher to sys ns

### DIFF
--- a/api/adminservice/v1/request_response.pb.go
+++ b/api/adminservice/v1/request_response.pb.go
@@ -28,6 +28,7 @@ import (
 	v12 "go.temporal.io/server/api/persistence/v1"
 	v15 "go.temporal.io/server/api/replication/v1"
 	v114 "go.temporal.io/server/api/taskqueue/v1"
+	_ "google.golang.org/genproto/googleapis/api/annotations"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
@@ -40,6 +41,75 @@ const (
 	// Verify that runtime/protoimpl is sufficiently up-to-date.
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
+
+// JobNamespace selects the namespace that hosts the batch operation's control
+// workflow. It is independent of `namespace`, which selects the executions the
+// operation acts on.
+type StartAdminBatchOperationRequest_JobNamespace int32
+
+const (
+	StartAdminBatchOperationRequest_JOB_NAMESPACE_UNSPECIFIED StartAdminBatchOperationRequest_JobNamespace = 0
+	StartAdminBatchOperationRequest_JOB_NAMESPACE_SYSTEM      StartAdminBatchOperationRequest_JobNamespace = // Run the control workflow in the `temporal-system` namespace, on the system
+	// worker. `temporal-system` is a local namespace and is therefore active in
+	// every cluster, so this works even when `namespace` is passive here.
+	1
+	StartAdminBatchOperationRequest_JOB_NAMESPACE_USER StartAdminBatchOperationRequest_JobNamespace = // Run the control workflow in the user namespace given by `namespace`, on that
+	// namespace's per-namespace worker. Only works when `namespace` is active in this
+	// cluster: creating a workflow in a passive global namespace is rejected with
+	// NamespaceNotActive.
+	2
+)
+
+// Enum value maps for StartAdminBatchOperationRequest_JobNamespace.
+var (
+	StartAdminBatchOperationRequest_JobNamespace_name = map[int32]string{
+		0: "JOB_NAMESPACE_UNSPECIFIED",
+		1: "JOB_NAMESPACE_SYSTEM",
+		2: "JOB_NAMESPACE_USER",
+	}
+	StartAdminBatchOperationRequest_JobNamespace_value = map[string]int32{
+		"JOB_NAMESPACE_UNSPECIFIED": 0,
+		"JOB_NAMESPACE_SYSTEM":      1,
+		"JOB_NAMESPACE_USER":        2,
+	}
+)
+
+func (x StartAdminBatchOperationRequest_JobNamespace) Enum() *StartAdminBatchOperationRequest_JobNamespace {
+	p := new(StartAdminBatchOperationRequest_JobNamespace)
+	*p = x
+	return p
+}
+
+func (x StartAdminBatchOperationRequest_JobNamespace) String() string {
+	switch x {
+	case StartAdminBatchOperationRequest_JOB_NAMESPACE_UNSPECIFIED:
+		return "StartAdminBatchOperationRequestJobNamespaceUnspecified"
+	case StartAdminBatchOperationRequest_JOB_NAMESPACE_SYSTEM:
+		return "StartAdminBatchOperationRequestJobNamespaceSystem"
+	case StartAdminBatchOperationRequest_JOB_NAMESPACE_USER:
+		return "StartAdminBatchOperationRequestJobNamespaceUser"
+	default:
+		return strconv.Itoa(int(x))
+	}
+
+}
+
+func (StartAdminBatchOperationRequest_JobNamespace) Descriptor() protoreflect.EnumDescriptor {
+	return file_temporal_server_api_adminservice_v1_request_response_proto_enumTypes[0].Descriptor()
+}
+
+func (StartAdminBatchOperationRequest_JobNamespace) Type() protoreflect.EnumType {
+	return &file_temporal_server_api_adminservice_v1_request_response_proto_enumTypes[0]
+}
+
+func (x StartAdminBatchOperationRequest_JobNamespace) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use StartAdminBatchOperationRequest_JobNamespace.Descriptor instead.
+func (StartAdminBatchOperationRequest_JobNamespace) EnumDescriptor() ([]byte, []int) {
+	return file_temporal_server_api_adminservice_v1_request_response_proto_rawDescGZIP(), []int{90, 0}
+}
 
 // Target scheduler implementation for migration.
 type MigrateScheduleRequest_SchedulerTarget int32
@@ -87,11 +157,11 @@ func (x MigrateScheduleRequest_SchedulerTarget) String() string {
 }
 
 func (MigrateScheduleRequest_SchedulerTarget) Descriptor() protoreflect.EnumDescriptor {
-	return file_temporal_server_api_adminservice_v1_request_response_proto_enumTypes[0].Descriptor()
+	return file_temporal_server_api_adminservice_v1_request_response_proto_enumTypes[1].Descriptor()
 }
 
 func (MigrateScheduleRequest_SchedulerTarget) Type() protoreflect.EnumType {
-	return &file_temporal_server_api_adminservice_v1_request_response_proto_enumTypes[0]
+	return &file_temporal_server_api_adminservice_v1_request_response_proto_enumTypes[1]
 }
 
 func (x MigrateScheduleRequest_SchedulerTarget) Number() protoreflect.EnumNumber {
@@ -5503,6 +5573,10 @@ type StartAdminBatchOperationRequest struct {
 	Executions []*v1.WorkflowExecution `protobuf:"bytes,5,rep,name=executions,proto3" json:"executions,omitempty"`
 	// The identity of the worker/client.
 	Identity string `protobuf:"bytes,6,opt,name=identity,proto3" json:"identity,omitempty"`
+	// Where to run the control workflow. JOB_NAMESPACE_UNSPECIFIED is rejected so that
+	// callers state their intent explicitly rather than inheriting a default that
+	// silently fails in passive clusters.
+	JobNamespace StartAdminBatchOperationRequest_JobNamespace `protobuf:"varint,7,opt,name=job_namespace,json=jobNamespace,proto3,enum=temporal.server.api.adminservice.v1.StartAdminBatchOperationRequest_JobNamespace" json:"job_namespace,omitempty"`
 	// The admin batch operation to perform.
 	//
 	// Types that are valid to be assigned to Operation:
@@ -5585,6 +5659,13 @@ func (x *StartAdminBatchOperationRequest) GetIdentity() string {
 	return ""
 }
 
+func (x *StartAdminBatchOperationRequest) GetJobNamespace() StartAdminBatchOperationRequest_JobNamespace {
+	if x != nil {
+		return x.JobNamespace
+	}
+	return StartAdminBatchOperationRequest_JOB_NAMESPACE_UNSPECIFIED
+}
+
 func (x *StartAdminBatchOperationRequest) GetOperation() isStartAdminBatchOperationRequest_Operation {
 	if x != nil {
 		return x.Operation
@@ -5613,7 +5694,12 @@ func (*StartAdminBatchOperationRequest_RefreshTasksOperation) isStartAdminBatchO
 }
 
 type StartAdminBatchOperationResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Workflow ID of the control workflow that was started, and the namespace it
+	// runs in. For JOB_NAMESPACE_SYSTEM these are derived from `job_id`, so callers
+	// must use them rather than `job_id` to look the job up afterwards.
+	JobWorkflowId string `protobuf:"bytes,1,opt,name=job_workflow_id,json=jobWorkflowId,proto3" json:"job_workflow_id,omitempty"`
+	JobNamespace  string `protobuf:"bytes,2,opt,name=job_namespace,json=jobNamespace,proto3" json:"job_namespace,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -5646,6 +5732,20 @@ func (x *StartAdminBatchOperationResponse) ProtoReflect() protoreflect.Message {
 // Deprecated: Use StartAdminBatchOperationResponse.ProtoReflect.Descriptor instead.
 func (*StartAdminBatchOperationResponse) Descriptor() ([]byte, []int) {
 	return file_temporal_server_api_adminservice_v1_request_response_proto_rawDescGZIP(), []int{91}
+}
+
+func (x *StartAdminBatchOperationResponse) GetJobWorkflowId() string {
+	if x != nil {
+		return x.JobWorkflowId
+	}
+	return ""
+}
+
+func (x *StartAdminBatchOperationResponse) GetJobNamespace() string {
+	if x != nil {
+		return x.JobNamespace
+	}
+	return ""
 }
 
 // BatchOperationRefreshTasks refreshes tasks for batch executions.
@@ -5919,7 +6019,7 @@ var File_temporal_server_api_adminservice_v1_request_response_proto protoreflect
 
 const file_temporal_server_api_adminservice_v1_request_response_proto_rawDesc = "" +
 	"\n" +
-	":temporal/server/api/adminservice/v1/request_response.proto\x12#temporal.server.api.adminservice.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a$temporal/api/common/v1/message.proto\x1a\"temporal/api/enums/v1/common.proto\x1a&temporal/api/enums/v1/task_queue.proto\x1a'temporal/api/namespace/v1/message.proto\x1a)temporal/api/replication/v1/message.proto\x1a'temporal/api/taskqueue/v1/message.proto\x1a%temporal/api/version/v1/message.proto\x1a&temporal/api/workflow/v1/message.proto\x1a,temporal/server/api/cluster/v1/message.proto\x1a'temporal/server/api/common/v1/dlq.proto\x1a*temporal/server/api/enums/v1/cluster.proto\x1a)temporal/server/api/enums/v1/common.proto\x1a&temporal/server/api/enums/v1/dlq.proto\x1a'temporal/server/api/enums/v1/task.proto\x1a+temporal/server/api/health/v1/message.proto\x1a,temporal/server/api/history/v1/message.proto\x1a.temporal/server/api/namespace/v1/message.proto\x1a9temporal/server/api/persistence/v1/cluster_metadata.proto\x1a3temporal/server/api/persistence/v1/executions.proto\x1a,temporal/server/api/persistence/v1/hsm.proto\x1a4temporal/server/api/persistence/v1/task_queues.proto\x1a.temporal/server/api/persistence/v1/tasks.proto\x1a?temporal/server/api/persistence/v1/workflow_mutable_state.proto\x1a0temporal/server/api/replication/v1/message.proto\x1a.temporal/server/api/taskqueue/v1/message.proto\"\x83\x01\n" +
+	":temporal/server/api/adminservice/v1/request_response.proto\x12#temporal.server.api.adminservice.v1\x1a\x1fgoogle/api/field_behavior.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a$temporal/api/common/v1/message.proto\x1a\"temporal/api/enums/v1/common.proto\x1a&temporal/api/enums/v1/task_queue.proto\x1a'temporal/api/namespace/v1/message.proto\x1a)temporal/api/replication/v1/message.proto\x1a'temporal/api/taskqueue/v1/message.proto\x1a%temporal/api/version/v1/message.proto\x1a&temporal/api/workflow/v1/message.proto\x1a,temporal/server/api/cluster/v1/message.proto\x1a'temporal/server/api/common/v1/dlq.proto\x1a*temporal/server/api/enums/v1/cluster.proto\x1a)temporal/server/api/enums/v1/common.proto\x1a&temporal/server/api/enums/v1/dlq.proto\x1a'temporal/server/api/enums/v1/task.proto\x1a+temporal/server/api/health/v1/message.proto\x1a,temporal/server/api/history/v1/message.proto\x1a.temporal/server/api/namespace/v1/message.proto\x1a9temporal/server/api/persistence/v1/cluster_metadata.proto\x1a3temporal/server/api/persistence/v1/executions.proto\x1a,temporal/server/api/persistence/v1/hsm.proto\x1a4temporal/server/api/persistence/v1/task_queues.proto\x1a.temporal/server/api/persistence/v1/tasks.proto\x1a?temporal/server/api/persistence/v1/workflow_mutable_state.proto\x1a0temporal/server/api/replication/v1/message.proto\x1a.temporal/server/api/taskqueue/v1/message.proto\"\x83\x01\n" +
 	"\x1aRebuildMutableStateRequest\x12\x1c\n" +
 	"\tnamespace\x18\x01 \x01(\tR\tnamespace\x12G\n" +
 	"\texecution\x18\x02 \x01(\v2).temporal.api.common.v1.WorkflowExecutionR\texecution\"\x1d\n" +
@@ -6324,7 +6424,7 @@ const file_temporal_server_api_adminservice_v1_request_response_proto_rawDesc = 
 	"\fpartition_id\x18\x04 \x01(\x05R\vpartitionId\"\x90\x01\n" +
 	"\x1cGetTaskQueueUserDataResponse\x12V\n" +
 	"\tuser_data\x18\x01 \x01(\v29.temporal.server.api.persistence.v1.TaskQueueTypeUserDataR\buserData\x12\x18\n" +
-	"\aversion\x18\x02 \x01(\x03R\aversion\"\x88\x03\n" +
+	"\aversion\x18\x02 \x01(\x03R\aversion\"\xe6\x04\n" +
 	"\x1fStartAdminBatchOperationRequest\x12\x1c\n" +
 	"\tnamespace\x18\x01 \x01(\tR\tnamespace\x12)\n" +
 	"\x10visibility_query\x18\x02 \x01(\tR\x0fvisibilityQuery\x12\x15\n" +
@@ -6333,11 +6433,18 @@ const file_temporal_server_api_adminservice_v1_request_response_proto_rawDesc = 
 	"\n" +
 	"executions\x18\x05 \x03(\v2).temporal.api.common.v1.WorkflowExecutionR\n" +
 	"executions\x12\x1a\n" +
-	"\bidentity\x18\x06 \x01(\tR\bidentity\x12y\n" +
+	"\bidentity\x18\x06 \x01(\tR\bidentity\x12{\n" +
+	"\rjob_namespace\x18\a \x01(\x0e2Q.temporal.server.api.adminservice.v1.StartAdminBatchOperationRequest.JobNamespaceB\x03\xe0A\x02R\fjobNamespace\x12y\n" +
 	"\x17refresh_tasks_operation\x18\n" +
-	" \x01(\v2?.temporal.server.api.adminservice.v1.BatchOperationRefreshTasksH\x00R\x15refreshTasksOperationB\v\n" +
-	"\toperation\"\"\n" +
-	" StartAdminBatchOperationResponse\"\x1c\n" +
+	" \x01(\v2?.temporal.server.api.adminservice.v1.BatchOperationRefreshTasksH\x00R\x15refreshTasksOperation\"_\n" +
+	"\fJobNamespace\x12\x1d\n" +
+	"\x19JOB_NAMESPACE_UNSPECIFIED\x10\x00\x12\x18\n" +
+	"\x14JOB_NAMESPACE_SYSTEM\x10\x01\x12\x16\n" +
+	"\x12JOB_NAMESPACE_USER\x10\x02B\v\n" +
+	"\toperation\"o\n" +
+	" StartAdminBatchOperationResponse\x12&\n" +
+	"\x0fjob_workflow_id\x18\x01 \x01(\tR\rjobWorkflowId\x12#\n" +
+	"\rjob_namespace\x18\x02 \x01(\tR\fjobNamespace\"\x1c\n" +
 	"\x1aBatchOperationRefreshTasks\"\xe7\x02\n" +
 	"\x16MigrateScheduleRequest\x12\x1c\n" +
 	"\tnamespace\x18\x01 \x01(\tR\tnamespace\x12\x1f\n" +
@@ -6365,261 +6472,263 @@ func file_temporal_server_api_adminservice_v1_request_response_proto_rawDescGZIP
 	return file_temporal_server_api_adminservice_v1_request_response_proto_rawDescData
 }
 
-var file_temporal_server_api_adminservice_v1_request_response_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_temporal_server_api_adminservice_v1_request_response_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
 var file_temporal_server_api_adminservice_v1_request_response_proto_msgTypes = make([]protoimpl.MessageInfo, 105)
 var file_temporal_server_api_adminservice_v1_request_response_proto_goTypes = []any{
-	(MigrateScheduleRequest_SchedulerTarget)(0),         // 0: temporal.server.api.adminservice.v1.MigrateScheduleRequest.SchedulerTarget
-	(*RebuildMutableStateRequest)(nil),                  // 1: temporal.server.api.adminservice.v1.RebuildMutableStateRequest
-	(*RebuildMutableStateResponse)(nil),                 // 2: temporal.server.api.adminservice.v1.RebuildMutableStateResponse
-	(*ImportWorkflowExecutionRequest)(nil),              // 3: temporal.server.api.adminservice.v1.ImportWorkflowExecutionRequest
-	(*ImportWorkflowExecutionResponse)(nil),             // 4: temporal.server.api.adminservice.v1.ImportWorkflowExecutionResponse
-	(*DescribeMutableStateRequest)(nil),                 // 5: temporal.server.api.adminservice.v1.DescribeMutableStateRequest
-	(*DescribeMutableStateResponse)(nil),                // 6: temporal.server.api.adminservice.v1.DescribeMutableStateResponse
-	(*DescribeHistoryHostRequest)(nil),                  // 7: temporal.server.api.adminservice.v1.DescribeHistoryHostRequest
-	(*DescribeHistoryHostResponse)(nil),                 // 8: temporal.server.api.adminservice.v1.DescribeHistoryHostResponse
-	(*CloseShardRequest)(nil),                           // 9: temporal.server.api.adminservice.v1.CloseShardRequest
-	(*CloseShardResponse)(nil),                          // 10: temporal.server.api.adminservice.v1.CloseShardResponse
-	(*GetShardRequest)(nil),                             // 11: temporal.server.api.adminservice.v1.GetShardRequest
-	(*GetShardResponse)(nil),                            // 12: temporal.server.api.adminservice.v1.GetShardResponse
-	(*ListHistoryTasksRequest)(nil),                     // 13: temporal.server.api.adminservice.v1.ListHistoryTasksRequest
-	(*ListHistoryTasksResponse)(nil),                    // 14: temporal.server.api.adminservice.v1.ListHistoryTasksResponse
-	(*Task)(nil),                                        // 15: temporal.server.api.adminservice.v1.Task
-	(*RemoveTaskRequest)(nil),                           // 16: temporal.server.api.adminservice.v1.RemoveTaskRequest
-	(*RemoveTaskResponse)(nil),                          // 17: temporal.server.api.adminservice.v1.RemoveTaskResponse
-	(*GetWorkflowExecutionRawHistoryV2Request)(nil),     // 18: temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryV2Request
-	(*GetWorkflowExecutionRawHistoryV2Response)(nil),    // 19: temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryV2Response
-	(*GetWorkflowExecutionRawHistoryRequest)(nil),       // 20: temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryRequest
-	(*GetWorkflowExecutionRawHistoryResponse)(nil),      // 21: temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryResponse
-	(*GetReplicationMessagesRequest)(nil),               // 22: temporal.server.api.adminservice.v1.GetReplicationMessagesRequest
-	(*GetReplicationMessagesResponse)(nil),              // 23: temporal.server.api.adminservice.v1.GetReplicationMessagesResponse
-	(*GetNamespaceReplicationMessagesRequest)(nil),      // 24: temporal.server.api.adminservice.v1.GetNamespaceReplicationMessagesRequest
-	(*GetNamespaceReplicationMessagesResponse)(nil),     // 25: temporal.server.api.adminservice.v1.GetNamespaceReplicationMessagesResponse
-	(*GetDLQReplicationMessagesRequest)(nil),            // 26: temporal.server.api.adminservice.v1.GetDLQReplicationMessagesRequest
-	(*GetDLQReplicationMessagesResponse)(nil),           // 27: temporal.server.api.adminservice.v1.GetDLQReplicationMessagesResponse
-	(*ReapplyEventsRequest)(nil),                        // 28: temporal.server.api.adminservice.v1.ReapplyEventsRequest
-	(*ReapplyEventsResponse)(nil),                       // 29: temporal.server.api.adminservice.v1.ReapplyEventsResponse
-	(*AddSearchAttributesRequest)(nil),                  // 30: temporal.server.api.adminservice.v1.AddSearchAttributesRequest
-	(*AddSearchAttributesResponse)(nil),                 // 31: temporal.server.api.adminservice.v1.AddSearchAttributesResponse
-	(*RemoveSearchAttributesRequest)(nil),               // 32: temporal.server.api.adminservice.v1.RemoveSearchAttributesRequest
-	(*RemoveSearchAttributesResponse)(nil),              // 33: temporal.server.api.adminservice.v1.RemoveSearchAttributesResponse
-	(*GetSearchAttributesRequest)(nil),                  // 34: temporal.server.api.adminservice.v1.GetSearchAttributesRequest
-	(*GetSearchAttributesResponse)(nil),                 // 35: temporal.server.api.adminservice.v1.GetSearchAttributesResponse
-	(*DescribeClusterRequest)(nil),                      // 36: temporal.server.api.adminservice.v1.DescribeClusterRequest
-	(*DescribeClusterResponse)(nil),                     // 37: temporal.server.api.adminservice.v1.DescribeClusterResponse
-	(*ListClustersRequest)(nil),                         // 38: temporal.server.api.adminservice.v1.ListClustersRequest
-	(*ListClustersResponse)(nil),                        // 39: temporal.server.api.adminservice.v1.ListClustersResponse
-	(*AddOrUpdateRemoteClusterRequest)(nil),             // 40: temporal.server.api.adminservice.v1.AddOrUpdateRemoteClusterRequest
-	(*AddOrUpdateRemoteClusterResponse)(nil),            // 41: temporal.server.api.adminservice.v1.AddOrUpdateRemoteClusterResponse
-	(*RemoveRemoteClusterRequest)(nil),                  // 42: temporal.server.api.adminservice.v1.RemoveRemoteClusterRequest
-	(*RemoveRemoteClusterResponse)(nil),                 // 43: temporal.server.api.adminservice.v1.RemoveRemoteClusterResponse
-	(*ListClusterMembersRequest)(nil),                   // 44: temporal.server.api.adminservice.v1.ListClusterMembersRequest
-	(*ListClusterMembersResponse)(nil),                  // 45: temporal.server.api.adminservice.v1.ListClusterMembersResponse
-	(*GetDLQMessagesRequest)(nil),                       // 46: temporal.server.api.adminservice.v1.GetDLQMessagesRequest
-	(*GetDLQMessagesResponse)(nil),                      // 47: temporal.server.api.adminservice.v1.GetDLQMessagesResponse
-	(*PurgeDLQMessagesRequest)(nil),                     // 48: temporal.server.api.adminservice.v1.PurgeDLQMessagesRequest
-	(*PurgeDLQMessagesResponse)(nil),                    // 49: temporal.server.api.adminservice.v1.PurgeDLQMessagesResponse
-	(*MergeDLQMessagesRequest)(nil),                     // 50: temporal.server.api.adminservice.v1.MergeDLQMessagesRequest
-	(*MergeDLQMessagesResponse)(nil),                    // 51: temporal.server.api.adminservice.v1.MergeDLQMessagesResponse
-	(*RefreshWorkflowTasksRequest)(nil),                 // 52: temporal.server.api.adminservice.v1.RefreshWorkflowTasksRequest
-	(*RefreshWorkflowTasksResponse)(nil),                // 53: temporal.server.api.adminservice.v1.RefreshWorkflowTasksResponse
-	(*ResendReplicationTasksRequest)(nil),               // 54: temporal.server.api.adminservice.v1.ResendReplicationTasksRequest
-	(*ResendReplicationTasksResponse)(nil),              // 55: temporal.server.api.adminservice.v1.ResendReplicationTasksResponse
-	(*GetTaskQueueTasksRequest)(nil),                    // 56: temporal.server.api.adminservice.v1.GetTaskQueueTasksRequest
-	(*GetTaskQueueTasksResponse)(nil),                   // 57: temporal.server.api.adminservice.v1.GetTaskQueueTasksResponse
-	(*DeleteWorkflowExecutionRequest)(nil),              // 58: temporal.server.api.adminservice.v1.DeleteWorkflowExecutionRequest
-	(*DeleteWorkflowExecutionResponse)(nil),             // 59: temporal.server.api.adminservice.v1.DeleteWorkflowExecutionResponse
-	(*StreamWorkflowReplicationMessagesRequest)(nil),    // 60: temporal.server.api.adminservice.v1.StreamWorkflowReplicationMessagesRequest
-	(*StreamWorkflowReplicationMessagesResponse)(nil),   // 61: temporal.server.api.adminservice.v1.StreamWorkflowReplicationMessagesResponse
-	(*GetNamespaceRequest)(nil),                         // 62: temporal.server.api.adminservice.v1.GetNamespaceRequest
-	(*GetNamespaceResponse)(nil),                        // 63: temporal.server.api.adminservice.v1.GetNamespaceResponse
-	(*GetDLQTasksRequest)(nil),                          // 64: temporal.server.api.adminservice.v1.GetDLQTasksRequest
-	(*GetDLQTasksResponse)(nil),                         // 65: temporal.server.api.adminservice.v1.GetDLQTasksResponse
-	(*PurgeDLQTasksRequest)(nil),                        // 66: temporal.server.api.adminservice.v1.PurgeDLQTasksRequest
-	(*PurgeDLQTasksResponse)(nil),                       // 67: temporal.server.api.adminservice.v1.PurgeDLQTasksResponse
-	(*DLQJobToken)(nil),                                 // 68: temporal.server.api.adminservice.v1.DLQJobToken
-	(*MergeDLQTasksRequest)(nil),                        // 69: temporal.server.api.adminservice.v1.MergeDLQTasksRequest
-	(*MergeDLQTasksResponse)(nil),                       // 70: temporal.server.api.adminservice.v1.MergeDLQTasksResponse
-	(*DescribeDLQJobRequest)(nil),                       // 71: temporal.server.api.adminservice.v1.DescribeDLQJobRequest
-	(*DescribeDLQJobResponse)(nil),                      // 72: temporal.server.api.adminservice.v1.DescribeDLQJobResponse
-	(*CancelDLQJobRequest)(nil),                         // 73: temporal.server.api.adminservice.v1.CancelDLQJobRequest
-	(*CancelDLQJobResponse)(nil),                        // 74: temporal.server.api.adminservice.v1.CancelDLQJobResponse
-	(*AddTasksRequest)(nil),                             // 75: temporal.server.api.adminservice.v1.AddTasksRequest
-	(*AddTasksResponse)(nil),                            // 76: temporal.server.api.adminservice.v1.AddTasksResponse
-	(*ListQueuesRequest)(nil),                           // 77: temporal.server.api.adminservice.v1.ListQueuesRequest
-	(*ListQueuesResponse)(nil),                          // 78: temporal.server.api.adminservice.v1.ListQueuesResponse
-	(*DeepHealthCheckRequest)(nil),                      // 79: temporal.server.api.adminservice.v1.DeepHealthCheckRequest
-	(*DeepHealthCheckResponse)(nil),                     // 80: temporal.server.api.adminservice.v1.DeepHealthCheckResponse
-	(*SyncWorkflowStateRequest)(nil),                    // 81: temporal.server.api.adminservice.v1.SyncWorkflowStateRequest
-	(*SyncWorkflowStateResponse)(nil),                   // 82: temporal.server.api.adminservice.v1.SyncWorkflowStateResponse
-	(*GenerateLastHistoryReplicationTasksRequest)(nil),  // 83: temporal.server.api.adminservice.v1.GenerateLastHistoryReplicationTasksRequest
-	(*GenerateLastHistoryReplicationTasksResponse)(nil), // 84: temporal.server.api.adminservice.v1.GenerateLastHistoryReplicationTasksResponse
-	(*DescribeTaskQueuePartitionRequest)(nil),           // 85: temporal.server.api.adminservice.v1.DescribeTaskQueuePartitionRequest
-	(*DescribeTaskQueuePartitionResponse)(nil),          // 86: temporal.server.api.adminservice.v1.DescribeTaskQueuePartitionResponse
-	(*ForceUnloadTaskQueuePartitionRequest)(nil),        // 87: temporal.server.api.adminservice.v1.ForceUnloadTaskQueuePartitionRequest
-	(*ForceUnloadTaskQueuePartitionResponse)(nil),       // 88: temporal.server.api.adminservice.v1.ForceUnloadTaskQueuePartitionResponse
-	(*GetTaskQueueUserDataRequest)(nil),                 // 89: temporal.server.api.adminservice.v1.GetTaskQueueUserDataRequest
-	(*GetTaskQueueUserDataResponse)(nil),                // 90: temporal.server.api.adminservice.v1.GetTaskQueueUserDataResponse
-	(*StartAdminBatchOperationRequest)(nil),             // 91: temporal.server.api.adminservice.v1.StartAdminBatchOperationRequest
-	(*StartAdminBatchOperationResponse)(nil),            // 92: temporal.server.api.adminservice.v1.StartAdminBatchOperationResponse
-	(*BatchOperationRefreshTasks)(nil),                  // 93: temporal.server.api.adminservice.v1.BatchOperationRefreshTasks
-	(*MigrateScheduleRequest)(nil),                      // 94: temporal.server.api.adminservice.v1.MigrateScheduleRequest
-	(*MigrateScheduleResponse)(nil),                     // 95: temporal.server.api.adminservice.v1.MigrateScheduleResponse
-	nil,                                                 // 96: temporal.server.api.adminservice.v1.GetReplicationMessagesResponse.ShardMessagesEntry
-	nil,                                                 // 97: temporal.server.api.adminservice.v1.AddSearchAttributesRequest.SearchAttributesEntry
-	nil,                                                 // 98: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.CustomAttributesEntry
-	nil,                                                 // 99: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.SystemAttributesEntry
-	nil,                                                 // 100: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.MappingEntry
-	nil,                                                 // 101: temporal.server.api.adminservice.v1.DescribeClusterResponse.SupportedClientsEntry
-	nil,                                                 // 102: temporal.server.api.adminservice.v1.DescribeClusterResponse.TagsEntry
-	(*AddTasksRequest_Task)(nil),                        // 103: temporal.server.api.adminservice.v1.AddTasksRequest.Task
-	(*ListQueuesResponse_QueueInfo)(nil),                // 104: temporal.server.api.adminservice.v1.ListQueuesResponse.QueueInfo
-	nil,                                                 // 105: temporal.server.api.adminservice.v1.DescribeTaskQueuePartitionResponse.VersionsInfoInternalEntry
-	(*v1.WorkflowExecution)(nil),                        // 106: temporal.api.common.v1.WorkflowExecution
-	(*v1.DataBlob)(nil),                                 // 107: temporal.api.common.v1.DataBlob
-	(*v11.VersionHistory)(nil),                          // 108: temporal.server.api.history.v1.VersionHistory
-	(*v12.WorkflowMutableState)(nil),                    // 109: temporal.server.api.persistence.v1.WorkflowMutableState
-	(*v13.NamespaceCacheInfo)(nil),                      // 110: temporal.server.api.namespace.v1.NamespaceCacheInfo
-	(*v12.ShardInfo)(nil),                               // 111: temporal.server.api.persistence.v1.ShardInfo
-	(*v11.TaskRange)(nil),                               // 112: temporal.server.api.history.v1.TaskRange
-	(v14.TaskType)(0),                                   // 113: temporal.server.api.enums.v1.TaskType
-	(*timestamppb.Timestamp)(nil),                       // 114: google.protobuf.Timestamp
-	(*v15.ReplicationToken)(nil),                        // 115: temporal.server.api.replication.v1.ReplicationToken
-	(*v15.ReplicationMessages)(nil),                     // 116: temporal.server.api.replication.v1.ReplicationMessages
-	(*v15.ReplicationTaskInfo)(nil),                     // 117: temporal.server.api.replication.v1.ReplicationTaskInfo
-	(*v15.ReplicationTask)(nil),                         // 118: temporal.server.api.replication.v1.ReplicationTask
-	(*v17.WorkflowExecutionInfo)(nil),                   // 119: temporal.api.workflow.v1.WorkflowExecutionInfo
-	(*v18.MembershipInfo)(nil),                          // 120: temporal.server.api.cluster.v1.MembershipInfo
-	(*v19.VersionInfo)(nil),                             // 121: temporal.api.version.v1.VersionInfo
-	(*v12.ClusterMetadata)(nil),                         // 122: temporal.server.api.persistence.v1.ClusterMetadata
-	(*durationpb.Duration)(nil),                         // 123: google.protobuf.Duration
-	(v14.ClusterMemberRole)(0),                          // 124: temporal.server.api.enums.v1.ClusterMemberRole
-	(*v18.ClusterMember)(nil),                           // 125: temporal.server.api.cluster.v1.ClusterMember
-	(v14.DeadLetterQueueType)(0),                        // 126: temporal.server.api.enums.v1.DeadLetterQueueType
-	(v16.TaskQueueType)(0),                              // 127: temporal.api.enums.v1.TaskQueueType
-	(*v12.AllocatedTaskInfo)(nil),                       // 128: temporal.server.api.persistence.v1.AllocatedTaskInfo
-	(*v15.SyncReplicationState)(nil),                    // 129: temporal.server.api.replication.v1.SyncReplicationState
-	(*v15.WorkflowReplicationMessages)(nil),             // 130: temporal.server.api.replication.v1.WorkflowReplicationMessages
-	(*v110.NamespaceInfo)(nil),                          // 131: temporal.api.namespace.v1.NamespaceInfo
-	(*v110.NamespaceConfig)(nil),                        // 132: temporal.api.namespace.v1.NamespaceConfig
-	(*v111.NamespaceReplicationConfig)(nil),             // 133: temporal.api.replication.v1.NamespaceReplicationConfig
-	(*v111.FailoverStatus)(nil),                         // 134: temporal.api.replication.v1.FailoverStatus
-	(*v112.HistoryDLQKey)(nil),                          // 135: temporal.server.api.common.v1.HistoryDLQKey
-	(*v112.HistoryDLQTask)(nil),                         // 136: temporal.server.api.common.v1.HistoryDLQTask
-	(*v112.HistoryDLQTaskMetadata)(nil),                 // 137: temporal.server.api.common.v1.HistoryDLQTaskMetadata
-	(v14.DLQOperationType)(0),                           // 138: temporal.server.api.enums.v1.DLQOperationType
-	(v14.DLQOperationState)(0),                          // 139: temporal.server.api.enums.v1.DLQOperationState
-	(v14.HealthState)(0),                                // 140: temporal.server.api.enums.v1.HealthState
-	(*v113.ServiceHealthDetail)(nil),                    // 141: temporal.server.api.health.v1.ServiceHealthDetail
-	(*v12.VersionedTransition)(nil),                     // 142: temporal.server.api.persistence.v1.VersionedTransition
-	(*v11.VersionHistories)(nil),                        // 143: temporal.server.api.history.v1.VersionHistories
-	(*v15.VersionedTransitionArtifact)(nil),             // 144: temporal.server.api.replication.v1.VersionedTransitionArtifact
-	(*v114.TaskQueuePartition)(nil),                     // 145: temporal.server.api.taskqueue.v1.TaskQueuePartition
-	(*v115.TaskQueueVersionSelection)(nil),              // 146: temporal.api.taskqueue.v1.TaskQueueVersionSelection
-	(*v114.PartitionScaleInfo)(nil),                     // 147: temporal.server.api.taskqueue.v1.PartitionScaleInfo
-	(*v12.TaskQueueTypeUserData)(nil),                   // 148: temporal.server.api.persistence.v1.TaskQueueTypeUserData
-	(v16.IndexedValueType)(0),                           // 149: temporal.api.enums.v1.IndexedValueType
-	(*v114.TaskQueueVersionInfoInternal)(nil),           // 150: temporal.server.api.taskqueue.v1.TaskQueueVersionInfoInternal
+	(StartAdminBatchOperationRequest_JobNamespace)(0),   // 0: temporal.server.api.adminservice.v1.StartAdminBatchOperationRequest.JobNamespace
+	(MigrateScheduleRequest_SchedulerTarget)(0),         // 1: temporal.server.api.adminservice.v1.MigrateScheduleRequest.SchedulerTarget
+	(*RebuildMutableStateRequest)(nil),                  // 2: temporal.server.api.adminservice.v1.RebuildMutableStateRequest
+	(*RebuildMutableStateResponse)(nil),                 // 3: temporal.server.api.adminservice.v1.RebuildMutableStateResponse
+	(*ImportWorkflowExecutionRequest)(nil),              // 4: temporal.server.api.adminservice.v1.ImportWorkflowExecutionRequest
+	(*ImportWorkflowExecutionResponse)(nil),             // 5: temporal.server.api.adminservice.v1.ImportWorkflowExecutionResponse
+	(*DescribeMutableStateRequest)(nil),                 // 6: temporal.server.api.adminservice.v1.DescribeMutableStateRequest
+	(*DescribeMutableStateResponse)(nil),                // 7: temporal.server.api.adminservice.v1.DescribeMutableStateResponse
+	(*DescribeHistoryHostRequest)(nil),                  // 8: temporal.server.api.adminservice.v1.DescribeHistoryHostRequest
+	(*DescribeHistoryHostResponse)(nil),                 // 9: temporal.server.api.adminservice.v1.DescribeHistoryHostResponse
+	(*CloseShardRequest)(nil),                           // 10: temporal.server.api.adminservice.v1.CloseShardRequest
+	(*CloseShardResponse)(nil),                          // 11: temporal.server.api.adminservice.v1.CloseShardResponse
+	(*GetShardRequest)(nil),                             // 12: temporal.server.api.adminservice.v1.GetShardRequest
+	(*GetShardResponse)(nil),                            // 13: temporal.server.api.adminservice.v1.GetShardResponse
+	(*ListHistoryTasksRequest)(nil),                     // 14: temporal.server.api.adminservice.v1.ListHistoryTasksRequest
+	(*ListHistoryTasksResponse)(nil),                    // 15: temporal.server.api.adminservice.v1.ListHistoryTasksResponse
+	(*Task)(nil),                                        // 16: temporal.server.api.adminservice.v1.Task
+	(*RemoveTaskRequest)(nil),                           // 17: temporal.server.api.adminservice.v1.RemoveTaskRequest
+	(*RemoveTaskResponse)(nil),                          // 18: temporal.server.api.adminservice.v1.RemoveTaskResponse
+	(*GetWorkflowExecutionRawHistoryV2Request)(nil),     // 19: temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryV2Request
+	(*GetWorkflowExecutionRawHistoryV2Response)(nil),    // 20: temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryV2Response
+	(*GetWorkflowExecutionRawHistoryRequest)(nil),       // 21: temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryRequest
+	(*GetWorkflowExecutionRawHistoryResponse)(nil),      // 22: temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryResponse
+	(*GetReplicationMessagesRequest)(nil),               // 23: temporal.server.api.adminservice.v1.GetReplicationMessagesRequest
+	(*GetReplicationMessagesResponse)(nil),              // 24: temporal.server.api.adminservice.v1.GetReplicationMessagesResponse
+	(*GetNamespaceReplicationMessagesRequest)(nil),      // 25: temporal.server.api.adminservice.v1.GetNamespaceReplicationMessagesRequest
+	(*GetNamespaceReplicationMessagesResponse)(nil),     // 26: temporal.server.api.adminservice.v1.GetNamespaceReplicationMessagesResponse
+	(*GetDLQReplicationMessagesRequest)(nil),            // 27: temporal.server.api.adminservice.v1.GetDLQReplicationMessagesRequest
+	(*GetDLQReplicationMessagesResponse)(nil),           // 28: temporal.server.api.adminservice.v1.GetDLQReplicationMessagesResponse
+	(*ReapplyEventsRequest)(nil),                        // 29: temporal.server.api.adminservice.v1.ReapplyEventsRequest
+	(*ReapplyEventsResponse)(nil),                       // 30: temporal.server.api.adminservice.v1.ReapplyEventsResponse
+	(*AddSearchAttributesRequest)(nil),                  // 31: temporal.server.api.adminservice.v1.AddSearchAttributesRequest
+	(*AddSearchAttributesResponse)(nil),                 // 32: temporal.server.api.adminservice.v1.AddSearchAttributesResponse
+	(*RemoveSearchAttributesRequest)(nil),               // 33: temporal.server.api.adminservice.v1.RemoveSearchAttributesRequest
+	(*RemoveSearchAttributesResponse)(nil),              // 34: temporal.server.api.adminservice.v1.RemoveSearchAttributesResponse
+	(*GetSearchAttributesRequest)(nil),                  // 35: temporal.server.api.adminservice.v1.GetSearchAttributesRequest
+	(*GetSearchAttributesResponse)(nil),                 // 36: temporal.server.api.adminservice.v1.GetSearchAttributesResponse
+	(*DescribeClusterRequest)(nil),                      // 37: temporal.server.api.adminservice.v1.DescribeClusterRequest
+	(*DescribeClusterResponse)(nil),                     // 38: temporal.server.api.adminservice.v1.DescribeClusterResponse
+	(*ListClustersRequest)(nil),                         // 39: temporal.server.api.adminservice.v1.ListClustersRequest
+	(*ListClustersResponse)(nil),                        // 40: temporal.server.api.adminservice.v1.ListClustersResponse
+	(*AddOrUpdateRemoteClusterRequest)(nil),             // 41: temporal.server.api.adminservice.v1.AddOrUpdateRemoteClusterRequest
+	(*AddOrUpdateRemoteClusterResponse)(nil),            // 42: temporal.server.api.adminservice.v1.AddOrUpdateRemoteClusterResponse
+	(*RemoveRemoteClusterRequest)(nil),                  // 43: temporal.server.api.adminservice.v1.RemoveRemoteClusterRequest
+	(*RemoveRemoteClusterResponse)(nil),                 // 44: temporal.server.api.adminservice.v1.RemoveRemoteClusterResponse
+	(*ListClusterMembersRequest)(nil),                   // 45: temporal.server.api.adminservice.v1.ListClusterMembersRequest
+	(*ListClusterMembersResponse)(nil),                  // 46: temporal.server.api.adminservice.v1.ListClusterMembersResponse
+	(*GetDLQMessagesRequest)(nil),                       // 47: temporal.server.api.adminservice.v1.GetDLQMessagesRequest
+	(*GetDLQMessagesResponse)(nil),                      // 48: temporal.server.api.adminservice.v1.GetDLQMessagesResponse
+	(*PurgeDLQMessagesRequest)(nil),                     // 49: temporal.server.api.adminservice.v1.PurgeDLQMessagesRequest
+	(*PurgeDLQMessagesResponse)(nil),                    // 50: temporal.server.api.adminservice.v1.PurgeDLQMessagesResponse
+	(*MergeDLQMessagesRequest)(nil),                     // 51: temporal.server.api.adminservice.v1.MergeDLQMessagesRequest
+	(*MergeDLQMessagesResponse)(nil),                    // 52: temporal.server.api.adminservice.v1.MergeDLQMessagesResponse
+	(*RefreshWorkflowTasksRequest)(nil),                 // 53: temporal.server.api.adminservice.v1.RefreshWorkflowTasksRequest
+	(*RefreshWorkflowTasksResponse)(nil),                // 54: temporal.server.api.adminservice.v1.RefreshWorkflowTasksResponse
+	(*ResendReplicationTasksRequest)(nil),               // 55: temporal.server.api.adminservice.v1.ResendReplicationTasksRequest
+	(*ResendReplicationTasksResponse)(nil),              // 56: temporal.server.api.adminservice.v1.ResendReplicationTasksResponse
+	(*GetTaskQueueTasksRequest)(nil),                    // 57: temporal.server.api.adminservice.v1.GetTaskQueueTasksRequest
+	(*GetTaskQueueTasksResponse)(nil),                   // 58: temporal.server.api.adminservice.v1.GetTaskQueueTasksResponse
+	(*DeleteWorkflowExecutionRequest)(nil),              // 59: temporal.server.api.adminservice.v1.DeleteWorkflowExecutionRequest
+	(*DeleteWorkflowExecutionResponse)(nil),             // 60: temporal.server.api.adminservice.v1.DeleteWorkflowExecutionResponse
+	(*StreamWorkflowReplicationMessagesRequest)(nil),    // 61: temporal.server.api.adminservice.v1.StreamWorkflowReplicationMessagesRequest
+	(*StreamWorkflowReplicationMessagesResponse)(nil),   // 62: temporal.server.api.adminservice.v1.StreamWorkflowReplicationMessagesResponse
+	(*GetNamespaceRequest)(nil),                         // 63: temporal.server.api.adminservice.v1.GetNamespaceRequest
+	(*GetNamespaceResponse)(nil),                        // 64: temporal.server.api.adminservice.v1.GetNamespaceResponse
+	(*GetDLQTasksRequest)(nil),                          // 65: temporal.server.api.adminservice.v1.GetDLQTasksRequest
+	(*GetDLQTasksResponse)(nil),                         // 66: temporal.server.api.adminservice.v1.GetDLQTasksResponse
+	(*PurgeDLQTasksRequest)(nil),                        // 67: temporal.server.api.adminservice.v1.PurgeDLQTasksRequest
+	(*PurgeDLQTasksResponse)(nil),                       // 68: temporal.server.api.adminservice.v1.PurgeDLQTasksResponse
+	(*DLQJobToken)(nil),                                 // 69: temporal.server.api.adminservice.v1.DLQJobToken
+	(*MergeDLQTasksRequest)(nil),                        // 70: temporal.server.api.adminservice.v1.MergeDLQTasksRequest
+	(*MergeDLQTasksResponse)(nil),                       // 71: temporal.server.api.adminservice.v1.MergeDLQTasksResponse
+	(*DescribeDLQJobRequest)(nil),                       // 72: temporal.server.api.adminservice.v1.DescribeDLQJobRequest
+	(*DescribeDLQJobResponse)(nil),                      // 73: temporal.server.api.adminservice.v1.DescribeDLQJobResponse
+	(*CancelDLQJobRequest)(nil),                         // 74: temporal.server.api.adminservice.v1.CancelDLQJobRequest
+	(*CancelDLQJobResponse)(nil),                        // 75: temporal.server.api.adminservice.v1.CancelDLQJobResponse
+	(*AddTasksRequest)(nil),                             // 76: temporal.server.api.adminservice.v1.AddTasksRequest
+	(*AddTasksResponse)(nil),                            // 77: temporal.server.api.adminservice.v1.AddTasksResponse
+	(*ListQueuesRequest)(nil),                           // 78: temporal.server.api.adminservice.v1.ListQueuesRequest
+	(*ListQueuesResponse)(nil),                          // 79: temporal.server.api.adminservice.v1.ListQueuesResponse
+	(*DeepHealthCheckRequest)(nil),                      // 80: temporal.server.api.adminservice.v1.DeepHealthCheckRequest
+	(*DeepHealthCheckResponse)(nil),                     // 81: temporal.server.api.adminservice.v1.DeepHealthCheckResponse
+	(*SyncWorkflowStateRequest)(nil),                    // 82: temporal.server.api.adminservice.v1.SyncWorkflowStateRequest
+	(*SyncWorkflowStateResponse)(nil),                   // 83: temporal.server.api.adminservice.v1.SyncWorkflowStateResponse
+	(*GenerateLastHistoryReplicationTasksRequest)(nil),  // 84: temporal.server.api.adminservice.v1.GenerateLastHistoryReplicationTasksRequest
+	(*GenerateLastHistoryReplicationTasksResponse)(nil), // 85: temporal.server.api.adminservice.v1.GenerateLastHistoryReplicationTasksResponse
+	(*DescribeTaskQueuePartitionRequest)(nil),           // 86: temporal.server.api.adminservice.v1.DescribeTaskQueuePartitionRequest
+	(*DescribeTaskQueuePartitionResponse)(nil),          // 87: temporal.server.api.adminservice.v1.DescribeTaskQueuePartitionResponse
+	(*ForceUnloadTaskQueuePartitionRequest)(nil),        // 88: temporal.server.api.adminservice.v1.ForceUnloadTaskQueuePartitionRequest
+	(*ForceUnloadTaskQueuePartitionResponse)(nil),       // 89: temporal.server.api.adminservice.v1.ForceUnloadTaskQueuePartitionResponse
+	(*GetTaskQueueUserDataRequest)(nil),                 // 90: temporal.server.api.adminservice.v1.GetTaskQueueUserDataRequest
+	(*GetTaskQueueUserDataResponse)(nil),                // 91: temporal.server.api.adminservice.v1.GetTaskQueueUserDataResponse
+	(*StartAdminBatchOperationRequest)(nil),             // 92: temporal.server.api.adminservice.v1.StartAdminBatchOperationRequest
+	(*StartAdminBatchOperationResponse)(nil),            // 93: temporal.server.api.adminservice.v1.StartAdminBatchOperationResponse
+	(*BatchOperationRefreshTasks)(nil),                  // 94: temporal.server.api.adminservice.v1.BatchOperationRefreshTasks
+	(*MigrateScheduleRequest)(nil),                      // 95: temporal.server.api.adminservice.v1.MigrateScheduleRequest
+	(*MigrateScheduleResponse)(nil),                     // 96: temporal.server.api.adminservice.v1.MigrateScheduleResponse
+	nil,                                                 // 97: temporal.server.api.adminservice.v1.GetReplicationMessagesResponse.ShardMessagesEntry
+	nil,                                                 // 98: temporal.server.api.adminservice.v1.AddSearchAttributesRequest.SearchAttributesEntry
+	nil,                                                 // 99: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.CustomAttributesEntry
+	nil,                                                 // 100: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.SystemAttributesEntry
+	nil,                                                 // 101: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.MappingEntry
+	nil,                                                 // 102: temporal.server.api.adminservice.v1.DescribeClusterResponse.SupportedClientsEntry
+	nil,                                                 // 103: temporal.server.api.adminservice.v1.DescribeClusterResponse.TagsEntry
+	(*AddTasksRequest_Task)(nil),                        // 104: temporal.server.api.adminservice.v1.AddTasksRequest.Task
+	(*ListQueuesResponse_QueueInfo)(nil),                // 105: temporal.server.api.adminservice.v1.ListQueuesResponse.QueueInfo
+	nil,                                                 // 106: temporal.server.api.adminservice.v1.DescribeTaskQueuePartitionResponse.VersionsInfoInternalEntry
+	(*v1.WorkflowExecution)(nil),                        // 107: temporal.api.common.v1.WorkflowExecution
+	(*v1.DataBlob)(nil),                                 // 108: temporal.api.common.v1.DataBlob
+	(*v11.VersionHistory)(nil),                          // 109: temporal.server.api.history.v1.VersionHistory
+	(*v12.WorkflowMutableState)(nil),                    // 110: temporal.server.api.persistence.v1.WorkflowMutableState
+	(*v13.NamespaceCacheInfo)(nil),                      // 111: temporal.server.api.namespace.v1.NamespaceCacheInfo
+	(*v12.ShardInfo)(nil),                               // 112: temporal.server.api.persistence.v1.ShardInfo
+	(*v11.TaskRange)(nil),                               // 113: temporal.server.api.history.v1.TaskRange
+	(v14.TaskType)(0),                                   // 114: temporal.server.api.enums.v1.TaskType
+	(*timestamppb.Timestamp)(nil),                       // 115: google.protobuf.Timestamp
+	(*v15.ReplicationToken)(nil),                        // 116: temporal.server.api.replication.v1.ReplicationToken
+	(*v15.ReplicationMessages)(nil),                     // 117: temporal.server.api.replication.v1.ReplicationMessages
+	(*v15.ReplicationTaskInfo)(nil),                     // 118: temporal.server.api.replication.v1.ReplicationTaskInfo
+	(*v15.ReplicationTask)(nil),                         // 119: temporal.server.api.replication.v1.ReplicationTask
+	(*v17.WorkflowExecutionInfo)(nil),                   // 120: temporal.api.workflow.v1.WorkflowExecutionInfo
+	(*v18.MembershipInfo)(nil),                          // 121: temporal.server.api.cluster.v1.MembershipInfo
+	(*v19.VersionInfo)(nil),                             // 122: temporal.api.version.v1.VersionInfo
+	(*v12.ClusterMetadata)(nil),                         // 123: temporal.server.api.persistence.v1.ClusterMetadata
+	(*durationpb.Duration)(nil),                         // 124: google.protobuf.Duration
+	(v14.ClusterMemberRole)(0),                          // 125: temporal.server.api.enums.v1.ClusterMemberRole
+	(*v18.ClusterMember)(nil),                           // 126: temporal.server.api.cluster.v1.ClusterMember
+	(v14.DeadLetterQueueType)(0),                        // 127: temporal.server.api.enums.v1.DeadLetterQueueType
+	(v16.TaskQueueType)(0),                              // 128: temporal.api.enums.v1.TaskQueueType
+	(*v12.AllocatedTaskInfo)(nil),                       // 129: temporal.server.api.persistence.v1.AllocatedTaskInfo
+	(*v15.SyncReplicationState)(nil),                    // 130: temporal.server.api.replication.v1.SyncReplicationState
+	(*v15.WorkflowReplicationMessages)(nil),             // 131: temporal.server.api.replication.v1.WorkflowReplicationMessages
+	(*v110.NamespaceInfo)(nil),                          // 132: temporal.api.namespace.v1.NamespaceInfo
+	(*v110.NamespaceConfig)(nil),                        // 133: temporal.api.namespace.v1.NamespaceConfig
+	(*v111.NamespaceReplicationConfig)(nil),             // 134: temporal.api.replication.v1.NamespaceReplicationConfig
+	(*v111.FailoverStatus)(nil),                         // 135: temporal.api.replication.v1.FailoverStatus
+	(*v112.HistoryDLQKey)(nil),                          // 136: temporal.server.api.common.v1.HistoryDLQKey
+	(*v112.HistoryDLQTask)(nil),                         // 137: temporal.server.api.common.v1.HistoryDLQTask
+	(*v112.HistoryDLQTaskMetadata)(nil),                 // 138: temporal.server.api.common.v1.HistoryDLQTaskMetadata
+	(v14.DLQOperationType)(0),                           // 139: temporal.server.api.enums.v1.DLQOperationType
+	(v14.DLQOperationState)(0),                          // 140: temporal.server.api.enums.v1.DLQOperationState
+	(v14.HealthState)(0),                                // 141: temporal.server.api.enums.v1.HealthState
+	(*v113.ServiceHealthDetail)(nil),                    // 142: temporal.server.api.health.v1.ServiceHealthDetail
+	(*v12.VersionedTransition)(nil),                     // 143: temporal.server.api.persistence.v1.VersionedTransition
+	(*v11.VersionHistories)(nil),                        // 144: temporal.server.api.history.v1.VersionHistories
+	(*v15.VersionedTransitionArtifact)(nil),             // 145: temporal.server.api.replication.v1.VersionedTransitionArtifact
+	(*v114.TaskQueuePartition)(nil),                     // 146: temporal.server.api.taskqueue.v1.TaskQueuePartition
+	(*v115.TaskQueueVersionSelection)(nil),              // 147: temporal.api.taskqueue.v1.TaskQueueVersionSelection
+	(*v114.PartitionScaleInfo)(nil),                     // 148: temporal.server.api.taskqueue.v1.PartitionScaleInfo
+	(*v12.TaskQueueTypeUserData)(nil),                   // 149: temporal.server.api.persistence.v1.TaskQueueTypeUserData
+	(v16.IndexedValueType)(0),                           // 150: temporal.api.enums.v1.IndexedValueType
+	(*v114.TaskQueueVersionInfoInternal)(nil),           // 151: temporal.server.api.taskqueue.v1.TaskQueueVersionInfoInternal
 }
 var file_temporal_server_api_adminservice_v1_request_response_proto_depIdxs = []int32{
-	106, // 0: temporal.server.api.adminservice.v1.RebuildMutableStateRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	106, // 1: temporal.server.api.adminservice.v1.ImportWorkflowExecutionRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	107, // 2: temporal.server.api.adminservice.v1.ImportWorkflowExecutionRequest.history_batches:type_name -> temporal.api.common.v1.DataBlob
-	108, // 3: temporal.server.api.adminservice.v1.ImportWorkflowExecutionRequest.version_history:type_name -> temporal.server.api.history.v1.VersionHistory
-	106, // 4: temporal.server.api.adminservice.v1.DescribeMutableStateRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	109, // 5: temporal.server.api.adminservice.v1.DescribeMutableStateResponse.cache_mutable_state:type_name -> temporal.server.api.persistence.v1.WorkflowMutableState
-	109, // 6: temporal.server.api.adminservice.v1.DescribeMutableStateResponse.database_mutable_state:type_name -> temporal.server.api.persistence.v1.WorkflowMutableState
-	106, // 7: temporal.server.api.adminservice.v1.DescribeHistoryHostRequest.workflow_execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	110, // 8: temporal.server.api.adminservice.v1.DescribeHistoryHostResponse.namespace_cache:type_name -> temporal.server.api.namespace.v1.NamespaceCacheInfo
-	111, // 9: temporal.server.api.adminservice.v1.GetShardResponse.shard_info:type_name -> temporal.server.api.persistence.v1.ShardInfo
-	112, // 10: temporal.server.api.adminservice.v1.ListHistoryTasksRequest.task_range:type_name -> temporal.server.api.history.v1.TaskRange
-	15,  // 11: temporal.server.api.adminservice.v1.ListHistoryTasksResponse.tasks:type_name -> temporal.server.api.adminservice.v1.Task
-	113, // 12: temporal.server.api.adminservice.v1.Task.task_type:type_name -> temporal.server.api.enums.v1.TaskType
-	114, // 13: temporal.server.api.adminservice.v1.Task.fire_time:type_name -> google.protobuf.Timestamp
-	114, // 14: temporal.server.api.adminservice.v1.RemoveTaskRequest.visibility_time:type_name -> google.protobuf.Timestamp
-	106, // 15: temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryV2Request.execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	107, // 16: temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryV2Response.history_batches:type_name -> temporal.api.common.v1.DataBlob
-	108, // 17: temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryV2Response.version_history:type_name -> temporal.server.api.history.v1.VersionHistory
-	106, // 18: temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	107, // 19: temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryResponse.history_batches:type_name -> temporal.api.common.v1.DataBlob
-	108, // 20: temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryResponse.version_history:type_name -> temporal.server.api.history.v1.VersionHistory
-	115, // 21: temporal.server.api.adminservice.v1.GetReplicationMessagesRequest.tokens:type_name -> temporal.server.api.replication.v1.ReplicationToken
-	96,  // 22: temporal.server.api.adminservice.v1.GetReplicationMessagesResponse.shard_messages:type_name -> temporal.server.api.adminservice.v1.GetReplicationMessagesResponse.ShardMessagesEntry
-	116, // 23: temporal.server.api.adminservice.v1.GetNamespaceReplicationMessagesResponse.messages:type_name -> temporal.server.api.replication.v1.ReplicationMessages
-	117, // 24: temporal.server.api.adminservice.v1.GetDLQReplicationMessagesRequest.task_infos:type_name -> temporal.server.api.replication.v1.ReplicationTaskInfo
-	118, // 25: temporal.server.api.adminservice.v1.GetDLQReplicationMessagesResponse.replication_tasks:type_name -> temporal.server.api.replication.v1.ReplicationTask
-	106, // 26: temporal.server.api.adminservice.v1.ReapplyEventsRequest.workflow_execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	107, // 27: temporal.server.api.adminservice.v1.ReapplyEventsRequest.events:type_name -> temporal.api.common.v1.DataBlob
-	97,  // 28: temporal.server.api.adminservice.v1.AddSearchAttributesRequest.search_attributes:type_name -> temporal.server.api.adminservice.v1.AddSearchAttributesRequest.SearchAttributesEntry
-	98,  // 29: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.custom_attributes:type_name -> temporal.server.api.adminservice.v1.GetSearchAttributesResponse.CustomAttributesEntry
-	99,  // 30: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.system_attributes:type_name -> temporal.server.api.adminservice.v1.GetSearchAttributesResponse.SystemAttributesEntry
-	100, // 31: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.mapping:type_name -> temporal.server.api.adminservice.v1.GetSearchAttributesResponse.MappingEntry
-	119, // 32: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.add_workflow_execution_info:type_name -> temporal.api.workflow.v1.WorkflowExecutionInfo
-	101, // 33: temporal.server.api.adminservice.v1.DescribeClusterResponse.supported_clients:type_name -> temporal.server.api.adminservice.v1.DescribeClusterResponse.SupportedClientsEntry
-	120, // 34: temporal.server.api.adminservice.v1.DescribeClusterResponse.membership_info:type_name -> temporal.server.api.cluster.v1.MembershipInfo
-	121, // 35: temporal.server.api.adminservice.v1.DescribeClusterResponse.version_info:type_name -> temporal.api.version.v1.VersionInfo
-	102, // 36: temporal.server.api.adminservice.v1.DescribeClusterResponse.tags:type_name -> temporal.server.api.adminservice.v1.DescribeClusterResponse.TagsEntry
-	122, // 37: temporal.server.api.adminservice.v1.ListClustersResponse.clusters:type_name -> temporal.server.api.persistence.v1.ClusterMetadata
-	123, // 38: temporal.server.api.adminservice.v1.ListClusterMembersRequest.last_heartbeat_within:type_name -> google.protobuf.Duration
-	124, // 39: temporal.server.api.adminservice.v1.ListClusterMembersRequest.role:type_name -> temporal.server.api.enums.v1.ClusterMemberRole
-	114, // 40: temporal.server.api.adminservice.v1.ListClusterMembersRequest.session_started_after_time:type_name -> google.protobuf.Timestamp
-	125, // 41: temporal.server.api.adminservice.v1.ListClusterMembersResponse.active_members:type_name -> temporal.server.api.cluster.v1.ClusterMember
-	126, // 42: temporal.server.api.adminservice.v1.GetDLQMessagesRequest.type:type_name -> temporal.server.api.enums.v1.DeadLetterQueueType
-	126, // 43: temporal.server.api.adminservice.v1.GetDLQMessagesResponse.type:type_name -> temporal.server.api.enums.v1.DeadLetterQueueType
-	118, // 44: temporal.server.api.adminservice.v1.GetDLQMessagesResponse.replication_tasks:type_name -> temporal.server.api.replication.v1.ReplicationTask
-	117, // 45: temporal.server.api.adminservice.v1.GetDLQMessagesResponse.replication_tasks_info:type_name -> temporal.server.api.replication.v1.ReplicationTaskInfo
-	126, // 46: temporal.server.api.adminservice.v1.PurgeDLQMessagesRequest.type:type_name -> temporal.server.api.enums.v1.DeadLetterQueueType
-	126, // 47: temporal.server.api.adminservice.v1.MergeDLQMessagesRequest.type:type_name -> temporal.server.api.enums.v1.DeadLetterQueueType
-	106, // 48: temporal.server.api.adminservice.v1.RefreshWorkflowTasksRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	127, // 49: temporal.server.api.adminservice.v1.GetTaskQueueTasksRequest.task_queue_type:type_name -> temporal.api.enums.v1.TaskQueueType
-	128, // 50: temporal.server.api.adminservice.v1.GetTaskQueueTasksResponse.tasks:type_name -> temporal.server.api.persistence.v1.AllocatedTaskInfo
-	106, // 51: temporal.server.api.adminservice.v1.DeleteWorkflowExecutionRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	129, // 52: temporal.server.api.adminservice.v1.StreamWorkflowReplicationMessagesRequest.sync_replication_state:type_name -> temporal.server.api.replication.v1.SyncReplicationState
-	130, // 53: temporal.server.api.adminservice.v1.StreamWorkflowReplicationMessagesResponse.messages:type_name -> temporal.server.api.replication.v1.WorkflowReplicationMessages
-	131, // 54: temporal.server.api.adminservice.v1.GetNamespaceResponse.info:type_name -> temporal.api.namespace.v1.NamespaceInfo
-	132, // 55: temporal.server.api.adminservice.v1.GetNamespaceResponse.config:type_name -> temporal.api.namespace.v1.NamespaceConfig
-	133, // 56: temporal.server.api.adminservice.v1.GetNamespaceResponse.replication_config:type_name -> temporal.api.replication.v1.NamespaceReplicationConfig
-	134, // 57: temporal.server.api.adminservice.v1.GetNamespaceResponse.failover_history:type_name -> temporal.api.replication.v1.FailoverStatus
-	135, // 58: temporal.server.api.adminservice.v1.GetDLQTasksRequest.dlq_key:type_name -> temporal.server.api.common.v1.HistoryDLQKey
-	136, // 59: temporal.server.api.adminservice.v1.GetDLQTasksResponse.dlq_tasks:type_name -> temporal.server.api.common.v1.HistoryDLQTask
-	135, // 60: temporal.server.api.adminservice.v1.PurgeDLQTasksRequest.dlq_key:type_name -> temporal.server.api.common.v1.HistoryDLQKey
-	137, // 61: temporal.server.api.adminservice.v1.PurgeDLQTasksRequest.inclusive_max_task_metadata:type_name -> temporal.server.api.common.v1.HistoryDLQTaskMetadata
-	135, // 62: temporal.server.api.adminservice.v1.MergeDLQTasksRequest.dlq_key:type_name -> temporal.server.api.common.v1.HistoryDLQKey
-	137, // 63: temporal.server.api.adminservice.v1.MergeDLQTasksRequest.inclusive_max_task_metadata:type_name -> temporal.server.api.common.v1.HistoryDLQTaskMetadata
-	135, // 64: temporal.server.api.adminservice.v1.DescribeDLQJobResponse.dlq_key:type_name -> temporal.server.api.common.v1.HistoryDLQKey
-	138, // 65: temporal.server.api.adminservice.v1.DescribeDLQJobResponse.operation_type:type_name -> temporal.server.api.enums.v1.DLQOperationType
-	139, // 66: temporal.server.api.adminservice.v1.DescribeDLQJobResponse.operation_state:type_name -> temporal.server.api.enums.v1.DLQOperationState
-	114, // 67: temporal.server.api.adminservice.v1.DescribeDLQJobResponse.start_time:type_name -> google.protobuf.Timestamp
-	114, // 68: temporal.server.api.adminservice.v1.DescribeDLQJobResponse.end_time:type_name -> google.protobuf.Timestamp
-	103, // 69: temporal.server.api.adminservice.v1.AddTasksRequest.tasks:type_name -> temporal.server.api.adminservice.v1.AddTasksRequest.Task
-	104, // 70: temporal.server.api.adminservice.v1.ListQueuesResponse.queues:type_name -> temporal.server.api.adminservice.v1.ListQueuesResponse.QueueInfo
-	140, // 71: temporal.server.api.adminservice.v1.DeepHealthCheckResponse.state:type_name -> temporal.server.api.enums.v1.HealthState
-	141, // 72: temporal.server.api.adminservice.v1.DeepHealthCheckResponse.services:type_name -> temporal.server.api.health.v1.ServiceHealthDetail
-	106, // 73: temporal.server.api.adminservice.v1.SyncWorkflowStateRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	142, // 74: temporal.server.api.adminservice.v1.SyncWorkflowStateRequest.versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
-	143, // 75: temporal.server.api.adminservice.v1.SyncWorkflowStateRequest.version_histories:type_name -> temporal.server.api.history.v1.VersionHistories
-	144, // 76: temporal.server.api.adminservice.v1.SyncWorkflowStateResponse.versioned_transition_artifact:type_name -> temporal.server.api.replication.v1.VersionedTransitionArtifact
-	106, // 77: temporal.server.api.adminservice.v1.GenerateLastHistoryReplicationTasksRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	145, // 78: temporal.server.api.adminservice.v1.DescribeTaskQueuePartitionRequest.task_queue_partition:type_name -> temporal.server.api.taskqueue.v1.TaskQueuePartition
-	146, // 79: temporal.server.api.adminservice.v1.DescribeTaskQueuePartitionRequest.build_ids:type_name -> temporal.api.taskqueue.v1.TaskQueueVersionSelection
-	105, // 80: temporal.server.api.adminservice.v1.DescribeTaskQueuePartitionResponse.versions_info_internal:type_name -> temporal.server.api.adminservice.v1.DescribeTaskQueuePartitionResponse.VersionsInfoInternalEntry
-	147, // 81: temporal.server.api.adminservice.v1.DescribeTaskQueuePartitionResponse.scale_info:type_name -> temporal.server.api.taskqueue.v1.PartitionScaleInfo
-	145, // 82: temporal.server.api.adminservice.v1.ForceUnloadTaskQueuePartitionRequest.task_queue_partition:type_name -> temporal.server.api.taskqueue.v1.TaskQueuePartition
-	127, // 83: temporal.server.api.adminservice.v1.GetTaskQueueUserDataRequest.task_queue_type:type_name -> temporal.api.enums.v1.TaskQueueType
-	148, // 84: temporal.server.api.adminservice.v1.GetTaskQueueUserDataResponse.user_data:type_name -> temporal.server.api.persistence.v1.TaskQueueTypeUserData
-	106, // 85: temporal.server.api.adminservice.v1.StartAdminBatchOperationRequest.executions:type_name -> temporal.api.common.v1.WorkflowExecution
-	93,  // 86: temporal.server.api.adminservice.v1.StartAdminBatchOperationRequest.refresh_tasks_operation:type_name -> temporal.server.api.adminservice.v1.BatchOperationRefreshTasks
-	0,   // 87: temporal.server.api.adminservice.v1.MigrateScheduleRequest.target:type_name -> temporal.server.api.adminservice.v1.MigrateScheduleRequest.SchedulerTarget
-	116, // 88: temporal.server.api.adminservice.v1.GetReplicationMessagesResponse.ShardMessagesEntry.value:type_name -> temporal.server.api.replication.v1.ReplicationMessages
-	149, // 89: temporal.server.api.adminservice.v1.AddSearchAttributesRequest.SearchAttributesEntry.value:type_name -> temporal.api.enums.v1.IndexedValueType
-	149, // 90: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.CustomAttributesEntry.value:type_name -> temporal.api.enums.v1.IndexedValueType
-	149, // 91: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.SystemAttributesEntry.value:type_name -> temporal.api.enums.v1.IndexedValueType
-	107, // 92: temporal.server.api.adminservice.v1.AddTasksRequest.Task.blob:type_name -> temporal.api.common.v1.DataBlob
-	150, // 93: temporal.server.api.adminservice.v1.DescribeTaskQueuePartitionResponse.VersionsInfoInternalEntry.value:type_name -> temporal.server.api.taskqueue.v1.TaskQueueVersionInfoInternal
-	94,  // [94:94] is the sub-list for method output_type
-	94,  // [94:94] is the sub-list for method input_type
-	94,  // [94:94] is the sub-list for extension type_name
-	94,  // [94:94] is the sub-list for extension extendee
-	0,   // [0:94] is the sub-list for field type_name
+	107, // 0: temporal.server.api.adminservice.v1.RebuildMutableStateRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	107, // 1: temporal.server.api.adminservice.v1.ImportWorkflowExecutionRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	108, // 2: temporal.server.api.adminservice.v1.ImportWorkflowExecutionRequest.history_batches:type_name -> temporal.api.common.v1.DataBlob
+	109, // 3: temporal.server.api.adminservice.v1.ImportWorkflowExecutionRequest.version_history:type_name -> temporal.server.api.history.v1.VersionHistory
+	107, // 4: temporal.server.api.adminservice.v1.DescribeMutableStateRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	110, // 5: temporal.server.api.adminservice.v1.DescribeMutableStateResponse.cache_mutable_state:type_name -> temporal.server.api.persistence.v1.WorkflowMutableState
+	110, // 6: temporal.server.api.adminservice.v1.DescribeMutableStateResponse.database_mutable_state:type_name -> temporal.server.api.persistence.v1.WorkflowMutableState
+	107, // 7: temporal.server.api.adminservice.v1.DescribeHistoryHostRequest.workflow_execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	111, // 8: temporal.server.api.adminservice.v1.DescribeHistoryHostResponse.namespace_cache:type_name -> temporal.server.api.namespace.v1.NamespaceCacheInfo
+	112, // 9: temporal.server.api.adminservice.v1.GetShardResponse.shard_info:type_name -> temporal.server.api.persistence.v1.ShardInfo
+	113, // 10: temporal.server.api.adminservice.v1.ListHistoryTasksRequest.task_range:type_name -> temporal.server.api.history.v1.TaskRange
+	16,  // 11: temporal.server.api.adminservice.v1.ListHistoryTasksResponse.tasks:type_name -> temporal.server.api.adminservice.v1.Task
+	114, // 12: temporal.server.api.adminservice.v1.Task.task_type:type_name -> temporal.server.api.enums.v1.TaskType
+	115, // 13: temporal.server.api.adminservice.v1.Task.fire_time:type_name -> google.protobuf.Timestamp
+	115, // 14: temporal.server.api.adminservice.v1.RemoveTaskRequest.visibility_time:type_name -> google.protobuf.Timestamp
+	107, // 15: temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryV2Request.execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	108, // 16: temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryV2Response.history_batches:type_name -> temporal.api.common.v1.DataBlob
+	109, // 17: temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryV2Response.version_history:type_name -> temporal.server.api.history.v1.VersionHistory
+	107, // 18: temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	108, // 19: temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryResponse.history_batches:type_name -> temporal.api.common.v1.DataBlob
+	109, // 20: temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryResponse.version_history:type_name -> temporal.server.api.history.v1.VersionHistory
+	116, // 21: temporal.server.api.adminservice.v1.GetReplicationMessagesRequest.tokens:type_name -> temporal.server.api.replication.v1.ReplicationToken
+	97,  // 22: temporal.server.api.adminservice.v1.GetReplicationMessagesResponse.shard_messages:type_name -> temporal.server.api.adminservice.v1.GetReplicationMessagesResponse.ShardMessagesEntry
+	117, // 23: temporal.server.api.adminservice.v1.GetNamespaceReplicationMessagesResponse.messages:type_name -> temporal.server.api.replication.v1.ReplicationMessages
+	118, // 24: temporal.server.api.adminservice.v1.GetDLQReplicationMessagesRequest.task_infos:type_name -> temporal.server.api.replication.v1.ReplicationTaskInfo
+	119, // 25: temporal.server.api.adminservice.v1.GetDLQReplicationMessagesResponse.replication_tasks:type_name -> temporal.server.api.replication.v1.ReplicationTask
+	107, // 26: temporal.server.api.adminservice.v1.ReapplyEventsRequest.workflow_execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	108, // 27: temporal.server.api.adminservice.v1.ReapplyEventsRequest.events:type_name -> temporal.api.common.v1.DataBlob
+	98,  // 28: temporal.server.api.adminservice.v1.AddSearchAttributesRequest.search_attributes:type_name -> temporal.server.api.adminservice.v1.AddSearchAttributesRequest.SearchAttributesEntry
+	99,  // 29: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.custom_attributes:type_name -> temporal.server.api.adminservice.v1.GetSearchAttributesResponse.CustomAttributesEntry
+	100, // 30: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.system_attributes:type_name -> temporal.server.api.adminservice.v1.GetSearchAttributesResponse.SystemAttributesEntry
+	101, // 31: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.mapping:type_name -> temporal.server.api.adminservice.v1.GetSearchAttributesResponse.MappingEntry
+	120, // 32: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.add_workflow_execution_info:type_name -> temporal.api.workflow.v1.WorkflowExecutionInfo
+	102, // 33: temporal.server.api.adminservice.v1.DescribeClusterResponse.supported_clients:type_name -> temporal.server.api.adminservice.v1.DescribeClusterResponse.SupportedClientsEntry
+	121, // 34: temporal.server.api.adminservice.v1.DescribeClusterResponse.membership_info:type_name -> temporal.server.api.cluster.v1.MembershipInfo
+	122, // 35: temporal.server.api.adminservice.v1.DescribeClusterResponse.version_info:type_name -> temporal.api.version.v1.VersionInfo
+	103, // 36: temporal.server.api.adminservice.v1.DescribeClusterResponse.tags:type_name -> temporal.server.api.adminservice.v1.DescribeClusterResponse.TagsEntry
+	123, // 37: temporal.server.api.adminservice.v1.ListClustersResponse.clusters:type_name -> temporal.server.api.persistence.v1.ClusterMetadata
+	124, // 38: temporal.server.api.adminservice.v1.ListClusterMembersRequest.last_heartbeat_within:type_name -> google.protobuf.Duration
+	125, // 39: temporal.server.api.adminservice.v1.ListClusterMembersRequest.role:type_name -> temporal.server.api.enums.v1.ClusterMemberRole
+	115, // 40: temporal.server.api.adminservice.v1.ListClusterMembersRequest.session_started_after_time:type_name -> google.protobuf.Timestamp
+	126, // 41: temporal.server.api.adminservice.v1.ListClusterMembersResponse.active_members:type_name -> temporal.server.api.cluster.v1.ClusterMember
+	127, // 42: temporal.server.api.adminservice.v1.GetDLQMessagesRequest.type:type_name -> temporal.server.api.enums.v1.DeadLetterQueueType
+	127, // 43: temporal.server.api.adminservice.v1.GetDLQMessagesResponse.type:type_name -> temporal.server.api.enums.v1.DeadLetterQueueType
+	119, // 44: temporal.server.api.adminservice.v1.GetDLQMessagesResponse.replication_tasks:type_name -> temporal.server.api.replication.v1.ReplicationTask
+	118, // 45: temporal.server.api.adminservice.v1.GetDLQMessagesResponse.replication_tasks_info:type_name -> temporal.server.api.replication.v1.ReplicationTaskInfo
+	127, // 46: temporal.server.api.adminservice.v1.PurgeDLQMessagesRequest.type:type_name -> temporal.server.api.enums.v1.DeadLetterQueueType
+	127, // 47: temporal.server.api.adminservice.v1.MergeDLQMessagesRequest.type:type_name -> temporal.server.api.enums.v1.DeadLetterQueueType
+	107, // 48: temporal.server.api.adminservice.v1.RefreshWorkflowTasksRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	128, // 49: temporal.server.api.adminservice.v1.GetTaskQueueTasksRequest.task_queue_type:type_name -> temporal.api.enums.v1.TaskQueueType
+	129, // 50: temporal.server.api.adminservice.v1.GetTaskQueueTasksResponse.tasks:type_name -> temporal.server.api.persistence.v1.AllocatedTaskInfo
+	107, // 51: temporal.server.api.adminservice.v1.DeleteWorkflowExecutionRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	130, // 52: temporal.server.api.adminservice.v1.StreamWorkflowReplicationMessagesRequest.sync_replication_state:type_name -> temporal.server.api.replication.v1.SyncReplicationState
+	131, // 53: temporal.server.api.adminservice.v1.StreamWorkflowReplicationMessagesResponse.messages:type_name -> temporal.server.api.replication.v1.WorkflowReplicationMessages
+	132, // 54: temporal.server.api.adminservice.v1.GetNamespaceResponse.info:type_name -> temporal.api.namespace.v1.NamespaceInfo
+	133, // 55: temporal.server.api.adminservice.v1.GetNamespaceResponse.config:type_name -> temporal.api.namespace.v1.NamespaceConfig
+	134, // 56: temporal.server.api.adminservice.v1.GetNamespaceResponse.replication_config:type_name -> temporal.api.replication.v1.NamespaceReplicationConfig
+	135, // 57: temporal.server.api.adminservice.v1.GetNamespaceResponse.failover_history:type_name -> temporal.api.replication.v1.FailoverStatus
+	136, // 58: temporal.server.api.adminservice.v1.GetDLQTasksRequest.dlq_key:type_name -> temporal.server.api.common.v1.HistoryDLQKey
+	137, // 59: temporal.server.api.adminservice.v1.GetDLQTasksResponse.dlq_tasks:type_name -> temporal.server.api.common.v1.HistoryDLQTask
+	136, // 60: temporal.server.api.adminservice.v1.PurgeDLQTasksRequest.dlq_key:type_name -> temporal.server.api.common.v1.HistoryDLQKey
+	138, // 61: temporal.server.api.adminservice.v1.PurgeDLQTasksRequest.inclusive_max_task_metadata:type_name -> temporal.server.api.common.v1.HistoryDLQTaskMetadata
+	136, // 62: temporal.server.api.adminservice.v1.MergeDLQTasksRequest.dlq_key:type_name -> temporal.server.api.common.v1.HistoryDLQKey
+	138, // 63: temporal.server.api.adminservice.v1.MergeDLQTasksRequest.inclusive_max_task_metadata:type_name -> temporal.server.api.common.v1.HistoryDLQTaskMetadata
+	136, // 64: temporal.server.api.adminservice.v1.DescribeDLQJobResponse.dlq_key:type_name -> temporal.server.api.common.v1.HistoryDLQKey
+	139, // 65: temporal.server.api.adminservice.v1.DescribeDLQJobResponse.operation_type:type_name -> temporal.server.api.enums.v1.DLQOperationType
+	140, // 66: temporal.server.api.adminservice.v1.DescribeDLQJobResponse.operation_state:type_name -> temporal.server.api.enums.v1.DLQOperationState
+	115, // 67: temporal.server.api.adminservice.v1.DescribeDLQJobResponse.start_time:type_name -> google.protobuf.Timestamp
+	115, // 68: temporal.server.api.adminservice.v1.DescribeDLQJobResponse.end_time:type_name -> google.protobuf.Timestamp
+	104, // 69: temporal.server.api.adminservice.v1.AddTasksRequest.tasks:type_name -> temporal.server.api.adminservice.v1.AddTasksRequest.Task
+	105, // 70: temporal.server.api.adminservice.v1.ListQueuesResponse.queues:type_name -> temporal.server.api.adminservice.v1.ListQueuesResponse.QueueInfo
+	141, // 71: temporal.server.api.adminservice.v1.DeepHealthCheckResponse.state:type_name -> temporal.server.api.enums.v1.HealthState
+	142, // 72: temporal.server.api.adminservice.v1.DeepHealthCheckResponse.services:type_name -> temporal.server.api.health.v1.ServiceHealthDetail
+	107, // 73: temporal.server.api.adminservice.v1.SyncWorkflowStateRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	143, // 74: temporal.server.api.adminservice.v1.SyncWorkflowStateRequest.versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
+	144, // 75: temporal.server.api.adminservice.v1.SyncWorkflowStateRequest.version_histories:type_name -> temporal.server.api.history.v1.VersionHistories
+	145, // 76: temporal.server.api.adminservice.v1.SyncWorkflowStateResponse.versioned_transition_artifact:type_name -> temporal.server.api.replication.v1.VersionedTransitionArtifact
+	107, // 77: temporal.server.api.adminservice.v1.GenerateLastHistoryReplicationTasksRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	146, // 78: temporal.server.api.adminservice.v1.DescribeTaskQueuePartitionRequest.task_queue_partition:type_name -> temporal.server.api.taskqueue.v1.TaskQueuePartition
+	147, // 79: temporal.server.api.adminservice.v1.DescribeTaskQueuePartitionRequest.build_ids:type_name -> temporal.api.taskqueue.v1.TaskQueueVersionSelection
+	106, // 80: temporal.server.api.adminservice.v1.DescribeTaskQueuePartitionResponse.versions_info_internal:type_name -> temporal.server.api.adminservice.v1.DescribeTaskQueuePartitionResponse.VersionsInfoInternalEntry
+	148, // 81: temporal.server.api.adminservice.v1.DescribeTaskQueuePartitionResponse.scale_info:type_name -> temporal.server.api.taskqueue.v1.PartitionScaleInfo
+	146, // 82: temporal.server.api.adminservice.v1.ForceUnloadTaskQueuePartitionRequest.task_queue_partition:type_name -> temporal.server.api.taskqueue.v1.TaskQueuePartition
+	128, // 83: temporal.server.api.adminservice.v1.GetTaskQueueUserDataRequest.task_queue_type:type_name -> temporal.api.enums.v1.TaskQueueType
+	149, // 84: temporal.server.api.adminservice.v1.GetTaskQueueUserDataResponse.user_data:type_name -> temporal.server.api.persistence.v1.TaskQueueTypeUserData
+	107, // 85: temporal.server.api.adminservice.v1.StartAdminBatchOperationRequest.executions:type_name -> temporal.api.common.v1.WorkflowExecution
+	0,   // 86: temporal.server.api.adminservice.v1.StartAdminBatchOperationRequest.job_namespace:type_name -> temporal.server.api.adminservice.v1.StartAdminBatchOperationRequest.JobNamespace
+	94,  // 87: temporal.server.api.adminservice.v1.StartAdminBatchOperationRequest.refresh_tasks_operation:type_name -> temporal.server.api.adminservice.v1.BatchOperationRefreshTasks
+	1,   // 88: temporal.server.api.adminservice.v1.MigrateScheduleRequest.target:type_name -> temporal.server.api.adminservice.v1.MigrateScheduleRequest.SchedulerTarget
+	117, // 89: temporal.server.api.adminservice.v1.GetReplicationMessagesResponse.ShardMessagesEntry.value:type_name -> temporal.server.api.replication.v1.ReplicationMessages
+	150, // 90: temporal.server.api.adminservice.v1.AddSearchAttributesRequest.SearchAttributesEntry.value:type_name -> temporal.api.enums.v1.IndexedValueType
+	150, // 91: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.CustomAttributesEntry.value:type_name -> temporal.api.enums.v1.IndexedValueType
+	150, // 92: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.SystemAttributesEntry.value:type_name -> temporal.api.enums.v1.IndexedValueType
+	108, // 93: temporal.server.api.adminservice.v1.AddTasksRequest.Task.blob:type_name -> temporal.api.common.v1.DataBlob
+	151, // 94: temporal.server.api.adminservice.v1.DescribeTaskQueuePartitionResponse.VersionsInfoInternalEntry.value:type_name -> temporal.server.api.taskqueue.v1.TaskQueueVersionInfoInternal
+	95,  // [95:95] is the sub-list for method output_type
+	95,  // [95:95] is the sub-list for method input_type
+	95,  // [95:95] is the sub-list for extension type_name
+	95,  // [95:95] is the sub-list for extension extendee
+	0,   // [0:95] is the sub-list for field type_name
 }
 
 func init() { file_temporal_server_api_adminservice_v1_request_response_proto_init() }
@@ -6645,7 +6754,7 @@ func file_temporal_server_api_adminservice_v1_request_response_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_temporal_server_api_adminservice_v1_request_response_proto_rawDesc), len(file_temporal_server_api_adminservice_v1_request_response_proto_rawDesc)),
-			NumEnums:      1,
+			NumEnums:      2,
 			NumMessages:   105,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/cmd/tools/getproto/files.go
+++ b/cmd/tools/getproto/files.go
@@ -7,7 +7,6 @@ package main
 import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 
-	nexusannotations "github.com/nexus-rpc/nexus-proto-annotations/go/nexusannotations/v1"
 	activity "go.temporal.io/api/activity/v1"
 	batch "go.temporal.io/api/batch/v1"
 	callback "go.temporal.io/api/callback/v1"
@@ -33,6 +32,7 @@ import (
 	worker "go.temporal.io/api/worker/v1"
 	workflow "go.temporal.io/api/workflow/v1"
 	workflowservice "go.temporal.io/api/workflowservice/v1"
+	annotations "google.golang.org/genproto/googleapis/api/annotations"
 	descriptorpb "google.golang.org/protobuf/types/descriptorpb"
 	anypb "google.golang.org/protobuf/types/known/anypb"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
@@ -44,6 +44,7 @@ import (
 
 func init() {
 	importMap = make(map[string]protoreflect.FileDescriptor)
+	importMap["google/api/field_behavior.proto"] = annotations.File_google_api_field_behavior_proto
 	importMap["google/protobuf/any.proto"] = anypb.File_google_protobuf_any_proto
 	importMap["google/protobuf/descriptor.proto"] = descriptorpb.File_google_protobuf_descriptor_proto
 	importMap["google/protobuf/duration.proto"] = durationpb.File_google_protobuf_duration_proto
@@ -51,7 +52,6 @@ func init() {
 	importMap["google/protobuf/field_mask.proto"] = fieldmaskpb.File_google_protobuf_field_mask_proto
 	importMap["google/protobuf/timestamp.proto"] = timestamppb.File_google_protobuf_timestamp_proto
 	importMap["google/protobuf/wrappers.proto"] = wrapperspb.File_google_protobuf_wrappers_proto
-	importMap["nexusannotations/v1/options.proto"] = nexusannotations.File_nexusannotations_v1_options_proto
 	importMap["temporal/api/activity/v1/message.proto"] = activity.File_temporal_api_activity_v1_message_proto
 	importMap["temporal/api/batch/v1/message.proto"] = batch.File_temporal_api_batch_v1_message_proto
 	importMap["temporal/api/callback/v1/message.proto"] = callback.File_temporal_api_callback_v1_message_proto

--- a/cmd/tools/getproto/main.go
+++ b/cmd/tools/getproto/main.go
@@ -43,10 +43,7 @@ func findProtoImports() []string {
 			fatalIfErr(err)
 			for line := range strings.SplitSeq(string(protoFile), "\n") {
 				if match := matchImport.FindStringSubmatch(line); len(match) > 0 {
-					i := match[1]
-					if strings.HasPrefix(i, "temporal/api/") ||
-						strings.HasPrefix(i, "google/") ||
-						strings.HasPrefix(i, "nexus/") {
+					if i := match[1]; isExternalImport(i) {
 						importMap[i] = struct{}{}
 					}
 				}
@@ -55,6 +52,18 @@ func findProtoImports() []string {
 		return nil
 	}))
 	return expmaps.Keys(importMap)
+}
+
+// isExternalImport reports whether a proto import is resolved from a Go module
+// rather than from proto/internal. A prefix missing from this list is never added
+// to the descriptor set, and protoc then fails with "File not found".
+func isExternalImport(path string) bool {
+	for _, prefix := range []string{"temporal/api/", "google/", "nexus/", "nexusannotations/"} {
+		if strings.HasPrefix(path, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func getImportName(i string) string {
@@ -82,6 +91,12 @@ func genFileList(protoImports []string) {
 			importName := getImportName(goImport)
 			goImportsMap[goImport] = importName
 			protoToPackage[i] = importName
+		} else if strings.HasPrefix(i, "google/api/") {
+			// The googleapis annotations all live in one Go package, which is not
+			// under types/known like the well-known types below.
+			const goImport = "google.golang.org/genproto/googleapis/api/annotations"
+			goImportsMap[goImport] = "annotations"
+			protoToPackage[i] = "annotations"
 		} else if strings.HasPrefix(i, "google/") {
 			base := strings.TrimSuffix(filepath.Base(i), ".proto") + "pb"
 			base = strings.ReplaceAll(base, "field_mask", "fieldmask")
@@ -157,7 +172,7 @@ func checkImports(files map[string]protoreflect.FileDescriptor) {
 		num := imports.Len()
 		for i := range num {
 			imp := imports.Get(i).Path()
-			if strings.HasPrefix(imp, "temporal/api/") || strings.HasPrefix(imp, "google/") || strings.HasPrefix(imp, "nexus/") {
+			if isExternalImport(imp) {
 				if _, ok := files[imp]; !ok {
 					missing[imp] = struct{}{}
 				}

--- a/common/authorization/default_authorizer_test.go
+++ b/common/authorization/default_authorizer_test.go
@@ -71,6 +71,10 @@ var (
 		APIName:   "/temporal.server.api.adminservice.v1.AdminService/AddSearchAttributes",
 		Namespace: testNamespace,
 	}
+	targetStartAdminBatchOperation = CallTarget{
+		APIName:   "/temporal.server.api.adminservice.v1.AdminService/StartAdminBatchOperation",
+		Namespace: testNamespace,
+	}
 )
 
 type (
@@ -140,6 +144,16 @@ func (s *defaultAuthorizerSuite) TestAuthorize() {
 		{"NamespaceReaderOnFooBar", claimsNamespaceReader, targetNamespaceWriteBar, DecisionDeny}, // namespace mismatch
 		{"NamespaceReaderOnListWorkflow", claimsNamespaceReader, targetGetSystemInfo, DecisionAllow},
 		{"NamespaceReaderOnOperatorNamespaceRead", claimsNamespaceReader, targetOperatorNamespaceRead, DecisionAllow},
+
+		// StartAdminBatchOperation can refresh tasks for any execution in the target
+		// namespace, so it is cluster-scoped admin only. Being admin of the namespace
+		// the batch acts on is not enough, and there is no WorkflowService equivalent.
+		{"SystemAdminOnStartAdminBatchOperation", claimsSystemAdmin, targetStartAdminBatchOperation, DecisionAllow},
+		{"SystemWriterOnStartAdminBatchOperation", claimsSystemWriter, targetStartAdminBatchOperation, DecisionDeny},
+		{"SystemReaderOnStartAdminBatchOperation", claimsSystemReader, targetStartAdminBatchOperation, DecisionDeny},
+		{"NamespaceAdminOnStartAdminBatchOperation", claimsNamespaceAdmin, targetStartAdminBatchOperation, DecisionDeny},
+		{"NamespaceWriterOnStartAdminBatchOperation", claimsNamespaceWriter, targetStartAdminBatchOperation, DecisionDeny},
+		{"RoleNoneOnStartAdminBatchOperation", claimsNone, targetStartAdminBatchOperation, DecisionDeny},
 
 		// healthcheck allowed to everyone
 		{"RoleNoneOnGetSystemInfo", claimsNone, targetGetSystemInfo, DecisionAllow},

--- a/common/primitives/task_queues.go
+++ b/common/primitives/task_queues.go
@@ -20,6 +20,7 @@ const (
 	AddSearchAttributesActivityTQ = "temporal-sys-add-search-attributes-activity-tq"
 	DeleteNamespaceActivityTQ     = "temporal-sys-delete-namespace-activity-tq"
 	DLQActivityTQ                 = "temporal-sys-dlq-activity-tq"
+	AdminBatchActivityTQ          = "temporal-sys-admin-batch-tq"
 )
 
 // IsInternalTaskQueueKind returns true if the task queue kind identifies a

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,6 @@ require (
 	github.com/lib/pq v1.12.3
 	github.com/maruel/panicparse/v2 v2.5.0
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/nexus-rpc/nexus-proto-annotations v0.1.0
 	github.com/nexus-rpc/sdk-go v0.6.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/olivere/elastic/v7 v7.0.32
@@ -104,6 +103,7 @@ require (
 	github.com/go-openapi/swag/typeutils v0.26.0 // indirect
 	github.com/go-openapi/swag/yamlutils v0.26.0 // indirect
 	github.com/hashicorp/go-version v1.9.0 // indirect
+	github.com/nexus-rpc/nexus-proto-annotations v0.1.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.56.0 // indirect
 	golang.org/x/perf v0.0.0-20260709024250-82a0b07e230d // indirect
 )
@@ -219,7 +219,7 @@ require (
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	google.golang.org/genproto v0.0.0-20260420184626-e10c466a9529 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20260420184626-e10c466a9529 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20260420184626-e10c466a9529
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260420184626-e10c466a9529 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/proto/internal/temporal/server/api/adminservice/v1/request_response.proto
+++ b/proto/internal/temporal/server/api/adminservice/v1/request_response.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package temporal.server.api.adminservice.v1;
 
+import "google/api/field_behavior.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 import "temporal/api/common/v1/message.proto";
@@ -621,6 +622,22 @@ message GetTaskQueueUserDataResponse {
 // StartAdminBatchOperationRequest starts an admin batch operation.
 // WARNING: Batch Operations are exposed to all users of the namespace. Admin Batch Operations should be exercised with caution.
 message StartAdminBatchOperationRequest {
+  // JobNamespace selects the namespace that hosts the batch operation's control
+  // workflow. It is independent of `namespace`, which selects the executions the
+  // operation acts on.
+  enum JobNamespace {
+    JOB_NAMESPACE_UNSPECIFIED = 0;
+    // Run the control workflow in the `temporal-system` namespace, on the system
+    // worker. `temporal-system` is a local namespace and is therefore active in
+    // every cluster, so this works even when `namespace` is passive here.
+    JOB_NAMESPACE_SYSTEM = 1;
+    // Run the control workflow in the user namespace given by `namespace`, on that
+    // namespace's per-namespace worker. Only works when `namespace` is active in this
+    // cluster: creating a workflow in a passive global namespace is rejected with
+    // NamespaceNotActive.
+    JOB_NAMESPACE_USER = 2;
+  }
+
   // Namespace that contains the batch operation.
   string namespace = 1;
 
@@ -641,13 +658,24 @@ message StartAdminBatchOperationRequest {
   // The identity of the worker/client.
   string identity = 6;
 
+  // Where to run the control workflow. JOB_NAMESPACE_UNSPECIFIED is rejected so that
+  // callers state their intent explicitly rather than inheriting a default that
+  // silently fails in passive clusters.
+  JobNamespace job_namespace = 7 [(google.api.field_behavior) = REQUIRED];
+
   // The admin batch operation to perform.
   oneof operation {
     BatchOperationRefreshTasks refresh_tasks_operation = 10;
   }
 }
 
-message StartAdminBatchOperationResponse {}
+message StartAdminBatchOperationResponse {
+  // Workflow ID of the control workflow that was started, and the namespace it
+  // runs in. For JOB_NAMESPACE_SYSTEM these are derived from `job_id`, so callers
+  // must use them rather than `job_id` to look the job up afterwards.
+  string job_workflow_id = 1;
+  string job_namespace = 2;
+}
 
 // BatchOperationRefreshTasks refreshes tasks for batch executions.
 // This regenerates all pending tasks for each execution.

--- a/service/frontend/admin_handler.go
+++ b/service/frontend/admin_handler.go
@@ -59,9 +59,11 @@ import (
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/sdk"
 	"go.temporal.io/server/common/searchattribute"
+	"go.temporal.io/server/common/searchattribute/sadefs"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/common/tqid"
 	"go.temporal.io/server/service/history/tasks"
+	"go.temporal.io/server/service/worker/adminbatcher"
 	"go.temporal.io/server/service/worker/batcher"
 	"go.temporal.io/server/service/worker/dlq"
 	"go.temporal.io/server/service/worker/dummy"
@@ -1280,17 +1282,38 @@ func (adh *AdminHandler) StartAdminBatchOperation(
 		return nil, err
 	}
 
+	// job namespace and task queues control where the batch workflow will run in,
+	// data namespace controls whose data the batch workflow will operate on
+	useSystemNS := request.GetJobNamespace() == adminservice.StartAdminBatchOperationRequest_JOB_NAMESPACE_SYSTEM
+	jobTaskQueue := primitives.PerNSWorkerTaskQueue
+	jobWorkflowType := batcher.BatchWFTypeProtobufName
+	jobWorkflowID := request.GetJobId()
+	jobNSID, jobNS := namespaceID, request.GetNamespace()
+	dataNSID, dataNS := namespaceID, request.GetNamespace()
+	// Every user namespace's jobs share the one temporal-system namespace, so the
+	// open-job count must be narrowed to the namespace this request is for.
+	openJobsQuery := batcher.OpenAdminBatchOperationQuery
+	if useSystemNS {
+		jobTaskQueue = primitives.DefaultWorkerTaskQueue
+		jobWorkflowType = adminbatcher.WorkflowTypeName
+		jobWorkflowID = adminbatcher.JobWorkflowID(dataNSID.String(), request.GetJobId())
+		jobNS, jobNSID = primitives.SystemLocalNamespace, primitives.SystemNamespaceID
+		openJobsQuery = fmt.Sprintf("%s AND %s STARTS_WITH '%s'",
+			batcher.OpenAdminBatchOperationQuery,
+			sadefs.WorkflowID,
+			adminbatcher.JobWorkflowIDPrefix(dataNSID.String()))
+	}
+
 	// Validate concurrent batch operation
 	maxConcurrentBatchOperation := adh.config.MaxConcurrentAdminBatchOperation(request.GetNamespace())
 	countResp, err := adh.visibilityMgr.CountWorkflowExecutions(ctx, &manager.CountWorkflowExecutionsRequest{
-		NamespaceID: namespaceID,
-		Namespace:   namespace.Name(request.GetNamespace()),
-		Query:       batcher.OpenAdminBatchOperationQuery,
+		NamespaceID: jobNSID,
+		Namespace:   namespace.Name(jobNS),
+		Query:       openJobsQuery,
 	})
 	if err != nil {
 		return nil, err
 	}
-
 	openAdminBatchOperationCount := int(countResp.Count)
 	if openAdminBatchOperationCount >= maxConcurrentBatchOperation {
 		return nil, &serviceerror.ResourceExhausted{
@@ -1302,10 +1325,11 @@ func (adh *AdminHandler) StartAdminBatchOperation(
 
 	input := &batchspb.BatchOperationInput{
 		AdminRequest: request,
-		NamespaceId:  namespaceID.String(),
+		NamespaceId:  dataNSID.String(),
 	}
 
 	identity := request.GetIdentity()
+
 	var batchTypeMemo string
 	switch op := request.Operation.(type) {
 	case *adminservice.StartAdminBatchOperationRequest_RefreshTasksOperation:
@@ -1325,7 +1349,12 @@ func (adh *AdminHandler) StartAdminBatchOperation(
 			batcher.BatchReasonMemo:        payload.EncodeString(request.GetReason()),
 		},
 	}
+	// todo: check if it is safe to add this to memo
+	if useSystemNS {
+		memo.Fields[batcher.AdminBatchUserNamespaceMemo] = payload.EncodeString(dataNS)
+	}
 
+	// todo: add data namespaces to the custom search attributes
 	var searchAttributes *commonpb.SearchAttributes
 	searchattribute.AddSearchAttributes(
 		&searchAttributes,
@@ -1334,10 +1363,10 @@ func (adh *AdminHandler) StartAdminBatchOperation(
 	)
 
 	startReq := &workflowservice.StartWorkflowExecutionRequest{
-		Namespace:                request.Namespace,
-		WorkflowId:               request.GetJobId(),
-		WorkflowType:             &commonpb.WorkflowType{Name: batcher.BatchWFTypeProtobufName},
-		TaskQueue:                &taskqueuepb.TaskQueue{Name: primitives.PerNSWorkerTaskQueue},
+		Namespace:                jobNS,
+		WorkflowId:               jobWorkflowID,
+		WorkflowType:             &commonpb.WorkflowType{Name: jobWorkflowType},
+		TaskQueue:                &taskqueuepb.TaskQueue{Name: jobTaskQueue},
 		Input:                    inputPayload,
 		Identity:                 identity,
 		RequestId:                uuid.NewString(),
@@ -1350,7 +1379,7 @@ func (adh *AdminHandler) StartAdminBatchOperation(
 	_, err = adh.historyClient.StartWorkflowExecution(
 		ctx,
 		common.CreateHistoryStartWorkflowRequest(
-			namespaceID.String(),
+			jobNSID.String(),
 			startReq,
 			nil,
 			nil,
@@ -1360,7 +1389,10 @@ func (adh *AdminHandler) StartAdminBatchOperation(
 	if err != nil {
 		return nil, err
 	}
-	return &adminservice.StartAdminBatchOperationResponse{}, nil
+	return &adminservice.StartAdminBatchOperationResponse{
+		JobWorkflowId: jobWorkflowID,
+		JobNamespace:  jobNS,
+	}, nil
 }
 
 func validateAdminBatchOperation(params *adminservice.StartAdminBatchOperationRequest) error {
@@ -1376,6 +1408,15 @@ func validateAdminBatchOperation(params *adminservice.StartAdminBatchOperationRe
 	}
 	if len(params.GetVisibilityQuery()) != 0 && len(params.GetExecutions()) != 0 {
 		return serviceerror.NewInvalidArgument("batch query and executions are mutually exclusive")
+	}
+
+	switch params.GetJobNamespace() {
+	case adminservice.StartAdminBatchOperationRequest_JOB_NAMESPACE_SYSTEM,
+		adminservice.StartAdminBatchOperationRequest_JOB_NAMESPACE_USER:
+	case adminservice.StartAdminBatchOperationRequest_JOB_NAMESPACE_UNSPECIFIED:
+		return serviceerror.NewInvalidArgument("JobNamespace is not set on request. Set JOB_NAMESPACE_SYSTEM to run the job in temporal-system (works in passive clusters), or JOB_NAMESPACE_USER to run it in the user namespace on the per-namespace worker.")
+	default:
+		return serviceerror.NewInvalidArgumentf("unknown JobNamespace %v", params.GetJobNamespace())
 	}
 
 	switch op := params.GetOperation().(type) {

--- a/service/worker/adminbatcher/activities.go
+++ b/service/worker/adminbatcher/activities.go
@@ -1,0 +1,36 @@
+package adminbatcher
+
+import (
+	"errors"
+
+	batchspb "go.temporal.io/server/api/batch/v1"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/primitives"
+)
+
+var (
+	errNonAdminBatch     = errors.New("only admin batch operations may run on the system worker")
+	errNamespaceMismatch = errors.New("namespace mismatch")
+	errNonUserNamespace  = errors.New("admin batch must target a user namespace")
+)
+
+// the activity forever runs in system namespace
+func validateAndResolveNSForAdminBatch(registry namespace.Registry) func(*batchspb.BatchOperationInput) (namespace.Name, error) {
+	return func(batchParams *batchspb.BatchOperationInput) (namespace.Name, error) {
+		adminReq := batchParams.GetAdminRequest()
+		if adminReq == nil {
+			return "", errNonAdminBatch
+		}
+		ns, err := registry.GetNamespaceName(namespace.ID(batchParams.GetNamespaceId()))
+		if err != nil {
+			return "", err
+		}
+		if ns.String() != adminReq.GetNamespace() {
+			return "", errNamespaceMismatch
+		}
+		if ns.String() == primitives.SystemLocalNamespace {
+			return "", errNonUserNamespace
+		}
+		return ns, nil
+	}
+}

--- a/service/worker/adminbatcher/activities_test.go
+++ b/service/worker/adminbatcher/activities_test.go
@@ -1,0 +1,88 @@
+package adminbatcher
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/api/adminservice/v1"
+	batchspb "go.temporal.io/server/api/batch/v1"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/primitives"
+	"go.uber.org/mock/gomock"
+)
+
+const (
+	userNSName  = "user-ns"
+	userNSID    = "user-ns-id"
+	otherNSName = "other-ns"
+)
+
+func TestValidateAndResolveNSForAdminBatch(t *testing.T) {
+	t.Run("resolves the namespace id from the registry", func(t *testing.T) {
+		resolver := newResolver(t, func(r *namespace.MockRegistry) {
+			r.EXPECT().GetNamespaceName(namespace.ID(userNSID)).Return(namespace.Name(userNSName), nil)
+		})
+		ns, err := resolver(&batchspb.BatchOperationInput{
+			NamespaceId:  userNSID,
+			AdminRequest: &adminservice.StartAdminBatchOperationRequest{Namespace: userNSName},
+		})
+		require.NoError(t, err)
+		require.Equal(t, namespace.Name(userNSName), ns)
+	})
+
+	t.Run("rejects a name that does not match the id", func(t *testing.T) {
+		resolver := newResolver(t, func(r *namespace.MockRegistry) {
+			r.EXPECT().GetNamespaceName(namespace.ID(userNSID)).Return(namespace.Name(userNSName), nil)
+		})
+		_, err := resolver(&batchspb.BatchOperationInput{
+			NamespaceId:  userNSID,
+			AdminRequest: &adminservice.StartAdminBatchOperationRequest{Namespace: otherNSName},
+		})
+		require.ErrorIs(t, err, errNamespaceMismatch)
+	})
+
+	t.Run("rejects a non-admin batch", func(t *testing.T) {
+		resolver := newResolver(t, nil)
+		_, err := resolver(&batchspb.BatchOperationInput{
+			NamespaceId: userNSID,
+			Request:     &workflowservice.StartBatchOperationRequest{Namespace: userNSName},
+		})
+		require.ErrorIs(t, err, errNonAdminBatch)
+	})
+
+	t.Run("rejects a batch targeting the system namespace", func(t *testing.T) {
+		resolver := newResolver(t, func(r *namespace.MockRegistry) {
+			r.EXPECT().GetNamespaceName(namespace.ID(primitives.SystemNamespaceID)).
+				Return(namespace.Name(primitives.SystemLocalNamespace), nil)
+		})
+		_, err := resolver(&batchspb.BatchOperationInput{
+			NamespaceId: primitives.SystemNamespaceID,
+			AdminRequest: &adminservice.StartAdminBatchOperationRequest{
+				Namespace: primitives.SystemLocalNamespace,
+			},
+		})
+		require.ErrorIs(t, err, errNonUserNamespace)
+	})
+
+	t.Run("propagates a registry lookup failure", func(t *testing.T) {
+		notFound := serviceerror.NewNamespaceNotFound(userNSID)
+		resolver := newResolver(t, func(r *namespace.MockRegistry) {
+			r.EXPECT().GetNamespaceName(namespace.ID(userNSID)).Return(namespace.EmptyName, notFound)
+		})
+		_, err := resolver(&batchspb.BatchOperationInput{
+			NamespaceId:  userNSID,
+			AdminRequest: &adminservice.StartAdminBatchOperationRequest{Namespace: userNSName},
+		})
+		require.ErrorIs(t, err, notFound)
+	})
+}
+
+func newResolver(t *testing.T, setup func(*namespace.MockRegistry)) func(*batchspb.BatchOperationInput) (namespace.Name, error) {
+	registry := namespace.NewMockRegistry(gomock.NewController(t))
+	if setup != nil {
+		setup(registry)
+	}
+	return validateAndResolveNSForAdminBatch(registry)
+}

--- a/service/worker/adminbatcher/fx.go
+++ b/service/worker/adminbatcher/fx.go
@@ -1,0 +1,48 @@
+package adminbatcher
+
+import (
+	sdkworker "go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/primitives"
+	"go.temporal.io/server/service/worker/batcher"
+	workercommon "go.temporal.io/server/service/worker/common"
+	"go.uber.org/fx"
+)
+
+type workerComponent struct {
+	activities *batcher.Activities
+}
+
+var Module = fx.Options(
+	fx.Provide(fx.Annotate(newComponent, fx.ResultTags(workercommon.WorkerComponentTag))),
+)
+
+func newComponent(
+	deps batcher.ActivityDeps,
+	dc *dynamicconfig.Collection,
+	namespaceRegistry namespace.Registry,
+) workercommon.WorkerComponent {
+	return &workerComponent{
+		activities: batcher.NewActivities(deps, dc, validateAndResolveNSForAdminBatch(namespaceRegistry)),
+	}
+}
+
+func (c *workerComponent) RegisterWorkflow(registry sdkworker.Registry) {
+	registry.RegisterWorkflowWithOptions(Workflow, workflow.RegisterOptions{Name: WorkflowTypeName})
+}
+
+func (c *workerComponent) DedicatedWorkflowWorkerOptions() *workercommon.DedicatedWorkerOptions {
+	return nil
+}
+
+func (c *workerComponent) RegisterActivities(registry sdkworker.Registry) {
+	registry.RegisterActivity(c.activities)
+}
+
+func (c *workerComponent) DedicatedActivityWorkerOptions() *workercommon.DedicatedWorkerOptions {
+	return &workercommon.DedicatedWorkerOptions{
+		TaskQueue: primitives.AdminBatchActivityTQ,
+	}
+}

--- a/service/worker/adminbatcher/workflow.go
+++ b/service/worker/adminbatcher/workflow.go
@@ -1,0 +1,21 @@
+package adminbatcher
+
+import (
+	"errors"
+
+	"go.temporal.io/sdk/workflow"
+	batchspb "go.temporal.io/server/api/batch/v1"
+	"go.temporal.io/server/common/primitives"
+	"go.temporal.io/server/service/worker/batcher"
+)
+
+const (
+	WorkflowTypeName = "temporal-sys-admin-batch-workflow"
+)
+
+func Workflow(ctx workflow.Context, batchParams *batchspb.BatchOperationInput) (batcher.HeartBeatDetails, error) {
+	if batchParams.GetAdminRequest() == nil {
+		return batcher.HeartBeatDetails{}, errors.New("admin batch workflow requires an admin request")
+	}
+	return batcher.RunBatchWorkflow(ctx, batchParams, primitives.AdminBatchActivityTQ)
+}

--- a/service/worker/adminbatcher/workflow_test.go
+++ b/service/worker/adminbatcher/workflow_test.go
@@ -1,0 +1,63 @@
+package adminbatcher
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+	"go.temporal.io/server/api/adminservice/v1"
+	batchspb "go.temporal.io/server/api/batch/v1"
+	"go.temporal.io/server/common/primitives"
+	"go.temporal.io/server/service/worker/batcher"
+)
+
+func TestWorkflow(t *testing.T) {
+	t.Run("rejects a batch without an admin request", func(t *testing.T) {
+		env := newTestEnv(t)
+		env.ExecuteWorkflow(WorkflowTypeName, &batchspb.BatchOperationInput{
+			NamespaceId: "ns-id",
+			Request:     &workflowservice.StartBatchOperationRequest{Namespace: "ns"},
+		})
+
+		require.True(t, env.IsWorkflowCompleted())
+		require.ErrorContains(t, env.GetWorkflowError(), "admin batch workflow requires an admin request")
+	})
+
+	t.Run("dispatches the batch activity to the admin batch task queue", func(t *testing.T) {
+		env := newTestEnv(t)
+
+		var taskQueue string
+		env.SetOnActivityStartedListener(func(info *activity.Info, _ context.Context, _ converter.EncodedValues) {
+			taskQueue = info.TaskQueue
+		})
+		env.OnActivity("BatchActivityWithProtobuf", mock.Anything, mock.Anything).
+			Return(batcher.HeartBeatDetails{SuccessCount: 1}, nil)
+
+		env.ExecuteWorkflow(WorkflowTypeName, &batchspb.BatchOperationInput{
+			NamespaceId: "ns-id",
+			AdminRequest: &adminservice.StartAdminBatchOperationRequest{
+				Namespace:  "ns",
+				Executions: []*commonpb.WorkflowExecution{{WorkflowId: "w"}},
+			},
+		})
+
+		require.True(t, env.IsWorkflowCompleted())
+		require.NoError(t, env.GetWorkflowError())
+		require.Equal(t, primitives.AdminBatchActivityTQ, taskQueue)
+	})
+}
+
+func newTestEnv(t *testing.T) *testsuite.TestWorkflowEnvironment {
+	env := (&testsuite.WorkflowTestSuite{}).NewTestWorkflowEnvironment()
+	t.Cleanup(func() { env.AssertExpectations(t) })
+	env.RegisterWorkflowWithOptions(Workflow, workflow.RegisterOptions{Name: WorkflowTypeName})
+	env.RegisterActivity(&batcher.Activities{})
+	return env
+}

--- a/service/worker/batcher/activities.go
+++ b/service/worker/batcher/activities.go
@@ -229,7 +229,7 @@ func fetchPage(
 
 // processWorkflowsWithProactiveFetching handles the core logic for both batch activity functions
 // nolint:revive,cognitive-complexity
-func (a *activities) processWorkflowsWithProactiveFetching(
+func (a *Activities) processWorkflowsWithProactiveFetching(
 	ctx context.Context,
 	config batchProcessorConfig,
 	startWorkerProcessor batchWorkerProcessor,
@@ -374,45 +374,64 @@ func (a *activities) processWorkflowsWithProactiveFetching(
 	return hbd, nil
 }
 
-type activities struct {
-	activityDeps
-	namespace   namespace.Name
-	namespaceID namespace.ID
-	rps         dynamicconfig.IntPropertyFnWithNamespaceFilter
-	concurrency dynamicconfig.IntPropertyFnWithNamespaceFilter
+type Activities struct {
+	ActivityDeps
+	validateAndResolveNamespace validateAndResolveNamespace
+	rps                         dynamicconfig.IntPropertyFnWithNamespaceFilter
+	concurrency                 dynamicconfig.IntPropertyFnWithNamespaceFilter
 }
 
-// checkNamespace validates that batchParams targets the worker's own namespace.
-// The NamespaceId, Request.Namespace (if set), and AdminRequest.Namespace (if set)
-// must all agree with the worker's bound namespace. This prevents cross-namespace
-// escalation via the privileged internal-frontend connection (NoopClaimMapper → RoleAdmin).
-func (a *activities) checkNamespace(batchParams *batchspb.BatchOperationInput) error {
-	if batchParams.NamespaceId != a.namespaceID.String() {
-		return errNamespaceMismatch
+func NewActivities(
+	deps ActivityDeps,
+	dc *dynamicconfig.Collection,
+	validateAndResolve validateAndResolveNamespace,
+) *Activities {
+	return &Activities{
+		ActivityDeps:                deps,
+		validateAndResolveNamespace: validateAndResolve,
+		rps:                         dynamicconfig.BatcherRPS.Get(dc),
+		concurrency:                 dynamicconfig.BatcherConcurrency.Get(dc),
 	}
-	ns := a.namespace.String()
-	if req := batchParams.GetRequest(); req != nil && req.GetNamespace() != ns {
-		return errNamespaceMismatch
+}
+
+type validateAndResolveNamespace func(*batchspb.BatchOperationInput) (namespace.Name, error)
+
+// validateAndResolveNSForUserBatch serves the per-namespace worker, which runs in
+// the user namespace it acts on. It covers both user batches and admin batches
+// started with JOB_NAMESPACE_USER, so NamespaceId, Request.Namespace (if set), and
+// AdminRequest.Namespace (if set) must all agree with that namespace. This prevents
+// cross-namespace escalation via the privileged internal-frontend connection
+// (NoopClaimMapper → RoleAdmin).
+func validateAndResolveNSForUserBatch(name namespace.Name, id namespace.ID) validateAndResolveNamespace {
+	return func(batchParams *batchspb.BatchOperationInput) (namespace.Name, error) {
+		if batchParams.GetNamespaceId() != id.String() {
+			return "", errNamespaceMismatch
+		}
+		ns := name.String()
+		if req := batchParams.GetRequest(); req != nil && req.GetNamespace() != ns {
+			return "", errNamespaceMismatch
+		}
+		if req := batchParams.GetAdminRequest(); req != nil && req.GetNamespace() != ns {
+			return "", errNamespaceMismatch
+		}
+		return name, nil
 	}
-	if req := batchParams.GetAdminRequest(); req != nil && req.GetNamespace() != ns {
-		return errNamespaceMismatch
-	}
-	return nil
 }
 
 // BatchActivityWithProtobuf is an activity for processing batch operations using protobuf as the input type.
 // nolint:revive,cognitive-complexity
-func (a *activities) BatchActivityWithProtobuf(ctx context.Context, batchParams *batchspb.BatchOperationInput) (HeartBeatDetails, error) {
+func (a *Activities) BatchActivityWithProtobuf(ctx context.Context, batchParams *batchspb.BatchOperationInput) (HeartBeatDetails, error) {
 	logger := a.getActivityLogger(ctx)
 	hbd := HeartBeatDetails{}
 	metricsHandler := a.MetricsHandler.WithTags(metrics.OperationTag(metrics.BatcherScope), metrics.NamespaceIDTag(batchParams.NamespaceId))
 
-	if err := a.checkNamespace(batchParams); err != nil {
+	nsName, err := a.validateAndResolveNamespace(batchParams)
+	if err != nil {
 		metrics.BatcherOperationFailures.With(metricsHandler).Record(1)
-		logger.Error("Failed to run batch operation due to namespace mismatch", tag.Error(err))
+		logger.Error("Failed to resolve the namespace of a batch operation", tag.Error(err))
 		return hbd, err
 	}
-	ns := a.namespace.String()
+	ns := nsName.String()
 
 	sdkClient := a.ClientFactory.NewClient(sdkclient.Options{
 		Namespace:     ns,
@@ -494,7 +513,7 @@ func (a *activities) BatchActivityWithProtobuf(ctx context.Context, batchParams 
 		namespace:               ns,
 		adjustedQuery:           visibilityQuery,
 		batchType:               batchParams.BatchType,
-		concurrency:             a.getOperationConcurrency(int(batchParams.Concurrency)),
+		concurrency:             a.getOperationConcurrency(ns, int(batchParams.Concurrency)),
 		initialPageToken:        hbd.PageToken,
 		initialExecutions:       executions,
 		initialTargetExecutions: targetExecutions,
@@ -517,7 +536,7 @@ func (a *activities) BatchActivityWithProtobuf(ctx context.Context, batchParams 
 	return a.processWorkflowsWithProactiveFetching(ctx, config, workerProcessor, rateLimiter, sdkClient, metricsHandler, logger, hbd)
 }
 
-func (a *activities) getActivityLogger(ctx context.Context) log.Logger {
+func (a *Activities) getActivityLogger(ctx context.Context) log.Logger {
 	wfInfo := activity.GetInfo(ctx)
 	return log.With(
 		a.Logger,
@@ -527,7 +546,7 @@ func (a *activities) getActivityLogger(ctx context.Context) log.Logger {
 	)
 }
 
-func (a *activities) adjustQueryBatchTypeEnum(query string, batchType enumspb.BatchOperationType) string {
+func (a *Activities) adjustQueryBatchTypeEnum(query string, batchType enumspb.BatchOperationType) string {
 	if len(query) == 0 {
 		// don't add anything if query is empty
 		return query
@@ -547,15 +566,15 @@ func (a *activities) adjustQueryBatchTypeEnum(query string, batchType enumspb.Ba
 	}
 }
 
-func (a *activities) adjustQueryAdminBatchType(adminReq *adminservice.StartAdminBatchOperationRequest) string {
+func (a *Activities) adjustQueryAdminBatchType(adminReq *adminservice.StartAdminBatchOperationRequest) string {
 	// RefreshWorkflowTasks applies to both open and closed workflows,
 	// so no additional filter is needed - return query as-is.
 	return adminReq.GetVisibilityQuery()
 }
 
-func (a *activities) getOperationConcurrency(concurrency int) int {
+func (a *Activities) getOperationConcurrency(ns string, concurrency int) int {
 	if concurrency <= 0 {
-		return a.concurrency(a.namespace.String())
+		return a.concurrency(ns)
 	}
 	return concurrency
 }
@@ -571,7 +590,7 @@ func taskTimeoutContext(ctx context.Context) (context.Context, context.CancelFun
 	return context.WithTimeout(ctx, defaultTaskTimeout)
 }
 
-func (a *activities) startTaskProcessor(
+func (a *Activities) startTaskProcessor(
 	ctx context.Context,
 	batchOperation *batchspb.BatchOperationInput,
 	namespace string,
@@ -615,7 +634,7 @@ func deterministicRequestID(jobID string, parts ...string) string {
 // processSingleTask processes a single batch task, bounding its execution with a
 // per-task timeout so that one hung operation cannot block the task processor.
 // nolint:revive,cognitive-complexity
-func (a *activities) processSingleTask(
+func (a *Activities) processSingleTask(
 	ctx context.Context,
 	batchOperation *batchspb.BatchOperationInput,
 	namespace string,
@@ -881,7 +900,7 @@ func isNonRetryableError(err error, batchType enumspb.BatchOperationType) bool {
 
 // processTaskWithRetries runs the task's operation, retrying retryable failures in place on
 // this goroutine, and sends exactly one response on respCh per task.
-func (a *activities) processTaskWithRetries(
+func (a *Activities) processTaskWithRetries(
 	ctx context.Context,
 	batchOperation *batchspb.BatchOperationInput,
 	ns string,
@@ -927,7 +946,7 @@ func isRetryableTaskError(err error, batchOperation *batchspb.BatchOperationInpu
 	return !nonRetryable
 }
 
-func (a *activities) processAdminTask(
+func (a *Activities) processAdminTask(
 	ctx context.Context,
 	batchOperation *batchspb.BatchOperationInput,
 	task task,

--- a/service/worker/batcher/activities_namespace_test.go
+++ b/service/worker/batcher/activities_namespace_test.go
@@ -25,41 +25,40 @@ import (
 // The per-NS worker's frontendClient dials internal-frontend (NoopClaimMapper →
 // RoleAdmin), so the activity MUST NOT forward a user-controlled namespace string
 // to frontendClient calls. The namespace for all downstream operations must be
-// the worker's bound namespace.
+// the job's user namespace.
 
 const (
-	boundNSName = "bound-ns"
-	boundNSID   = "bound-ns-id"
+	userNSName  = "user-ns"
+	userNSID    = "user-ns-id"
 	otherNSName = "other-ns"
 )
 
-func newBoundActivities(frontend workflowservice.WorkflowServiceClient) *activities {
-	return &activities{
-		activityDeps: activityDeps{
+func newUserNamespaceActivities(frontend workflowservice.WorkflowServiceClient) *Activities {
+	return &Activities{
+		ActivityDeps: ActivityDeps{
 			MetricsHandler: metrics.NoopMetricsHandler,
 			Logger:         log.NewTestLogger(),
 			FrontendClient: frontend,
 		},
-		namespace:   namespace.Name(boundNSName),
-		namespaceID: namespace.ID(boundNSID),
-		rps:         dynamicconfig.GetIntPropertyFnFilteredByNamespace(50),
-		concurrency: dynamicconfig.GetIntPropertyFnFilteredByNamespace(1),
+		validateAndResolveNamespace: validateAndResolveNSForUserBatch(namespace.Name(userNSName), namespace.ID(userNSID)),
+		rps:                         dynamicconfig.GetIntPropertyFnFilteredByNamespace(50),
+		concurrency:                 dynamicconfig.GetIntPropertyFnFilteredByNamespace(1),
 	}
 }
 
 // TestBatchActivityWithProtobuf_RejectsMismatchedRequestNamespace verifies that
 // BatchActivityWithProtobuf rejects a request whose Request.Namespace differs
-// from the worker's bound namespace, even when NamespaceId is valid.
+// from the job's user namespace, even when NamespaceId is valid.
 // This blocks the cross-namespace attack where an attacker submits a valid
 // NamespaceId for their own namespace but sets Request.Namespace to a victim's.
 func TestBatchActivityWithProtobuf_RejectsMismatchedRequestNamespace(t *testing.T) {
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestActivityEnvironment()
-	a := newBoundActivities(nil)
+	a := newUserNamespaceActivities(nil)
 	env.RegisterActivity(a.BatchActivityWithProtobuf)
 
 	input := &batchspb.BatchOperationInput{
-		NamespaceId: boundNSID, // ID check passes; name check must catch the mismatch
+		NamespaceId: userNSID, // ID check passes; name check must catch the mismatch
 		Request: &workflowservice.StartBatchOperationRequest{
 			Namespace: otherNSName, // mismatched — must be rejected
 			Operation: &workflowservice.StartBatchOperationRequest_SignalOperation{
@@ -79,11 +78,11 @@ func TestBatchActivityWithProtobuf_RejectsMismatchedRequestNamespace(t *testing.
 func TestBatchActivityWithProtobuf_RejectsMismatchedAdminRequestNamespace(t *testing.T) {
 	ts := testsuite.WorkflowTestSuite{}
 	env := ts.NewTestActivityEnvironment()
-	a := newBoundActivities(nil)
+	a := newUserNamespaceActivities(nil)
 	env.RegisterActivity(a.BatchActivityWithProtobuf)
 
 	input := &batchspb.BatchOperationInput{
-		NamespaceId: boundNSID,
+		NamespaceId: userNSID,
 		AdminRequest: &adminservice.StartAdminBatchOperationRequest{
 			Namespace:  otherNSName, // mismatched — must be rejected
 			Executions: []*commonpb.WorkflowExecution{{WorkflowId: "w"}},
@@ -95,12 +94,12 @@ func TestBatchActivityWithProtobuf_RejectsMismatchedAdminRequestNamespace(t *tes
 	require.ErrorContains(t, err, errNamespaceMismatch.Error())
 }
 
-// TestStartTaskProcessor_UsesWorkerBoundNamespaceForSignal verifies that when
+// TestStartTaskProcessor_UsesUserNamespaceForSignal verifies that when
 // BatchActivityWithProtobuf dispatches via startTaskProcessor, the namespace
-// delivered to frontendClient.SignalWorkflowExecution is the worker's bound
+// delivered to frontendClient.SignalWorkflowExecution is the job's user
 // namespace. This is a belt-and-suspenders check: even if the early validation
-// above is ever relaxed, the namespace used in operations stays worker-bound.
-func TestStartTaskProcessor_UsesWorkerBoundNamespaceForSignal(t *testing.T) {
+// above is ever relaxed, the namespace used in operations stays that namespace.
+func TestStartTaskProcessor_UsesUserNamespaceForSignal(t *testing.T) {
 	r := require.New(t)
 	ctrl := gomock.NewController(t)
 	mockFE := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
@@ -113,13 +112,13 @@ func TestStartTaskProcessor_UsesWorkerBoundNamespaceForSignal(t *testing.T) {
 			return &workflowservice.SignalWorkflowExecutionResponse{}, nil
 		})
 
-	a := newBoundActivities(mockFE)
+	a := newUserNamespaceActivities(mockFE)
 
 	// Simulate the namespace that BatchActivityWithProtobuf derives —
-	// with the fix this is always a.namespace.String().
-	ns := a.namespace.String()
+	// with the fix this is always the job's user namespace.
+	ns := userNSName
 	batchOp := &batchspb.BatchOperationInput{
-		NamespaceId: boundNSID,
+		NamespaceId: userNSID,
 		Request: &workflowservice.StartBatchOperationRequest{
 			Namespace: ns,
 			Operation: &workflowservice.StartBatchOperationRequest_SignalOperation{
@@ -151,6 +150,6 @@ func TestStartTaskProcessor_UsesWorkerBoundNamespaceForSignal(t *testing.T) {
 	<-done
 
 	r.NotNil(captured)
-	r.Equal(boundNSName, captured.Namespace,
-		"frontendClient.SignalWorkflowExecution must receive the worker's bound namespace")
+	r.Equal(userNSName, captured.Namespace,
+		"frontendClient.SignalWorkflowExecution must receive the job's user namespace")
 }

--- a/service/worker/batcher/activities_test.go
+++ b/service/worker/batcher/activities_test.go
@@ -11,6 +11,7 @@ import (
 	"unicode"
 
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	activitypb "go.temporal.io/api/activity/v1"
 	batchpb "go.temporal.io/api/batch/v1"
@@ -30,6 +31,7 @@ import (
 	"go.temporal.io/server/api/historyservicemock/v1"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/quotas"
 	"go.temporal.io/server/common/testing/mockapi/workflowservicemock/v1"
@@ -510,7 +512,7 @@ func (s *activitiesSuite) TestAdjustQueryBatchTypeEnum() {
 	}
 	for _, testRun := range tests {
 		s.Run(testRun.name, func() {
-			a := activities{}
+			a := Activities{}
 			adjustedQuery := a.adjustQueryBatchTypeEnum(testRun.query, testRun.batchType)
 			s.Equal(testRun.expectedResult, adjustedQuery)
 		})
@@ -518,7 +520,7 @@ func (s *activitiesSuite) TestAdjustQueryBatchTypeEnum() {
 }
 
 func (s *activitiesSuite) TestAdjustQueryAdminBatchType() {
-	a := activities{}
+	a := Activities{}
 
 	s.Run("Empty query", func() {
 		adminReq := &adminservice.StartAdminBatchOperationRequest{
@@ -569,8 +571,8 @@ func (s *activitiesSuite) TestProcessAdminTask_RefreshWorkflowTasks() {
 	ctx := context.Background()
 	mockHistoryClient := historyservicemock.NewMockHistoryServiceClient(s.controller)
 
-	a := &activities{
-		activityDeps: activityDeps{
+	a := &Activities{
+		ActivityDeps: ActivityDeps{
 			HistoryClient: mockHistoryClient,
 		},
 	}
@@ -619,8 +621,8 @@ func (s *activitiesSuite) TestProcessAdminTask_RefreshWorkflowTasks_Error() {
 	ctx := context.Background()
 	mockHistoryClient := historyservicemock.NewMockHistoryServiceClient(s.controller)
 
-	a := &activities{
-		activityDeps: activityDeps{
+	a := &Activities{
+		ActivityDeps: ActivityDeps{
 			HistoryClient: mockHistoryClient,
 		},
 	}
@@ -782,8 +784,8 @@ func (s *activitiesSuite) TestStartTaskProcessor_SignalUsesWorkerNamespace() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	a := &activities{
-		activityDeps: activityDeps{
+	a := &Activities{
+		ActivityDeps: ActivityDeps{
 			FrontendClient: s.mockFrontendClient,
 			Logger:         log.NewTestLogger(),
 			MetricsHandler: metrics.NoopMetricsHandler,
@@ -848,8 +850,8 @@ func (s *activitiesSuite) TestStartTaskProcessor_RetryableErrorsDoNotDeadlock() 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	a := &activities{
-		activityDeps: activityDeps{
+	a := &Activities{
+		ActivityDeps: ActivityDeps{
 			FrontendClient: s.mockFrontendClient,
 			Logger:         log.NewTestLogger(),
 			MetricsHandler: metrics.NoopMetricsHandler,
@@ -916,8 +918,8 @@ func (s *activitiesSuite) TestStartTaskProcessor_ActivityTerminalStateIsNotRetri
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	a := &activities{
-		activityDeps: activityDeps{
+	a := &Activities{
+		ActivityDeps: ActivityDeps{
 			FrontendClient: s.mockFrontendClient,
 			Logger:         log.NewTestLogger(),
 			MetricsHandler: metrics.NoopMetricsHandler,
@@ -1082,7 +1084,7 @@ func (s *activitiesSuite) TestProcessWorkflowsWithProactiveFetching_ProcessesAll
 		}
 	}
 
-	a := &activities{}
+	a := &Activities{}
 	config := batchProcessorConfig{
 		adjustedQuery: "ExecutionStatus = 'Completed'",
 		concurrency:   3,
@@ -1176,7 +1178,7 @@ func (s *activitiesSuite) TestProcessWorkflowsWithProactiveFetching_ProcessesAll
 		}
 	}
 
-	a := &activities{}
+	a := &Activities{}
 	config := batchProcessorConfig{
 		namespace:     "test-namespace",
 		adjustedQuery: "ActivityType = 'test-activity'",
@@ -1265,7 +1267,7 @@ func (s *activitiesSuite) TestProcessWorkflowsWithProactiveFetching_InitialTarge
 				}
 			}
 
-			a := &activities{}
+			a := &Activities{}
 			config := batchProcessorConfig{
 				batchType:               tt.batchType,
 				concurrency:             1,
@@ -1329,7 +1331,7 @@ func (s *activitiesSuite) TestProcessWorkflowsWithProactiveFetching_LegacyActivi
 		}
 	}
 
-	a := &activities{}
+	a := &Activities{}
 	config := batchProcessorConfig{
 		batchType:         enumspb.BATCH_OPERATION_TYPE_TERMINATE_ACTIVITY,
 		concurrency:       1,
@@ -1362,7 +1364,7 @@ func (s *activitiesSuite) TestProcessWorkflowsWithProactiveFetching_LegacyActivi
 func (s *activitiesSuite) TestProcessAdminTask_UnknownOperation() {
 	ctx := context.Background()
 
-	a := &activities{}
+	a := &Activities{}
 
 	// AdminRequest with nil operation
 	batchOperation := &batchspb.BatchOperationInput{
@@ -1386,4 +1388,41 @@ func (s *activitiesSuite) TestProcessAdminTask_UnknownOperation() {
 	err := a.processAdminTask(ctx, batchOperation, testTask, limiter)
 	s.Require().Error(err)
 	s.Contains(err.Error(), "unknown admin batch type")
+}
+
+func TestValidateAndResolveNSForUserBatch(t *testing.T) {
+	resolve := validateAndResolveNSForUserBatch(namespace.Name(userNSName), namespace.ID(userNSID))
+
+	t.Run("resolves to the job's user namespace", func(t *testing.T) {
+		ns, err := resolve(&batchspb.BatchOperationInput{
+			NamespaceId: userNSID,
+			Request:     &workflowservice.StartBatchOperationRequest{Namespace: userNSName},
+		})
+		require.NoError(t, err)
+		require.Equal(t, namespace.Name(userNSName), ns)
+	})
+
+	t.Run("rejects another namespace id", func(t *testing.T) {
+		_, err := resolve(&batchspb.BatchOperationInput{
+			NamespaceId: "other-ns-id",
+			Request:     &workflowservice.StartBatchOperationRequest{Namespace: userNSName},
+		})
+		require.ErrorIs(t, err, errNamespaceMismatch)
+	})
+
+	t.Run("rejects another namespace name on a request", func(t *testing.T) {
+		_, err := resolve(&batchspb.BatchOperationInput{
+			NamespaceId: userNSID,
+			Request:     &workflowservice.StartBatchOperationRequest{Namespace: otherNSName},
+		})
+		require.ErrorIs(t, err, errNamespaceMismatch)
+	})
+
+	t.Run("rejects another namespace name on an admin request", func(t *testing.T) {
+		_, err := resolve(&batchspb.BatchOperationInput{
+			NamespaceId:  userNSID,
+			AdminRequest: &adminservice.StartAdminBatchOperationRequest{Namespace: otherNSName},
+		})
+		require.ErrorIs(t, err, errNamespaceMismatch)
+	})
 }

--- a/service/worker/batcher/fx.go
+++ b/service/worker/batcher/fx.go
@@ -31,12 +31,12 @@ type (
 	AdminBatcherRateLimiter quotas.RequestRateLimiter
 
 	workerComponent struct {
-		activityDeps   activityDeps
+		activityDeps   ActivityDeps
 		dc             *dynamicconfig.Collection
 		enabledFeature dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	}
 
-	activityDeps struct {
+	ActivityDeps struct {
 		fx.In
 		MetricsHandler          metrics.Handler
 		Logger                  log.Logger
@@ -79,11 +79,11 @@ func AdminBatcherRateLimiterProvider(
 
 func NewResult(
 	dc *dynamicconfig.Collection,
-	params activityDeps,
+	activityDeps ActivityDeps,
 ) fxResult {
 	return fxResult{
 		Component: &workerComponent{
-			activityDeps:   params,
+			activityDeps:   activityDeps,
 			dc:             dc,
 			enabledFeature: dynamicconfig.EnableBatcherNamespace.Get(dc),
 		},
@@ -104,16 +104,6 @@ func (s *workerComponent) Register(registry sdkworker.Registry, ns *namespace.Na
 	registry.RegisterWorkflowWithOptions(BatchWorkflowProtobuf, workflow.RegisterOptions{Name: BatchWFTypeName})
 	// Newer version of the batch workflow which was rewritten to accept a proto struct as input.
 	registry.RegisterWorkflowWithOptions(BatchWorkflowProtobuf, workflow.RegisterOptions{Name: BatchWFTypeProtobufName})
-	registry.RegisterActivity(s.activities(ns.Name(), ns.ID()))
+	registry.RegisterActivity(NewActivities(s.activityDeps, s.dc, validateAndResolveNSForUserBatch(ns.Name(), ns.ID())))
 	return nil
-}
-
-func (s *workerComponent) activities(name namespace.Name, id namespace.ID) *activities {
-	return &activities{
-		activityDeps: s.activityDeps,
-		namespace:    name,
-		namespaceID:  id,
-		rps:          dynamicconfig.BatcherRPS.Get(s.dc),
-		concurrency:  dynamicconfig.BatcherConcurrency.Get(s.dc),
-	}
 }

--- a/service/worker/batcher/workflow.go
+++ b/service/worker/batcher/workflow.go
@@ -41,6 +41,9 @@ const (
 	// Workflow batch operation memo type strings retain their legacy persisted
 	// values so pre-upgrade frontends can read jobs started during a rollout.
 
+	// AdminBatchUserNamespaceMemo stores the user namespace of this admin batch job in memo.
+	AdminBatchUserNamespaceMemo = "admin_batch_user_namespace"
+
 	// BatchTypeTerminateWorkflows is batch type for terminating workflows
 	BatchTypeTerminateWorkflows = "terminate"
 	// BatchTypeCancelWorkflows is batch type for canceling workflows
@@ -126,25 +129,36 @@ var (
 		BackoffCoefficient: 1.7,
 		MaximumInterval:    5 * time.Minute,
 	}
-
-	batchActivityOptions = workflow.ActivityOptions{
-		ScheduleToStartTimeout: 5 * time.Minute,
-		StartToCloseTimeout:    infiniteDuration,
-		RetryPolicy:            &batchActivityRetryPolicy,
-	}
 )
 
 // BatchWorkflowProtobuf is the workflow that runs a batch job of resetting workflows.
 func BatchWorkflowProtobuf(ctx workflow.Context, batchParams *batchspb.BatchOperationInput) (HeartBeatDetails, error) {
+	return RunBatchWorkflow(ctx, batchParams, "")
+}
+
+// RunBatchWorkflow executes the batch activity and records its stats, scheduling
+// the activity on activityTaskQueue when set and on the workflow's own task queue
+// otherwise. Hosts other than the per-namespace worker build their workflow on
+// top of this.
+func RunBatchWorkflow(
+	ctx workflow.Context,
+	batchParams *batchspb.BatchOperationInput,
+	activityTaskQueue string,
+) (HeartBeatDetails, error) {
 	if batchParams == nil {
 		return HeartBeatDetails{}, errors.New("batchParams is nil")
 	}
 
 	batchParams = setDefaultParams(batchParams)
-	batchActivityOptions.HeartbeatTimeout = batchParams.ActivityHeartbeatTimeout.AsDuration()
-	opt := workflow.WithActivityOptions(ctx, batchActivityOptions)
+	opt := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		TaskQueue:              activityTaskQueue,
+		ScheduleToStartTimeout: 5 * time.Minute,
+		StartToCloseTimeout:    infiniteDuration,
+		RetryPolicy:            &batchActivityRetryPolicy,
+		HeartbeatTimeout:       batchParams.ActivityHeartbeatTimeout.AsDuration(),
+	})
 	var result HeartBeatDetails
-	var ac *activities
+	var ac *Activities
 	err := workflow.ExecuteActivity(opt, ac.BatchActivityWithProtobuf, batchParams).Get(ctx, &result)
 	if err != nil {
 		return HeartBeatDetails{}, err

--- a/service/worker/batcher/workflow_test.go
+++ b/service/worker/batcher/workflow_test.go
@@ -38,7 +38,7 @@ func (s *batcherSuite) TearDownTest() {
 }
 
 func (s *batcherSuite) TestBatchWorkflow_ValidParams_Query_Protobuf() {
-	var ac *activities
+	var ac *Activities
 	s.env.OnActivity(ac.BatchActivityWithProtobuf, mock.Anything, mock.Anything).Return(HeartBeatDetails{
 		SuccessCount: 42,
 		ErrorCount:   27,
@@ -70,7 +70,7 @@ func (s *batcherSuite) TestBatchWorkflow_ValidParams_Query_Protobuf() {
 }
 
 func (s *batcherSuite) TestBatchWorkflow_ValidParams_Executions_Protobuf() {
-	var ac *activities
+	var ac *Activities
 	s.env.OnActivity(ac.BatchActivityWithProtobuf, mock.Anything, mock.Anything).Return(HeartBeatDetails{
 		SuccessCount: 42,
 		ErrorCount:   27,

--- a/service/worker/fx.go
+++ b/service/worker/fx.go
@@ -32,6 +32,7 @@ import (
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/testing/testhooks"
 	"go.temporal.io/server/service"
+	"go.temporal.io/server/service/worker/adminbatcher"
 	"go.temporal.io/server/service/worker/batcher"
 	workercommon "go.temporal.io/server/service/worker/common"
 	"go.temporal.io/server/service/worker/deletenamespace"
@@ -52,6 +53,7 @@ var Module = fx.Options(
 	callback.Module,
 	scheduler.Module,
 	batcher.Module,
+	adminbatcher.Module,
 	workerdeployment.Module,
 	wcicomponent.Module,
 	dlq.Module,

--- a/tests/admin_batch_refresh_workflow_tasks_test.go
+++ b/tests/admin_batch_refresh_workflow_tasks_test.go
@@ -75,10 +75,11 @@ func (s *AdminBatchRefreshWorkflowTasksTestSuite) TestStartAdminBatchOperation_R
 
 	// Start admin batch operation to refresh workflow tasks using executions list
 	resp, err := env.AdminClient().StartAdminBatchOperation(s.Context(), &adminservice.StartAdminBatchOperationRequest{
-		Namespace: env.Namespace().String(),
-		JobId:     uuid.NewString(),
-		Reason:    "test refresh workflow tasks",
-		Identity:  "test-identity",
+		Namespace:    env.Namespace().String(),
+		JobId:        uuid.NewString(),
+		Reason:       "test refresh workflow tasks",
+		Identity:     "test-identity",
+		JobNamespace: adminservice.StartAdminBatchOperationRequest_JOB_NAMESPACE_USER,
 		Executions: []*commonpb.WorkflowExecution{
 			{WorkflowId: workflowRun1.GetID(), RunId: workflowRun1.GetRunID()},
 			{WorkflowId: workflowRun2.GetID(), RunId: workflowRun2.GetRunID()},
@@ -124,6 +125,7 @@ func (s *AdminBatchRefreshWorkflowTasksTestSuite) TestStartAdminBatchOperation_R
 		JobId:           uuid.NewString(),
 		Reason:          "test refresh workflow tasks with query",
 		Identity:        "test-identity",
+		JobNamespace:    adminservice.StartAdminBatchOperationRequest_JOB_NAMESPACE_USER,
 		Operation: &adminservice.StartAdminBatchOperationRequest_RefreshTasksOperation{
 			RefreshTasksOperation: &adminservice.BatchOperationRefreshTasks{},
 		},
@@ -244,9 +246,10 @@ func (s *AdminBatchRefreshWorkflowTasksTestSuite) TestStartAdminBatchOperation_0
 		Executions: []*commonpb.WorkflowExecution{
 			{WorkflowId: workflowRun2.GetID(), RunId: workflowRun2.GetRunID()},
 		},
-		JobId:    uuid.NewString(),
-		Reason:   "test admin batch",
-		Identity: "test-identity",
+		JobId:        uuid.NewString(),
+		Reason:       "test admin batch",
+		Identity:     "test-identity",
+		JobNamespace: adminservice.StartAdminBatchOperationRequest_JOB_NAMESPACE_USER,
 		Operation: &adminservice.StartAdminBatchOperationRequest_RefreshTasksOperation{
 			RefreshTasksOperation: &adminservice.BatchOperationRefreshTasks{},
 		},

--- a/tests/admin_batch_system_namespace_test.go
+++ b/tests/admin_batch_system_namespace_test.go
@@ -1,0 +1,281 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	batchpb "go.temporal.io/api/batch/v1"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	sdkclient "go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/workflow"
+	"go.temporal.io/server/api/adminservice/v1"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/payloads"
+	"go.temporal.io/server/common/primitives"
+	"go.temporal.io/server/common/searchattribute/sadefs"
+	"go.temporal.io/server/common/testing/parallelsuite"
+	"go.temporal.io/server/service/worker/adminbatcher"
+	"go.temporal.io/server/service/worker/batcher"
+	"go.temporal.io/server/tests/testcore"
+)
+
+// AdminBatchSystemNamespaceTestSuite covers admin batch jobs hosted in
+// temporal-system rather than in the target user namespace.
+type AdminBatchSystemNamespaceTestSuite struct {
+	parallelsuite.Suite[*AdminBatchSystemNamespaceTestSuite]
+}
+
+func TestAdminBatchSystemNamespaceTestSuite(t *testing.T) {
+	parallelsuite.Run(t, &AdminBatchSystemNamespaceTestSuite{})
+}
+
+func (s *AdminBatchSystemNamespaceTestSuite) idleWorkflow(ctx workflow.Context) error {
+	return workflow.Await(ctx, func() bool { return false })
+}
+
+// startWorkflows starts n workflows that never complete, so that a refresh always
+// has live executions to regenerate tasks for.
+func (s *AdminBatchSystemNamespaceTestSuite) startWorkflows(env *testcore.TestEnv, n int) []*commonpb.WorkflowExecution {
+	env.SdkWorker().RegisterWorkflow(s.idleWorkflow)
+	executions := make([]*commonpb.WorkflowExecution, 0, n)
+	for range n {
+		run, err := env.SdkClient().ExecuteWorkflow(s.Context(), sdkclient.StartWorkflowOptions{
+			ID:        testcore.RandomizeStr("wf_id-" + s.T().Name()),
+			TaskQueue: env.WorkerTaskQueue(),
+		}, s.idleWorkflow)
+		s.NoError(err)
+		executions = append(executions, &commonpb.WorkflowExecution{WorkflowId: run.GetID(), RunId: run.GetRunID()})
+	}
+	return executions
+}
+
+func (s *AdminBatchSystemNamespaceTestSuite) startSystemJob(
+	env *testcore.TestEnv,
+	jobID string,
+	executions []*commonpb.WorkflowExecution,
+) error {
+	return s.startNamespaceSystemJob(env, env.Namespace().String(), jobID, executions...)
+}
+
+func (s *AdminBatchSystemNamespaceTestSuite) startNamespaceSystemJob(
+	env *testcore.TestEnv,
+	ns string,
+	jobID string,
+	executions ...*commonpb.WorkflowExecution,
+) error {
+	resp, err := env.AdminClient().StartAdminBatchOperation(s.Context(), &adminservice.StartAdminBatchOperationRequest{
+		Namespace:    ns,
+		JobId:        jobID,
+		Reason:       "admin batch system namespace test",
+		Identity:     "test-identity",
+		JobNamespace: adminservice.StartAdminBatchOperationRequest_JOB_NAMESPACE_SYSTEM,
+		Executions:   executions,
+		Operation: &adminservice.StartAdminBatchOperationRequest_RefreshTasksOperation{
+			RefreshTasksOperation: &adminservice.BatchOperationRefreshTasks{},
+		},
+	})
+	if err == nil {
+		// Callers cannot reconstruct the control workflow's ID, so the response must
+		// report it.
+		s.Equal(primitives.SystemLocalNamespace, resp.GetJobNamespace())
+		s.True(strings.HasSuffix(resp.GetJobWorkflowId(), ":"+jobID), "got %q", resp.GetJobWorkflowId())
+	}
+	return err
+}
+
+func (s *AdminBatchSystemNamespaceTestSuite) jobWorkflowID(env *testcore.TestEnv, jobID string) string {
+	return adminbatcher.JobWorkflowID(env.NamespaceID().String(), jobID)
+}
+
+func (s *AdminBatchSystemNamespaceTestSuite) awaitJobResult(env *testcore.TestEnv, jobID string) batcher.HeartBeatDetails {
+	client, err := sdkclient.Dial(sdkclient.Options{
+		HostPort:  env.FrontendGRPCAddress(),
+		Namespace: primitives.SystemLocalNamespace,
+	})
+	s.NoError(err)
+	defer client.Close()
+
+	var result batcher.HeartBeatDetails
+	s.NoError(client.GetWorkflow(s.Context(), s.jobWorkflowID(env, jobID), "").Get(s.Context(), &result))
+	return result
+}
+
+// TestRateLimiterAppliesToSystemNamespaceJobs pins the admin batcher's RPS well
+// below the number of targets and checks the job takes at least as long as that
+// limit allows. The limiter is a host-level limit shared by every admin batch job,
+// and moving the job into temporal-system must not bypass it.
+func (s *AdminBatchSystemNamespaceTestSuite) TestRateLimiterAppliesToSystemNamespaceJobs() {
+	const rps = 2
+	const numWorkflows = 8
+
+	env := s.newSystemTestEnv(
+		testcore.WithDynamicConfig(dynamicconfig.AdminBatcherHostRPS, rps),
+		testcore.WithDynamicConfig(dynamicconfig.AdminBatcherGlobalRPS, 0),
+	)
+	executions := s.startWorkflows(env, numWorkflows)
+
+	jobID := uuid.NewString()
+	start := time.Now()
+	s.NoError(s.startSystemJob(env, jobID, executions))
+
+	result := s.awaitJobResult(env, jobID)
+	elapsed := time.Since(start)
+
+	s.Equal(numWorkflows, result.SuccessCount)
+	s.Zero(result.ErrorCount)
+
+	// The limiter's burst equals its rps, so the first rps refreshes go through
+	// immediately and the rest are paced. Unthrottled, this job takes ~50ms.
+	minDuration := time.Duration(numWorkflows-rps) * time.Second / rps
+	s.GreaterOrEqual(elapsed, minDuration,
+		"job finished in %v, faster than %d refreshes at %d rps allows", elapsed, numWorkflows, rps)
+}
+
+// TestConcurrencyCapIsScopedToTheUserNamespace checks that the open-job cap counts
+// only the jobs of the namespace being requested. Every namespace's jobs live in
+// the one temporal-system namespace, so an unscoped count would let one namespace's
+// jobs exhaust another's quota.
+func (s *AdminBatchSystemNamespaceTestSuite) TestConcurrencyCapIsScopedToTheUserNamespace() {
+	env := s.newSystemTestEnv(
+		testcore.WithDynamicConfig(dynamicconfig.FrontendMaxConcurrentAdminBatchOperationPerNamespace, 1),
+		testcore.WithDynamicConfig(dynamicconfig.AdminBatcherHostRPS, 1),
+		testcore.WithDynamicConfig(dynamicconfig.AdminBatcherGlobalRPS, 0),
+	)
+	executions := s.startWorkflows(env, 20)
+
+	firstJobID := uuid.NewString()
+	s.NoError(s.startSystemJob(env, firstJobID, executions))
+	s.awaitOpenJobIndexed(env, env.NamespaceID().String())
+
+	err := s.startSystemJob(env, uuid.NewString(), executions[:1])
+	var resourceExhausted *serviceerror.ResourceExhausted
+	s.ErrorAs(err, &resourceExhausted, "a second concurrent job for the same namespace must be rejected")
+
+	// A second namespace on the same cluster has its own quota, even though both
+	// namespaces' jobs are hosted in the one temporal-system namespace.
+	otherNS, otherExecution := s.registerNamespaceWithWorkflow(env)
+	s.NoError(s.startNamespaceSystemJob(env, otherNS, uuid.NewString(), otherExecution),
+		"another namespace's open job must not consume this namespace's quota")
+}
+
+// registerNamespaceWithWorkflow adds a second namespace to the same cluster and
+// starts one execution in it. No worker is needed: refreshing tasks does not
+// require the workflow to make progress.
+func (s *AdminBatchSystemNamespaceTestSuite) registerNamespaceWithWorkflow(env *testcore.TestEnv) (string, *commonpb.WorkflowExecution) {
+	nsName := namespace.Name(testcore.RandomizeStr("other-ns"))
+	_, err := env.RegisterNamespace(nsName, 1, enumspb.ARCHIVAL_STATE_DISABLED, "", "")
+	s.NoError(err)
+
+	wfID := testcore.RandomizeStr("other-wf")
+	resp, err := env.FrontendClient().StartWorkflowExecution(s.Context(), &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:    uuid.NewString(),
+		Namespace:    nsName.String(),
+		WorkflowId:   wfID,
+		WorkflowType: &commonpb.WorkflowType{Name: "idleWorkflow"},
+		TaskQueue:    &taskqueuepb.TaskQueue{Name: "other-tq", Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		Identity:     "test-identity",
+	})
+	s.NoError(err)
+	return nsName.String(), &commonpb.WorkflowExecution{WorkflowId: wfID, RunId: resp.GetRunId()}
+}
+
+// awaitOpenJobIndexed waits until the running job is visible to the count query the
+// frontend uses to enforce the cap.
+func (s *AdminBatchSystemNamespaceTestSuite) awaitOpenJobIndexed(env *testcore.TestEnv, nsID string) {
+	query := batcher.OpenAdminBatchOperationQuery +
+		" AND " + sadefs.WorkflowID + " STARTS_WITH '" + adminbatcher.JobWorkflowIDPrefix(nsID) + "'"
+	s.AwaitTruef(func() bool {
+		resp, err := env.FrontendClient().CountWorkflowExecutions(s.Context(), &workflowservice.CountWorkflowExecutionsRequest{
+			Namespace: primitives.SystemLocalNamespace,
+			Query:     query,
+		})
+		return err == nil && resp.GetCount() >= 1
+	}, 20*time.Second, 200*time.Millisecond, "the open job should be indexed in temporal-system")
+}
+
+// TestSystemNamespaceJobDoesNotDisturbUserBatchOperations runs an ordinary
+// user-facing batch operation alongside a system-hosted admin job. The two use
+// different task queues, workflow types and quotas, so both must complete.
+func (s *AdminBatchSystemNamespaceTestSuite) TestSystemNamespaceJobDoesNotDisturbUserBatchOperations() {
+	env := s.newSystemTestEnv()
+	executions := s.startWorkflows(env, 2)
+
+	adminJobID := uuid.NewString()
+	s.NoError(s.startSystemJob(env, adminJobID, executions))
+
+	userJobID := uuid.NewString()
+	_, err := env.FrontendClient().StartBatchOperation(s.Context(), &workflowservice.StartBatchOperationRequest{
+		Namespace:  env.Namespace().String(),
+		JobId:      userJobID,
+		Reason:     "user batch alongside an admin batch",
+		Executions: executions,
+		Operation: &workflowservice.StartBatchOperationRequest_SignalOperation{
+			SignalOperation: &batchpb.BatchOperationSignal{
+				Signal:   "test-signal",
+				Input:    payloads.EncodeString("test-input"),
+				Identity: "test-identity",
+			},
+		},
+	})
+	s.NoError(err)
+
+	result := s.awaitJobResult(env, adminJobID)
+	s.Equal(len(executions), result.SuccessCount)
+
+	// The user batch runs on the per-namespace worker in the user namespace, and is
+	// unaffected by the admin job living in temporal-system.
+	s.AwaitTruef(func() bool {
+		resp, err := env.FrontendClient().DescribeBatchOperation(s.Context(), &workflowservice.DescribeBatchOperationRequest{
+			Namespace: env.Namespace().String(),
+			JobId:     userJobID,
+		})
+		return err == nil && resp.GetState() == enumspb.BATCH_OPERATION_STATE_COMPLETED
+	}, 30*time.Second, 250*time.Millisecond, "the user batch operation should still complete")
+}
+
+// TestJobIsIsolatedFromTheUserNamespace checks the job workflow only ever exists in
+// temporal-system, under a workflow ID scoped by the user namespace it acts on.
+func (s *AdminBatchSystemNamespaceTestSuite) TestJobIsIsolatedFromTheUserNamespace() {
+	env := s.newSystemTestEnv()
+	executions := s.startWorkflows(env, 1)
+
+	jobID := uuid.NewString()
+	s.NoError(s.startSystemJob(env, jobID, executions))
+	s.awaitJobResult(env, jobID)
+
+	jobWorkflowID := s.jobWorkflowID(env, jobID)
+	desc, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+		Namespace: primitives.SystemLocalNamespace,
+		Execution: &commonpb.WorkflowExecution{WorkflowId: jobWorkflowID},
+	})
+	s.NoError(err)
+	s.Equal(adminbatcher.WorkflowTypeName, desc.GetWorkflowExecutionInfo().GetType().GetName())
+	s.Equal(primitives.DefaultWorkerTaskQueue, desc.GetWorkflowExecutionInfo().GetTaskQueue())
+
+	for _, wfID := range []string{jobID, jobWorkflowID} {
+		_, err = env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: env.Namespace().String(),
+			Execution: &commonpb.WorkflowExecution{WorkflowId: wfID},
+		})
+		var notFound *serviceerror.NotFound
+		s.ErrorAs(err, &notFound, "the job must not exist in the user namespace under id %q", wfID)
+	}
+}
+
+func (s *AdminBatchSystemNamespaceTestSuite) newSystemTestEnv(opts ...testcore.TestOption) *testcore.TestEnv {
+	base := []testcore.TestOption{
+		// These tests assert on what the job actually does, so the system worker
+		// that hosts it must be running. A dedicated cluster also keeps the
+		// temporal-system job count free of other suites' jobs.
+		testcore.WithWorkerService("admin batch jobs are hosted on the system worker"),
+		testcore.WithDynamicConfig(dynamicconfig.FrontendMaxConcurrentAdminBatchOperationPerNamespace, 10),
+	}
+	return testcore.NewEnv(s.T(), append(base, opts...)...)
+}

--- a/tests/xdc/admin_batch_refresh_tasks_test.go
+++ b/tests/xdc/admin_batch_refresh_tasks_test.go
@@ -1,0 +1,310 @@
+package xdc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	historypb "go.temporal.io/api/history/v1"
+	"go.temporal.io/api/serviceerror"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	sdkclient "go.temporal.io/sdk/client"
+	"go.temporal.io/server/api/adminservice/v1"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/primitives"
+	"go.temporal.io/server/common/testing/await"
+	"go.temporal.io/server/service/history/tasks"
+	"go.temporal.io/server/service/worker/adminbatcher"
+	"go.temporal.io/server/service/worker/batcher"
+	"go.temporal.io/server/tests/testcore"
+)
+
+const (
+	// The test namespaces are active in cluster 0 and passive in cluster 1.
+	activeClusterIdx  = 0
+	passiveClusterIdx = 1
+)
+
+type adminBatchRefreshTasksSuite struct {
+	xdcBaseSuite
+}
+
+func TestAdminBatchRefreshTasksSuite(t *testing.T) {
+	t.Parallel()
+	s := &adminBatchRefreshTasksSuite{}
+	suite.Run(t, s)
+}
+
+func (s *adminBatchRefreshTasksSuite) SetupSuite() {
+	s.logger = log.NewTestLogger()
+	s.setupSuite(testcore.WithClusterHistoryTaskRecorder())
+}
+
+func (s *adminBatchRefreshTasksSuite) TearDownSuite() {
+	s.tearDownSuite()
+}
+
+func (s *adminBatchRefreshTasksSuite) SetupTest() {
+	s.setupTest()
+}
+
+// run is s.Run with the suite's require.Assertions rebound to the subtest's T, so a
+// failure aborts and is reported against the subtest rather than its parent.
+func (s *adminBatchRefreshTasksSuite) run(name string, subtest func()) {
+	parent := s.Assertions
+	s.Run(name, func() {
+		s.Assertions = require.New(s.T())
+		defer func() { s.Assertions = parent }()
+		subtest()
+	})
+}
+
+type refreshTarget struct {
+	ns   string
+	nsID string
+	exec *commonpb.WorkflowExecution
+}
+
+// TestRefreshTasksInSystemNamespace runs admin batch refresh-tasks jobs hosted in
+// temporal-system, from the cluster where the target namespace is active and from
+// the cluster where it is passive. temporal-system is a local namespace and is
+// therefore active in every cluster, so neither the per-namespace worker's
+// active-in-cluster gate nor the rejection of workflow starts in a passive global
+// namespace applies.
+func (s *adminBatchRefreshTasksSuite) TestRefreshTasksInSystemNamespace() {
+	ctx := testcore.NewContext()
+
+	ns1 := s.newReplicatedNamespaceWithWorkflow(ctx)
+	ns2 := s.newReplicatedNamespaceWithWorkflow(ctx)
+
+	for _, cl := range []struct {
+		name string
+		idx  int
+	}{
+		{name: "active", idx: activeClusterIdx},
+		{name: "passive", idx: passiveClusterIdx},
+	} {
+		for _, target := range []refreshTarget{ns1, ns2} {
+			s.run(cl.name+"/"+target.ns, func() {
+				s.assertNamespaceActiveIn(ctx, target.ns, activeClusterIdx)
+
+				tasksBefore := s.countRefreshedTasks(cl.idx, target)
+				jobID := s.runAdminBatch(ctx, cl.idx, target, adminservice.StartAdminBatchOperationRequest_JOB_NAMESPACE_SYSTEM)
+
+				s.assertJobHostedInSystemNamespace(ctx, cl.idx, jobID)
+				s.assertJobAbsentFrom(ctx, cl.idx, target.ns, jobID)
+				s.Greater(s.countRefreshedTasks(cl.idx, target), tasksBefore,
+					"refresh must regenerate tasks for the execution in the user namespace")
+			})
+		}
+	}
+}
+
+// TestUserJobNamespaceFallback covers the pre-existing per-namespace-worker path.
+// It still works where the namespace is active, and is still rejected where it is
+// passive -- which is the limitation the system-namespace host removes.
+func (s *adminBatchRefreshTasksSuite) TestUserJobNamespaceFallback() {
+	ctx := testcore.NewContext()
+	target := s.newReplicatedNamespaceWithWorkflow(ctx)
+
+	s.run("active cluster runs the job in the user namespace", func() {
+		tasksBefore := s.countRefreshedTasks(activeClusterIdx, target)
+		jobID := s.runAdminBatch(ctx, activeClusterIdx, target, adminservice.StartAdminBatchOperationRequest_JOB_NAMESPACE_USER)
+
+		desc, err := s.clusters[activeClusterIdx].FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: target.ns,
+			Execution: &commonpb.WorkflowExecution{WorkflowId: jobID},
+		})
+		s.NoError(err)
+		s.Equal(batcher.BatchWFTypeProtobufName, desc.GetWorkflowExecutionInfo().GetType().GetName())
+		s.Equal(primitives.PerNSWorkerTaskQueue, desc.GetWorkflowExecutionInfo().GetTaskQueue())
+
+		s.assertJobAbsentFrom(ctx, activeClusterIdx, primitives.SystemLocalNamespace, jobID)
+		s.Greater(s.countRefreshedTasks(activeClusterIdx, target), tasksBefore)
+	})
+
+	s.run("passive cluster rejects the job", func() {
+		_, err := s.startAdminBatch(ctx, passiveClusterIdx, target,
+			adminservice.StartAdminBatchOperationRequest_JOB_NAMESPACE_USER, uuid.NewString())
+		s.Error(err, "a job workflow cannot be created in a namespace that is passive in this cluster")
+		var notActive *serviceerror.NamespaceNotActive
+		s.ErrorAs(err, &notActive)
+	})
+}
+
+func (s *adminBatchRefreshTasksSuite) TestJobNamespaceIsRequired() {
+	ctx := testcore.NewContext()
+	target := s.newReplicatedNamespaceWithWorkflow(ctx)
+
+	_, err := s.startAdminBatch(ctx, passiveClusterIdx, target,
+		adminservice.StartAdminBatchOperationRequest_JOB_NAMESPACE_UNSPECIFIED, uuid.NewString())
+	var invalidArgument *serviceerror.InvalidArgument
+	s.ErrorAs(err, &invalidArgument)
+}
+
+func (s *adminBatchRefreshTasksSuite) newReplicatedNamespaceWithWorkflow(ctx context.Context) refreshTarget {
+	ns := s.createGlobalNamespace()
+
+	wfID := "wf-" + uuid.NewString()
+	resp, err := s.clusters[activeClusterIdx].FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:    uuid.NewString(),
+		Namespace:    ns,
+		WorkflowId:   wfID,
+		WorkflowType: &commonpb.WorkflowType{Name: "admin-batch-xdc-test-type"},
+		TaskQueue:    &taskqueuepb.TaskQueue{Name: "admin-batch-xdc-test-tq", Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		Identity:     "admin-batch-xdc-test",
+	})
+	s.NoError(err)
+
+	target := refreshTarget{
+		ns:   ns,
+		nsID: s.namespaceID(ctx, ns),
+		exec: &commonpb.WorkflowExecution{WorkflowId: wfID, RunId: resp.GetRunId()},
+	}
+
+	s.waitForClusterSynced()
+	// Read through the admin service: it is never redirected to the active cluster,
+	// so this confirms the execution really is present in the passive cluster.
+	await.RequireTrue(s.T(), func() bool {
+		_, err := s.clusters[passiveClusterIdx].AdminClient().DescribeMutableState(ctx, &adminservice.DescribeMutableStateRequest{
+			Namespace: ns,
+			Execution: target.exec,
+		})
+		return err == nil
+	}, replicationWaitTime, replicationCheckInterval)
+
+	return target
+}
+
+func (s *adminBatchRefreshTasksSuite) namespaceID(ctx context.Context, ns string) string {
+	resp, err := s.clusters[activeClusterIdx].FrontendClient().DescribeNamespace(ctx, &workflowservice.DescribeNamespaceRequest{
+		Namespace: ns,
+	})
+	s.NoError(err)
+	return resp.GetNamespaceInfo().GetId()
+}
+
+func (s *adminBatchRefreshTasksSuite) assertNamespaceActiveIn(ctx context.Context, ns string, clusterIdx int) {
+	for i, c := range s.clusters {
+		resp, err := c.FrontendClient().DescribeNamespace(ctx, &workflowservice.DescribeNamespaceRequest{Namespace: ns})
+		s.NoError(err)
+		s.Equal(s.clusters[clusterIdx].ClusterName(), resp.GetReplicationConfig().GetActiveClusterName(),
+			"cluster %d disagrees about which cluster is active for %s", i, ns)
+	}
+}
+
+func (s *adminBatchRefreshTasksSuite) startAdminBatch(
+	ctx context.Context,
+	clusterIdx int,
+	target refreshTarget,
+	jobNamespace adminservice.StartAdminBatchOperationRequest_JobNamespace,
+	jobID string,
+) (*adminservice.StartAdminBatchOperationResponse, error) {
+	return s.clusters[clusterIdx].AdminClient().StartAdminBatchOperation(ctx, &adminservice.StartAdminBatchOperationRequest{
+		Namespace:    target.ns,
+		JobId:        jobID,
+		Reason:       "refresh tasks lost on this cluster",
+		Identity:     "admin-batch-xdc-test",
+		JobNamespace: jobNamespace,
+		Executions:   []*commonpb.WorkflowExecution{target.exec},
+		Operation: &adminservice.StartAdminBatchOperationRequest_RefreshTasksOperation{
+			RefreshTasksOperation: &adminservice.BatchOperationRefreshTasks{},
+		},
+	})
+}
+
+// runAdminBatch starts a job, waits for it to finish, and asserts the targeted
+// execution was refreshed without error. It returns the job workflow ID.
+func (s *adminBatchRefreshTasksSuite) runAdminBatch(
+	ctx context.Context,
+	clusterIdx int,
+	target refreshTarget,
+	jobNamespace adminservice.StartAdminBatchOperationRequest_JobNamespace,
+) string {
+	jobID := "admin-batch-" + uuid.NewString()
+	_, err := s.startAdminBatch(ctx, clusterIdx, target, jobNamespace, jobID)
+	s.NoError(err)
+
+	jobNS, jobWorkflowID := primitives.SystemLocalNamespace, adminbatcher.JobWorkflowID(target.nsID, jobID)
+	if jobNamespace == adminservice.StartAdminBatchOperationRequest_JOB_NAMESPACE_USER {
+		jobNS, jobWorkflowID = target.ns, jobID
+	}
+	client := s.namespaceClient(clusterIdx, jobNS)
+	defer client.Close()
+
+	var result batcher.HeartBeatDetails
+	s.NoError(client.GetWorkflow(ctx, jobWorkflowID, "").Get(ctx, &result))
+	s.Equal(1, result.SuccessCount)
+	s.Zero(result.ErrorCount)
+	return jobWorkflowID
+}
+
+func (s *adminBatchRefreshTasksSuite) namespaceClient(clusterIdx int, ns string) sdkclient.Client {
+	client, err := sdkclient.Dial(sdkclient.Options{
+		HostPort:  s.clusters[clusterIdx].Host().FrontendGRPCAddress(),
+		Namespace: ns,
+	})
+	s.NoError(err)
+	return client
+}
+
+// countRefreshedTasks counts the transfer tasks written for the target execution in
+// the given cluster. RefreshWorkflowTasks regenerates them, so the count growing is
+// direct evidence that the job acted on the user namespace's data.
+func (s *adminBatchRefreshTasksSuite) countRefreshedTasks(clusterIdx int, target refreshTarget) int {
+	return s.clusters[clusterIdx].GetHistoryTaskRecorder().CountTasksForWorkflow(
+		tasks.CategoryTransfer, target.nsID, target.exec.GetWorkflowId(), target.exec.GetRunId(), nil)
+}
+
+func (s *adminBatchRefreshTasksSuite) assertJobHostedInSystemNamespace(ctx context.Context, clusterIdx int, jobID string) {
+	desc, err := s.clusters[clusterIdx].FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+		Namespace: primitives.SystemLocalNamespace,
+		Execution: &commonpb.WorkflowExecution{WorkflowId: jobID},
+	})
+	s.NoError(err)
+	info := desc.GetWorkflowExecutionInfo()
+	s.Equal(adminbatcher.WorkflowTypeName, info.GetType().GetName())
+	s.Equal(primitives.DefaultWorkerTaskQueue, info.GetTaskQueue())
+	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, info.GetStatus())
+
+	s.Equal(primitives.AdminBatchActivityTQ, s.activityTaskQueue(ctx, clusterIdx, jobID),
+		"the batch activity must run on the dedicated admin batch queue, not the default system queue")
+}
+
+func (s *adminBatchRefreshTasksSuite) activityTaskQueue(ctx context.Context, clusterIdx int, jobID string) string {
+	var scheduled []*historypb.HistoryEvent
+	var nextPageToken []byte
+	for {
+		resp, err := s.clusters[clusterIdx].FrontendClient().GetWorkflowExecutionHistory(ctx, &workflowservice.GetWorkflowExecutionHistoryRequest{
+			Namespace:     primitives.SystemLocalNamespace,
+			Execution:     &commonpb.WorkflowExecution{WorkflowId: jobID},
+			NextPageToken: nextPageToken,
+		})
+		s.NoError(err)
+		for _, event := range resp.GetHistory().GetEvents() {
+			if event.GetEventType() == enumspb.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED {
+				scheduled = append(scheduled, event)
+			}
+		}
+		nextPageToken = resp.GetNextPageToken()
+		if len(nextPageToken) == 0 {
+			break
+		}
+	}
+	s.Len(scheduled, 1)
+	return scheduled[0].GetActivityTaskScheduledEventAttributes().GetTaskQueue().GetName()
+}
+
+func (s *adminBatchRefreshTasksSuite) assertJobAbsentFrom(ctx context.Context, clusterIdx int, ns, jobID string) {
+	_, err := s.clusters[clusterIdx].FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+		Namespace: ns,
+		Execution: &commonpb.WorkflowExecution{WorkflowId: jobID},
+	})
+	var notFound *serviceerror.NotFound
+	s.ErrorAs(err, &notFound, "the job must not exist in namespace %s", ns)
+}

--- a/tools/tdbg/commands.go
+++ b/tools/tdbg/commands.go
@@ -765,6 +765,11 @@ func AdminBatchRefreshWorkflowTasks(c *cli.Context, clientFactory ClientFactory,
 		return err
 	}
 
+	jobNamespace, jobNamespaceStr, err := parseJobNamespace(c)
+	if err != nil {
+		return err
+	}
+
 	jobID := c.String(FlagJobID)
 	if jobID == "" {
 		jobID = fmt.Sprintf("batch-refresh-%d", time.Now().UnixNano())
@@ -782,16 +787,21 @@ func AdminBatchRefreshWorkflowTasks(c *cli.Context, clientFactory ClientFactory,
 		return fmt.Errorf("unable to count workflow executions: %w", err)
 	}
 
-	msg := fmt.Sprintf("Will refresh tasks for %d execution(s) matching query %q in namespace %q. Continue Y/N?",
-		countResp.GetCount(), query, nsName)
+	msg := fmt.Sprintf(
+		"Will refresh tasks for %d execution(s) matching query %q in namespace %q.\n"+
+			"The batch job itself will run in %s (--%s=%s).\n"+
+			"Continue Y/N?",
+		countResp.GetCount(), query, nsName,
+		jobNamespaceDescription(jobNamespace, nsName), FlagJobNamespace, jobNamespaceStr)
 	prompter.Prompt(msg)
 
-	_, err = adminClient.StartAdminBatchOperation(ctx, &adminservice.StartAdminBatchOperationRequest{
+	resp, err := adminClient.StartAdminBatchOperation(ctx, &adminservice.StartAdminBatchOperationRequest{
 		Namespace:       nsName,
 		VisibilityQuery: query,
 		JobId:           jobID,
 		Reason:          reason,
 		Identity:        getCurrentUserFromEnv(),
+		JobNamespace:    jobNamespace,
 		Operation: &adminservice.StartAdminBatchOperationRequest_RefreshTasksOperation{
 			RefreshTasksOperation: &adminservice.BatchOperationRefreshTasks{},
 		},
@@ -800,8 +810,13 @@ func AdminBatchRefreshWorkflowTasks(c *cli.Context, clientFactory ClientFactory,
 		return fmt.Errorf("unable to start batch refresh workflow tasks: %w", err)
 	}
 
+	// The server derives the control workflow's ID from the job ID, so report what
+	// it actually started rather than what was requested.
 	// nolint:errcheck // assuming that write will succeed.
-	fmt.Fprintf(c.App.Writer, "Batch Refresh Workflow Tasks started successfully for Job ID: %s\n", jobID)
+	fmt.Fprintf(c.App.Writer,
+		"Batch Refresh Workflow Tasks started successfully for Job ID: %s\n"+
+			"Track it with: tdbg --%s %s execution describe --%s %s\n",
+		jobID, FlagNamespace, resp.GetJobNamespace(), FlagBusinessID, resp.GetJobWorkflowId())
 	return nil
 }
 
@@ -918,6 +933,42 @@ func AdminMigrateSchedule(c *cli.Context, clientFactory ClientFactory) error {
 		return migrateSchedulesFromStdin(c, clientFactory, target, targetStr)
 	default:
 		return fmt.Errorf("specify one of: --%s, --%s, or pipe JSON lines on stdin", FlagScheduleID, FlagFromVisibility)
+	}
+}
+
+// parseJobNamespace resolves the required --job-namespace flag. It is required rather than
+// defaulted because the wrong choice fails in ways that are not obvious: "user" cannot start
+// a job at all in a cluster where the namespace is passive.
+func parseJobNamespace(c *cli.Context) (adminservice.StartAdminBatchOperationRequest_JobNamespace, string, error) {
+	value, err := getRequiredOption(c, FlagJobNamespace)
+	if err != nil {
+		return 0, "", err
+	}
+	switch strings.ToLower(value) {
+	case "system":
+		return adminservice.StartAdminBatchOperationRequest_JOB_NAMESPACE_SYSTEM, value, nil
+	case "user":
+		return adminservice.StartAdminBatchOperationRequest_JOB_NAMESPACE_USER, value, nil
+	default:
+		return 0, "", fmt.Errorf("invalid %s %q, valid values are: system, user", FlagJobNamespace, value)
+	}
+}
+
+func jobNamespaceDescription(
+	jobNamespace adminservice.StartAdminBatchOperationRequest_JobNamespace,
+	targetNamespace string,
+) string {
+	switch jobNamespace {
+	case adminservice.StartAdminBatchOperationRequest_JOB_NAMESPACE_SYSTEM:
+		return fmt.Sprintf("the %q namespace, so it runs in this cluster even if %q is passive here",
+			primitives.SystemLocalNamespace, targetNamespace)
+	case adminservice.StartAdminBatchOperationRequest_JOB_NAMESPACE_USER:
+		return fmt.Sprintf("user namespace %q on its per-namespace worker, which requires %q to be active in this cluster",
+			targetNamespace, targetNamespace)
+	case adminservice.StartAdminBatchOperationRequest_JOB_NAMESPACE_UNSPECIFIED:
+		return "an unspecified namespace"
+	default:
+		return jobNamespace.String()
 	}
 }
 

--- a/tools/tdbg/flags.go
+++ b/tools/tdbg/flags.go
@@ -76,6 +76,7 @@ var (
 	FlagMinPass                    = "min-pass"
 	FlagVisibilityQuery            = "query"
 	FlagJobID                      = "job-id"
+	FlagJobNamespace               = "job-namespace"
 	FlagDecode                     = "decode"
 	FlagScheduleID                 = "schedule-id"
 	FlagScheduleIDAlias            = []string{"sid"}

--- a/tools/tdbg/tdbg_commands.go
+++ b/tools/tdbg/tdbg_commands.go
@@ -10,6 +10,7 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/service/history/tasks"
 	"go.uber.org/multierr"
 )
@@ -210,6 +211,14 @@ func newAdminExecutionCommands(clientFactory ClientFactory, prompterFactory Prom
 				&cli.StringFlag{
 					Name:  FlagJobID,
 					Usage: "Optional job ID (auto-generated if not provided)",
+				},
+				&cli.StringFlag{
+					Name: FlagJobNamespace,
+					Usage: "Required with --" + FlagVisibilityQuery + ". Namespace that hosts the batch job workflow: " +
+						"'system' runs it in " + primitives.SystemLocalNamespace + " on the system worker, which works even when " +
+						"--" + FlagNamespace + " is passive in this cluster; " +
+						"'user' runs it in --" + FlagNamespace + " on the per-namespace worker, which requires that " +
+						"namespace to be active here. This only changes where the job runs, never which executions it acts on.",
 				},
 			},
 			Action: func(c *cli.Context) error {


### PR DESCRIPTION
## What changed?
1. add admin batch jobs to temporal-system namespace

## Why?
so that admin batch workflows can be run in every cluster and run operations for passive clusters 

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
