### PR TITLE
Cleanup/consolidate completionHandler test infra

### DIFF
--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -27,7 +26,6 @@ import (
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
 	commonnexus "go.temporal.io/server/common/nexus"
-	"go.temporal.io/server/common/nexus/nexusrpc"
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/retrypolicy"
@@ -9861,15 +9859,6 @@ func (env *standaloneActivityEnv) startActivityWithType(ctx context.Context, act
 	})
 }
 
-func (env *standaloneActivityEnv) runNexusCompletionHTTPServer(t *testing.T, h *completionHandler) string {
-	hh := nexusrpc.NewCompletionHTTPHandler(nexusrpc.CompletionHandlerOptions{Handler: h})
-	srv := httptest.NewServer(hh)
-	t.Cleanup(func() {
-		srv.Close()
-	})
-	return srv.URL
-}
-
 func (s *standaloneActivityTestSuite) TestCallbacks() {
 	env := s.newTestEnv()
 	t := s.T()
@@ -10004,15 +9993,7 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		ch := &completionHandler{
-			requestCh:         make(chan *nexusrpc.CompletionRequest, 1),
-			requestCompleteCh: make(chan error, 1),
-		}
-		defer func() {
-			close(ch.requestCh)
-			close(ch.requestCompleteCh)
-		}()
-		callbackAddress := env.runNexusCompletionHTTPServer(t, ch)
+		ch, callbackAddress := newNexusCompletionHandler(t)
 
 		_, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
 			Namespace:    env.Namespace().String(),
@@ -10075,15 +10056,7 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		ch := &completionHandler{
-			requestCh:         make(chan *nexusrpc.CompletionRequest, 1),
-			requestCompleteCh: make(chan error, 1),
-		}
-		defer func() {
-			close(ch.requestCh)
-			close(ch.requestCompleteCh)
-		}()
-		callbackAddress := env.runNexusCompletionHTTPServer(t, ch)
+		ch, callbackAddress := newNexusCompletionHandler(t)
 
 		_, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
 			Namespace:    env.Namespace().String(),
@@ -10149,15 +10122,7 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		ch := &completionHandler{
-			requestCh:         make(chan *nexusrpc.CompletionRequest, 1),
-			requestCompleteCh: make(chan error, 1),
-		}
-		defer func() {
-			close(ch.requestCh)
-			close(ch.requestCompleteCh)
-		}()
-		callbackAddress := env.runNexusCompletionHTTPServer(t, ch)
+		ch, callbackAddress := newNexusCompletionHandler(t)
 
 		startResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
 			Namespace:    env.Namespace().String(),
@@ -10224,15 +10189,7 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		ch := &completionHandler{
-			requestCh:         make(chan *nexusrpc.CompletionRequest, 1),
-			requestCompleteCh: make(chan error, 1),
-		}
-		defer func() {
-			close(ch.requestCh)
-			close(ch.requestCompleteCh)
-		}()
-		callbackAddress := env.runNexusCompletionHTTPServer(t, ch)
+		ch, callbackAddress := newNexusCompletionHandler(t)
 
 		_, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
 			Namespace:    env.Namespace().String(),
@@ -10306,15 +10263,7 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		activityID := testcore.RandomizeStr(t.Name())
 		taskQueue := testcore.RandomizeStr(t.Name())
 
-		ch := &completionHandler{
-			requestCh:         make(chan *nexusrpc.CompletionRequest, 1),
-			requestCompleteCh: make(chan error, 1),
-		}
-		defer func() {
-			close(ch.requestCh)
-			close(ch.requestCompleteCh)
-		}()
-		callbackAddress := env.runNexusCompletionHTTPServer(t, ch)
+		ch, callbackAddress := newNexusCompletionHandler(t)
 
 		_, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
 			Namespace:    env.Namespace().String(),
@@ -10409,15 +10358,6 @@ func (s *standaloneActivityTestSuite) TestCallbacksDisabled() {
 		})
 		require.ErrorContains(t, err, "completion callbacks are not enabled for this namespace")
 	})
