### PR TITLE
Separate test diagnostics and timeout parsing

### DIFF
--- a/tools/testrunner/diagnostics.go
+++ b/tools/testrunner/diagnostics.go
@@ -1,12 +1,7 @@
 package testrunner
 
 import (
-	"fmt"
-	"io"
-	"slices"
 	"strings"
-
-	"github.com/maruel/panicparse/v2/stack"
 )
 
 const (
@@ -15,63 +10,6 @@ const (
 	noFailureDetails     = "(error details not found)"
 	goTestFailLinePrefix = "--- FAIL:"
 )
-
-// parseTestTimeouts parses the stdout of a test run and returns the stacktrace and names of tests that timed out.
-func parseTestTimeouts(stdout string) (stacktrace string, timedoutTests []string) {
-	lines := strings.Split(strings.ReplaceAll(stdout, "\r\n", "\n"), "\n")
-	for i := 0; i < len(lines); i++ {
-		line := lines[i]
-		if strings.HasPrefix(line, "FAIL") {
-			// ignore
-		} else if strings.HasPrefix(line, "panic: test timed out after") {
-			// parse names of tests that timed out
-			for {
-				i++
-				line = strings.TrimSpace(lines[i])
-				if strings.HasPrefix(line, "Test") {
-					timedoutTests = append(timedoutTests, strings.Split(line, " ")[0])
-				}
-				if line == "" {
-					break
-				}
-			}
-		} else if len(timedoutTests) > 0 {
-			// collect stracktrace
-			stacktrace += line + "\n"
-		}
-	}
-
-	stacktrace = fmt.Sprintf("%d timed out test(s):\n\t%v\n\n%v",
-		len(timedoutTests), strings.Join(timedoutTests, "\n\t"), testOnlyStacktrace(stacktrace))
-	return
-}
-
-// testOnlyStacktrace removes all but the test stacktraces from the full stacktrace.
-func testOnlyStacktrace(stacktrace string) string {
-	var res string
-	snap, _, err := stack.ScanSnapshot(strings.NewReader(stacktrace), io.Discard, stack.DefaultOpts())
-	if err != nil && err != io.EOF {
-		return fmt.Sprintf("failed to parse stacktrace: %v", err)
-	}
-	if snap == nil {
-		return "failed to find a stacktrace"
-	}
-	res = "abridged stacktrace:\n"
-	for _, goroutine := range snap.Goroutines {
-		shouldPrint := slices.ContainsFunc(goroutine.Stack.Calls, func(call stack.Call) bool {
-			return strings.HasSuffix(call.RemoteSrcPath, "_test.go")
-		})
-		if shouldPrint {
-			res += fmt.Sprintf("\tgoroutine %d [%v]:\n", goroutine.ID, goroutine.State)
-			for _, call := range goroutine.Stack.Calls {
-				file := call.RemoteSrcPath
-				res += fmt.Sprintf("\t\t%s:%d\n", file, call.Line)
-			}
-			res += "\n"
-		}
-	}
-	return res
-}
 
 // alert captures a prominent issue detected from stdout/stderr of test runs.
 type alert struct {

--- a/tools/testrunner/diagnostics_test.go
+++ b/tools/testrunner/diagnostics_test.go
@@ -7,21 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseTestTimeouts(t *testing.T) {
-	logInput, err := os.ReadFile("testdata/timeout-input.log")
-	require.NoError(t, err)
-	logOutput, err := os.ReadFile("testdata/timeout-output.log")
-	require.NoError(t, err)
-
-	stacktrace, tests := parseTestTimeouts(string(logInput))
-	require.Equal(t, []string{
-		"TestActivityApiResetClientTestSuite",
-		"TestNDCFuncTestSuite",
-		"TestActivityApiStateReplicationSuite",
-	}, tests)
-	require.Equal(t, string(logOutput), stacktrace)
-}
-
 func TestParseFailedTestsFromOutput(t *testing.T) {
 	t.Run("ExtractsFailedTestNames", func(t *testing.T) {
 		stdout := `

--- a/tools/testrunner/timeout.go
+++ b/tools/testrunner/timeout.go
@@ -1,0 +1,66 @@
+package testrunner
+
+import (
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+
+	"github.com/maruel/panicparse/v2/stack"
+)
+
+// parseTestTimeouts parses the stdout of a test run and returns the stacktrace and names of tests that timed out.
+func parseTestTimeouts(stdout string) (stacktrace string, timedoutTests []string) {
+	lines := strings.Split(strings.ReplaceAll(stdout, "\r\n", "\n"), "\n")
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+		if strings.HasPrefix(line, "FAIL") {
+			// ignore
+		} else if strings.HasPrefix(line, "panic: test timed out after") {
+			// parse names of tests that timed out
+			for i++; i < len(lines); i++ {
+				line = strings.TrimSpace(lines[i])
+				if strings.HasPrefix(line, "Test") {
+					timedoutTests = append(timedoutTests, strings.Split(line, " ")[0])
+				}
+				if line == "" {
+					break
+				}
+			}
+		} else if len(timedoutTests) > 0 {
+			// collect stracktrace
+			stacktrace += line + "\n"
+		}
+	}
+
+	stacktrace = fmt.Sprintf("%d timed out test(s):\n\t%v\n\n%v",
+		len(timedoutTests), strings.Join(timedoutTests, "\n\t"), testOnlyStacktrace(stacktrace))
+	return
+}
+
+// testOnlyStacktrace removes all but the test stacktraces from the full stacktrace.
+func testOnlyStacktrace(stacktrace string) string {
+	var res string
+	snap, _, err := stack.ScanSnapshot(strings.NewReader(stacktrace), io.Discard, stack.DefaultOpts())
+	if err != nil && err != io.EOF {
+		return fmt.Sprintf("failed to parse stacktrace: %v", err)
+	}
+	if snap == nil {
+		return "failed to find a stacktrace"
+	}
+	res = "abridged stacktrace:\n"
+	for _, goroutine := range snap.Goroutines {
+		shouldPrint := slices.ContainsFunc(goroutine.Stack.Calls, func(call stack.Call) bool {
+			return strings.HasSuffix(call.RemoteSrcPath, "_test.go")
+		})
+		if shouldPrint {
+			res += fmt.Sprintf("\tgoroutine %d [%v]:\n", goroutine.ID, goroutine.State)
+			for _, call := range goroutine.Stack.Calls {
+				file := call.RemoteSrcPath
+				res += fmt.Sprintf("\t\t%s:%d\n", file, call.Line)
+			}
+			res += "\n"
+		}
+	}
+	return res
+}

--- a/tools/testrunner/timeout_test.go
+++ b/tools/testrunner/timeout_test.go
@@ -1,0 +1,29 @@
+package testrunner
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTestTimeouts(t *testing.T) {
+	logInput, err := os.ReadFile("testdata/timeout-input.log")
+	require.NoError(t, err)
+	logOutput, err := os.ReadFile("testdata/timeout-output.log")
+	require.NoError(t, err)
+
+	stacktrace, tests := parseTestTimeouts(string(logInput))
+	require.Equal(t, []string{
+		"TestActivityApiResetClientTestSuite",
+		"TestNDCFuncTestSuite",
+		"TestActivityApiStateReplicationSuite",
+	}, tests)
+	require.Equal(t, string(logOutput), stacktrace)
+}
+
+func TestParseTestTimeoutsTruncatedAfterPanic(t *testing.T) {
+	stacktrace, tests := parseTestTimeouts("panic: test timed out after 1m")
+	require.Empty(t, tests)
+	require.Contains(t, stacktrace, "0 timed out test(s)")
+}


### PR DESCRIPTION
Separates diagnostic parsing and timeout parsing into focused files without changing behavior. Existing comments and tests move with their implementations so the later canonical conversion is a semantic diff instead of a delete-and-add rewrite.

Stack: depends on #11512. The canonical result model follows in #11514.
