### PR TITLE
fix(activity): close standalone activity as TIMED_OUT instead of FAILED on worker-reported schedule timeout

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -650,6 +650,28 @@ func (a *Activity) HandleFailed(
 		return &historyservice.RespondActivityTaskFailedResponse{}, nil
 	}
 
+	// A worker-reported schedule-to-start or schedule-to-close timeout is a server-enforced
+	// deadline, not an execution failure. Close the activity as TIMED_OUT (mirroring the
+	// timer-queue path in activity_tasks.go) instead of FAILED.
+	if timeoutType := failure.GetTimeoutFailureInfo().GetTimeoutType(); timeoutType == enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START ||
+		timeoutType == enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE {
+		// Record the same retry state the timer handlers use for these deadlines.
+		timedOutRetryState := enumspb.RETRY_STATE_TIMEOUT
+		if a.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED {
+			timedOutRetryState = enumspb.RETRY_STATE_CANCEL_REQUESTED
+		}
+		if err := TransitionTimedOut.Apply(a, ctx, timeoutEvent{
+			timeoutType:    timeoutType,
+			retryState:     timedOutRetryState,
+			metricsHandler: enrichedHandler,
+			// Preserve the real underlying failure the worker attached, if any.
+			cause: failure.GetCause(),
+		}); err != nil {
+			return nil, err
+		}
+		return &historyservice.RespondActivityTaskFailedResponse{}, nil
+	}
+
 	if err := TransitionFailed.Apply(a, ctx, failedEvent{
 		req:             event.Request,
 		retryState:      retryState,

--- a/chasm/lib/activity/model/vocabulary.go
+++ b/chasm/lib/activity/model/vocabulary.go
@@ -85,10 +85,6 @@ var (
 	FailByIDRetryablyWithHeartbeatTimeoutFailure    = Event{Type: RespondFailedByIDType, Failure: &Failure{Type: HeartbeatTimeoutFailureType}}
 	FailByIDWithScheduleToStartTimeoutFailure       = Event{Type: RespondFailedByIDType, Failure: &Failure{Type: ScheduleToStartTimeoutFailureType}}
 	FailByIDWithScheduleToCloseTimeoutFailure       = Event{Type: RespondFailedByIDType, Failure: &Failure{Type: ScheduleToCloseTimeoutFailureType}}
-	// The *WithCause variants wrap an underlying application failure as the timeout's Cause, modeling
-	// a worker that reports a schedule timeout while carrying the real failure that drove it.
-	FailByIDWithScheduleToStartTimeoutFailureWithCause = Event{Type: RespondFailedByIDType, Failure: &Failure{Type: ScheduleToStartTimeoutFailureType, WithCause: true}}
-	FailByIDWithScheduleToCloseTimeoutFailureWithCause = Event{Type: RespondFailedByIDType, Failure: &Failure{Type: ScheduleToCloseTimeoutFailureType, WithCause: true}}
 	FailByIDRetryablyWithUnknownFailure             = Event{Type: RespondFailedByIDType, Failure: &Failure{Type: UnknownFailureType}}
 	RespondCanceled                                 = Event{Type: RespondCanceledType}
 	RequestCancel                                   = Event{Type: RequestCancelType}

--- a/chasm/lib/activity/model/vocabulary.go
+++ b/chasm/lib/activity/model/vocabulary.go
@@ -52,6 +52,7 @@ type Failure struct {
 	Type         FailureType
 	Retryable    bool // controls the non-retryable flag for application and server failures.
 	LargeMessage bool // sends a failure message exceeding activityFailureSizeLimit
+	WithCause    bool // for a timeout failure, wrap an underlying application failure as its Cause
 }
 
 // FailureType identifies the kind of failure a RespondFailed event reports.
@@ -84,6 +85,10 @@ var (
 	FailByIDRetryablyWithHeartbeatTimeoutFailure    = Event{Type: RespondFailedByIDType, Failure: &Failure{Type: HeartbeatTimeoutFailureType}}
 	FailByIDWithScheduleToStartTimeoutFailure       = Event{Type: RespondFailedByIDType, Failure: &Failure{Type: ScheduleToStartTimeoutFailureType}}
 	FailByIDWithScheduleToCloseTimeoutFailure       = Event{Type: RespondFailedByIDType, Failure: &Failure{Type: ScheduleToCloseTimeoutFailureType}}
+	// The *WithCause variants wrap an underlying application failure as the timeout's Cause, modeling
+	// a worker that reports a schedule timeout while carrying the real failure that drove it.
+	FailByIDWithScheduleToStartTimeoutFailureWithCause = Event{Type: RespondFailedByIDType, Failure: &Failure{Type: ScheduleToStartTimeoutFailureType, WithCause: true}}
+	FailByIDWithScheduleToCloseTimeoutFailureWithCause = Event{Type: RespondFailedByIDType, Failure: &Failure{Type: ScheduleToCloseTimeoutFailureType, WithCause: true}}
 	FailByIDRetryablyWithUnknownFailure             = Event{Type: RespondFailedByIDType, Failure: &Failure{Type: UnknownFailureType}}
 	RespondCanceled                                 = Event{Type: RespondCanceledType}
 	RequestCancel                                   = Event{Type: RequestCancelType}
@@ -158,7 +163,7 @@ func (e Event) String() string {
 		if e.Failure.Type == ApplicationFailureType || e.Failure.Type == ServerFailureType {
 			return fmt.Sprintf("%s[retryable=%v,heartbeatDetails=%v,failureType=%d]", e.Type.String(), e.Failure.Retryable, e.HasHeartbeatDetails, e.Failure.Type)
 		}
-		return fmt.Sprintf("%s[heartbeatDetails=%v,failureType=%d]", e.Type.String(), e.HasHeartbeatDetails, e.Failure.Type)
+		return fmt.Sprintf("%s[heartbeatDetails=%v,failureType=%d,withCause=%v]", e.Type.String(), e.HasHeartbeatDetails, e.Failure.Type, e.Failure.WithCause)
 	case ResetType:
 		return fmt.Sprintf("%s[keepPaused=%v,resetHeartbeat=%v]", e.Type.String(), e.KeepPaused, e.ResetHeartbeat)
 	default:

--- a/chasm/lib/activity/statemachine.go
+++ b/chasm/lib/activity/statemachine.go
@@ -386,6 +386,11 @@ type timeoutEvent struct {
 	metricsHandler metrics.Handler
 	timeoutType    enumspb.TimeoutType
 	retryState     enumspb.RetryState
+	// cause, when set, is recorded as the Cause of a synthesized schedule-to-start or
+	// schedule-to-close timeout failure. It lets a worker-reported timeout (via
+	// RespondActivityTaskFailed[ById]) surface the real underlying failure. When nil, the prior
+	// attempt's failure is used, which is the timer-queue path.
+	cause *failurepb.Failure
 }
 
 // TransitionTimedOut transitions to TimedOut status.
@@ -409,11 +414,17 @@ var TransitionTimedOut = chasm.NewTransition(
 			switch timeoutType {
 			case enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START,
 				enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE:
+				// Prefer a worker-reported cause (RespondActivityTaskFailed[ById]) over the prior
+				// attempt's failure so the real underlying failure is surfaced when present.
+				cause := priorAttemptFailure
+				if event.cause != nil {
+					cause = event.cause
+				}
 				err = a.recordScheduleToStartOrCloseTimeoutFailure(
 					ctx,
 					timeoutType,
 					fmt.Sprintf(common.FailureReasonActivityTimeout, timeoutType.String()),
-					priorAttemptFailure,
+					cause,
 				)
 			case enumspb.TIMEOUT_TYPE_START_TO_CLOSE:
 				failure := createStartToCloseTimeoutFailure()

--- a/tests/activity_driver.go
+++ b/tests/activity_driver.go
@@ -259,13 +259,13 @@ func respondFailedFailure(e model.Event, nextRetryDelay time.Duration) *failurep
 			FailureInfo: &failurepb.Failure_ServerFailureInfo{ServerFailureInfo: &failurepb.ServerFailureInfo{NonRetryable: !e.Failure.Retryable}},
 		}
 	case model.StartToCloseTimeoutFailureType:
-		return syntheticTimeoutFailure(enumspb.TIMEOUT_TYPE_START_TO_CLOSE)
+		return syntheticTimeoutFailure(enumspb.TIMEOUT_TYPE_START_TO_CLOSE, e.Failure.WithCause)
 	case model.HeartbeatTimeoutFailureType:
-		return syntheticTimeoutFailure(enumspb.TIMEOUT_TYPE_HEARTBEAT)
+		return syntheticTimeoutFailure(enumspb.TIMEOUT_TYPE_HEARTBEAT, e.Failure.WithCause)
 	case model.ScheduleToStartTimeoutFailureType:
-		return syntheticTimeoutFailure(enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START)
+		return syntheticTimeoutFailure(enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START, e.Failure.WithCause)
 	case model.ScheduleToCloseTimeoutFailureType:
-		return syntheticTimeoutFailure(enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE)
+		return syntheticTimeoutFailure(enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE, e.Failure.WithCause)
 	case model.UnknownFailureType:
 		return &failurepb.Failure{Message: "test unknown failure"}
 	default:
@@ -274,14 +274,23 @@ func respondFailedFailure(e model.Event, nextRetryDelay time.Duration) *failurep
 }
 
 // syntheticTimeoutFailure creates a worker-reported timeout for the by-ID failure RPC,
-// exercising failure classification rather than the server's timeout-task path.
-func syntheticTimeoutFailure(timeoutType enumspb.TimeoutType) *failurepb.Failure {
-	return &failurepb.Failure{
+// exercising failure classification rather than the server's timeout-task path. When withCause is
+// set, the timeout wraps an underlying application failure as its Cause, modeling a worker that
+// reports the real failure alongside the timeout.
+func syntheticTimeoutFailure(timeoutType enumspb.TimeoutType, withCause bool) *failurepb.Failure {
+	failure := &failurepb.Failure{
 		Message: "test synthetic timeout failure",
 		FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
 			TimeoutType: timeoutType,
 		}},
 	}
+	if withCause {
+		failure.Cause = &failurepb.Failure{
+			Message:     "test failure",
+			FailureInfo: &failurepb.Failure_ApplicationFailureInfo{ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{Type: "TestFailure"}},
+		}
+	}
+	return failure
 }
 
 // activityTimeoutInfo is the information a driver uses to identify a timeout.

--- a/tests/activity_parity_test.go
+++ b/tests/activity_parity_test.go
@@ -252,18 +252,20 @@ func (s *activityParityTestSuite) TestTimeoutPreservesUnderlyingFailureCause() {
 	// no prior attempt here, so a preserved cause can only have come from the worker-reported
 	// failure, exercising the by-ID timeout path end to end.
 	s.Run("ScheduleToStartViaRespondFailedByID", func(s *activityParityTestSuite) {
+		fail := model.Event{Type: model.RespondFailedByIDType, Failure: &model.Failure{Type: model.ScheduleToStartTimeoutFailureType, WithCause: true}}
 		assertCausePreserved(s.T(), activityConfig{},
 			[]model.Event{
 				model.Poll,
-				model.FailByIDWithScheduleToStartTimeoutFailureWithCause,
+				fail,
 			},
 		)
 	})
 	s.Run("ScheduleToCloseViaRespondFailedByID", func(s *activityParityTestSuite) {
+		fail := model.Event{Type: model.RespondFailedByIDType, Failure: &model.Failure{Type: model.ScheduleToCloseTimeoutFailureType, WithCause: true}}
 		assertCausePreserved(s.T(), activityConfig{},
 			[]model.Event{
 				model.Poll,
-				model.FailByIDWithScheduleToCloseTimeoutFailureWithCause,
+				fail,
 			},
 		)
 	})

--- a/tests/activity_parity_test.go
+++ b/tests/activity_parity_test.go
@@ -156,8 +156,8 @@ func (s *activityParityTestSuite) TestSyntheticFailuresHaveRetryParity() {
 		})
 	}
 
-	// Both implementations close these failures without retrying. WFA surfaces them as timed out,
-	// while SAA surfaces worker-reported timeouts as failed, so terminal status itself is not parity.
+	// Both implementations close these failures without retrying, and surface them as timed out,
+	// and set terminal state as timeout.
 	nonRetryableTimeouts := []struct {
 		name  string
 		event model.Event
@@ -178,8 +178,8 @@ func (s *activityParityTestSuite) TestSyntheticFailuresHaveRetryParity() {
 			s.Run("StandaloneActivity", func(s *activityParityTestSuite) {
 				t := s.T()
 				require.Equal(t, activityTerminalOutcome{
-					status:     enumspb.ACTIVITY_EXECUTION_STATUS_FAILED,
-					retryState: enumspb.RETRY_STATE_NON_RETRYABLE_FAILURE,
+					status:     enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT,
+					retryState: enumspb.RETRY_STATE_TIMEOUT,
 				}, newSAADriver(t, env, cfg).driveTrace(t, trace).terminalOutcome(t))
 			})
 		})
@@ -244,6 +244,26 @@ func (s *activityParityTestSuite) TestTimeoutPreservesUnderlyingFailureCause() {
 				model.Poll,
 				model.FailRetryably,
 				model.ScheduleToCloseElapses,
+			},
+		)
+	})
+	// A worker may report a schedule-to-start or schedule-to-close timeout directly through
+	// RespondActivityTaskFailedById while carrying the real failure as the timeout's Cause. There is
+	// no prior attempt here, so a preserved cause can only have come from the worker-reported
+	// failure, exercising the by-ID timeout path end to end.
+	s.Run("ScheduleToStartViaRespondFailedByID", func(s *activityParityTestSuite) {
+		assertCausePreserved(s.T(), activityConfig{},
+			[]model.Event{
+				model.Poll,
+				model.FailByIDWithScheduleToStartTimeoutFailureWithCause,
+			},
+		)
+	})
+	s.Run("ScheduleToCloseViaRespondFailedByID", func(s *activityParityTestSuite) {
+		assertCausePreserved(s.T(), activityConfig{},
+			[]model.Event{
+				model.Poll,
+				model.FailByIDWithScheduleToCloseTimeoutFailureWithCause,
 			},
 		)
 	})


### PR DESCRIPTION
## What changed?

A worker reporting a schedule-to-start/close timeout via RespondActivityTaskFailed[ById]
now closes a standalone (CHASM) activity as TIMED_OUT instead of FAILED, mirroring
the timer-queue path and the workflow-activity behavior. The reported failure's Cause,
if present, is preserved on the timeout outcome, otherwise prior attempt's failure
is used as the cause. 

The specific changes are as follows:
HandleFailed: route these timeouts to TransitionTimedOut
timeoutEvent: add optional cause, preferred over the prior attempt's failure
tests: parity coverage for the by-ID timeout and cause-preservation path

## Why?

This is for parity with workflow activity, which was changed in PR #9132 to return 
retry state of TIMEOUT instead of NON_RETRYABLE_FAILURE when the schedule
to close or schedule to start timeout causes the activity to  close. In the case of
standalone activity, the worker-reported schedule-to-start or schedule-to-close
timeout should behave similarly. 

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [x] added new functional/activity parity test(s)