-}
-
-func (s *standaloneActivityTestSuite) runNexusCompletionHTTPServer(t *testing.T, h *completionHandler) string {
-	hh := nexusrpc.NewCompletionHTTPHandler(nexusrpc.CompletionHandlerOptions{Handler: h})
-	srv := httptest.NewServer(hh)
-	t.Cleanup(func() {
-		srv.Close()
-	})
-	return srv.URL
 }
 
 func (s *standaloneActivityTestSuite) TestPauseActivityExecution() {

--- a/tests/callbacks_migration_test.go
+++ b/tests/callbacks_migration_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -15,7 +14,6 @@ import (
 	"go.temporal.io/sdk/workflow"
 	"go.temporal.io/server/chasm/lib/callback"
 	"go.temporal.io/server/common/dynamicconfig"
-	"go.temporal.io/server/common/nexus/nexusrpc"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/tests/testcore"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -41,15 +39,6 @@ func (s *CallbacksMigrationSuite) newTestEnv() *testcore.TestEnv {
 	)
 }
 
-func (s *CallbacksMigrationSuite) runNexusCompletionHTTPServer(h *completionHandler) string {
-	hh := nexusrpc.NewCompletionHTTPHandler(nexusrpc.CompletionHandlerOptions{Handler: h})
-	srv := httptest.NewServer(hh)
-	s.T().Cleanup(func() {
-		srv.Close()
-	})
-	return srv.URL
-}
-
 // TODO (seankane): This test can be removed once CHASM callbacks are the default
 func (s *CallbacksMigrationSuite) TestWorkflowCallbacks_CHASM_Enabled_Mid_WF() {
 	// This test verifies that when CHASM is enabled mid-workflow, callbacks still work correctly.
@@ -67,15 +56,7 @@ func (s *CallbacksMigrationSuite) TestWorkflowCallbacks_CHASM_Enabled_Mid_WF() {
 	workflowType := "blockingWorkflow"
 	workflowID := env.Tv().WorkflowID()
 
-	ch := &completionHandler{
-		requestCh:         make(chan *nexusrpc.CompletionRequest, 1),
-		requestCompleteCh: make(chan error, 1),
-	}
-	defer func() {
-		close(ch.requestCh)
-		close(ch.requestCompleteCh)
-	}()
-	callbackAddress := s.runNexusCompletionHTTPServer(ch)
+	ch, callbackAddress := newNexusCompletionHandler(s.T())
 
 	// Register workflow that blocks until it receives a signal
 	blockingWorkflow := func(ctx workflow.Context) (int, error) {
@@ -180,15 +161,7 @@ func (s *CallbacksMigrationSuite) TestWorkflowCallbacks_CHASM_Disabled_Mid_WF() 
 	workflowType := "blockingWorkflow"
 	workflowID := env.Tv().WorkflowID()
 
-	ch := &completionHandler{
-		requestCh:         make(chan *nexusrpc.CompletionRequest, 1),
-		requestCompleteCh: make(chan error, 1),
-	}
-	defer func() {
-		close(ch.requestCh)
-		close(ch.requestCompleteCh)
-	}()
-	callbackAddress := s.runNexusCompletionHTTPServer(ch)
+	ch, callbackAddress := newNexusCompletionHandler(s.T())
 
 	// Register workflow that blocks until it receives a signal
 	blockingWorkflow := func(ctx workflow.Context) (int, error) {
@@ -286,23 +259,8 @@ func (s *CallbacksMigrationSuite) TestWorkflowCallbacks_MixedCallbacks() {
 	workflowType := "blockingWorkflow"
 	workflowID := env.Tv().WorkflowID()
 
-	ch1 := &completionHandler{
-		requestCh:         make(chan *nexusrpc.CompletionRequest, 1),
-		requestCompleteCh: make(chan error, 1),
-	}
-	ch2 := &completionHandler{
-		requestCh:         make(chan *nexusrpc.CompletionRequest, 1),
-		requestCompleteCh: make(chan error, 1),
-	}
-	defer func() {
-		close(ch1.requestCh)
-		close(ch1.requestCompleteCh)
-		close(ch2.requestCh)
-		close(ch2.requestCompleteCh)
-	}()
-
-	callbackAddress1 := s.runNexusCompletionHTTPServer(ch1)
-	callbackAddress2 := s.runNexusCompletionHTTPServer(ch2)
+	ch1, callbackAddress1 := newNexusCompletionHandler(s.T())
+	ch2, callbackAddress2 := newNexusCompletionHandler(s.T())
 
 	// Register workflow that blocks until it receives a signal
 	blockingWorkflow := func(ctx workflow.Context) (int, error) {

--- a/tests/callbacks_test.go
+++ b/tests/callbacks_test.go
@@ -1,9 +1,7 @@
 package tests
 
 import (
-	"context"
 	"errors"
-	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -22,7 +20,6 @@ import (
 	"go.temporal.io/server/chasm/lib/callback"
 	"go.temporal.io/server/common/dynamicconfig"
 	commonnexus "go.temporal.io/server/common/nexus"
-	"go.temporal.io/server/common/nexus/nexusrpc"
 	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/common/testing/protoassert"
@@ -31,39 +28,6 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
-
-// completionHandler is a nexusrpc completion handler that hands each delivered completion to the
-// test on requestCh, then waits on requestCompleteCh for the error to return to the caller.
-type completionHandler struct {
-	requestCh         chan *nexusrpc.CompletionRequest
-	requestCompleteCh chan error
-}
-
-func (h *completionHandler) CompleteOperation(ctx context.Context, request *nexusrpc.CompletionRequest) error {
-	h.requestCh <- request
-	return <-h.requestCompleteCh
-}
-
-// newNexusCompletionHandler returns a completion handler along with the URL of an HTTP server that
-// delivers completions to it, for use as the target of a completion callback. The server shuts
-// down when t cleans up.
-func newNexusCompletionHandler(t *testing.T) (*completionHandler, string) {
-	// Buffered so tests can queue up multiple completion requests for convenience.
-	ch := &completionHandler{
-		requestCh:         make(chan *nexusrpc.CompletionRequest, 4),
-		requestCompleteCh: make(chan error, 4),
-	}
-
-	httpHandler := nexusrpc.CompletionHandlerOptions{Handler: ch}
-	srv := httptest.NewServer(nexusrpc.NewCompletionHTTPHandler(httpHandler))
-
-	t.Cleanup(func() {
-		// Unblock any handler still waiting on a response; srv.Close waits for in-flight requests.
-		close(ch.requestCompleteCh)
-		srv.Close()
-	})
-	return ch, srv.URL
-}
 
 type CallbacksSuite struct {
 	parallelsuite.Suite[*CallbacksSuite]

--- a/tests/callbacks_test.go
+++ b/tests/callbacks_test.go
@@ -32,6 +32,8 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
+// completionHandler is a nexusrpc completion handler that hands each delivered completion to the
+// test on requestCh, then waits on requestCompleteCh for the error to return to the caller.
 type completionHandler struct {
 	requestCh         chan *nexusrpc.CompletionRequest
 	requestCompleteCh chan error
@@ -40,6 +42,27 @@ type completionHandler struct {
 func (h *completionHandler) CompleteOperation(ctx context.Context, request *nexusrpc.CompletionRequest) error {
 	h.requestCh <- request
 	return <-h.requestCompleteCh
+}
+
+// newNexusCompletionHandler returns a completion handler along with the URL of an HTTP server that
+// delivers completions to it, for use as the target of a completion callback. The server shuts
+// down when t cleans up.
+func newNexusCompletionHandler(t *testing.T) (*completionHandler, string) {
+	// Buffered so tests can queue up multiple completion requests for convenience.
+	ch := &completionHandler{
+		requestCh:         make(chan *nexusrpc.CompletionRequest, 4),
+		requestCompleteCh: make(chan error, 4),
+	}
+
+	httpHandler := nexusrpc.CompletionHandlerOptions{Handler: ch}
+	srv := httptest.NewServer(nexusrpc.NewCompletionHTTPHandler(httpHandler))
+
+	t.Cleanup(func() {
+		// Unblock any handler still waiting on a response; srv.Close waits for in-flight requests.
+		close(ch.requestCompleteCh)
+		srv.Close()
+	})
+	return ch, srv.URL
 }
 
 type CallbacksSuite struct {
@@ -55,15 +78,6 @@ func TestCallbacksSuiteCHASM(t *testing.T) {
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMCallbacks, true),
 	})
-}
-
-func (s *CallbacksSuite) runNexusCompletionHTTPServer(t *testing.T, h *completionHandler) string {
-	hh := nexusrpc.NewCompletionHTTPHandler(nexusrpc.CompletionHandlerOptions{Handler: h})
-	srv := httptest.NewServer(hh)
-	t.Cleanup(func() {
-		srv.Close()
-	})
-	return srv.URL
 }
 
 func (s *CallbacksSuite) newTestEnv(opts ...testcore.TestOption) *testcore.TestEnv {
@@ -322,15 +336,7 @@ func (s *CallbacksSuite) TestWorkflowNexusCallbacks_CarriedOver(opts []testcore.
 			workflowType := "test"
 			workflowID := env.Tv().WorkflowID()
 
-			ch := &completionHandler{
-				requestCh:         make(chan *nexusrpc.CompletionRequest, 2),
-				requestCompleteCh: make(chan error, 2),
-			}
-			defer func() {
-				close(ch.requestCh)
-				close(ch.requestCompleteCh)
-			}()
-			callbackAddress := s.runNexusCompletionHTTPServer(s.T(), ch)
+			ch, callbackAddress := newNexusCompletionHandler(s.T())
 
 			env.SdkWorker().RegisterWorkflowWithOptions(tc.wf, workflow.RegisterOptions{Name: workflowType})
 
@@ -523,15 +529,7 @@ func (s *CallbacksSuite) TestNexusResetWorkflowWithCallback(opts []testcore.Test
 	taskQueue := &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL}
 	workflowID := env.Tv().WorkflowID()
 
-	ch := &completionHandler{
-		requestCh:         make(chan *nexusrpc.CompletionRequest, 2),
-		requestCompleteCh: make(chan error, 2),
-	}
-	defer func() {
-		close(ch.requestCh)
-		close(ch.requestCompleteCh)
-	}()
-	callbackAddress := s.runNexusCompletionHTTPServer(s.T(), ch)
+	ch, callbackAddress := newNexusCompletionHandler(s.T())
 
 	// A workflow that completes once it has been reset.
 	longRunningWorkflow := func(ctx workflow.Context) error {
@@ -707,15 +705,7 @@ func (s *CallbacksSuite) TestNexusResetWorkflowWithCallback_ResetToNotBaseRun(op
 	taskQueue := &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL}
 	workflowID := env.Tv().WorkflowID()
 
-	ch := &completionHandler{
-		requestCh:         make(chan *nexusrpc.CompletionRequest, 1),
-		requestCompleteCh: make(chan error, 1),
-	}
-	defer func() {
-		close(ch.requestCh)
-		close(ch.requestCompleteCh)
-	}()
-	callbackAddress := s.runNexusCompletionHTTPServer(s.T(), ch)
+	ch, callbackAddress := newNexusCompletionHandler(s.T())
 
 	env.SdkWorker().RegisterWorkflow(blockingWorkflow)
 

--- a/tests/nexus_test_base.go
+++ b/tests/nexus_test_base.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"context"
 	"errors"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/google/uuid"
@@ -345,4 +346,55 @@ func (env *NexusTestEnv) respondNexusTaskCompletedWithOperationError(ctx context
 		return err
 	}
 	return nil
+}
+
+// completionHandler is a nexusrpc completion handler that hands each delivered completion to the
+// test on requestCh, then waits on requestCompleteCh for the error to return to the caller.
+type completionHandler struct {
+	requestCh         chan *nexusrpc.CompletionRequest
+	requestCompleteCh chan error
+	doneCh            chan struct{}
+}
+
+func (h *completionHandler) CompleteOperation(ctx context.Context, request *nexusrpc.CompletionRequest) error {
+	// Push the request to the requests channel.
+	select {
+	case h.requestCh <- request:
+	case <-h.doneCh:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	// Pull from the rsponse channel.
+	select {
+	case err := <-h.requestCompleteCh:
+		return err
+	case <-h.doneCh:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// newNexusCompletionHandler returns a completion handler along with the URL of an HTTP server that
+// delivers completions to it, for use as the target of a completion callback. The server shuts
+// down when t cleans up.
+func newNexusCompletionHandler(t *testing.T) (*completionHandler, string) {
+	// Buffered so the server can deliver several completions (or retries) before the test drains them.
+	ch := &completionHandler{
+		requestCh:         make(chan *nexusrpc.CompletionRequest, 4),
+		requestCompleteCh: make(chan error, 4),
+		doneCh:            make(chan struct{}),
+	}
+
+	httpHandler := nexusrpc.CompletionHandlerOptions{Handler: ch}
+	srv := httptest.NewServer(nexusrpc.NewCompletionHTTPHandler(httpHandler))
+
+	t.Cleanup(func() {
+		// Unblock any calls to CompleteOperation; srv.Close waits for in-flight requests.
+		close(ch.doneCh)
+		srv.Close()
+	})
+	return ch, srv.URL
 }

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -32,7 +31,6 @@ import (
 	schedulerpb "go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/headers"
-	"go.temporal.io/server/common/nexus/nexusrpc"
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/primitives"
@@ -2624,20 +2622,7 @@ func testResetWithAdditionalCallback(t *testing.T, newContext contextFactory, en
 	wid := "sched-test-reset-extra-cb-wf"
 	wt := "sched-test-reset-extra-cb-wt"
 
-	ch := &completionHandler{
-		requestCh:         make(chan *nexusrpc.CompletionRequest, 1),
-		requestCompleteCh: make(chan error, 1),
-	}
-	defer func() {
-		close(ch.requestCh)
-		close(ch.requestCompleteCh)
-	}()
-	secondCallbackURL := func() string {
-		hh := nexusrpc.NewCompletionHTTPHandler(nexusrpc.CompletionHandlerOptions{Handler: ch})
-		srv := httptest.NewServer(hh)
-		t.Cleanup(func() { srv.Close() })
-		return srv.URL + "/callback"
-	}()
+	ch, secondCallbackURL := newNexusCompletionHandler(t)
 
 	s.SdkWorker().RegisterWorkflowWithOptions(func(ctx workflow.Context) error {
 		sigCh := workflow.GetSignalChannel(ctx, "complete")


### PR DESCRIPTION
## What changed?

When trying to clean up some PRs for worker callbacks, I noticed some unnecessary duplication and cruft in our testcases for completion handlers.

Essentially it's this:
<img width="567" height="216" alt="image" src="https://github.com/user-attachments/assets/c64b759c-c5be-4fc3-a346-92cf77e1f6db" />

Rather than having N places where we construct a `completionHandler` and several implementations of spinning up an `httptest` webserver, we now just have a single `newNexusCompletionHandler` function that does both.

## Why?

Remove boilerplate, making tests more concise and easier to read.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

If there was some subtle behavioral change this could undermine our testing.