### PR TITLE
Extract shared JUnit XML handling

### DIFF
--- a/tools/common/junit/junit.go
+++ b/tools/common/junit/junit.go
@@ -64,7 +64,7 @@ func Read(path string) (*Testsuites, error) {
 func Write(path string, testsuites *Testsuites) error {
 	f, err := os.Create(path)
 	if err != nil {
-		return fmt.Errorf("failed to open JUnit report file: %w", err)
+		return fmt.Errorf("failed to create JUnit report file: %w", err)
 	}
 	defer func() { _ = f.Close() }()
 

--- a/tools/common/junit/junit.go
+++ b/tools/common/junit/junit.go
@@ -17,14 +17,8 @@ type Testsuite = junitxml.Testsuite
 // Testcase is a JUnit test case.
 type Testcase = junitxml.Testcase
 
-// Property is a JUnit test-suite property.
-type Property = junitxml.Property
-
 // Result is a JUnit test-case failure or error.
 type Result = junitxml.Result
-
-// Output is captured JUnit test output.
-type Output = junitxml.Output
 
 // Read reads a JUnit XML file with either a testsuites or testsuite root.
 func Read(path string) (*Testsuites, error) {

--- a/tools/common/junit/junit.go
+++ b/tools/common/junit/junit.go
@@ -39,7 +39,13 @@ func Read(path string) (*junitxml.Testsuites, error) {
 			if err := decoder.DecodeElement(&testsuite, &root); err != nil {
 				return nil, fmt.Errorf("failed to read JUnit report file: %w", err)
 			}
-			return &junitxml.Testsuites{Suites: []junitxml.Testsuite{testsuite}}, nil
+			return &junitxml.Testsuites{
+				Tests:    testsuite.Tests,
+				Errors:   testsuite.Errors,
+				Failures: testsuite.Failures,
+				Time:     testsuite.Time,
+				Suites:   []junitxml.Testsuite{testsuite},
+			}, nil
 		default:
 			return nil, fmt.Errorf("failed to read JUnit report file: unexpected root element %q", root.Name.Local)
 		}

--- a/tools/common/junit/junit.go
+++ b/tools/common/junit/junit.go
@@ -1,0 +1,63 @@
+package junit
+
+import (
+	"encoding/xml"
+	"fmt"
+	"os"
+
+	junitxml "github.com/jstemmer/go-junit-report/v2/junit"
+)
+
+// Read reads a JUnit XML file with either a testsuites or testsuite root.
+func Read(path string) (*junitxml.Testsuites, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open JUnit report file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	decoder := xml.NewDecoder(f)
+	for {
+		token, err := decoder.Token()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read JUnit report file: %w", err)
+		}
+		root, ok := token.(xml.StartElement)
+		if !ok {
+			continue
+		}
+
+		switch root.Name.Local {
+		case "testsuites":
+			var testsuites junitxml.Testsuites
+			if err := decoder.DecodeElement(&testsuites, &root); err != nil {
+				return nil, fmt.Errorf("failed to read JUnit report file: %w", err)
+			}
+			return &testsuites, nil
+		case "testsuite":
+			var testsuite junitxml.Testsuite
+			if err := decoder.DecodeElement(&testsuite, &root); err != nil {
+				return nil, fmt.Errorf("failed to read JUnit report file: %w", err)
+			}
+			return &junitxml.Testsuites{Suites: []junitxml.Testsuite{testsuite}}, nil
+		default:
+			return nil, fmt.Errorf("failed to read JUnit report file: unexpected root element %q", root.Name.Local)
+		}
+	}
+}
+
+// Write writes a JUnit XML file.
+func Write(path string, testsuites *junitxml.Testsuites) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("failed to open JUnit report file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	encoder := xml.NewEncoder(f)
+	encoder.Indent("", "    ")
+	if err := encoder.Encode(testsuites); err != nil {
+		return fmt.Errorf("failed to write JUnit report file: %w", err)
+	}
+	return nil
+}

--- a/tools/common/junit/junit.go
+++ b/tools/common/junit/junit.go
@@ -2,6 +2,7 @@ package junit
 
 import (
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"os"
 
@@ -20,6 +21,8 @@ type Testcase = junitxml.Testcase
 // Result is a JUnit test-case failure or error.
 type Result = junitxml.Result
 
+var errRead = errors.New("failed to read JUnit report file")
+
 // Read reads a JUnit XML file with either a testsuites or testsuite root.
 func Read(path string) (*Testsuites, error) {
 	f, err := os.Open(path)
@@ -32,7 +35,7 @@ func Read(path string) (*Testsuites, error) {
 	for {
 		token, err := decoder.Token()
 		if err != nil {
-			return nil, fmt.Errorf("failed to read JUnit report file: %w", err)
+			return nil, fmt.Errorf("%w: %w", errRead, err)
 		}
 		root, ok := token.(xml.StartElement)
 		if !ok {
@@ -43,19 +46,19 @@ func Read(path string) (*Testsuites, error) {
 		case "testsuites":
 			var testsuites Testsuites
 			if err := decoder.DecodeElement(&testsuites, &root); err != nil {
-				return nil, fmt.Errorf("failed to read JUnit report file: %w", err)
+				return nil, fmt.Errorf("%w: %w", errRead, err)
 			}
 			return &testsuites, nil
 		case "testsuite":
 			var testsuite Testsuite
 			if err := decoder.DecodeElement(&testsuite, &root); err != nil {
-				return nil, fmt.Errorf("failed to read JUnit report file: %w", err)
+				return nil, fmt.Errorf("%w: %w", errRead, err)
 			}
 			testsuites := &Testsuites{Time: testsuite.Time}
 			testsuites.AddSuite(testsuite)
 			return testsuites, nil
 		default:
-			return nil, fmt.Errorf("failed to read JUnit report file: unexpected root element %q", root.Name.Local)
+			return nil, fmt.Errorf("%w: unexpected root element %q", errRead, root.Name.Local)
 		}
 	}
 }

--- a/tools/common/junit/junit.go
+++ b/tools/common/junit/junit.go
@@ -55,6 +55,7 @@ func Read(path string) (*Testsuites, error) {
 				Tests:    testsuite.Tests,
 				Errors:   testsuite.Errors,
 				Failures: testsuite.Failures,
+				Skipped:  testsuite.Skipped,
 				Time:     testsuite.Time,
 				Suites:   []Testsuite{testsuite},
 			}, nil

--- a/tools/common/junit/junit.go
+++ b/tools/common/junit/junit.go
@@ -8,8 +8,26 @@ import (
 	junitxml "github.com/jstemmer/go-junit-report/v2/junit"
 )
 
+// Testsuites is a JUnit test-suite collection.
+type Testsuites = junitxml.Testsuites
+
+// Testsuite is a JUnit test suite.
+type Testsuite = junitxml.Testsuite
+
+// Testcase is a JUnit test case.
+type Testcase = junitxml.Testcase
+
+// Property is a JUnit test-suite property.
+type Property = junitxml.Property
+
+// Result is a JUnit test-case failure or error.
+type Result = junitxml.Result
+
+// Output is captured JUnit test output.
+type Output = junitxml.Output
+
 // Read reads a JUnit XML file with either a testsuites or testsuite root.
-func Read(path string) (*junitxml.Testsuites, error) {
+func Read(path string) (*Testsuites, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open JUnit report file: %w", err)
@@ -29,22 +47,22 @@ func Read(path string) (*junitxml.Testsuites, error) {
 
 		switch root.Name.Local {
 		case "testsuites":
-			var testsuites junitxml.Testsuites
+			var testsuites Testsuites
 			if err := decoder.DecodeElement(&testsuites, &root); err != nil {
 				return nil, fmt.Errorf("failed to read JUnit report file: %w", err)
 			}
 			return &testsuites, nil
 		case "testsuite":
-			var testsuite junitxml.Testsuite
+			var testsuite Testsuite
 			if err := decoder.DecodeElement(&testsuite, &root); err != nil {
 				return nil, fmt.Errorf("failed to read JUnit report file: %w", err)
 			}
-			return &junitxml.Testsuites{
+			return &Testsuites{
 				Tests:    testsuite.Tests,
 				Errors:   testsuite.Errors,
 				Failures: testsuite.Failures,
 				Time:     testsuite.Time,
-				Suites:   []junitxml.Testsuite{testsuite},
+				Suites:   []Testsuite{testsuite},
 			}, nil
 		default:
 			return nil, fmt.Errorf("failed to read JUnit report file: unexpected root element %q", root.Name.Local)
@@ -53,7 +71,7 @@ func Read(path string) (*junitxml.Testsuites, error) {
 }
 
 // Write writes a JUnit XML file.
-func Write(path string, testsuites *junitxml.Testsuites) error {
+func Write(path string, testsuites *Testsuites) error {
 	f, err := os.Create(path)
 	if err != nil {
 		return fmt.Errorf("failed to open JUnit report file: %w", err)

--- a/tools/common/junit/junit.go
+++ b/tools/common/junit/junit.go
@@ -51,14 +51,9 @@ func Read(path string) (*Testsuites, error) {
 			if err := decoder.DecodeElement(&testsuite, &root); err != nil {
 				return nil, fmt.Errorf("failed to read JUnit report file: %w", err)
 			}
-			return &Testsuites{
-				Tests:    testsuite.Tests,
-				Errors:   testsuite.Errors,
-				Failures: testsuite.Failures,
-				Skipped:  testsuite.Skipped,
-				Time:     testsuite.Time,
-				Suites:   []Testsuite{testsuite},
-			}, nil
+			testsuites := &Testsuites{Time: testsuite.Time}
+			testsuites.AddSuite(testsuite)
+			return testsuites, nil
 		default:
 			return nil, fmt.Errorf("failed to read JUnit report file: unexpected root element %q", root.Name.Local)
 		}

--- a/tools/common/junit/junit_test.go
+++ b/tools/common/junit/junit_test.go
@@ -36,18 +36,23 @@ func TestRead(t *testing.T) {
 			},
 		},
 		{
-			name: "testsuite root",
-			content: `<testsuite name="suite" tests="1" failures="0" errors="0" id="0" time="">
-    <testcase name="TestOne" classname="example.com/tests"></testcase>
+			name: "testsuite root with skipped testcase",
+			content: `<testsuite name="suite" tests="1" failures="0" errors="0" skipped="1" id="0" time="">
+	<testcase name="TestOne" classname="example.com/tests">
+		<skipped></skipped>
+	</testcase>
 </testsuite>`,
 			want: Testsuites{
-				Tests: 1,
+				Tests:   1,
+				Skipped: 1,
 				Suites: []Testsuite{{
-					Name:  "suite",
-					Tests: 1,
+					Name:    "suite",
+					Tests:   1,
+					Skipped: 1,
 					Testcases: []Testcase{{
 						Name:      "TestOne",
 						Classname: "example.com/tests",
+						Skipped:   &Result{},
 					}},
 				}},
 			},

--- a/tools/common/junit/junit_test.go
+++ b/tools/common/junit/junit_test.go
@@ -36,19 +36,27 @@ func TestRead(t *testing.T) {
 			},
 		},
 		{
-			name: "testsuite root with skipped testcase",
-			content: `<testsuite name="suite" tests="1" failures="0" errors="0" skipped="1" id="0" time="">
+			name: "testsuite root with aggregate attributes",
+			content: `<testsuite name="suite" tests="10" failures="3" errors="2" skipped="4" disabled="1" id="0" time="5.5">
 	<testcase name="TestOne" classname="example.com/tests">
 		<skipped></skipped>
 	</testcase>
 </testsuite>`,
 			want: Testsuites{
-				Tests:   1,
-				Skipped: 1,
+				Tests:    10,
+				Errors:   2,
+				Failures: 3,
+				Skipped:  4,
+				Disabled: 1,
+				Time:     "5.5",
 				Suites: []Testsuite{{
-					Name:    "suite",
-					Tests:   1,
-					Skipped: 1,
+					Name:     "suite",
+					Tests:    10,
+					Failures: 3,
+					Errors:   2,
+					Disabled: 1,
+					Skipped:  4,
+					Time:     "5.5",
 					Testcases: []Testcase{{
 						Name:      "TestOne",
 						Classname: "example.com/tests",
@@ -67,6 +75,40 @@ func TestRead(t *testing.T) {
 			report, err := Read(path)
 			require.NoError(t, err)
 			require.Equal(t, tt.want, *report)
+		})
+	}
+}
+
+func TestReadErrors(t *testing.T) {
+	t.Run("missing file", func(t *testing.T) {
+		_, err := Read(filepath.Join(t.TempDir(), "missing.xml"))
+		require.ErrorContains(t, err, "failed to open JUnit report file")
+	})
+
+	tests := []struct {
+		name    string
+		content string
+		wantErr string
+	}{
+		{
+			name:    "unexpected root",
+			content: `<foo></foo>`,
+			wantErr: `unexpected root element "foo"`,
+		},
+		{
+			name:    "malformed XML",
+			content: `<testsuite>`,
+			wantErr: "failed to read JUnit report file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "junit.xml")
+			require.NoError(t, os.WriteFile(path, []byte(tt.content), 0o644))
+
+			_, err := Read(path)
+			require.ErrorContains(t, err, tt.wantErr)
 		})
 	}
 }

--- a/tools/common/junit/junit_test.go
+++ b/tools/common/junit/junit_test.go
@@ -1,0 +1,90 @@
+package junit
+
+import (
+	"encoding/xml"
+	"os"
+	"path/filepath"
+	"testing"
+
+	junitxml "github.com/jstemmer/go-junit-report/v2/junit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRead(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    junitxml.Testsuites
+	}{
+		{
+			name: "testsuites root",
+			content: `<testsuites tests="1">
+    <testsuite name="suite" tests="1" failures="0" errors="0" id="0" time="">
+        <testcase name="TestOne" classname="example.com/tests"></testcase>
+    </testsuite>
+</testsuites>`,
+			want: junitxml.Testsuites{
+				XMLName: xml.Name{Local: "testsuites"},
+				Tests:   1,
+			},
+		},
+		{
+			name: "testsuite root",
+			content: `<testsuite name="suite" tests="1" failures="0" errors="0" id="0" time="">
+    <testcase name="TestOne" classname="example.com/tests"></testcase>
+</testsuite>`,
+			want: junitxml.Testsuites{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "junit.xml")
+			require.NoError(t, os.WriteFile(path, []byte(tt.content), 0o644))
+
+			report, err := Read(path)
+			require.NoError(t, err)
+			tt.want.Suites = []junitxml.Testsuite{{
+				Name:     "suite",
+				Tests:    1,
+				Failures: 0,
+				Errors:   0,
+				ID:       0,
+				Time:     "",
+				Testcases: []junitxml.Testcase{{
+					Name:      "TestOne",
+					Classname: "example.com/tests",
+				}},
+			}}
+			require.Equal(t, tt.want, *report)
+		})
+	}
+}
+
+func TestWrite(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "junit.xml")
+	report := &junitxml.Testsuites{
+		Tests: 1,
+		Suites: []junitxml.Testsuite{{
+			Name:     "suite",
+			Tests:    1,
+			Failures: 0,
+			Errors:   0,
+			ID:       0,
+			Time:     "",
+			Testcases: []junitxml.Testcase{{
+				Name:      "TestOne",
+				Classname: "example.com/tests",
+			}},
+		}},
+	}
+
+	require.NoError(t, Write(path, report))
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, `<testsuites tests="1">
+    <testsuite name="suite" tests="1" failures="0" errors="0" id="0" time="">
+        <testcase name="TestOne" classname="example.com/tests"></testcase>
+    </testsuite>
+</testsuites>`, string(content))
+}

--- a/tools/common/junit/junit_test.go
+++ b/tools/common/junit/junit_test.go
@@ -83,6 +83,7 @@ func TestReadErrors(t *testing.T) {
 	t.Run("missing file", func(t *testing.T) {
 		_, err := Read(filepath.Join(t.TempDir(), "missing.xml"))
 		require.ErrorContains(t, err, "failed to open JUnit report file")
+		require.NotErrorIs(t, err, errRead)
 	})
 
 	tests := []struct {
@@ -109,6 +110,7 @@ func TestReadErrors(t *testing.T) {
 
 			_, err := Read(path)
 			require.ErrorContains(t, err, tt.wantErr)
+			require.ErrorIs(t, err, errRead)
 		})
 	}
 }

--- a/tools/common/junit/junit_test.go
+++ b/tools/common/junit/junit_test.go
@@ -25,6 +25,14 @@ func TestRead(t *testing.T) {
 			want: Testsuites{
 				XMLName: xml.Name{Local: "testsuites"},
 				Tests:   1,
+				Suites: []Testsuite{{
+					Name:  "suite",
+					Tests: 1,
+					Testcases: []Testcase{{
+						Name:      "TestOne",
+						Classname: "example.com/tests",
+					}},
+				}},
 			},
 		},
 		{
@@ -32,7 +40,17 @@ func TestRead(t *testing.T) {
 			content: `<testsuite name="suite" tests="1" failures="0" errors="0" id="0" time="">
     <testcase name="TestOne" classname="example.com/tests"></testcase>
 </testsuite>`,
-			want: Testsuites{Tests: 1},
+			want: Testsuites{
+				Tests: 1,
+				Suites: []Testsuite{{
+					Name:  "suite",
+					Tests: 1,
+					Testcases: []Testcase{{
+						Name:      "TestOne",
+						Classname: "example.com/tests",
+					}},
+				}},
+			},
 		},
 	}
 
@@ -43,18 +61,6 @@ func TestRead(t *testing.T) {
 
 			report, err := Read(path)
 			require.NoError(t, err)
-			tt.want.Suites = []Testsuite{{
-				Name:     "suite",
-				Tests:    1,
-				Failures: 0,
-				Errors:   0,
-				ID:       0,
-				Time:     "",
-				Testcases: []Testcase{{
-					Name:      "TestOne",
-					Classname: "example.com/tests",
-				}},
-			}}
 			require.Equal(t, tt.want, *report)
 		})
 	}

--- a/tools/common/junit/junit_test.go
+++ b/tools/common/junit/junit_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	junitxml "github.com/jstemmer/go-junit-report/v2/junit"
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,7 +13,7 @@ func TestRead(t *testing.T) {
 	tests := []struct {
 		name    string
 		content string
-		want    junitxml.Testsuites
+		want    Testsuites
 	}{
 		{
 			name: "testsuites root",
@@ -23,7 +22,7 @@ func TestRead(t *testing.T) {
         <testcase name="TestOne" classname="example.com/tests"></testcase>
     </testsuite>
 </testsuites>`,
-			want: junitxml.Testsuites{
+			want: Testsuites{
 				XMLName: xml.Name{Local: "testsuites"},
 				Tests:   1,
 			},
@@ -33,7 +32,7 @@ func TestRead(t *testing.T) {
 			content: `<testsuite name="suite" tests="1" failures="0" errors="0" id="0" time="">
     <testcase name="TestOne" classname="example.com/tests"></testcase>
 </testsuite>`,
-			want: junitxml.Testsuites{},
+			want: Testsuites{Tests: 1},
 		},
 	}
 
@@ -44,14 +43,14 @@ func TestRead(t *testing.T) {
 
 			report, err := Read(path)
 			require.NoError(t, err)
-			tt.want.Suites = []junitxml.Testsuite{{
+			tt.want.Suites = []Testsuite{{
 				Name:     "suite",
 				Tests:    1,
 				Failures: 0,
 				Errors:   0,
 				ID:       0,
 				Time:     "",
-				Testcases: []junitxml.Testcase{{
+				Testcases: []Testcase{{
 					Name:      "TestOne",
 					Classname: "example.com/tests",
 				}},
@@ -63,16 +62,16 @@ func TestRead(t *testing.T) {
 
 func TestWrite(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "junit.xml")
-	report := &junitxml.Testsuites{
+	report := &Testsuites{
 		Tests: 1,
-		Suites: []junitxml.Testsuite{{
+		Suites: []Testsuite{{
 			Name:     "suite",
 			Tests:    1,
 			Failures: 0,
 			Errors:   0,
 			ID:       0,
 			Time:     "",
-			Testcases: []junitxml.Testcase{{
+			Testcases: []Testcase{{
 				Name:      "TestOne",
 				Classname: "example.com/tests",
 			}},

--- a/tools/flakereport/parallel.go
+++ b/tools/flakereport/parallel.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"go.temporal.io/server/tools/common/github"
-	commonjunit "go.temporal.io/server/tools/common/junit"
+	"go.temporal.io/server/tools/common/junit"
 )
 
 // ArtifactJob represents a job to download and process an artifact
@@ -127,7 +127,7 @@ func processArtifactJob(ctx context.Context, job ArtifactJob, totalArtifacts int
 
 	// Parse JUnit XML files
 	for _, xmlFile := range xmlFiles {
-		suites, err := commonjunit.Read(xmlFile)
+		suites, err := junit.Read(xmlFile)
 		if err != nil {
 			fmt.Printf("  Warning: Failed to parse %s: %v\n", filepath.Base(xmlFile), err)
 			continue

--- a/tools/flakereport/parallel.go
+++ b/tools/flakereport/parallel.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"go.temporal.io/server/tools/common/github"
+	commonjunit "go.temporal.io/server/tools/common/junit"
 )
 
 // ArtifactJob represents a job to download and process an artifact
@@ -126,7 +127,7 @@ func processArtifactJob(ctx context.Context, job ArtifactJob, totalArtifacts int
 
 	// Parse JUnit XML files
 	for _, xmlFile := range xmlFiles {
-		suites, err := parseJUnitFile(xmlFile)
+		suites, err := commonjunit.Read(xmlFile)
 		if err != nil {
 			fmt.Printf("  Warning: Failed to parse %s: %v\n", filepath.Base(xmlFile), err)
 			continue

--- a/tools/flakereport/parser.go
+++ b/tools/flakereport/parser.go
@@ -1,9 +1,7 @@
 package flakereport
 
 import (
-	"encoding/xml"
 	"fmt"
-	"os"
 	"regexp"
 	"sort"
 	"strconv"
@@ -15,36 +13,6 @@ import (
 
 var finalRegex = regexp.MustCompile(`\s*\(final\)$`)
 var trailingSuffixRegex = regexp.MustCompile(`\s*\([^)]+\)$`)
-
-// parseJUnitFile reads and parses a single JUnit XML file
-func parseJUnitFile(filePath string) (*junit.Testsuites, error) {
-	file, err := os.Open(filePath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open file %s: %w", filePath, err)
-	}
-	defer func() {
-		if err := file.Close(); err != nil {
-			fmt.Printf("Warning: Failed to close file %s: %v\n", filePath, err)
-		}
-	}()
-
-	var testsuites junit.Testsuites
-	decoder := xml.NewDecoder(file)
-	if err := decoder.Decode(&testsuites); err != nil {
-		// Try parsing as a single testsuite
-		if _, seekErr := file.Seek(0, 0); seekErr != nil {
-			return nil, fmt.Errorf("failed to seek file %s: %w", filePath, seekErr)
-		}
-		var testsuite junit.Testsuite
-		decoder = xml.NewDecoder(file)
-		if err := decoder.Decode(&testsuite); err != nil {
-			return nil, fmt.Errorf("failed to parse JUnit XML %s: %w", filePath, err)
-		}
-		testsuites.Suites = []junit.Testsuite{testsuite}
-	}
-
-	return &testsuites, nil
-}
 
 // topLevelTestName extracts the suite/top-level test name from a test name.
 // For "TestSuiteV0/TestMethod" returns "TestSuiteV0".

--- a/tools/flakereport/parser.go
+++ b/tools/flakereport/parser.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jstemmer/go-junit-report/v2/junit"
+	"go.temporal.io/server/tools/common/junit"
 )
 
 var finalRegex = regexp.MustCompile(`\s*\(final\)$`)

--- a/tools/optimize-test-sharding/main.go
+++ b/tools/optimize-test-sharding/main.go
@@ -2,7 +2,6 @@ package optimizetestsharding
 
 import (
 	"context"
-	"encoding/xml"
 	"errors"
 	"flag"
 	"fmt"
@@ -16,8 +15,8 @@ import (
 	"strings"
 
 	"github.com/dgryski/go-farm"
-	"github.com/jstemmer/go-junit-report/v2/junit"
 	"go.temporal.io/server/tools/common/github"
+	commonjunit "go.temporal.io/server/tools/common/junit"
 )
 
 const (
@@ -195,14 +194,8 @@ func loadTestData(dir string) (map[string][]float64, error) {
 }
 
 func processJUnitReport(filename string, tmap map[string][]float64) error {
-	file, err := os.Open(filename)
+	testsuites, err := commonjunit.Read(filename)
 	if err != nil {
-		return err
-	}
-	defer func() { _ = file.Close() }()
-
-	var testsuites junit.Testsuites
-	if err := xml.NewDecoder(file).Decode(&testsuites); err != nil {
 		return err
 	}
 

--- a/tools/optimize-test-sharding/main.go
+++ b/tools/optimize-test-sharding/main.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/dgryski/go-farm"
 	"go.temporal.io/server/tools/common/github"
-	commonjunit "go.temporal.io/server/tools/common/junit"
+	"go.temporal.io/server/tools/common/junit"
 )
 
 const (
@@ -194,7 +194,7 @@ func loadTestData(dir string) (map[string][]float64, error) {
 }
 
 func processJUnitReport(filename string, tmap map[string][]float64) error {
-	testsuites, err := commonjunit.Read(filename)
+	testsuites, err := junit.Read(filename)
 	if err != nil {
 		return err
 	}

--- a/tools/testrunner/junit.go
+++ b/tools/testrunner/junit.go
@@ -1,12 +1,9 @@
 package testrunner
 
 import (
-	"encoding/xml"
 	"errors"
 	"fmt"
 	"iter"
-	"log"
-	"os"
 	"slices"
 	"strings"
 
@@ -33,22 +30,7 @@ const (
 
 type junitReport struct {
 	junit.Testsuites
-	path          string
 	reportingErrs []error
-}
-
-func (j *junitReport) read() error {
-	f, err := os.Open(j.path)
-	if err != nil {
-		return fmt.Errorf("failed to open junit report file: %w", err)
-	}
-	defer f.Close()
-
-	decoder := xml.NewDecoder(f)
-	if err = decoder.Decode(&j.Testsuites); err != nil {
-		return fmt.Errorf("failed to read junit report file: %w", err)
-	}
-	return nil
 }
 
 // generateReport builds a JUnit report for failures that the runner
@@ -81,22 +63,6 @@ func generateFailure(kind failureType, data string) *junit.Result {
 		Type:    string(kind),
 		Data:    data,
 	}
-}
-
-func (j *junitReport) write() error {
-	f, err := os.Create(j.path)
-	if err != nil {
-		return fmt.Errorf("failed to open junit report file: %w", err)
-	}
-	defer f.Close()
-
-	encoder := xml.NewEncoder(f)
-	encoder.Indent("", "    ")
-	if err = encoder.Encode(j.Testsuites); err != nil {
-		return fmt.Errorf("failed to write junit report file: %w", err)
-	}
-	log.Printf("wrote junit report to %s", j.path)
-	return nil
 }
 
 // appendSyntheticFailure adds a failure entry under a "testrunner" suite for

--- a/tools/testrunner/junit.go
+++ b/tools/testrunner/junit.go
@@ -7,7 +7,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/jstemmer/go-junit-report/v2/junit"
+	"go.temporal.io/server/tools/common/junit"
 )
 
 // alertsSuiteName is the JUnit suite name used for structural alerts (data

--- a/tools/testrunner/junit.go
+++ b/tools/testrunner/junit.go
@@ -33,6 +33,14 @@ type junitReport struct {
 	reportingErrs []error
 }
 
+func readReport(path string) (*junitReport, error) {
+	testsuites, err := junit.Read(path)
+	if err != nil {
+		return nil, err
+	}
+	return &junitReport{Testsuites: *testsuites}, nil
+}
+
 // generateReport builds a JUnit report for failures that the runner
 // derives itself, such as timeouts and crashes. Failure.Type stores the
 // canonical failure type (for example TIMEOUT or CRASH), and Failure.Data is

--- a/tools/testrunner/junit_test.go
+++ b/tools/testrunner/junit_test.go
@@ -314,7 +314,6 @@ func TestJUnitXMLWellFormed(t *testing.T) {
 			// Additional validation: ensure we can re-parse it using our own read method
 			testsuites, err := commonjunit.Read(out.Name())
 			require.NoError(t, err, "Should be able to re-read the written XML")
-			require.NotEmpty(t, testsuites.Suites)
 
 			// Validate that the structure is reasonable
 			require.NotEmpty(t, parsed.Suites, "Should have at least one test suite")

--- a/tools/testrunner/junit_test.go
+++ b/tools/testrunner/junit_test.go
@@ -322,7 +322,7 @@ func TestJUnitXMLWellFormed(t *testing.T) {
 
 func mustReadReportFixture(t *testing.T, path string) *junitReport {
 	t.Helper()
-	testsuites, err := junit.Read(path)
+	report, err := readReport(path)
 	require.NoError(t, err)
-	return &junitReport{Testsuites: *testsuites}
+	return report
 }

--- a/tools/testrunner/junit_test.go
+++ b/tools/testrunner/junit_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/jstemmer/go-junit-report/v2/junit"
 	"github.com/stretchr/testify/require"
 	commonjunit "go.temporal.io/server/tools/common/junit"
 )
@@ -213,7 +212,7 @@ func TestMergeReports_PreservesOriginalFailureDataWhenExtractionFindsNothing(t *
 	require.Equal(t, "plain failure output with no recognizable block", merged.Suites[0].Testcases[0].Failure.Data)
 }
 
-func collectTestNames(suites []junit.Testsuite) []string {
+func collectTestNames(suites []commonjunit.Testsuite) []string {
 	var testNames []string
 	for _, suite := range suites {
 		for _, test := range suite.Testcases {
@@ -307,12 +306,12 @@ func TestJUnitXMLWellFormed(t *testing.T) {
 			require.NoError(t, err)
 
 			// Validate that the content is well-formed XML
-			var parsed junit.Testsuites
+			var parsed commonjunit.Testsuites
 			err = xml.Unmarshal(content, &parsed)
 			require.NoError(t, err, "Written XML should be well-formed and parseable")
 
 			// Additional validation: ensure we can re-parse it using our own read method
-			testsuites, err := commonjunit.Read(out.Name())
+			_, err = commonjunit.Read(out.Name())
 			require.NoError(t, err, "Should be able to re-read the written XML")
 
 			// Validate that the structure is reasonable

--- a/tools/testrunner/junit_test.go
+++ b/tools/testrunner/junit_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/jstemmer/go-junit-report/v2/junit"
 	"github.com/stretchr/testify/require"
+	commonjunit "go.temporal.io/server/tools/common/junit"
 )
 
 func TestReadJUnitReport(t *testing.T) {
@@ -29,8 +30,7 @@ func TestGenerateJUnitReportForTimedoutTests(t *testing.T) {
 		"TestCallbacksSuite/TestWorkflowCallbacks_2",
 	}
 	j := generateReport(testNames, "timeout", failureTypeTimeout)
-	j.path = out.Name()
-	require.NoError(t, j.write())
+	require.NoError(t, commonjunit.Write(out.Name(), &j.Testsuites))
 	requireReportEquals(t, "testdata/junit-timeout-output.xml", out.Name())
 }
 
@@ -73,8 +73,7 @@ func TestAppendAlertsSuite(t *testing.T) {
 		require.NoError(t, os.Remove(out.Name()))
 	}()
 
-	j.path = out.Name()
-	require.NoError(t, j.write())
+	require.NoError(t, commonjunit.Write(out.Name(), &j.Testsuites))
 
 	// Compare against the expected output file
 	requireReportEquals(t, "testdata/junit-alerts-output.xml", out.Name())
@@ -300,10 +299,8 @@ func TestJUnitXMLWellFormed(t *testing.T) {
 
 			// Setup the report
 			j := tt.setup()
-			j.path = out.Name()
-
 			// Write the report
-			require.NoError(t, j.write())
+			require.NoError(t, commonjunit.Write(out.Name(), &j.Testsuites))
 
 			// Read the written file
 			content, err := os.ReadFile(out.Name())
@@ -315,8 +312,9 @@ func TestJUnitXMLWellFormed(t *testing.T) {
 			require.NoError(t, err, "Written XML should be well-formed and parseable")
 
 			// Additional validation: ensure we can re-parse it using our own read method
-			j2 := &junitReport{path: out.Name()}
-			require.NoError(t, j2.read(), "Should be able to re-read the written XML")
+			testsuites, err := commonjunit.Read(out.Name())
+			require.NoError(t, err, "Should be able to re-read the written XML")
+			require.NotEmpty(t, testsuites.Suites)
 
 			// Validate that the structure is reasonable
 			require.NotEmpty(t, parsed.Suites, "Should have at least one test suite")
@@ -326,7 +324,7 @@ func TestJUnitXMLWellFormed(t *testing.T) {
 
 func mustReadReportFixture(t *testing.T, path string) *junitReport {
 	t.Helper()
-	report := &junitReport{path: path}
-	require.NoError(t, report.read())
-	return report
+	testsuites, err := commonjunit.Read(path)
+	require.NoError(t, err)
+	return &junitReport{Testsuites: *testsuites}
 }

--- a/tools/testrunner/junit_test.go
+++ b/tools/testrunner/junit_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	commonjunit "go.temporal.io/server/tools/common/junit"
+	"go.temporal.io/server/tools/common/junit"
 )
 
 func TestReadJUnitReport(t *testing.T) {
@@ -29,7 +29,7 @@ func TestGenerateJUnitReportForTimedoutTests(t *testing.T) {
 		"TestCallbacksSuite/TestWorkflowCallbacks_2",
 	}
 	j := generateReport(testNames, "timeout", failureTypeTimeout)
-	require.NoError(t, commonjunit.Write(out.Name(), &j.Testsuites))
+	require.NoError(t, junit.Write(out.Name(), &j.Testsuites))
 	requireReportEquals(t, "testdata/junit-timeout-output.xml", out.Name())
 }
 
@@ -72,7 +72,7 @@ func TestAppendAlertsSuite(t *testing.T) {
 		require.NoError(t, os.Remove(out.Name()))
 	}()
 
-	require.NoError(t, commonjunit.Write(out.Name(), &j.Testsuites))
+	require.NoError(t, junit.Write(out.Name(), &j.Testsuites))
 
 	// Compare against the expected output file
 	requireReportEquals(t, "testdata/junit-alerts-output.xml", out.Name())
@@ -212,7 +212,7 @@ func TestMergeReports_PreservesOriginalFailureDataWhenExtractionFindsNothing(t *
 	require.Equal(t, "plain failure output with no recognizable block", merged.Suites[0].Testcases[0].Failure.Data)
 }
 
-func collectTestNames(suites []commonjunit.Testsuite) []string {
+func collectTestNames(suites []junit.Testsuite) []string {
 	var testNames []string
 	for _, suite := range suites {
 		for _, test := range suite.Testcases {
@@ -299,19 +299,19 @@ func TestJUnitXMLWellFormed(t *testing.T) {
 			// Setup the report
 			j := tt.setup()
 			// Write the report
-			require.NoError(t, commonjunit.Write(out.Name(), &j.Testsuites))
+			require.NoError(t, junit.Write(out.Name(), &j.Testsuites))
 
 			// Read the written file
 			content, err := os.ReadFile(out.Name())
 			require.NoError(t, err)
 
 			// Validate that the content is well-formed XML
-			var parsed commonjunit.Testsuites
+			var parsed junit.Testsuites
 			err = xml.Unmarshal(content, &parsed)
 			require.NoError(t, err, "Written XML should be well-formed and parseable")
 
 			// Additional validation: ensure we can re-parse it using our own read method
-			_, err = commonjunit.Read(out.Name())
+			_, err = junit.Read(out.Name())
 			require.NoError(t, err, "Should be able to re-read the written XML")
 
 			// Validate that the structure is reasonable
@@ -322,7 +322,7 @@ func TestJUnitXMLWellFormed(t *testing.T) {
 
 func mustReadReportFixture(t *testing.T, path string) *junitReport {
 	t.Helper()
-	testsuites, err := commonjunit.Read(path)
+	testsuites, err := junit.Read(path)
 	require.NoError(t, err)
 	return &junitReport{Testsuites: *testsuites}
 }

--- a/tools/testrunner/testrunner.go
+++ b/tools/testrunner/testrunner.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	commonjunit "go.temporal.io/server/tools/common/junit"
 )
 
 const (
@@ -44,6 +45,7 @@ type attempt struct {
 	runner           *runner
 	number           int
 	exitErr          *exec.ExitError
+	junitPath        string
 	junitReport      *junitReport
 	coverProfilePath string
 }
@@ -53,7 +55,7 @@ func (a *attempt) run(ctx context.Context, args []string) (string, error) {
 		if strings.HasPrefix(arg, coverProfileFlag) {
 			args[i] = coverProfileFlag + a.coverProfilePath
 		} else if strings.HasPrefix(arg, junitReportFlag) {
-			args[i] = junitReportFlag + a.junitReport.path
+			args[i] = junitReportFlag + a.junitPath
 		}
 	}
 	log.Printf("starting test attempt #%d: %v %v",
@@ -193,9 +195,8 @@ func (r *runner) newAttempt() *attempt {
 			strings.TrimSuffix(r.coverProfilePath, codeCoverageExtension),
 			len(r.attempts),
 			codeCoverageExtension),
-		junitReport: &junitReport{
-			path: filepath.Join(os.TempDir(), fmt.Sprintf("temporalio-temporal-%s-junit.xml", uuid.NewString())),
-		},
+		junitPath:   filepath.Join(os.TempDir(), fmt.Sprintf("temporalio-temporal-%s-junit.xml", uuid.NewString())),
+		junitReport: &junitReport{},
 	}
 	r.attempts = append(r.attempts, a)
 	return a
@@ -249,10 +250,10 @@ func Main() {
 // nolint:revive,deep-exit
 func (r *runner) reportCrash() {
 	jr := generateReport([]string{r.crashName}, "crash", failureTypeCrash)
-	jr.path = r.junitOutputPath
-	if err := jr.write(); err != nil {
+	if err := commonjunit.Write(r.junitOutputPath, &jr.Testsuites); err != nil {
 		log.Fatal(err)
 	}
+	log.Printf("wrote junit report to %s", r.junitOutputPath)
 }
 
 func (r *runner) generateSummary() error {
@@ -264,11 +265,11 @@ func (r *runner) generateSummary() error {
 
 	reports := make([]*junitReport, 0, len(paths))
 	for _, path := range paths {
-		report := &junitReport{path: path}
-		if err := report.read(); err != nil {
+		testsuites, err := commonjunit.Read(path)
+		if err != nil {
 			return fmt.Errorf("failed to read junit report %q: %w", path, err)
 		}
-		reports = append(reports, report)
+		reports = append(reports, &junitReport{Testsuites: *testsuites})
 	}
 
 	summary := newSummaryFromReports(reports)
@@ -313,10 +314,11 @@ func (r *runner) writeCurrentReport() {
 	if len(r.alerts) > 0 {
 		merged.appendAlertsSuite(r.alerts)
 	}
-	merged.path = r.junitOutputPath
-	if err := merged.write(); err != nil {
+	if err := commonjunit.Write(r.junitOutputPath, &merged.Testsuites); err != nil {
 		log.Printf("warning: failed to write intermediate report: %v", err)
+		return
 	}
+	log.Printf("wrote junit report to %s", r.junitOutputPath)
 }
 
 // nolint:revive,deep-exit
@@ -340,7 +342,8 @@ func (r *runner) runTests(ctx context.Context, args []string) {
 			log.Printf("total timeout reached, collecting partial results from %d completed attempt(s)", a-1)
 			totalTimeoutFired = true
 			// Try to read whatever gotestsum managed to write before it was killed.
-			if readErr := currentAttempt.junitReport.read(); readErr != nil {
+			testsuites, readErr := commonjunit.Read(currentAttempt.junitPath)
+			if readErr != nil {
 				// gotestsum didn't finish writing a JUnit XML. Fall back to parsing
 				// stdout for any "--- FAIL:" lines that completed before the kill.
 				if failedTests := parseFailedTestsFromOutput(stdout); len(failedTests) > 0 {
@@ -348,6 +351,8 @@ func (r *runner) runTests(ctx context.Context, args []string) {
 				}
 				// If no failed tests are found either, the current attempt's report
 				// remains empty and mergeReports will include only prior attempts.
+			} else {
+				currentAttempt.junitReport.Testsuites = *testsuites
 			}
 			// Without this, a mid-run timeout leaves an empty JUnit and CI shows green.
 			currentAttempt.junitReport.appendSyntheticFailure(
@@ -374,9 +379,11 @@ func (r *runner) runTests(ctx context.Context, args []string) {
 		}
 
 		// All tests were run, parse JUnit XML output.
-		if err = currentAttempt.junitReport.read(); err != nil {
+		testsuites, err := commonjunit.Read(currentAttempt.junitPath)
+		if err != nil {
 			log.Fatal(err)
 		}
+		currentAttempt.junitReport.Testsuites = *testsuites
 
 		// Write intermediate results so they survive if we are killed externally
 		// between attempts (e.g. a GitHub Actions job timeout fires after this
@@ -424,10 +431,10 @@ func (r *runner) runTests(ctx context.Context, args []string) {
 	if len(r.alerts) > 0 {
 		mergedReport.appendAlertsSuite(r.alerts)
 	}
-	mergedReport.path = r.junitOutputPath
-	if err = mergedReport.write(); err != nil {
+	if err = commonjunit.Write(r.junitOutputPath, &mergedReport.Testsuites); err != nil {
 		log.Fatal(err)
 	}
+	log.Printf("wrote junit report to %s", r.junitOutputPath)
 
 	// Skip the strict rerun-coverage check when the total timeout fired: the
 	// in-progress attempt was killed before it could execute all expected tests.

--- a/tools/testrunner/testrunner.go
+++ b/tools/testrunner/testrunner.go
@@ -250,10 +250,9 @@ func Main() {
 // nolint:revive,deep-exit
 func (r *runner) reportCrash() {
 	jr := generateReport([]string{r.crashName}, "crash", failureTypeCrash)
-	if err := commonjunit.Write(r.junitOutputPath, &jr.Testsuites); err != nil {
+	if err := r.writeReport(jr); err != nil {
 		log.Fatal(err)
 	}
-	log.Printf("wrote junit report to %s", r.junitOutputPath)
 }
 
 func (r *runner) generateSummary() error {
@@ -296,6 +295,14 @@ func (r *runner) generateSummary() error {
 	return nil
 }
 
+func (r *runner) writeReport(report *junitReport) error {
+	if err := commonjunit.Write(r.junitOutputPath, &report.Testsuites); err != nil {
+		return err
+	}
+	log.Printf("wrote junit report to %s", r.junitOutputPath)
+	return nil
+}
+
 // writeCurrentReport writes the merged report from all completed attempts to the
 // final output path. It is called after each attempt so that partial results
 // survive if the process is killed externally between attempts.
@@ -314,11 +321,10 @@ func (r *runner) writeCurrentReport() {
 	if len(r.alerts) > 0 {
 		merged.appendAlertsSuite(r.alerts)
 	}
-	if err := commonjunit.Write(r.junitOutputPath, &merged.Testsuites); err != nil {
+	if err := r.writeReport(merged); err != nil {
 		log.Printf("warning: failed to write intermediate report: %v", err)
 		return
 	}
-	log.Printf("wrote junit report to %s", r.junitOutputPath)
 }
 
 // nolint:revive,deep-exit
@@ -431,10 +437,9 @@ func (r *runner) runTests(ctx context.Context, args []string) {
 	if len(r.alerts) > 0 {
 		mergedReport.appendAlertsSuite(r.alerts)
 	}
-	if err = commonjunit.Write(r.junitOutputPath, &mergedReport.Testsuites); err != nil {
+	if err = r.writeReport(mergedReport); err != nil {
 		log.Fatal(err)
 	}
-	log.Printf("wrote junit report to %s", r.junitOutputPath)
 
 	// Skip the strict rerun-coverage check when the total timeout fired: the
 	// in-progress attempt was killed before it could execute all expected tests.

--- a/tools/testrunner/testrunner.go
+++ b/tools/testrunner/testrunner.go
@@ -323,7 +323,6 @@ func (r *runner) writeCurrentReport() {
 	}
 	if err := r.writeReport(merged); err != nil {
 		log.Printf("warning: failed to write intermediate report: %v", err)
-		return
 	}
 }
 

--- a/tools/testrunner/testrunner.go
+++ b/tools/testrunner/testrunner.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	commonjunit "go.temporal.io/server/tools/common/junit"
+	"go.temporal.io/server/tools/common/junit"
 )
 
 const (
@@ -264,7 +264,7 @@ func (r *runner) generateSummary() error {
 
 	reports := make([]*junitReport, 0, len(paths))
 	for _, path := range paths {
-		testsuites, err := commonjunit.Read(path)
+		testsuites, err := junit.Read(path)
 		if err != nil {
 			return fmt.Errorf("failed to read junit report %q: %w", path, err)
 		}
@@ -296,7 +296,7 @@ func (r *runner) generateSummary() error {
 }
 
 func (r *runner) writeReport(report *junitReport) error {
-	if err := commonjunit.Write(r.junitOutputPath, &report.Testsuites); err != nil {
+	if err := junit.Write(r.junitOutputPath, &report.Testsuites); err != nil {
 		return err
 	}
 	log.Printf("wrote junit report to %s", r.junitOutputPath)
@@ -348,7 +348,7 @@ func (r *runner) runTests(ctx context.Context, args []string) {
 			log.Printf("total timeout reached, collecting partial results from %d completed attempt(s)", a-1)
 			totalTimeoutFired = true
 			// Try to read whatever gotestsum managed to write before it was killed.
-			testsuites, readErr := commonjunit.Read(currentAttempt.junitPath)
+			testsuites, readErr := junit.Read(currentAttempt.junitPath)
 			if readErr != nil {
 				// gotestsum didn't finish writing a JUnit XML. Fall back to parsing
 				// stdout for any "--- FAIL:" lines that completed before the kill.
@@ -385,7 +385,7 @@ func (r *runner) runTests(ctx context.Context, args []string) {
 		}
 
 		// All tests were run, parse JUnit XML output.
-		testsuites, err := commonjunit.Read(currentAttempt.junitPath)
+		testsuites, err := junit.Read(currentAttempt.junitPath)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/tools/testrunner/testrunner.go
+++ b/tools/testrunner/testrunner.go
@@ -264,11 +264,11 @@ func (r *runner) generateSummary() error {
 
 	reports := make([]*junitReport, 0, len(paths))
 	for _, path := range paths {
-		testsuites, err := junit.Read(path)
+		report, err := readReport(path)
 		if err != nil {
 			return fmt.Errorf("failed to read junit report %q: %w", path, err)
 		}
-		reports = append(reports, &junitReport{Testsuites: *testsuites})
+		reports = append(reports, report)
 	}
 
 	summary := newSummaryFromReports(reports)
@@ -347,7 +347,7 @@ func (r *runner) runTests(ctx context.Context, args []string) {
 			log.Printf("total timeout reached, collecting partial results from %d completed attempt(s)", a-1)
 			totalTimeoutFired = true
 			// Try to read whatever gotestsum managed to write before it was killed.
-			testsuites, readErr := junit.Read(currentAttempt.junitPath)
+			report, readErr := readReport(currentAttempt.junitPath)
 			if readErr != nil {
 				// gotestsum didn't finish writing a JUnit XML. Fall back to parsing
 				// stdout for any "--- FAIL:" lines that completed before the kill.
@@ -357,7 +357,7 @@ func (r *runner) runTests(ctx context.Context, args []string) {
 				// If no failed tests are found either, the current attempt's report
 				// remains empty and mergeReports will include only prior attempts.
 			} else {
-				currentAttempt.junitReport.Testsuites = *testsuites
+				currentAttempt.junitReport = report
 			}
 			// Without this, a mid-run timeout leaves an empty JUnit and CI shows green.
 			currentAttempt.junitReport.appendSyntheticFailure(
@@ -384,11 +384,11 @@ func (r *runner) runTests(ctx context.Context, args []string) {
 		}
 
 		// All tests were run, parse JUnit XML output.
-		testsuites, err := junit.Read(currentAttempt.junitPath)
+		report, err := readReport(currentAttempt.junitPath)
 		if err != nil {
 			log.Fatal(err)
 		}
-		currentAttempt.junitReport.Testsuites = *testsuites
+		currentAttempt.junitReport = report
 
 		// Write intermediate results so they survive if we are killed externally
 		// between attempts (e.g. a GitHub Actions job timeout fires after this

--- a/tools/testrunner/testrunner_test.go
+++ b/tools/testrunner/testrunner_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	commonjunit "go.temporal.io/server/tools/common/junit"
+	"go.temporal.io/server/tools/common/junit"
 )
 
 func TestRunnerSanitizeAndParseArgs(t *testing.T) {
@@ -197,7 +197,7 @@ func TestWriteCurrentReport(t *testing.T) {
 
 	r.writeCurrentReport()
 
-	testsuites, err := commonjunit.Read(out.Name())
+	testsuites, err := junit.Read(out.Name())
 	require.NoError(t, err)
 	result := &junitReport{Testsuites: *testsuites}
 	require.Equal(t, 2, result.Failures)
@@ -212,7 +212,7 @@ func TestWriteCurrentReport(t *testing.T) {
 
 	r.writeCurrentReport()
 
-	testsuites, err = commonjunit.Read(out.Name())
+	testsuites, err = junit.Read(out.Name())
 	require.NoError(t, err)
 	result2 := &junitReport{Testsuites: *testsuites}
 	require.Equal(t, 4, result2.Failures) // 2 from attempt 1 + 2 from attempt 2
@@ -241,13 +241,13 @@ func TestRunnerPrintSummary(t *testing.T) {
 	report1.Suites[0].Testcases[0].Name = "TestAlpha"
 	report1.Suites[0].Testcases[0].Failure.Type = string(failureTypeFailed)
 	report1.Suites[0].Testcases[0].Failure.Data = "alpha failure"
-	require.NoError(t, commonjunit.Write(filepath.Join(dir, "junit.alpha.xml"), &report1.Testsuites))
+	require.NoError(t, junit.Write(filepath.Join(dir, "junit.alpha.xml"), &report1.Testsuites))
 	report2 := mustReadReportFixture(t, "testdata/junit-single-failure.xml")
 	report2.Suites[0].Name = "SuiteB"
 	report2.Suites[0].Testcases[0].Name = "TestBeta"
 	report2.Suites[0].Testcases[0].Failure.Type = string(failureTypeFailed)
 	report2.Suites[0].Testcases[0].Failure.Data = "beta failure"
-	require.NoError(t, commonjunit.Write(filepath.Join(dir, "junit.beta.xml"), &report2.Testsuites))
+	require.NoError(t, junit.Write(filepath.Join(dir, "junit.beta.xml"), &report2.Testsuites))
 
 	r := newRunner()
 	summaryMarkdownPath := filepath.Join(dir, "test-summary.md")
@@ -274,7 +274,7 @@ func TestRunnerPrintSummary(t *testing.T) {
 func TestRunnerPrintSummarySkipsEmptySummary(t *testing.T) {
 	dir := t.TempDir()
 	report := mustReadReportFixture(t, "testdata/junit-empty.xml")
-	require.NoError(t, commonjunit.Write(filepath.Join(dir, "junit.empty.xml"), &report.Testsuites))
+	require.NoError(t, junit.Write(filepath.Join(dir, "junit.empty.xml"), &report.Testsuites))
 
 	r := newRunner()
 	_, err := r.sanitizeAndParseArgs(summaryCommand, []string{

--- a/tools/testrunner/testrunner_test.go
+++ b/tools/testrunner/testrunner_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	commonjunit "go.temporal.io/server/tools/common/junit"
 )
 
 func TestRunnerSanitizeAndParseArgs(t *testing.T) {
@@ -196,8 +197,9 @@ func TestWriteCurrentReport(t *testing.T) {
 
 	r.writeCurrentReport()
 
-	result := &junitReport{path: out.Name()}
-	require.NoError(t, result.read())
+	testsuites, err := commonjunit.Read(out.Name())
+	require.NoError(t, err)
+	result := &junitReport{Testsuites: *testsuites}
 	require.Equal(t, 2, result.Failures)
 	require.Len(t, result.Suites, 1)
 
@@ -210,8 +212,9 @@ func TestWriteCurrentReport(t *testing.T) {
 
 	r.writeCurrentReport()
 
-	result2 := &junitReport{path: out.Name()}
-	require.NoError(t, result2.read())
+	testsuites, err = commonjunit.Read(out.Name())
+	require.NoError(t, err)
+	result2 := &junitReport{Testsuites: *testsuites}
 	require.Equal(t, 4, result2.Failures) // 2 from attempt 1 + 2 from attempt 2
 	require.Len(t, result2.Suites, 2)
 }
@@ -238,15 +241,13 @@ func TestRunnerPrintSummary(t *testing.T) {
 	report1.Suites[0].Testcases[0].Name = "TestAlpha"
 	report1.Suites[0].Testcases[0].Failure.Type = string(failureTypeFailed)
 	report1.Suites[0].Testcases[0].Failure.Data = "alpha failure"
-	report1.path = filepath.Join(dir, "junit.alpha.xml")
-	require.NoError(t, report1.write())
+	require.NoError(t, commonjunit.Write(filepath.Join(dir, "junit.alpha.xml"), &report1.Testsuites))
 	report2 := mustReadReportFixture(t, "testdata/junit-single-failure.xml")
 	report2.Suites[0].Name = "SuiteB"
 	report2.Suites[0].Testcases[0].Name = "TestBeta"
 	report2.Suites[0].Testcases[0].Failure.Type = string(failureTypeFailed)
 	report2.Suites[0].Testcases[0].Failure.Data = "beta failure"
-	report2.path = filepath.Join(dir, "junit.beta.xml")
-	require.NoError(t, report2.write())
+	require.NoError(t, commonjunit.Write(filepath.Join(dir, "junit.beta.xml"), &report2.Testsuites))
 
 	r := newRunner()
 	summaryMarkdownPath := filepath.Join(dir, "test-summary.md")
@@ -273,8 +274,7 @@ func TestRunnerPrintSummary(t *testing.T) {
 func TestRunnerPrintSummarySkipsEmptySummary(t *testing.T) {
 	dir := t.TempDir()
 	report := mustReadReportFixture(t, "testdata/junit-empty.xml")
-	report.path = filepath.Join(dir, "junit.empty.xml")
-	require.NoError(t, report.write())
+	require.NoError(t, commonjunit.Write(filepath.Join(dir, "junit.empty.xml"), &report.Testsuites))
 
 	r := newRunner()
 	_, err := r.sanitizeAndParseArgs(summaryCommand, []string{

--- a/tools/testrunner/testrunner_test.go
+++ b/tools/testrunner/testrunner_test.go
@@ -197,9 +197,8 @@ func TestWriteCurrentReport(t *testing.T) {
 
 	r.writeCurrentReport()
 
-	testsuites, err := junit.Read(out.Name())
+	result, err := readReport(out.Name())
 	require.NoError(t, err)
-	result := &junitReport{Testsuites: *testsuites}
 	require.Equal(t, 2, result.Failures)
 	require.Len(t, result.Suites, 1)
 
@@ -212,9 +211,8 @@ func TestWriteCurrentReport(t *testing.T) {
 
 	r.writeCurrentReport()
 
-	testsuites, err = junit.Read(out.Name())
+	result2, err := readReport(out.Name())
 	require.NoError(t, err)
-	result2 := &junitReport{Testsuites: *testsuites}
 	require.Equal(t, 4, result2.Failures) // 2 from attempt 1 + 2 from attempt 2
 	require.Len(t, result2.Suites, 2)
 }


### PR DESCRIPTION
## What changed?
Extract generic JUnit XML file reading and writing into `tools/common/junit`.

## Why?

Centralizing format-level JUnit handling.