### PR TITLE
Reuse one persistence factory during server initialization

### DIFF
--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -390,6 +390,7 @@ func (s *ServerFx) provideBootstrapPersistenceFactory(
 // This function should be called only once, Server doesn't support multiple restarts.
 func (s *ServerFx) Start() error {
 	err := s.app.Start(context.Background())
+	// Release bootstrap persistence when service startup returns; running services use their own factories.
 	s.closeBootstrapPersistenceFactory()
 	if err != nil {
 		return err
@@ -706,7 +707,7 @@ func ApplyClusterMetadataConfigProvider(
 	if err != nil {
 		return svc.ClusterMetadata, svc.Persistence, fmt.Errorf("error initializing cluster metadata manager: %w", err)
 	}
-	// The manager borrows persistence resources that are closed with the factory.
+	// Do not close the manager here because the factory owns and closes its persistence resources.
 
 	visCSAOverride := map[enumspb.IndexedValueType]int{}
 	for tpName, value := range svc.Visibility.PersistenceCustomSearchAttributes {

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -709,7 +709,6 @@ func ApplyClusterMetadataConfigProvider(
 	if err != nil {
 		return svc.ClusterMetadata, svc.Persistence, fmt.Errorf("error initializing cluster metadata manager: %w", err)
 	}
-	defer clusterMetadataManager.Close()
 
 	visCSAOverride := map[enumspb.IndexedValueType]int{}
 	for tpName, value := range svc.Visibility.PersistenceCustomSearchAttributes {

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -135,18 +135,6 @@ type (
 		TestHooks                  testhooks.TestHooks
 		EventLoggerProvider        otellog.LoggerProvider
 	}
-
-	bootstrapPersistenceFactoryParams struct {
-		fx.In
-
-		Config                     *config.Config
-		ServiceResolver            resolver.ServiceResolver
-		CustomDataStoreFactory     persistenceClient.AbstractDataStoreFactory
-		Logger                     log.Logger
-		MetricsHandler             metrics.Handler
-		PersistenceFactoryProvider persistenceClient.FactoryProviderFn
-		Serializer                 serialization.Serializer
-	}
 )
 
 var (
@@ -184,10 +172,8 @@ func NewServerFx(topLevelModule fx.Option, opts ...ServerOption) (server *Server
 	s.app = fx.New(
 		topLevelModule,
 		fx.Supply(opts),
-		fx.Provide(func(params bootstrapPersistenceFactoryParams) persistenceClient.Factory {
-			s.bootstrapPersistenceFactory = newBootstrapPersistenceFactory(params)
-			return s.bootstrapPersistenceFactory
-		}),
+		// Record ownership when Fx constructs the factory so it can be closed if a later invoke fails.
+		fx.Provide(s.provideBootstrapPersistenceFactory),
 		fx.Populate(&s.startupSynchronizationMode),
 		fx.Populate(&s.logger),
 	)
@@ -199,9 +185,12 @@ func NewServerFx(topLevelModule fx.Option, opts ...ServerOption) (server *Server
 
 func ServerOptionsProvider(opts []ServerOption) (serverOptionsProvider, error) {
 	so := newServerOptions(opts)
-	if err := so.loadAndValidate(); err != nil {
+
+	err := so.loadAndValidate()
+	if err != nil {
 		return serverOptionsProvider{}, err
 	}
+
 	// Logger
 	logger := so.logger
 	if logger == nil {
@@ -209,7 +198,7 @@ func ServerOptionsProvider(opts []ServerOption) (serverOptionsProvider, error) {
 	}
 
 	persistenceConfig := so.config.Persistence
-	err := verifyPersistenceCompatibleVersion(persistenceConfig, so.persistenceServiceResolver, logger)
+	err = verifyPersistenceCompatibleVersion(persistenceConfig, so.persistenceServiceResolver, logger)
 	if err != nil {
 		return serverOptionsProvider{}, err
 	}
@@ -366,27 +355,36 @@ func ServerOptionsProvider(opts []ServerOption) (serverOptionsProvider, error) {
 	}, nil
 }
 
-func newBootstrapPersistenceFactory(params bootstrapPersistenceFactoryParams) persistenceClient.Factory {
-	persistenceMetricsHandler := params.MetricsHandler.WithTags(metrics.ServiceNameTag(primitives.ServerService))
-	clusterName := persistenceClient.ClusterName(params.Config.ClusterMetadata.CurrentClusterName)
+func (s *ServerFx) provideBootstrapPersistenceFactory(
+	cfg *config.Config,
+	serviceResolver resolver.ServiceResolver,
+	customDataStoreFactory persistenceClient.AbstractDataStoreFactory,
+	logger log.Logger,
+	metricsHandler metrics.Handler,
+	persistenceFactoryProvider persistenceClient.FactoryProviderFn,
+	serializer serialization.Serializer,
+) persistenceClient.Factory {
+	persistenceMetricsHandler := metricsHandler.WithTags(metrics.ServiceNameTag(primitives.ServerService))
+	clusterName := persistenceClient.ClusterName(cfg.ClusterMetadata.CurrentClusterName)
 	dataStoreFactory := persistenceClient.DataStoreFactoryProvider(
 		clusterName,
-		params.ServiceResolver,
-		&params.Config.Persistence,
-		params.CustomDataStoreFactory,
-		params.Logger,
+		serviceResolver,
+		&cfg.Persistence,
+		customDataStoreFactory,
+		logger,
 		persistenceMetricsHandler,
 		telemetry.NoopTracerProvider,
-		params.Serializer,
+		serializer,
 	)
-	return params.PersistenceFactoryProvider(persistenceClient.NewFactoryParams{
+	s.bootstrapPersistenceFactory = persistenceFactoryProvider(persistenceClient.NewFactoryParams{
 		DataStoreFactory: dataStoreFactory,
-		Cfg:              &params.Config.Persistence,
+		Cfg:              &cfg.Persistence,
 		ClusterName:      clusterName,
 		MetricsHandler:   persistenceMetricsHandler,
-		Logger:           params.Logger,
-		Serializer:       params.Serializer,
+		Logger:           logger,
+		Serializer:       serializer,
 	})
+	return s.bootstrapPersistenceFactory
 }
 
 // Start temporal server.
@@ -709,6 +707,7 @@ func ApplyClusterMetadataConfigProvider(
 	if err != nil {
 		return svc.ClusterMetadata, svc.Persistence, fmt.Errorf("error initializing cluster metadata manager: %w", err)
 	}
+	// Do not close the manager: its store shares resources owned by the bootstrap factory.
 
 	visCSAOverride := map[enumspb.IndexedValueType]int{}
 	for tpName, value := range svc.Visibility.PersistenceCustomSearchAttributes {

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -349,6 +349,8 @@ func ServerOptionsProvider(opts []ServerOption) (serverOptionsProvider, error) {
 	}, nil
 }
 
+// provideBootstrapPersistenceFactory records the factory as soon as Fx constructs it so it can
+// be closed if later graph construction fails.
 func (s *ServerFx) provideBootstrapPersistenceFactory(
 	cfg *config.Config,
 	serviceResolver resolver.ServiceResolver,
@@ -700,7 +702,7 @@ func ApplyClusterMetadataConfigProvider(
 	if err != nil {
 		return svc.ClusterMetadata, svc.Persistence, fmt.Errorf("error initializing cluster metadata manager: %w", err)
 	}
-	// Do not close the manager because the factory owns and closes its persistence resources.
+	// Do not close the manager: it shares the factory's data store, which the factory's owner closes.
 
 	visCSAOverride := map[enumspb.IndexedValueType]int{}
 	for tpName, value := range svc.Visibility.PersistenceCustomSearchAttributes {

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -390,8 +390,8 @@ func (s *ServerFx) provideBootstrapPersistenceFactory(
 // This function should be called only once, Server doesn't support multiple restarts.
 func (s *ServerFx) Start() error {
 	err := s.app.Start(context.Background())
+	s.closeBootstrapPersistenceFactory()
 	if err != nil {
-		s.closeBootstrapPersistenceFactory()
 		return err
 	}
 

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -390,8 +390,7 @@ func (s *ServerFx) provideBootstrapPersistenceFactory(
 // This function should be called only once, Server doesn't support multiple restarts.
 func (s *ServerFx) Start() error {
 	err := s.app.Start(context.Background())
-	// Release bootstrap persistence when service startup returns; running services use their own factories.
-	s.closeBootstrapPersistenceFactory()
+	s.closeBootstrapPersistenceFactory() // release now that app has started
 	if err != nil {
 		return err
 	}

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -90,9 +90,10 @@ type (
 	}
 
 	ServerFx struct {
-		app                        *fx.App
-		startupSynchronizationMode synchronizationModeParams
-		logger                     log.Logger
+		app                         *fx.App
+		startupSynchronizationMode  synchronizationModeParams
+		logger                      log.Logger
+		bootstrapPersistenceFactory persistenceClient.Factory
 	}
 
 	serverOptionsProvider struct {
@@ -134,6 +135,18 @@ type (
 		TestHooks                  testhooks.TestHooks
 		EventLoggerProvider        otellog.LoggerProvider
 	}
+
+	bootstrapPersistenceFactoryParams struct {
+		fx.In
+
+		Config                     *config.Config
+		ServiceResolver            resolver.ServiceResolver
+		CustomDataStoreFactory     persistenceClient.AbstractDataStoreFactory
+		Logger                     log.Logger
+		MetricsHandler             metrics.Handler
+		PersistenceFactoryProvider persistenceClient.FactoryProviderFn
+		Serializer                 serialization.Serializer
+	}
 )
 
 var (
@@ -160,28 +173,35 @@ var (
 	)
 )
 
-func NewServerFx(topLevelModule fx.Option, opts ...ServerOption) (*ServerFx, error) {
-	var s ServerFx
+func NewServerFx(topLevelModule fx.Option, opts ...ServerOption) (server *ServerFx, err error) {
+	s := &ServerFx{}
+	defer func() {
+		if server == nil {
+			s.closeBootstrapPersistenceFactory()
+		}
+	}()
+
 	s.app = fx.New(
 		topLevelModule,
 		fx.Supply(opts),
+		fx.Provide(func(params bootstrapPersistenceFactoryParams) persistenceClient.Factory {
+			s.bootstrapPersistenceFactory = newBootstrapPersistenceFactory(params)
+			return s.bootstrapPersistenceFactory
+		}),
 		fx.Populate(&s.startupSynchronizationMode),
 		fx.Populate(&s.logger),
 	)
 	if err := s.app.Err(); err != nil {
 		return nil, err
 	}
-	return &s, nil
+	return s, nil
 }
 
 func ServerOptionsProvider(opts []ServerOption) (serverOptionsProvider, error) {
 	so := newServerOptions(opts)
-
-	err := so.loadAndValidate()
-	if err != nil {
+	if err := so.loadAndValidate(); err != nil {
 		return serverOptionsProvider{}, err
 	}
-
 	// Logger
 	logger := so.logger
 	if logger == nil {
@@ -189,7 +209,7 @@ func ServerOptionsProvider(opts []ServerOption) (serverOptionsProvider, error) {
 	}
 
 	persistenceConfig := so.config.Persistence
-	err = verifyPersistenceCompatibleVersion(persistenceConfig, so.persistenceServiceResolver, logger)
+	err := verifyPersistenceCompatibleVersion(persistenceConfig, so.persistenceServiceResolver, logger)
 	if err != nil {
 		return serverOptionsProvider{}, err
 	}
@@ -346,11 +366,35 @@ func ServerOptionsProvider(opts []ServerOption) (serverOptionsProvider, error) {
 	}, nil
 }
 
+func newBootstrapPersistenceFactory(params bootstrapPersistenceFactoryParams) persistenceClient.Factory {
+	persistenceMetricsHandler := params.MetricsHandler.WithTags(metrics.ServiceNameTag(primitives.ServerService))
+	clusterName := persistenceClient.ClusterName(params.Config.ClusterMetadata.CurrentClusterName)
+	dataStoreFactory := persistenceClient.DataStoreFactoryProvider(
+		clusterName,
+		params.ServiceResolver,
+		&params.Config.Persistence,
+		params.CustomDataStoreFactory,
+		params.Logger,
+		persistenceMetricsHandler,
+		telemetry.NoopTracerProvider,
+		params.Serializer,
+	)
+	return params.PersistenceFactoryProvider(persistenceClient.NewFactoryParams{
+		DataStoreFactory: dataStoreFactory,
+		Cfg:              &params.Config.Persistence,
+		ClusterName:      clusterName,
+		MetricsHandler:   persistenceMetricsHandler,
+		Logger:           params.Logger,
+		Serializer:       params.Serializer,
+	})
+}
+
 // Start temporal server.
 // This function should be called only once, Server doesn't support multiple restarts.
 func (s *ServerFx) Start() error {
 	err := s.app.Start(context.Background())
 	if err != nil {
+		s.closeBootstrapPersistenceFactory()
 		return err
 	}
 
@@ -366,7 +410,17 @@ func (s *ServerFx) Start() error {
 
 // Stop stops the server.
 func (s *ServerFx) Stop() error {
-	return s.app.Stop(context.Background())
+	err := s.app.Stop(context.Background())
+	s.closeBootstrapPersistenceFactory()
+	return err
+}
+
+func (s *ServerFx) closeBootstrapPersistenceFactory() {
+	factory := s.bootstrapPersistenceFactory
+	s.bootstrapPersistenceFactory = nil
+	if factory != nil {
+		factory.Close()
+	}
 }
 
 func (svc *ServicesMetadata) Stop(ctx context.Context) {
@@ -646,38 +700,10 @@ func WorkerServiceProvider(
 func ApplyClusterMetadataConfigProvider(
 	logger log.Logger,
 	svc *config.Config,
-	persistenceServiceResolver resolver.ServiceResolver,
-	persistenceFactoryProvider persistenceClient.FactoryProviderFn,
-	customDataStoreFactory persistenceClient.AbstractDataStoreFactory,
-	customVisibilityStoreFactory visibility.VisibilityStoreFactory,
-	metricsHandler metrics.Handler,
-	serializer serialization.Serializer,
+	factory persistenceClient.Factory,
 ) (*cluster.Config, config.Persistence, error) {
 	ctx := context.TODO()
 	logger = log.With(logger, tag.ComponentMetadataInitializer)
-	metricsHandler = metricsHandler.WithTags(metrics.ServiceNameTag(primitives.ServerService))
-	clusterName := persistenceClient.ClusterName(svc.ClusterMetadata.CurrentClusterName)
-	dataStoreFactory := persistenceClient.DataStoreFactoryProvider(
-		clusterName,
-		persistenceServiceResolver,
-		&svc.Persistence,
-		customDataStoreFactory,
-		logger,
-		metricsHandler,
-		telemetry.NoopTracerProvider,
-		serializer,
-	)
-	factory := persistenceFactoryProvider(persistenceClient.NewFactoryParams{
-		DataStoreFactory:           dataStoreFactory,
-		Cfg:                        &svc.Persistence,
-		PersistenceMaxQPS:          nil,
-		PersistenceNamespaceMaxQPS: nil,
-		ClusterName:                persistenceClient.ClusterName(svc.ClusterMetadata.CurrentClusterName),
-		MetricsHandler:             metricsHandler,
-		Logger:                     logger,
-		Serializer:                 serializer,
-	})
-	defer factory.Close()
 
 	clusterMetadataManager, err := factory.NewClusterMetadataManager()
 	if err != nil {

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -706,7 +706,7 @@ func ApplyClusterMetadataConfigProvider(
 	if err != nil {
 		return svc.ClusterMetadata, svc.Persistence, fmt.Errorf("error initializing cluster metadata manager: %w", err)
 	}
-	// Do not close the manager: its store shares resources owned by the bootstrap factory.
+	// The manager borrows persistence resources that are closed with the factory.
 
 	visCSAOverride := map[enumspb.IndexedValueType]int{}
 	for tpName, value := range svc.Visibility.PersistenceCustomSearchAttributes {

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -407,8 +407,7 @@ func (s *ServerFx) Start() error {
 
 // Stop stops the server.
 func (s *ServerFx) Stop() error {
-	err := s.app.Stop(context.Background())
-	return err
+	return s.app.Stop(context.Background())
 }
 
 func (s *ServerFx) closeBootstrapPersistenceFactory() {

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -390,7 +390,7 @@ func (s *ServerFx) provideBootstrapPersistenceFactory(
 // This function should be called only once, Server doesn't support multiple restarts.
 func (s *ServerFx) Start() error {
 	err := s.app.Start(context.Background())
-	s.closeBootstrapPersistenceFactory() // release now that app has started
+	s.closeBootstrapPersistenceFactory() // safe now that app has started
 	if err != nil {
 		return err
 	}

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -707,7 +707,7 @@ func ApplyClusterMetadataConfigProvider(
 	if err != nil {
 		return svc.ClusterMetadata, svc.Persistence, fmt.Errorf("error initializing cluster metadata manager: %w", err)
 	}
-	// Do not close the manager here because the factory owns and closes its persistence resources.
+	// Do not close the manager because the factory owns and closes its persistence resources.
 
 	visCSAOverride := map[enumspb.IndexedValueType]int{}
 	for tpName, value := range svc.Visibility.PersistenceCustomSearchAttributes {

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -161,14 +161,8 @@ var (
 	)
 )
 
-func NewServerFx(topLevelModule fx.Option, opts ...ServerOption) (server *ServerFx, err error) {
+func NewServerFx(topLevelModule fx.Option, opts ...ServerOption) (*ServerFx, error) {
 	s := &ServerFx{}
-	defer func() {
-		if server == nil {
-			s.closeBootstrapPersistenceFactory()
-		}
-	}()
-
 	s.app = fx.New(
 		topLevelModule,
 		fx.Supply(opts),
@@ -177,6 +171,7 @@ func NewServerFx(topLevelModule fx.Option, opts ...ServerOption) (server *Server
 		fx.Populate(&s.logger),
 	)
 	if err := s.app.Err(); err != nil {
+		s.closeBootstrapPersistenceFactory()
 		return nil, err
 	}
 	return s, nil

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -408,7 +408,6 @@ func (s *ServerFx) Start() error {
 // Stop stops the server.
 func (s *ServerFx) Stop() error {
 	err := s.app.Stop(context.Background())
-	s.closeBootstrapPersistenceFactory()
 	return err
 }
 

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -172,7 +172,6 @@ func NewServerFx(topLevelModule fx.Option, opts ...ServerOption) (server *Server
 	s.app = fx.New(
 		topLevelModule,
 		fx.Supply(opts),
-		// Record ownership when Fx constructs the factory so it can be closed if a later invoke fails.
 		fx.Provide(s.provideBootstrapPersistenceFactory),
 		fx.Populate(&s.startupSynchronizationMode),
 		fx.Populate(&s.logger),

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -407,6 +407,7 @@ func (s *ServerFx) Start() error {
 
 // Stop stops the server.
 func (s *ServerFx) Stop() error {
+	defer s.closeBootstrapPersistenceFactory()
 	return s.app.Stop(context.Background())
 }
 

--- a/temporal/fx_test.go
+++ b/temporal/fx_test.go
@@ -12,37 +12,10 @@ import (
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/persistence"
-	persistenceClient "go.temporal.io/server/common/persistence/client"
 	"go.temporal.io/server/service/history/tasks"
 	"go.temporal.io/server/tests/testutils"
-	"go.uber.org/fx"
 	"go.uber.org/mock/gomock"
 )
-
-type closeTrackingPersistenceFactory struct {
-	persistenceClient.Factory
-	closed bool
-}
-
-func (f *closeTrackingPersistenceFactory) Close() {
-	f.closed = true
-}
-
-func TestServerFxStartClosesBootstrapPersistenceFactory(t *testing.T) {
-	t.Parallel()
-
-	factory := &closeTrackingPersistenceFactory{}
-	server := &ServerFx{
-		app:                         fx.New(),
-		bootstrapPersistenceFactory: factory,
-	}
-	t.Cleanup(func() {
-		require.NoError(t, server.Stop())
-	})
-
-	require.NoError(t, server.Start())
-	require.True(t, factory.closed)
-}
 
 func TestInitCurrentClusterMetadataRecord(t *testing.T) {
 	configDir := path.Join(testutils.GetRepoRootDirectory(), "config")

--- a/temporal/fx_test.go
+++ b/temporal/fx_test.go
@@ -12,10 +12,37 @@ import (
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/persistence"
+	persistenceClient "go.temporal.io/server/common/persistence/client"
 	"go.temporal.io/server/service/history/tasks"
 	"go.temporal.io/server/tests/testutils"
+	"go.uber.org/fx"
 	"go.uber.org/mock/gomock"
 )
+
+type closeTrackingPersistenceFactory struct {
+	persistenceClient.Factory
+	closed bool
+}
+
+func (f *closeTrackingPersistenceFactory) Close() {
+	f.closed = true
+}
+
+func TestServerFxStartClosesBootstrapPersistenceFactory(t *testing.T) {
+	t.Parallel()
+
+	factory := &closeTrackingPersistenceFactory{}
+	server := &ServerFx{
+		app:                         fx.New(),
+		bootstrapPersistenceFactory: factory,
+	}
+	t.Cleanup(func() {
+		require.NoError(t, server.Stop())
+	})
+
+	require.NoError(t, server.Start())
+	require.True(t, factory.closed)
+}
 
 func TestInitCurrentClusterMetadataRecord(t *testing.T) {
 	configDir := path.Join(testutils.GetRepoRootDirectory(), "config")

--- a/temporal/server_impl.go
+++ b/temporal/server_impl.go
@@ -7,19 +7,12 @@ import (
 	"slices"
 	"time"
 
-	"go.opentelemetry.io/otel/trace"
-	"go.temporal.io/server/common/cluster"
-	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
-	"go.temporal.io/server/common/metrics"
 	persistenceClient "go.temporal.io/server/common/persistence/client"
-	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/primitives"
-	"go.temporal.io/server/common/resolver"
 	"go.temporal.io/server/common/resource"
-	"go.temporal.io/server/common/telemetry"
 	"go.uber.org/multierr"
 )
 
@@ -32,12 +25,7 @@ type (
 		logger           log.Logger
 		namespaceLogger  resource.NamespaceLogger
 
-		persistenceConfig          config.Persistence
-		clusterMetadata            *cluster.Config
-		persistenceFactoryProvider persistenceClient.FactoryProviderFn
-		metricsHandler             metrics.Handler
-		tracerProvider             trace.TracerProvider
-		serializer                 serialization.Serializer
+		bootstrapPersistenceFactory persistenceClient.Factory
 	}
 )
 
@@ -59,29 +47,20 @@ func NewServerFxImpl(
 	namespaceLogger resource.NamespaceLogger,
 	stoppedCh chan any,
 	servicesGroup ServicesGroupIn,
-	persistenceConfig config.Persistence,
-	clusterMetadata *cluster.Config,
-	persistenceFactoryProvider persistenceClient.FactoryProviderFn,
-	metricsHandler metrics.Handler,
-	serializer serialization.Serializer,
+	bootstrapPersistenceFactory persistenceClient.Factory,
 ) *ServerImpl {
 	s := &ServerImpl{
-		so:                         opts,
-		stoppedCh:                  stoppedCh,
-		logger:                     logger,
-		namespaceLogger:            namespaceLogger,
-		persistenceConfig:          persistenceConfig,
-		clusterMetadata:            clusterMetadata,
-		persistenceFactoryProvider: persistenceFactoryProvider,
-		metricsHandler:             metricsHandler,
+		so:                          opts,
+		stoppedCh:                   stoppedCh,
+		logger:                      logger,
+		namespaceLogger:             namespaceLogger,
+		bootstrapPersistenceFactory: bootstrapPersistenceFactory,
 	}
 	for _, svcMeta := range servicesGroup.Services {
 		if svcMeta != nil {
 			s.servicesMetadata = append(s.servicesMetadata, svcMeta)
 		}
 	}
-	// Store serializer for use in Start()
-	s.serializer = serializer
 	return s
 }
 
@@ -91,14 +70,8 @@ func (s *ServerImpl) Start(ctx context.Context) error {
 
 	if err := initSystemNamespaces(
 		ctx,
-		&s.persistenceConfig,
-		s.clusterMetadata.CurrentClusterName,
-		s.so.persistenceServiceResolver,
-		s.persistenceFactoryProvider,
-		s.logger,
-		s.so.customDataStoreFactory,
-		s.metricsHandler,
-		s.serializer,
+		s.so.config.ClusterMetadata.CurrentClusterName,
+		s.bootstrapPersistenceFactory,
 	); err != nil {
 		return fmt.Errorf("unable to initialize system namespace: %w", err)
 	}
@@ -147,39 +120,9 @@ func (s *ServerImpl) startServices() error {
 
 func initSystemNamespaces(
 	ctx context.Context,
-	cfg *config.Persistence,
 	currentClusterName string,
-	persistenceServiceResolver resolver.ServiceResolver,
-	persistenceFactoryProvider persistenceClient.FactoryProviderFn,
-	logger log.Logger,
-	customDataStoreFactory persistenceClient.AbstractDataStoreFactory,
-	metricsHandler metrics.Handler,
-	serializer serialization.Serializer,
+	factory persistenceClient.Factory,
 ) error {
-	clusterName := persistenceClient.ClusterName(currentClusterName)
-	metricsHandler = metricsHandler.WithTags(metrics.ServiceNameTag(primitives.ServerService))
-	dataStoreFactory := persistenceClient.DataStoreFactoryProvider(
-		clusterName,
-		persistenceServiceResolver,
-		cfg,
-		customDataStoreFactory,
-		logger,
-		metricsHandler,
-		telemetry.NoopTracerProvider,
-		serializer,
-	)
-	factory := persistenceFactoryProvider(persistenceClient.NewFactoryParams{
-		DataStoreFactory:           dataStoreFactory,
-		Cfg:                        cfg,
-		PersistenceMaxQPS:          nil,
-		PersistenceNamespaceMaxQPS: nil,
-		ClusterName:                persistenceClient.ClusterName(currentClusterName),
-		MetricsHandler:             metricsHandler,
-		Logger:                     logger,
-		Serializer:                 serializer,
-	})
-	defer factory.Close()
-
 	metadataManager, err := factory.NewMetadataManager()
 	if err != nil {
 		return fmt.Errorf("unable to initialize metadata manager: %w", err)

--- a/temporal/server_impl.go
+++ b/temporal/server_impl.go
@@ -127,7 +127,7 @@ func initSystemNamespaces(
 	if err != nil {
 		return fmt.Errorf("unable to initialize metadata manager: %w", err)
 	}
-	// The manager borrows persistence resources that are closed with the factory.
+	// Do not close the manager here because the factory owns and closes its persistence resources.
 	ctx, cancel := context.WithTimeout(
 		headers.SetCallerInfo(ctx, headers.SystemBackgroundHighCallerInfo),
 		30*time.Second,

--- a/temporal/server_impl.go
+++ b/temporal/server_impl.go
@@ -127,7 +127,7 @@ func initSystemNamespaces(
 	if err != nil {
 		return fmt.Errorf("unable to initialize metadata manager: %w", err)
 	}
-	// Do not close the manager here because the factory owns and closes its persistence resources.
+	defer metadataManager.Close()
 	ctx, cancel := context.WithTimeout(
 		headers.SetCallerInfo(ctx, headers.SystemBackgroundHighCallerInfo),
 		30*time.Second,

--- a/temporal/server_impl.go
+++ b/temporal/server_impl.go
@@ -25,6 +25,7 @@ type (
 		logger           log.Logger
 		namespaceLogger  resource.NamespaceLogger
 
+		// bootstrapPersistenceFactory must only be used during Start; ServerFx closes it after startup.
 		bootstrapPersistenceFactory persistenceClient.Factory
 	}
 )
@@ -127,7 +128,7 @@ func initSystemNamespaces(
 	if err != nil {
 		return fmt.Errorf("unable to initialize metadata manager: %w", err)
 	}
-	// Do not close the manager because the factory owns and closes its persistence resources.
+	// Do not close the manager: it shares the factory's data store, which the factory's owner closes.
 	ctx, cancel := context.WithTimeout(
 		headers.SetCallerInfo(ctx, headers.SystemBackgroundHighCallerInfo),
 		30*time.Second,

--- a/temporal/server_impl.go
+++ b/temporal/server_impl.go
@@ -127,7 +127,6 @@ func initSystemNamespaces(
 	if err != nil {
 		return fmt.Errorf("unable to initialize metadata manager: %w", err)
 	}
-	defer metadataManager.Close()
 	ctx, cancel := context.WithTimeout(
 		headers.SetCallerInfo(ctx, headers.SystemBackgroundHighCallerInfo),
 		30*time.Second,

--- a/temporal/server_impl.go
+++ b/temporal/server_impl.go
@@ -127,6 +127,7 @@ func initSystemNamespaces(
 	if err != nil {
 		return fmt.Errorf("unable to initialize metadata manager: %w", err)
 	}
+	// Do not close the manager: its store shares resources owned by the bootstrap factory.
 	ctx, cancel := context.WithTimeout(
 		headers.SetCallerInfo(ctx, headers.SystemBackgroundHighCallerInfo),
 		30*time.Second,

--- a/temporal/server_impl.go
+++ b/temporal/server_impl.go
@@ -127,7 +127,7 @@ func initSystemNamespaces(
 	if err != nil {
 		return fmt.Errorf("unable to initialize metadata manager: %w", err)
 	}
-	// Do not close the manager: its store shares resources owned by the bootstrap factory.
+	// The manager borrows persistence resources that are closed with the factory.
 	ctx, cancel := context.WithTimeout(
 		headers.SetCallerInfo(ctx, headers.SystemBackgroundHighCallerInfo),
 		30*time.Second,

--- a/temporal/server_impl.go
+++ b/temporal/server_impl.go
@@ -127,7 +127,7 @@ func initSystemNamespaces(
 	if err != nil {
 		return fmt.Errorf("unable to initialize metadata manager: %w", err)
 	}
-	defer metadataManager.Close()
+	// Do not close the manager because the factory owns and closes its persistence resources.
 	ctx, cancel := context.WithTimeout(
 		headers.SetCallerInfo(ctx, headers.SystemBackgroundHighCallerInfo),
 		30*time.Second,

--- a/tests/testcore/test_cluster.go
+++ b/tests/testcore/test_cluster.go
@@ -28,16 +28,12 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/membership/static"
-	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/metrics/metricstest"
 	"go.temporal.io/server/common/persistence"
-	persistenceclient "go.temporal.io/server/common/persistence/client"
 	persistencetests "go.temporal.io/server/common/persistence/persistence-tests"
-	"go.temporal.io/server/common/persistence/serialization"
 	esclient "go.temporal.io/server/common/persistence/visibility/store/elasticsearch/client"
 	"go.temporal.io/server/common/pprof"
 	"go.temporal.io/server/common/primitives"
-	"go.temporal.io/server/common/resolver"
 	"go.temporal.io/server/common/rpc/auth"
 	"go.temporal.io/server/common/rpc/encryption"
 	"go.temporal.io/server/common/telemetry"
@@ -260,12 +256,7 @@ func newClusterWithPersistenceTestBaseFactory(
 	clusterMetadataConfig, pConfig, err = temporal.ApplyClusterMetadataConfigProvider(
 		logger,
 		cfg,
-		resolver.NewNoopResolver(),
-		persistenceclient.FactoryProvider,
-		testBase.AbstractDataStoreFactory,
-		testBase.VisibilityStoreFactory,
-		metrics.NoopMetricsHandler,
-		serialization.NewSerializer(),
+		testBase.Factory,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## What changed?

Reuse a single persistence factory during server initialization.

## Why?

Server initialization previously constructed and closed a separate persistence factory for each bootstrap operation.

This also helps with https://github.com/temporalio/temporal/pull/11458 as this change ensures there's uninterrupted ownership of the sqlite database.