### PR TITLE
Scope test diagnostics to canonical results

### DIFF
--- a/tools/testrunner/diagnostics.go
+++ b/tools/testrunner/diagnostics.go
@@ -1,307 +1,59 @@
 package testrunner
 
 import (
+	"fmt"
+	"slices"
 	"strings"
 )
 
-const (
-	// noFailureDetails is returned by parseFailureDetails when no recognisable
-	// failure block is found.
-	noFailureDetails     = "(error details not found)"
-	goTestFailLinePrefix = "--- FAIL:"
-)
+const goTestFailLinePrefix = "--- FAIL:"
 
-// alert captures a prominent issue detected from stdout/stderr of test runs.
-type alert struct {
-	Type    failureType
-	Summary string
-	Details string
-	Tests   []string
+type outputScope struct {
+	packageName string
+	test        *testID
 }
 
-// primaryTestName returns a single representative test name for an alert.
-// Preference order:
-// 1) Fully-qualified test name containing ".Test"
-// 2) First detected test name
-func primaryTestName(tests []string) string {
-	if len(tests) == 0 {
-		return ""
-	}
-	for _, t := range tests {
-		if strings.Contains(t, ".Test") {
-			return t
-		}
-	}
-	return tests[0]
-}
-
-// preferFullyQualifiedTestName returns the best display name for a test.
-// If the primary name is not fully-qualified (e.g., "TestXxx"), but a
-// fully-qualified variant exists in the list (e.g., "pkg/path.TestXxx"),
-// this returns the fully-qualified variant.
-func preferFullyQualifiedTestName(tests []string) string {
-	primary := primaryTestName(tests)
-	if primary == "" || strings.Contains(primary, ".Test") {
-		return primary
-	}
-	// Try to find an FQN that ends with "."+primary
-	suffix := "." + primary
-	for _, t := range tests {
-		if strings.HasSuffix(t, suffix) {
-			return t
-		}
-	}
-	return primary
-}
-
-// parseAlerts scans a gotestsum/go test stdout stream and extracts high-priority
-// alerts such as data races and panics. It returns a slice of alerts in the
-// order they were encountered.
-func parseAlerts(stdout string) []alert {
-	lines := strings.Split(strings.ReplaceAll(stdout, "\r\n", "\n"), "\n")
-	var alerts []alert
-
-	for i := 0; i < len(lines); i++ {
-		line := lines[i]
-
-		if a, next, ok := tryParseDataRace(lines, i, line); ok {
-			alerts = append(alerts, a)
-			i = next
-			continue
-		}
-		if a, next, ok := tryParsePanic(lines, i, line); ok {
-			alerts = append(alerts, a)
-			i = next
-			continue
-		}
-		if a, next, ok := tryParseFatal(lines, i, line); ok {
-			alerts = append(alerts, a)
-			i = next
-			continue
-		}
-	}
-
-	return alerts
-}
-
-// extractTestNames tries to identify Go test function names from a log block.
-// It looks for fully-qualified names like pkg.TestXxx(...) and Go test failure lines.
-func extractTestNames(block string) []string {
-	var tests []string
-	seen := make(map[string]struct{})
-	for line := range strings.SplitSeq(block, "\n") {
-		l := strings.TrimSpace(line)
-		if l == "" {
-			continue
-		}
-		if name, ok := parseTripleDashTestName(l); ok {
-			addUniqueTest(&tests, seen, name)
-			continue
-		}
-		if name, ok := parseFullyQualifiedTestName(l); ok {
-			addUniqueTest(&tests, seen, name)
-			continue
-		}
-		if name, ok := parsePlainTestName(l); ok {
-			addUniqueTest(&tests, seen, name)
-		}
-	}
-	return tests
-}
-
-// addUniqueTest appends name to tests if not already seen.
-func addUniqueTest(tests *[]string, seen map[string]struct{}, name string) {
-	if _, ok := seen[name]; ok {
-		return
-	}
-	seen[name] = struct{}{}
-	*tests = append(*tests, name)
-}
-
-// parseTripleDashTestName parses Go test failure lines and returns the test name if present.
-func parseTripleDashTestName(line string) (string, bool) {
-	if !strings.HasPrefix(line, goTestFailLinePrefix) {
-		return "", false
-	}
-	name := strings.TrimSpace(strings.TrimPrefix(line, goTestFailLinePrefix))
-	name, _, _ = strings.Cut(name, " ")
-	if !strings.HasPrefix(name, "Test") {
-		return "", false
-	}
-	return name, true
-}
-
-// parseFullyQualifiedTestName extracts names like "pkg/path.TestName" from a line.
-func parseFullyQualifiedTestName(line string) (string, bool) {
-	idx := strings.Index(line, ".Test")
-	if idx < 0 {
-		return "", false
-	}
-	// Include the package/path qualifier preceding ".Test"
-	start := 0
-	if sp := strings.LastIndex(line[:idx], " "); sp >= 0 {
-		start = sp + 1
-	}
-	if p := strings.Index(line[idx:], "("); p > 0 {
-		return line[start : idx+p], true
-	}
-	return "", false
-}
-
-// parsePlainTestName extracts a leading "TestName(" form.
-func parsePlainTestName(line string) (string, bool) {
-	if !strings.HasPrefix(line, "Test") || !strings.Contains(line, "(") {
-		return "", false
-	}
-	name := line
-	if p := strings.Index(name, "("); p > 0 {
-		name = name[:p]
-	}
-	return name, true
-}
-
-// tryParseDataRace parses a data race alert at position i if present.
-func tryParseDataRace(lines []string, i int, line string) (alert, int, bool) {
-	if !strings.HasPrefix(line, "WARNING: DATA RACE") {
-		return alert{}, i, false
-	}
-	start := findRaceBlockStart(lines, i)
-	// Merge contiguous race-report sections into a single alert. The Go race
-	// detector may emit multiple "WARNING: DATA RACE" blocks back-to-back,
-	// each wrapped by a line of ==================. Treat adjacent sections as
-	// a single logical alert until we either hit a test boundary or a race
-	// boundary that is not followed by another race section.
-	block, end := collectBlock(lines, start, func(curLine string, idx, start int) bool {
-		// Stop at PASS/FAIL boundaries always.
-		if isTestResultBoundary(curLine) {
-			return true
-		}
-		// If we hit a race boundary after we've started, only stop if the next
-		// non-current line does not continue the race report.
-		if idx > start && isRaceBoundary(curLine) {
-			if idx+1 < len(lines) {
-				next := strings.TrimSpace(lines[idx+1])
-				if isRaceBoundary(next) || strings.HasPrefix(next, "WARNING: DATA RACE") {
-					return false
-				}
-			}
-			return true
-		}
-		return false
-	})
-	return alert{
-		Type:    failureTypeDataRace,
-		Summary: "Data race detected",
-		Details: block,
-		Tests:   extractTestNames(block),
-	}, end, true
-}
-
-// tryParsePanic parses a non-timeout panic alert at position i if present.
-func tryParsePanic(lines []string, i int, line string) (alert, int, bool) {
-	if !strings.HasPrefix(line, "panic: ") || strings.HasPrefix(line, "panic: test timed out after") {
-		return alert{}, i, false
-	}
-	block, end := collectBlock(lines, i, shouldStopOnTestBoundary)
-	return alert{
-		Type:    failureTypePanic,
-		Summary: strings.TrimSpace(strings.TrimPrefix(line, "panic: ")),
-		Details: block,
-		Tests:   extractTestNames(block),
-	}, end, true
-}
-
-// tryParseFatal parses a runtime fatal error alert at position i if present.
-func tryParseFatal(lines []string, i int, line string) (alert, int, bool) {
-	if !strings.HasPrefix(line, "fatal error: ") {
-		return alert{}, i, false
-	}
-	block, end := collectBlock(lines, i, shouldStopOnTestBoundary)
-	return alert{
-		Type:    failureTypeFatal,
-		Summary: strings.TrimSpace(strings.TrimPrefix(line, "fatal error: ")),
-		Details: block,
-		Tests:   extractTestNames(block),
-	}, end, true
-}
-
-// findRaceBlockStart searches upward for the race report delimiter.
-func findRaceBlockStart(lines []string, i int) int {
-	start := i
-	for j := i - 1; j >= 0; j-- {
-		if isRaceBoundary(lines[j]) {
-			start = j
-			break
-		}
-	}
-	return start
-}
-
-// collectBlock builds a block from start until the stop condition is met.
-func collectBlock(lines []string, start int, stop func(line string, idx, start int) bool) (string, int) {
-	var b strings.Builder
-	for j := start; j < len(lines); j++ {
-		b.WriteString(lines[j])
-		b.WriteByte('\n')
-		if stop(lines[j], j, start) {
-			return b.String(), j
-		}
-	}
-	return b.String(), len(lines) - 1
-}
-
-func isRaceBoundary(line string) bool {
-	return strings.HasPrefix(strings.TrimSpace(line), "==================")
-}
-
-func isTestResultBoundary(line string) bool {
-	return strings.HasPrefix(line, "FAIL") || strings.HasPrefix(line, "PASS")
-}
-
-func shouldStopOnTestBoundary(line string, _ int, _ int) bool {
-	return isTestResultBoundary(line)
-}
-
-// parseFailedTestsFromOutput extracts failing test names from gotestsum stdout.
-// It looks for Go test failure lines produced as tests complete, and is
-// used when the test binary was killed externally before producing a JUnit XML.
-func parseFailedTestsFromOutput(stdout string) []string {
-	var failed []string
-	seen := make(map[string]struct{})
-	for line := range strings.SplitSeq(strings.ReplaceAll(stdout, "\r\n", "\n"), "\n") {
-		line = strings.TrimSpace(line)
-		if !strings.HasPrefix(line, goTestFailLinePrefix) {
-			continue
-		}
-		if name, ok := parseTripleDashTestName(line); ok {
-			addUniqueTest(&failed, seen, name)
-		}
-	}
-	return failed
-}
-
-// parseFailureDetails extracts the actionable part of a JUnit failure Data block.
-func parseFailureDetails(data string) string {
-	lines := normalizedFailureLines(data)
+func extractFailureEvidence(output string) failureEvidence {
+	lines := normalizedFailureLines(output)
 
 	// Prefer assertion blocks because they contain the useful testify failure
 	// detail and can be selected from the end while ignoring trailing logs.
 	if block, ok := findLastAssertionFailureBlock(lines); ok {
-		return block
+		return failureEvidence{details: block, actionable: true}
+	}
+	if diagnostics := extractDiagnostics(outputScope{}, output); len(diagnostics) > 0 {
+		details := make([]string, 0, len(diagnostics))
+		for _, diagnostic := range diagnostics {
+			if detail := strings.TrimSpace(diagnostic.details); detail != "" {
+				details = append(details, detail)
+			}
+		}
+		if len(details) > 0 {
+			return failureEvidence{details: strings.Join(details, "\n\n"), actionable: true}
+		}
 	}
 	// Some failures, such as gomock errors, do not include an Error Trace.
 	// Fall back to the last Go test output block in those cases.
 	if start, end, ok := findLastTestOutputFailureBlock(lines); ok {
-		return strings.Join(lines[start:end], "\n")
+		details := strings.Join(lines[start:end], "\n")
+		return failureEvidence{
+			details: details,
+			actionable: strings.Contains(details, "Unexpected call to") ||
+				strings.Contains(details, "missing call(s) to") ||
+				strings.Contains(details, "test exceeded timeout") ||
+				strings.Contains(details, "panic:") ||
+				strings.Contains(details, "WARNING: DATA RACE") ||
+				strings.Contains(details, "fatal error:"),
+		}
 	}
-	return noFailureDetails
+	return failureEvidence{}
 }
 
 func normalizedFailureLines(data string) []string {
 	lines := strings.Split(strings.ReplaceAll(data, "\r\n", "\n"), "\n")
 	for len(lines) > 0 {
-		t := strings.TrimSpace(lines[len(lines)-1])
-		if t != "" && t != "FAIL" {
+		trimmed := strings.TrimSpace(lines[len(lines)-1])
+		if trimmed != "" && trimmed != "FAIL" {
 			break
 		}
 		lines = lines[:len(lines)-1]
@@ -311,23 +63,23 @@ func normalizedFailureLines(data string) []string {
 
 func findLastAssertionFailureBlock(lines []string) (string, bool) {
 	var failLine string
-	for i := len(lines) - 1; i >= 0; i-- {
-		line := strings.TrimSpace(lines[i])
+	for i, rawLine := range slices.Backward(lines) {
+		line := strings.TrimSpace(rawLine)
 		if failLine == "" && strings.HasPrefix(line, goTestFailLinePrefix) {
 			// Keep the final Go test failure line because it carries the test duration.
 			failLine = line
 			continue
 		}
-		if !strings.Contains(lines[i], "Error Trace:") {
+		if !strings.Contains(rawLine, "Error Trace:") {
 			continue
 		}
 
 		// Include the nearest preceding line when present. For testify this is
 		// the file header; for await failures this is the attempt marker.
 		start := i
-		for prev := i - 1; prev >= 0; prev-- {
-			if strings.TrimSpace(lines[prev]) != "" {
-				start = prev
+		for previous, previousLine := range slices.Backward(lines[:i]) {
+			if strings.TrimSpace(previousLine) != "" {
+				start = previous
 				break
 			}
 		}
@@ -360,8 +112,8 @@ func endOfAssertionBlock(lines []string, start int) int {
 }
 
 func findLastTestOutputFailureBlock(lines []string) (start, end int, ok bool) {
-	for start := len(lines) - 1; start >= 0; start-- {
-		if !isTestOutputLine(lines[start]) {
+	for start, line := range slices.Backward(lines) {
+		if !isTestOutputLine(line) {
 			continue
 		}
 		end := start + 1
@@ -379,4 +131,243 @@ func findLastTestOutputFailureBlock(lines []string) (start, end int, ok bool) {
 // distinguishes log entries from assertion block content.
 func isTestOutputLine(line string) bool {
 	return len(line) > 4 && line[:4] == "    " && line[4] != ' ' && line[4] != '\t'
+}
+
+// extractDiagnostics scans one event-owned output scope for high-priority
+// diagnostics such as data races, panics, fatals, and test-binary timeouts.
+func extractDiagnostics(scope outputScope, output string) []diagnostic {
+	lines := strings.Split(strings.ReplaceAll(output, "\r\n", "\n"), "\n")
+	var diagnostics []diagnostic
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+		var parsed diagnostic
+		var next int
+		switch {
+		case strings.HasPrefix(line, "WARNING: DATA RACE"):
+			parsed, next = tryParseDataRace(lines, i)
+		case strings.HasPrefix(line, "panic: ") && !strings.HasPrefix(line, "panic: test timed out after"):
+			parsed, next = tryParsePanic(lines, i)
+		case strings.HasPrefix(line, "fatal error: "):
+			parsed, next = tryParseFatal(lines, i)
+		default:
+			continue
+		}
+		parsed.packageName = scope.packageName
+		parsed.tests = diagnosticTestIDs(scope, extractTestNames(parsed.details))
+		diagnostics = append(diagnostics, parsed)
+		i = next
+	}
+	if timeout := extractTimeoutDiagnostic(scope, output); timeout != nil {
+		diagnostics = append(diagnostics, *timeout)
+	}
+	return diagnostics
+}
+
+func diagnosticTestIDs(scope outputScope, names []string) []testID {
+	if scope.test != nil {
+		return []testID{*scope.test}
+	}
+	if scope.packageName == "" {
+		return nil
+	}
+	var ids []testID
+	seen := make(map[testID]struct{})
+	for _, name := range names {
+		if index := strings.LastIndex(name, ".Test"); index >= 0 {
+			name = name[index+1:]
+		}
+		id := testID{scope.packageName, name}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+func dedupeDiagnostics(diagnostics []diagnostic) []diagnostic {
+	seen := make(map[string]struct{}, len(diagnostics))
+	result := make([]diagnostic, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		tests := slices.Clone(diagnostic.tests)
+		slices.SortFunc(tests, compareTestID)
+		var key strings.Builder
+		key.WriteString(fmt.Sprintf("%d\n%s\n%s", diagnostic.kind, diagnostic.packageName, diagnostic.details))
+		for _, id := range tests {
+			key.WriteString("\n" + id.packageName + "\t" + id.testName)
+		}
+		if _, ok := seen[key.String()]; ok {
+			continue
+		}
+		seen[key.String()] = struct{}{}
+		result = append(result, diagnostic)
+	}
+	return result
+}
+
+// tryParseDataRace parses a data race diagnostic at position index.
+func tryParseDataRace(lines []string, index int) (diagnostic, int) {
+	start := findRaceBlockStart(lines, index)
+	// Merge contiguous race-report sections into a single diagnostic. The Go race
+	// detector may emit multiple "WARNING: DATA RACE" blocks back-to-back,
+	// each wrapped by a line of ==================. Treat adjacent sections as
+	// a single logical diagnostic until we either hit a test boundary or a race
+	// boundary that is not followed by another race section.
+	block, end := collectBlock(lines, start, func(current string, currentIndex, start int) bool {
+		// Stop at PASS/FAIL boundaries always.
+		if isTestResultBoundary(current) {
+			return true
+		}
+		// If we hit a race boundary after we've started, only stop if the next
+		// non-current line does not continue the race report.
+		if currentIndex > start && isRaceBoundary(current) {
+			if currentIndex+1 < len(lines) {
+				next := strings.TrimSpace(lines[currentIndex+1])
+				if isRaceBoundary(next) || strings.HasPrefix(next, "WARNING: DATA RACE") {
+					return false
+				}
+			}
+			return true
+		}
+		return false
+	})
+	return diagnostic{
+		kind:    diagnosticDataRace,
+		summary: "Data race detected",
+		details: block,
+	}, end
+}
+
+// tryParsePanic parses a non-timeout panic diagnostic at position index.
+func tryParsePanic(lines []string, index int) (diagnostic, int) {
+	block, end := collectBlock(lines, index, shouldStopOnTestBoundary)
+	return diagnostic{
+		kind:    diagnosticPanic,
+		summary: strings.TrimSpace(strings.TrimPrefix(lines[index], "panic: ")),
+		details: block,
+	}, end
+}
+
+// tryParseFatal parses a runtime fatal error diagnostic at position index.
+func tryParseFatal(lines []string, index int) (diagnostic, int) {
+	block, end := collectBlock(lines, index, shouldStopOnTestBoundary)
+	return diagnostic{
+		kind:    diagnosticFatal,
+		summary: strings.TrimSpace(strings.TrimPrefix(lines[index], "fatal error: ")),
+		details: block,
+	}, end
+}
+
+// extractTestNames tries to identify Go test function names from a log block.
+// It looks for fully-qualified names like pkg.TestXxx(...) and Go test failure lines.
+func extractTestNames(block string) []string {
+	var tests []string
+	seen := make(map[string]struct{})
+	for line := range strings.SplitSeq(block, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if name, ok := parseTripleDashTestName(line); ok {
+			addUniqueTest(&tests, seen, name)
+			continue
+		}
+		if name, ok := parseFullyQualifiedTestName(line); ok {
+			addUniqueTest(&tests, seen, name)
+			continue
+		}
+		if name, ok := parsePlainTestName(line); ok {
+			addUniqueTest(&tests, seen, name)
+		}
+	}
+	return tests
+}
+
+// addUniqueTest appends name to tests if not already seen.
+func addUniqueTest(tests *[]string, seen map[string]struct{}, name string) {
+	if _, ok := seen[name]; ok {
+		return
+	}
+	seen[name] = struct{}{}
+	*tests = append(*tests, name)
+}
+
+// parseTripleDashTestName parses Go test failure lines and returns the test name if present.
+func parseTripleDashTestName(line string) (string, bool) {
+	if !strings.HasPrefix(line, goTestFailLinePrefix) {
+		return "", false
+	}
+	name := strings.TrimSpace(strings.TrimPrefix(line, goTestFailLinePrefix))
+	name, _, _ = strings.Cut(name, " ")
+	if !strings.HasPrefix(name, "Test") {
+		return "", false
+	}
+	return name, true
+}
+
+// parseFullyQualifiedTestName extracts names like "pkg/path.TestName" from a line.
+func parseFullyQualifiedTestName(line string) (string, bool) {
+	index := strings.Index(line, ".Test")
+	if index < 0 {
+		return "", false
+	}
+	// Include the package/path qualifier preceding ".Test"
+	start := 0
+	if space := strings.LastIndex(line[:index], " "); space >= 0 {
+		start = space + 1
+	}
+	if parenthesis := strings.Index(line[index:], "("); parenthesis > 0 {
+		return line[start : index+parenthesis], true
+	}
+	return "", false
+}
+
+// parsePlainTestName extracts a leading "TestName(" form.
+func parsePlainTestName(line string) (string, bool) {
+	if !strings.HasPrefix(line, "Test") || !strings.Contains(line, "(") {
+		return "", false
+	}
+	name := line
+	if parenthesis := strings.Index(name, "("); parenthesis > 0 {
+		name = name[:parenthesis]
+	}
+	return name, true
+}
+
+// findRaceBlockStart searches upward for the race report delimiter.
+func findRaceBlockStart(lines []string, index int) int {
+	start := index
+	for i := index - 1; i >= 0; i-- {
+		if isRaceBoundary(lines[i]) {
+			start = i
+			break
+		}
+	}
+	return start
+}
+
+// collectBlock builds a block from start until the stop condition is met.
+func collectBlock(lines []string, start int, stop func(line string, index, start int) bool) (string, int) {
+	var block strings.Builder
+	for i := start; i < len(lines); i++ {
+		block.WriteString(lines[i])
+		block.WriteByte('\n')
+		if stop(lines[i], i, start) {
+			return block.String(), i
+		}
+	}
+	return block.String(), len(lines) - 1
+}
+
+func isRaceBoundary(line string) bool {
+	return strings.HasPrefix(strings.TrimSpace(line), "==================")
+}
+
+func isTestResultBoundary(line string) bool {
+	return strings.HasPrefix(line, "FAIL") || strings.HasPrefix(line, "PASS")
+}
+
+func shouldStopOnTestBoundary(line string, _, _ int) bool {
+	return isTestResultBoundary(line)
 }

--- a/tools/testrunner/diagnostics_test.go
+++ b/tools/testrunner/diagnostics_test.go
@@ -7,196 +7,98 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseFailedTestsFromOutput(t *testing.T) {
-	t.Run("ExtractsFailedTestNames", func(t *testing.T) {
-		stdout := `
-=== RUN   TestFoo
-=== RUN   TestFoo/SubTest1
-    foo_test.go:42: assertion failed
---- FAIL: TestFoo/SubTest1 (1.23s)
---- FAIL: TestFoo (1.23s)
-=== RUN   TestBar
---- PASS: TestBar (0.00s)
-=== RUN   TestBaz
-    baz_test.go:10: something wrong
---- FAIL: TestBaz (0.50s)
-FAIL
-`
-		got := parseFailedTestsFromOutput(stdout)
-		require.Equal(t, []string{"TestFoo/SubTest1", "TestFoo", "TestBaz"}, got)
-	})
-
-	t.Run("DeduplicatesDuplicateLines", func(t *testing.T) {
-		stdout := `
---- FAIL: TestDupe (0.10s)
---- FAIL: TestDupe (0.10s)
---- FAIL: TestOther (0.20s)
-`
-		got := parseFailedTestsFromOutput(stdout)
-		require.Equal(t, []string{"TestDupe", "TestOther"}, got)
-	})
-
-	t.Run("ReturnsEmptyWhenNoFailures", func(t *testing.T) {
-		stdout := `
-=== RUN   TestPass
---- PASS: TestPass (0.01s)
-ok  	go.temporal.io/server/tests
-`
-		got := parseFailedTestsFromOutput(stdout)
-		require.Empty(t, got)
-	})
-
-	t.Run("ReturnsEmptyOnEmptyInput", func(t *testing.T) {
-		require.Empty(t, parseFailedTestsFromOutput(""))
-	})
-}
-
-func TestParseAlerts_DataRaceAndPanic(t *testing.T) {
+func TestExtractDiagnosticsUsesEventScope(t *testing.T) {
 	input, err := os.ReadFile("testdata/alerts-input.log")
 	require.NoError(t, err)
+	id := testID{"example.com/tests", "TestOwned"}
 
-	alerts := parseAlerts(string(input))
-	require.NotEmpty(t, alerts)
-	require.Len(t, alerts, 2)
-
-	require.Contains(t, alerts[0].Details, "WARNING: DATA RACE")
-	require.Contains(t, alerts[0].Tests[0], "test.TestDataRaceExample")
-	require.Contains(t, primaryTestName(alerts[0].Tests), "test.TestDataRaceExample")
-	require.Contains(t, alerts[1].Details, "panic: ")
-	require.Contains(t, alerts[1].Tests[0], "test.TestPanicExample")
-	require.Contains(t, primaryTestName(alerts[1].Tests), "TestPanicExample")
-
-	// Ensure dedupe works
-	deduped := dedupeAlerts(append(alerts, alerts...))
-	require.Len(t, alerts, len(deduped))
+	diagnostics := extractDiagnostics(outputScope{packageName: id.packageName, test: &id}, string(input))
+	require.Len(t, diagnostics, 2)
+	require.Equal(t, diagnosticDataRace, diagnostics[0].kind)
+	require.Equal(t, []testID{id}, diagnostics[0].tests)
+	require.Equal(t, diagnosticPanic, diagnostics[1].kind)
+	require.Equal(t, []testID{id}, diagnostics[1].tests)
+	require.Len(t, dedupeDiagnostics(append(diagnostics, diagnostics...)), 2)
 }
 
-func TestParseFailureDetails(t *testing.T) {
+func TestExtractFailureEvidence(t *testing.T) {
 	tests := []struct {
 		name        string
-		data        string
+		output      string
 		contains    []string
 		notContains []string
-		exact       string
+		actionable  bool
 	}{
 		{
-			name: "extracts testify block",
-			data: `    suite_test.go:42: some log line
-    suite_test.go:43: another log line
-    suite_test.go:85:
-        	Error Trace:	suite_test.go:85
-        	Error:      	Not equal:
-        	            	expected: 1
-        	            	actual  : 2
-FAIL`,
-			contains:    []string{"Error Trace:", "expected: 1"},
-			notContains: []string{"some log line", "FAIL"},
-		},
-		{
-			name: "keeps testify file header line",
-			data: `    suite_test.go:85:
-        	Error Trace:	suite_test.go:85
-        	Error:      	Not equal:
-        	            	expected: 1
-        	            	actual  : 2
-FAIL`,
-			contains: []string{
-				"suite_test.go:85:",
-				"Error Trace:",
-			},
-		},
-		{
-			name: "uses last gomock style block",
-			data: `=== RUN   TestFoo
-=== CONT  TestFoo
-    test_env.go:1: some log
-    mock_file.go:42: Unexpected call to SomeMethod(...)
-        expected call at foo_test.go:10 doesn't match argument at index 0.
-        Got:  "actual"
-        Want: is equal to "expected"
-FAIL`,
-			contains:    []string{"Unexpected call", "Got:", "Want:"},
-			notContains: []string{"some log"},
-		},
-		{
-			name: "uses last failure block when multiple exist",
-			data: `=== RUN   TestFoo
-    helper.go:1: some setup log
-    first_mock.go:10: first failure
-        first continuation
-    second_mock.go:20: second failure
-        second continuation
-FAIL`,
-			contains:    []string{"second_mock.go:20", "second continuation"},
-			notContains: []string{"first_mock.go:10", "first continuation", "some setup log"},
-		},
-		{
-			name:  "returns sentinel when no output exists",
-			data:  "FAIL\n",
-			exact: noFailureDetails,
-		},
-		{
-			name: "stops before logs printed after assertion block",
-			data: `    suite_test.go:481:
-            Error Trace:    suite_test.go:481
-            Error:          Not equal:
-                            expected: false
-                            actual  : true
-            Test:           TestSuite/TestCase
-    logger.go:146: some info log after the assertion
-    controller.go:97: missing call(s) to ...
-FAIL`,
-			contains:    []string{"Error Trace:", "expected: false"},
-			notContains: []string{"logger.go", "controller.go"},
-		},
-		{
-			name:        "strips trailing FAIL marker",
-			data:        "    foo_test.go:1:\n\tError Trace:\tfoo_test.go:1\n\tError:\toops\n\n\nFAIL\n",
-			contains:    []string{"Error Trace:"},
+			name: "structured assertion",
+			output: "    suite_test.go:85:\n" +
+				"        Error Trace:\tsuite_test.go:85\n" +
+				"        Error:\tNot equal\nFAIL\n",
+			contains:    []string{"suite_test.go:85:", "Error Trace:"},
 			notContains: []string{"FAIL"},
+			actionable:  true,
+		},
+		{
+			name: "uses last failure block",
+			output: "    helper.go:1: setup log\n" +
+				"    first_mock.go:10: first failure\n        first continuation\n" +
+				"    second_mock.go:20: Unexpected call to SomeMethod(...)\n        second continuation\nFAIL\n",
+			contains:    []string{"second_mock.go:20", "second continuation"},
+			notContains: []string{"first_mock.go:10", "first continuation", "setup log"},
+			actionable:  true,
+		},
+		{
+			name: "stops before logs after assertion block",
+			output: "    suite_test.go:481:\n" +
+				"        Error Trace: suite_test.go:481\n" +
+				"        Error: Not equal\n" +
+				"        Test: TestSuite/TestCase\n" +
+				"    logger.go:146: info after assertion\n" +
+				"    controller.go:97: missing call(s)\nFAIL\n",
+			contains:    []string{"Error Trace:", "Not equal"},
+			notContains: []string{"logger.go", "controller.go"},
+			actionable:  true,
 		},
 		{
 			name: "keeps last await attempt without trailing logs",
-			data: `    report.go:54: attempt errors:
-  --- attempt 1 ---
-    
-    Error Trace:	suite_test.go:10
-    Error:      	first failure
-
-  --- attempt 2 ---
-    
-    Error Trace:	suite_test.go:10
-    Error:      	penultimate failure
-
-  --- attempt 3 ---
-    
-    Error Trace:	suite_test.go:10
-    Error:      	last failure
-
-logger.go:146: network dial error connection refused
---- FAIL: TestSuite/TestCase (92.93s)
-FAIL`,
-			contains: []string{
-				"--- attempt 3 ---",
-				"Error:      \tlast failure",
-				"--- FAIL: TestSuite/TestCase (92.93s)",
-			},
-			notContains: []string{"attempts omitted", "--- attempt 1 ---", "first failure", "--- attempt 2 ---", "penultimate failure", "logger.go", "connection refused"},
+			output: "    report.go:54: attempt errors:\n" +
+				"  --- attempt 1 ---\n    Error Trace:\tsuite_test.go:10\n    Error:\tfirst failure\n\n" +
+				"  --- attempt 2 ---\n    Error Trace:\tsuite_test.go:10\n    Error:\tlast failure\n\n" +
+				"logger.go:146: connection refused\n--- FAIL: TestSuite/TestCase (1.00s)\nFAIL\n",
+			contains:    []string{"--- attempt 2 ---", "last failure", "--- FAIL: TestSuite/TestCase (1.00s)"},
+			notContains: []string{"--- attempt 1 ---", "first failure", "logger.go", "connection refused"},
+			actionable:  true,
 		},
+		{
+			name:       "generic event-owned log",
+			output:     "    parent_test.go:20: cleanup log\nFAIL\n",
+			contains:   []string{"cleanup log"},
+			actionable: false,
+		},
+		{
+			name: "content-free timeout does not replace failure evidence",
+			output: "    controller.go:1: Unexpected call to SomeMethod(...)\n" +
+				"panic: test timed out after 10m0s",
+			contains:   []string{"Unexpected call to SomeMethod"},
+			actionable: true,
+		},
+		{name: "raw panic", output: "panic: parent panic\n", contains: []string{"panic: parent panic"}, actionable: true},
+		{name: "raw data race", output: "WARNING: DATA RACE\nwrite at address\n", contains: []string{"WARNING: DATA RACE"}, actionable: true},
+		{name: "raw fatal", output: "fatal error: concurrent map writes\n", contains: []string{"fatal error:"}, actionable: true},
+		{name: "no detail", output: "FAIL\n"},
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := parseFailureDetails(tt.data)
-			if tt.exact != "" {
-				require.Equal(t, tt.exact, got)
-				return
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			evidence := extractFailureEvidence(test.output)
+			require.Equal(t, test.actionable, evidence.actionable)
+			if len(test.contains) == 0 {
+				require.Empty(t, evidence.details)
 			}
-			for _, want := range tt.contains {
-				require.Contains(t, got, want)
+			for _, expected := range test.contains {
+				require.Contains(t, evidence.details, expected)
 			}
-			for _, unwanted := range tt.notContains {
-				require.NotContains(t, got, unwanted)
+			for _, unexpected := range test.notContains {
+				require.NotContains(t, evidence.details, unexpected)
 			}
 		})
 	}

--- a/tools/testrunner/legacy_diagnostics.go
+++ b/tools/testrunner/legacy_diagnostics.go
@@ -1,0 +1,93 @@
+package testrunner
+
+import "strings"
+
+// noFailureDetails is returned by parseFailureDetails when no recognisable
+// failure block is found.
+const noFailureDetails = "(error details not found)"
+
+// alert captures a prominent issue detected from stdout/stderr of test runs.
+type alert struct {
+	Type    failureType
+	Summary string
+	Details string
+	Tests   []string
+}
+
+// primaryTestName returns a single representative test name for an alert.
+// Preference order:
+// 1) Fully-qualified test name containing ".Test"
+// 2) First detected test name
+func primaryTestName(tests []string) string {
+	if len(tests) == 0 {
+		return ""
+	}
+	for _, test := range tests {
+		if strings.Contains(test, ".Test") {
+			return test
+		}
+	}
+	return tests[0]
+}
+
+// parseAlerts scans a gotestsum/go test stdout stream and extracts high-priority
+// alerts such as data races and panics. It returns a slice of alerts in the
+// order they were encountered.
+func parseAlerts(output string) []alert {
+	diagnostics := extractDiagnostics(outputScope{}, output)
+	alerts := make([]alert, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		if diagnostic.kind == diagnosticTimeout {
+			continue
+		}
+		alerts = append(alerts, alert{
+			Type:    failureTypeForDiagnostic(diagnostic.kind),
+			Summary: diagnostic.summary,
+			Details: diagnostic.details,
+			Tests:   extractTestNames(diagnostic.details),
+		})
+	}
+	return alerts
+}
+
+// parseFailedTestsFromOutput extracts failing test names from gotestsum stdout.
+// It looks for Go test failure lines produced as tests complete, and is
+// used when the test binary was killed externally before producing a JUnit XML.
+func parseFailedTestsFromOutput(output string) []string {
+	var failed []string
+	seen := make(map[string]struct{})
+	for line := range strings.SplitSeq(strings.ReplaceAll(output, "\r\n", "\n"), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, goTestFailLinePrefix) {
+			continue
+		}
+		if name, ok := parseTripleDashTestName(line); ok {
+			addUniqueTest(&failed, seen, name)
+		}
+	}
+	return failed
+}
+
+// parseFailureDetails extracts the actionable part of a JUnit failure Data block.
+func parseFailureDetails(data string) string {
+	evidence := extractFailureEvidence(data)
+	if evidence.details == "" {
+		return noFailureDetails
+	}
+	return evidence.details
+}
+
+func failureTypeForDiagnostic(kind diagnosticKind) failureType {
+	switch kind {
+	case diagnosticDataRace:
+		return failureTypeDataRace
+	case diagnosticPanic:
+		return failureTypePanic
+	case diagnosticFatal:
+		return failureTypeFatal
+	case diagnosticTimeout:
+		return failureTypeTimeout
+	default:
+		return failureTypeFailed
+	}
+}

--- a/tools/testrunner/legacy_diagnostics_test.go
+++ b/tools/testrunner/legacy_diagnostics_test.go
@@ -1,0 +1,48 @@
+package testrunner
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseFailedTestsFromOutput(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   []string
+	}{
+		{
+			name: "extracts failed test names",
+			output: "--- FAIL: TestFoo/SubTest1 (1.23s)\n" +
+				"--- FAIL: TestFoo (1.23s)\n" +
+				"--- PASS: TestBar (0.00s)\n" +
+				"--- FAIL: TestBaz (0.50s)\n",
+			want: []string{"TestFoo/SubTest1", "TestFoo", "TestBaz"},
+		},
+		{
+			name:   "deduplicates duplicate lines",
+			output: "--- FAIL: TestDupe (0.10s)\n--- FAIL: TestDupe (0.10s)\n--- FAIL: TestOther (0.20s)\n",
+			want:   []string{"TestDupe", "TestOther"},
+		},
+		{name: "returns empty when no failures", output: "--- PASS: TestPass (0.01s)\n"},
+		{name: "returns empty on empty input"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, parseFailedTestsFromOutput(test.output))
+		})
+	}
+}
+
+func TestParseAlertsPreservesDetectedTestNames(t *testing.T) {
+	input, err := os.ReadFile("testdata/alerts-input.log")
+	require.NoError(t, err)
+
+	alerts := parseAlerts(string(input))
+	require.Len(t, alerts, 2)
+	require.Contains(t, alerts[0].Tests, "test.TestDataRaceExample")
+	require.Contains(t, alerts[1].Tests, "test.TestPanicExample")
+	require.Len(t, dedupeAlerts(append(alerts, alerts...)), len(alerts))
+}

--- a/tools/testrunner/timeout.go
+++ b/tools/testrunner/timeout.go
@@ -9,6 +9,46 @@ import (
 	"github.com/maruel/panicparse/v2/stack"
 )
 
+func extractTimeoutDiagnostic(scope outputScope, output string) *diagnostic {
+	if !strings.Contains(output, "panic: test timed out after") {
+		return nil
+	}
+	stacktrace, names := parseTestTimeouts(output)
+	details := stacktrace
+	if len(names) == 0 {
+		details = ""
+	}
+	diagnostic := &diagnostic{
+		kind:        diagnosticTimeout,
+		summary:     timeoutHeadline(output),
+		details:     details,
+		packageName: scope.packageName,
+	}
+	if scope.test != nil {
+		diagnostic.tests = []testID{*scope.test}
+		return diagnostic
+	}
+	if scope.packageName != "" {
+		for _, name := range names {
+			if name == "" {
+				continue
+			}
+			diagnostic.tests = append(diagnostic.tests, testID{scope.packageName, name})
+		}
+	}
+	return diagnostic
+}
+
+func timeoutHeadline(output string) string {
+	for line := range strings.Lines(output) {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "panic: test timed out after") {
+			return line
+		}
+	}
+	return "test timed out"
+}
+
 // parseTestTimeouts parses the stdout of a test run and returns the stacktrace and names of tests that timed out.
 func parseTestTimeouts(stdout string) (stacktrace string, timedoutTests []string) {
 	lines := strings.Split(strings.ReplaceAll(stdout, "\r\n", "\n"), "\n")
@@ -18,7 +58,8 @@ func parseTestTimeouts(stdout string) (stacktrace string, timedoutTests []string
 			// ignore
 		} else if strings.HasPrefix(line, "panic: test timed out after") {
 			// parse names of tests that timed out
-			for i++; i < len(lines); i++ {
+			for i+1 < len(lines) {
+				i++
 				line = strings.TrimSpace(lines[i])
 				if strings.HasPrefix(line, "Test") {
 					timedoutTests = append(timedoutTests, strings.Split(line, " ")[0])
@@ -28,7 +69,7 @@ func parseTestTimeouts(stdout string) (stacktrace string, timedoutTests []string
 				}
 			}
 		} else if len(timedoutTests) > 0 {
-			// collect stracktrace
+			// collect stacktrace
 			stacktrace += line + "\n"
 		}
 	}
@@ -40,27 +81,26 @@ func parseTestTimeouts(stdout string) (stacktrace string, timedoutTests []string
 
 // testOnlyStacktrace removes all but the test stacktraces from the full stacktrace.
 func testOnlyStacktrace(stacktrace string) string {
-	var res string
-	snap, _, err := stack.ScanSnapshot(strings.NewReader(stacktrace), io.Discard, stack.DefaultOpts())
+	var result string
+	snapshot, _, err := stack.ScanSnapshot(strings.NewReader(stacktrace), io.Discard, stack.DefaultOpts())
 	if err != nil && err != io.EOF {
 		return fmt.Sprintf("failed to parse stacktrace: %v", err)
 	}
-	if snap == nil {
+	if snapshot == nil {
 		return "failed to find a stacktrace"
 	}
-	res = "abridged stacktrace:\n"
-	for _, goroutine := range snap.Goroutines {
+	result = "abridged stacktrace:\n"
+	for _, goroutine := range snapshot.Goroutines {
 		shouldPrint := slices.ContainsFunc(goroutine.Stack.Calls, func(call stack.Call) bool {
 			return strings.HasSuffix(call.RemoteSrcPath, "_test.go")
 		})
 		if shouldPrint {
-			res += fmt.Sprintf("\tgoroutine %d [%v]:\n", goroutine.ID, goroutine.State)
+			result += fmt.Sprintf("\tgoroutine %d [%v]:\n", goroutine.ID, goroutine.State)
 			for _, call := range goroutine.Stack.Calls {
-				file := call.RemoteSrcPath
-				res += fmt.Sprintf("\t\t%s:%d\n", file, call.Line)
+				result += fmt.Sprintf("\t\t%s:%d\n", call.RemoteSrcPath, call.Line)
 			}
-			res += "\n"
+			result += "\n"
 		}
 	}
-	return res
+	return result
 }


### PR DESCRIPTION
Converts test output analysis to package-aware canonical diagnostics and failure evidence. The existing runner reaches the new implementation through a temporary compatibility adapter, so there is still one parser implementation while the production cutover remains isolated.

Stack: depends on #11514. The Go test JSON recorder follows in #11515.
