### PR TITLE
move admin batch jobs to sys ns

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1130,10 +1130,17 @@ so forwarding by endpoint ID will not work out of the box.`,
 		true,
 		`FrontendEnableBatcher enables batcher-related RPCs in the frontend`,
 	)
+	// Deprecated: FrontendMaxConcurrentAdminBatchOperationPerNamespace is no longer honored. Use
+	// FrontendMaxConcurrentAdminBatchOperation instead.
 	FrontendMaxConcurrentAdminBatchOperationPerNamespace = NewNamespaceIntSetting(
 		"frontend.MaxConcurrentAdminBatchOperationPerNamespace",
 		1,
-		`FrontendMaxConcurrentAdminBatchOperationPerNamespace is the max concurrent admin batch operation job count per namespace`,
+		`Deprecated: no longer honored. Use frontend.MaxConcurrentAdminBatchOperation instead.`,
+	)
+	FrontendMaxConcurrentAdminBatchOperation = NewGlobalIntSetting(
+		"frontend.MaxConcurrentAdminBatchOperation",
+		1,
+		`FrontendMaxConcurrentAdminBatchOperation is the max concurrent admin batch operation job count. Admin batch operations only run in the temporal-system namespace.`,
 	)
 	FrontendEnableBatchOperationsForStandaloneActivities = NewNamespaceBoolSetting(
 		"frontend.enableBatchOperationsForStandaloneActivities",

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1139,7 +1139,7 @@ so forwarding by endpoint ID will not work out of the box.`,
 	)
 	FrontendMaxConcurrentAdminBatchOperation = NewGlobalIntSetting(
 		"frontend.MaxConcurrentAdminBatchOperation",
-		1,
+		10,
 		`FrontendMaxConcurrentAdminBatchOperation is the max concurrent admin batch operation job count. Admin batch operations only run in the temporal-system namespace.`,
 	)
 	FrontendEnableBatchOperationsForStandaloneActivities = NewNamespaceBoolSetting(

--- a/service/frontend/admin_handler.go
+++ b/service/frontend/admin_handler.go
@@ -1286,8 +1286,8 @@ func (adh *AdminHandler) StartAdminBatchOperation(
 	operateJobID := request.JobId
 	sysNS, sysNSID := primitives.SystemLocalNamespace, primitives.SystemNamespaceID
 
-	// concurrency control of the overal admin batch ops in the system namespace
-	maxConcurrentBatchOperation := adh.config.MaxConcurrentAdminBatchOperation(sysNS)
+	// Admin batch operations only run in the system namespace, so the concurrency limit is global.
+	maxConcurrentBatchOperation := adh.config.MaxConcurrentAdminBatchOperation()
 	countResp, err := adh.visibilityMgr.CountWorkflowExecutions(ctx, &manager.CountWorkflowExecutionsRequest{
 		NamespaceID: namespace.ID(sysNSID),
 		Namespace:   namespace.Name(sysNS),

--- a/service/frontend/admin_handler.go
+++ b/service/frontend/admin_handler.go
@@ -1287,7 +1287,7 @@ func (adh *AdminHandler) StartAdminBatchOperation(
 	sysNS, sysNSID := primitives.SystemLocalNamespace, primitives.SystemNamespaceID
 
 	// concurrency control of the overal admin batch ops in the system namespace
-	maxConcurrentBatchOperation := adh.config.MaxConcurrentAdminBatchOperation(request.GetNamespace())
+	maxConcurrentBatchOperation := adh.config.MaxConcurrentAdminBatchOperation(sysNS)
 	countResp, err := adh.visibilityMgr.CountWorkflowExecutions(ctx, &manager.CountWorkflowExecutionsRequest{
 		NamespaceID: namespace.ID(sysNSID),
 		Namespace:   namespace.Name(sysNS),

--- a/service/frontend/admin_handler.go
+++ b/service/frontend/admin_handler.go
@@ -1275,22 +1275,27 @@ func (adh *AdminHandler) StartAdminBatchOperation(
 		return nil, err
 	}
 
-	namespaceID, err := adh.namespaceRegistry.GetNamespaceID(namespace.Name(request.GetNamespace()))
+	// The admin batch workflow runs in the system namespace so admin batches can operate on passive clusters
+	// of a target namespace and can operate fast when the target namespace is overloaded.
+	// The target namespace reaches the activity through the workflow input and AdminRequest.
+	targetNS := request.GetNamespace()
+	targetNSID, err := adh.namespaceRegistry.GetNamespaceID(namespace.Name(targetNS))
 	if err != nil {
 		return nil, err
 	}
+	operateJobID := request.JobId
+	sysNS, sysNSID := primitives.SystemLocalNamespace, primitives.SystemNamespaceID
 
-	// Validate concurrent batch operation
+	// concurrency control of the overal admin batch ops in the system namespace
 	maxConcurrentBatchOperation := adh.config.MaxConcurrentAdminBatchOperation(request.GetNamespace())
 	countResp, err := adh.visibilityMgr.CountWorkflowExecutions(ctx, &manager.CountWorkflowExecutionsRequest{
-		NamespaceID: namespaceID,
-		Namespace:   namespace.Name(request.GetNamespace()),
+		NamespaceID: namespace.ID(sysNSID),
+		Namespace:   namespace.Name(sysNS),
 		Query:       batcher.OpenAdminBatchOperationQuery,
 	})
 	if err != nil {
 		return nil, err
 	}
-
 	openAdminBatchOperationCount := int(countResp.Count)
 	if openAdminBatchOperationCount >= maxConcurrentBatchOperation {
 		return nil, &serviceerror.ResourceExhausted{
@@ -1300,9 +1305,11 @@ func (adh *AdminHandler) StartAdminBatchOperation(
 		}
 	}
 
-	input := &batchspb.BatchOperationInput{
+	// batchOperation input and payload have the data namespace, and
+	// the request to start workflow will use operate namespace for routing
+	batchOperationInput := &batchspb.BatchOperationInput{
 		AdminRequest: request,
-		NamespaceId:  namespaceID.String(),
+		NamespaceId:  targetNSID.String(),
 	}
 
 	identity := request.GetIdentity()
@@ -1314,7 +1321,7 @@ func (adh *AdminHandler) StartAdminBatchOperation(
 		return nil, serviceerror.NewInvalidArgumentf("The operation type %T is not supported", op)
 	}
 
-	inputPayload, err := payloads.Encode(input)
+	batchOperationInputPayload, err := payloads.Encode(batchOperationInput)
 	if err != nil {
 		return nil, err
 	}
@@ -1334,11 +1341,11 @@ func (adh *AdminHandler) StartAdminBatchOperation(
 	)
 
 	startReq := &workflowservice.StartWorkflowExecutionRequest{
-		Namespace:                request.Namespace,
-		WorkflowId:               request.GetJobId(),
+		Namespace:                sysNS,
+		WorkflowId:               operateJobID,
 		WorkflowType:             &commonpb.WorkflowType{Name: batcher.BatchWFTypeProtobufName},
 		TaskQueue:                &taskqueuepb.TaskQueue{Name: primitives.PerNSWorkerTaskQueue},
-		Input:                    inputPayload,
+		Input:                    batchOperationInputPayload,
 		Identity:                 identity,
 		RequestId:                uuid.NewString(),
 		WorkflowIdConflictPolicy: enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL,
@@ -1350,7 +1357,7 @@ func (adh *AdminHandler) StartAdminBatchOperation(
 	_, err = adh.historyClient.StartWorkflowExecution(
 		ctx,
 		common.CreateHistoryStartWorkflowRequest(
-			namespaceID.String(),
+			sysNSID,
 			startReq,
 			nil,
 			nil,

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -197,8 +197,8 @@ type Config struct {
 	// Batch operation dynamic configs
 	MaxConcurrentBatchOperation     dynamicconfig.IntPropertyFnWithNamespaceFilter
 	MaxExecutionCountBatchOperation dynamicconfig.IntPropertyFnWithNamespaceFilter
-	// Admin Batch operation dynamic config
-	MaxConcurrentAdminBatchOperation             dynamicconfig.IntPropertyFnWithNamespaceFilter
+	// Admin batch operations only run in the temporal-system namespace, so this limit is global.
+	MaxConcurrentAdminBatchOperation             dynamicconfig.IntPropertyFn
 	EnableBatchOperationsForStandaloneActivities dynamicconfig.BoolPropertyFnWithNamespaceFilter
 
 	EnableUpdateWorkflowExecution                              dynamicconfig.BoolPropertyFnWithNamespaceFilter
@@ -393,7 +393,7 @@ func NewConfig(
 		EnableBatcher:                                dynamicconfig.FrontendEnableBatcher.Get(dc),
 		MaxConcurrentBatchOperation:                  dynamicconfig.FrontendMaxConcurrentBatchOperationPerNamespace.Get(dc),
 		MaxExecutionCountBatchOperation:              dynamicconfig.FrontendMaxExecutionCountBatchOperationPerNamespace.Get(dc),
-		MaxConcurrentAdminBatchOperation:             dynamicconfig.FrontendMaxConcurrentAdminBatchOperationPerNamespace.Get(dc),
+		MaxConcurrentAdminBatchOperation:             dynamicconfig.FrontendMaxConcurrentAdminBatchOperation.Get(dc),
 		EnableBatchOperationsForStandaloneActivities: dynamicconfig.FrontendEnableBatchOperationsForStandaloneActivities.Get(dc),
 
 		EnableUpdateWorkflowExecution:                              dynamicconfig.FrontendEnableUpdateWorkflowExecution.Get(dc),

--- a/service/worker/batcher/activities.go
+++ b/service/worker/batcher/activities.go
@@ -47,7 +47,8 @@ const (
 )
 
 var (
-	errNamespaceMismatch = errors.New("namespace mismatch")
+	errNamespaceMismatch            = errors.New("namespace mismatch")
+	errAdminBatchNamespaceNotSystem = errors.New("admin batches should run in the system namespace")
 
 	batchQuotaRequest = quotas.Request{
 		Token: 1,
@@ -383,32 +384,25 @@ type activities struct {
 	concurrency dynamicconfig.IntPropertyFnWithNamespaceFilter
 }
 
-// checkNamespace validates that batchParams targets the worker's own namespace.
-// This prevents cross-namespace escalation via the privileged internal-frontend connection
-// (NoopClaimMapper → RoleAdmin).
-//
-// The temporal-system worker is exempt for admin batches: it has to reach namespaces that are
-// passive in this cluster, which have no per-namespace worker of their own. Safe because
-// AdminRequest is only set by StartAdminBatchOperation (admin claims required), and frontend
-// StartWorkflowExecution rejects user starts on PerNSWorkerTaskQueue.
-func (a *activities) checkNamespace(batchParams *batchspb.BatchOperationInput) error {
-
-	// we allow admins to run batch jobs in the system namespace for other user namespaces
-	if a.namespaceID.String() == primitives.SystemNamespaceID && isAdminRequest(batchParams) {
-		return nil
+func (a *activities) checkAndGetTargetNamespace(batchParams *batchspb.BatchOperationInput) (string, error) {
+	activityNamespaceID := a.namespaceID.String()
+	batchInputNamespaceID := batchParams.GetNamespaceId()
+	// admin batches
+	if isAdminRequest(batchParams) {
+		if activityNamespaceID != primitives.SystemNamespaceID {
+			return "", errAdminBatchNamespaceNotSystem
+		}
+		adminReq := batchParams.GetAdminRequest()
+		return adminReq.Namespace, nil
 	}
-
-	if batchParams.NamespaceId != a.namespaceID.String() {
-		return errNamespaceMismatch
+	// user batch
+	if batchInputNamespaceID != activityNamespaceID {
+		return "", errNamespaceMismatch
 	}
-	ns := a.namespace.String()
-	if req := batchParams.GetRequest(); req != nil && req.GetNamespace() != ns {
-		return errNamespaceMismatch
+	if req := batchParams.GetRequest(); req != nil && req.GetNamespace() != a.namespace.String() {
+		return "", errNamespaceMismatch
 	}
-	if req := batchParams.GetAdminRequest(); req != nil && req.GetNamespace() != ns {
-		return errNamespaceMismatch
-	}
-	return nil
+	return a.namespace.String(), nil
 }
 
 // todo: check if this a solid and safe way
@@ -423,15 +417,11 @@ func (a *activities) BatchActivityWithProtobuf(ctx context.Context, batchParams 
 	hbd := HeartBeatDetails{}
 	metricsHandler := a.MetricsHandler.WithTags(metrics.OperationTag(metrics.BatcherScope), metrics.NamespaceIDTag(batchParams.NamespaceId))
 
-	if err := a.checkNamespace(batchParams); err != nil {
+	targetNS, err := a.checkAndGetTargetNamespace(batchParams)
+	if err != nil {
 		metrics.BatcherOperationFailures.With(metricsHandler).Record(1)
 		logger.Error("Failed to run batch operation due to namespace mismatch", tag.Error(err))
 		return hbd, err
-	}
-
-	targetNS := a.namespace.String()
-	if isAdminRequest(batchParams) {
-		targetNS = batchParams.GetAdminRequest().GetNamespace()
 	}
 
 	sdkClientForTargetNS := a.ClientFactory.NewClient(sdkclient.Options{

--- a/service/worker/batcher/activities.go
+++ b/service/worker/batcher/activities.go
@@ -29,6 +29,7 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/quotas"
 	"go.temporal.io/server/common/sdk"
 	"go.temporal.io/server/common/worker_versioning"
@@ -383,10 +384,20 @@ type activities struct {
 }
 
 // checkNamespace validates that batchParams targets the worker's own namespace.
-// The NamespaceId, Request.Namespace (if set), and AdminRequest.Namespace (if set)
-// must all agree with the worker's bound namespace. This prevents cross-namespace
-// escalation via the privileged internal-frontend connection (NoopClaimMapper → RoleAdmin).
+// This prevents cross-namespace escalation via the privileged internal-frontend connection
+// (NoopClaimMapper → RoleAdmin).
+//
+// The temporal-system worker is exempt for admin batches: it has to reach namespaces that are
+// passive in this cluster, which have no per-namespace worker of their own. Safe because
+// AdminRequest is only set by StartAdminBatchOperation (admin claims required), and frontend
+// StartWorkflowExecution rejects user starts on PerNSWorkerTaskQueue.
 func (a *activities) checkNamespace(batchParams *batchspb.BatchOperationInput) error {
+
+	// we allow admins to run batch jobs in the system namespace for other user namespaces
+	if a.namespaceID.String() == primitives.SystemNamespaceID && isAdminRequest(batchParams) {
+		return nil
+	}
+
 	if batchParams.NamespaceId != a.namespaceID.String() {
 		return errNamespaceMismatch
 	}
@@ -398,6 +409,11 @@ func (a *activities) checkNamespace(batchParams *batchspb.BatchOperationInput) e
 		return errNamespaceMismatch
 	}
 	return nil
+}
+
+// todo: check if this a solid and safe way
+func isAdminRequest(batchParams *batchspb.BatchOperationInput) bool {
+	return batchParams.AdminRequest != nil
 }
 
 // BatchActivityWithProtobuf is an activity for processing batch operations using protobuf as the input type.
@@ -412,13 +428,17 @@ func (a *activities) BatchActivityWithProtobuf(ctx context.Context, batchParams 
 		logger.Error("Failed to run batch operation due to namespace mismatch", tag.Error(err))
 		return hbd, err
 	}
-	ns := a.namespace.String()
 
-	sdkClient := a.ClientFactory.NewClient(sdkclient.Options{
-		Namespace:     ns,
+	targetNS := a.namespace.String()
+	if isAdminRequest(batchParams) {
+		targetNS = batchParams.GetAdminRequest().GetNamespace()
+	}
+
+	sdkClientForTargetNS := a.ClientFactory.NewClient(sdkclient.Options{
+		Namespace:     targetNS,
 		DataConverter: sdk.PreferProtoDataConverter,
 	})
-	defer sdkClient.Close()
+	defer sdkClientForTargetNS.Close()
 	startOver := true
 	if activity.HasHeartbeatDetails(ctx) {
 		if err := activity.GetHeartbeatDetails(ctx, &hbd); err == nil {
@@ -447,7 +467,7 @@ func (a *activities) BatchActivityWithProtobuf(ctx context.Context, batchParams 
 		executions = batchParams.Request.Executions
 		targetExecutions = batchParams.Request.GetTargetExecutions()
 		rateLimiter = quotas.NewRequestRateLimiterAdapter(quotas.NewDefaultOutgoingRateLimiter(func() float64 {
-			return float64(a.rps(ns))
+			return float64(a.rps(targetNS))
 		}))
 	}
 
@@ -460,8 +480,8 @@ func (a *activities) BatchActivityWithProtobuf(ctx context.Context, batchParams 
 				// Activity batch types operate on activity executions, which are
 				// counted via CountActivityExecutions rather than CountWorkflow.
 				var resp *workflowservice.CountActivityExecutionsResponse
-				resp, err = sdkClient.WorkflowService().CountActivityExecutions(ctx, &workflowservice.CountActivityExecutionsRequest{
-					Namespace: ns,
+				resp, err = sdkClientForTargetNS.WorkflowService().CountActivityExecutions(ctx, &workflowservice.CountActivityExecutionsRequest{
+					Namespace: targetNS,
 					Query:     visibilityQuery,
 				})
 				if err == nil {
@@ -469,7 +489,7 @@ func (a *activities) BatchActivityWithProtobuf(ctx context.Context, batchParams 
 				}
 			} else {
 				var resp *workflowservice.CountWorkflowExecutionsResponse
-				resp, err = sdkClient.CountWorkflow(ctx, &workflowservice.CountWorkflowExecutionsRequest{
+				resp, err = sdkClientForTargetNS.CountWorkflow(ctx, &workflowservice.CountWorkflowExecutionsRequest{
 					Query: visibilityQuery,
 				})
 				if err == nil {
@@ -492,7 +512,7 @@ func (a *activities) BatchActivityWithProtobuf(ctx context.Context, batchParams 
 
 	// Prepare configuration for shared processing function
 	config := batchProcessorConfig{
-		namespace:               ns,
+		namespace:               targetNS,
 		adjustedQuery:           visibilityQuery,
 		batchType:               batchParams.BatchType,
 		concurrency:             a.getOperationConcurrency(int(batchParams.Concurrency)),
@@ -512,10 +532,10 @@ func (a *activities) BatchActivityWithProtobuf(ctx context.Context, batchParams 
 		metricsHandler metrics.Handler,
 		logger log.Logger,
 	) {
-		a.startTaskProcessor(ctx, batchParams, ns, taskCh, respCh, rateLimiter, sdkClient, frontendClient, metricsHandler, logger)
+		a.startTaskProcessor(ctx, batchParams, targetNS, taskCh, respCh, rateLimiter, sdkClient, frontendClient, metricsHandler, logger)
 	}
 
-	return a.processWorkflowsWithProactiveFetching(ctx, config, workerProcessor, rateLimiter, sdkClient, metricsHandler, logger, hbd)
+	return a.processWorkflowsWithProactiveFetching(ctx, config, workerProcessor, rateLimiter, sdkClientForTargetNS, metricsHandler, logger, hbd)
 }
 
 func (a *activities) getActivityLogger(ctx context.Context) log.Logger {

--- a/service/worker/batcher/activities_namespace_test.go
+++ b/service/worker/batcher/activities_namespace_test.go
@@ -16,6 +16,7 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/quotas"
 	"go.temporal.io/server/common/testing/mockapi/workflowservicemock/v1"
 	"go.uber.org/mock/gomock"
@@ -74,25 +75,29 @@ func TestBatchActivityWithProtobuf_RejectsMismatchedRequestNamespace(t *testing.
 	require.ErrorContains(t, err, errNamespaceMismatch.Error())
 }
 
-// TestBatchActivityWithProtobuf_RejectsMismatchedAdminRequestNamespace verifies
-// that the same namespace mismatch check applies to admin batch requests.
-func TestBatchActivityWithProtobuf_RejectsMismatchedAdminRequestNamespace(t *testing.T) {
-	ts := testsuite.WorkflowTestSuite{}
-	env := ts.NewTestActivityEnvironment()
-	a := newBoundActivities(nil)
-	env.RegisterActivity(a.BatchActivityWithProtobuf)
-
+func TestCheckAndGetTargetNamespace_AdminRequest(t *testing.T) {
 	input := &batchspb.BatchOperationInput{
-		NamespaceId: boundNSID,
 		AdminRequest: &adminservice.StartAdminBatchOperationRequest{
-			Namespace:  otherNSName, // mismatched — must be rejected
-			Executions: []*commonpb.WorkflowExecution{{WorkflowId: "w"}},
+			Namespace: otherNSName,
 		},
 	}
 
-	_, err := env.ExecuteActivity(a.BatchActivityWithProtobuf, input)
-	require.Error(t, err)
-	require.ErrorContains(t, err, errNamespaceMismatch.Error())
+	t.Run("rejects request outside system namespace", func(t *testing.T) {
+		targetNamespace, err := newBoundActivities(nil).checkAndGetTargetNamespace(input)
+
+		require.ErrorIs(t, err, errAdminBatchNamespaceNotSystem)
+		require.Empty(t, targetNamespace)
+	})
+
+	t.Run("returns target namespace for system worker", func(t *testing.T) {
+		a := newBoundActivities(nil)
+		a.namespaceID = namespace.ID(primitives.SystemNamespaceID)
+
+		targetNamespace, err := a.checkAndGetTargetNamespace(input)
+
+		require.NoError(t, err)
+		require.Equal(t, otherNSName, targetNamespace)
+	})
 }
 
 // TestStartTaskProcessor_UsesWorkerBoundNamespaceForSignal verifies that when

--- a/tests/admin_batch_refresh_workflow_tasks_test.go
+++ b/tests/admin_batch_refresh_workflow_tasks_test.go
@@ -41,7 +41,7 @@ func (s *AdminBatchRefreshWorkflowTasksTestSuite) newTestEnv(opts ...testcore.Te
 	// that haven't completed yet. The isolation test (A_SeparateLimitFromFrontendBatchOperation)
 	// explicitly sets limit to 1 to verify frontend and admin batch ops use separate limits.
 	baseOpts := []testcore.TestOption{
-		testcore.WithDynamicConfig(dynamicconfig.FrontendMaxConcurrentAdminBatchOperationPerNamespace, 10),
+		testcore.WithDynamicConfig(dynamicconfig.FrontendMaxConcurrentAdminBatchOperation, 10),
 	}
 	return testcore.NewEnv(s.T(), append(baseOpts, opts...)...)
 }
@@ -258,7 +258,7 @@ func (s *AdminBatchRefreshWorkflowTasksTestSuite) TestStartAdminBatchOperation_I
 func (s *AdminBatchRefreshWorkflowTasksTestSuite) TestStartAdminBatchOperation_0_SeparateLimitFromFrontendBatchOperation() {
 	env := s.newTestEnv(
 		testcore.WithDynamicConfig(dynamicconfig.FrontendMaxConcurrentBatchOperationPerNamespace, 1),
-		testcore.WithDynamicConfig(dynamicconfig.FrontendMaxConcurrentAdminBatchOperationPerNamespace, 1),
+		testcore.WithDynamicConfig(dynamicconfig.FrontendMaxConcurrentAdminBatchOperation, 1),
 	)
 
 	env.SdkWorker().RegisterWorkflow(s.simpleWorkflow)

--- a/tests/admin_batch_refresh_workflow_tasks_test.go
+++ b/tests/admin_batch_refresh_workflow_tasks_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 	"time"
 
@@ -16,7 +17,9 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/primitives"
+	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.temporal.io/server/common/testing/parallelsuite"
+	"go.temporal.io/server/service/worker/batcher"
 	"go.temporal.io/server/tests/testcore"
 	"go.temporal.io/server/tools/tdbg"
 	"go.temporal.io/server/tools/tdbg/tdbgtest"
@@ -146,7 +149,8 @@ func (s *AdminBatchRefreshWorkflowTasksTestSuite) TestTdbgRefreshTasks_StartsBat
 
 	// tdbg qualifies the job ID with the namespace: the batch workflow runs in the system namespace,
 	// where job IDs from every namespace share one workflow ID space.
-	batchWorkflowID := jobID + ":" + ns
+	batchWorkflowIDPrefix := ns + ":"
+	batchWorkflowID := batchWorkflowIDPrefix + jobID
 	resp, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
 		Namespace: primitives.SystemLocalNamespace,
 		Execution: &commonpb.WorkflowExecution{WorkflowId: batchWorkflowID},
@@ -161,6 +165,23 @@ func (s *AdminBatchRefreshWorkflowTasksTestSuite) TestTdbgRefreshTasks_StartsBat
 	})
 	var notFound *serviceerror.NotFound
 	s.ErrorAs(err, &notFound)
+
+	s.Await(func(s *AdminBatchRefreshWorkflowTasksTestSuite) {
+		resp, err := env.FrontendClient().ListWorkflowExecutions(s.Context(), &workflowservice.ListWorkflowExecutionsRequest{
+			Namespace: primitives.SystemLocalNamespace,
+			Query: fmt.Sprintf("%s = '%s' AND WorkflowId STARTS_WITH '%s'",
+				sadefs.TemporalNamespaceDivision,
+				batcher.AdminNamespaceDivision,
+				batchWorkflowIDPrefix,
+			),
+		})
+		s.NoError(err)
+		var workflowIDs []string
+		for _, execution := range resp.GetExecutions() {
+			workflowIDs = append(workflowIDs, execution.GetExecution().GetWorkflowId())
+		}
+		s.Contains(workflowIDs, batchWorkflowID)
+	}, 10*time.Second, 500*time.Millisecond)
 }
 
 func (s *AdminBatchRefreshWorkflowTasksTestSuite) TestStartAdminBatchOperation_InvalidArgument_NoOperation() {

--- a/tests/admin_batch_refresh_workflow_tasks_test.go
+++ b/tests/admin_batch_refresh_workflow_tasks_test.go
@@ -1,12 +1,11 @@
 package tests
 
 import (
+	"bytes"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	batchpb "go.temporal.io/api/batch/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
@@ -16,8 +15,11 @@ import (
 	"go.temporal.io/server/api/adminservice/v1"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/payloads"
+	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/tests/testcore"
+	"go.temporal.io/server/tools/tdbg"
+	"go.temporal.io/server/tools/tdbg/tdbgtest"
 	"google.golang.org/grpc/codes"
 )
 
@@ -44,6 +46,17 @@ func (s *AdminBatchRefreshWorkflowTasksTestSuite) newTestEnv(opts ...testcore.Te
 func (s *AdminBatchRefreshWorkflowTasksTestSuite) simpleWorkflow(ctx workflow.Context) (string, error) {
 	// Simple workflow that just returns
 	return "done", nil
+}
+
+func (s *AdminBatchRefreshWorkflowTasksTestSuite) runTdbg(env *testcore.TestEnv, args ...string) error {
+	var out bytes.Buffer
+	return tdbgtest.NewCliApp(
+		func(params *tdbg.Params) {
+			params.ClientFactory = tdbg.NewClientFactory(tdbg.WithFrontendAddress(env.FrontendGRPCAddress()))
+			params.Writer = &out
+			params.ErrWriter = &out
+		},
+	).RunContext(s.Context(), append([]string{"tdbg"}, args...))
 }
 
 func (s *AdminBatchRefreshWorkflowTasksTestSuite) createWorkflow(env *testcore.TestEnv, workflowFn any) sdkclient.WorkflowRun {
@@ -91,7 +104,8 @@ func (s *AdminBatchRefreshWorkflowTasksTestSuite) TestStartAdminBatchOperation_R
 	s.NotNil(resp)
 }
 
-func (s *AdminBatchRefreshWorkflowTasksTestSuite) TestStartAdminBatchOperation_RefreshWorkflowTasks_WithVisibilityQuery() {
+// The job's execution is covered by the xdc suite; this test only covers tdbg starting it.
+func (s *AdminBatchRefreshWorkflowTasksTestSuite) TestTdbgRefreshTasks_StartsBatchJobInSystemNamespace() {
 	env := s.newTestEnv()
 
 	env.SdkWorker().RegisterWorkflow(s.simpleWorkflow)
@@ -107,29 +121,46 @@ func (s *AdminBatchRefreshWorkflowTasksTestSuite) TestStartAdminBatchOperation_R
 	err = workflowRun2.Get(s.Context(), &out)
 	s.NoError(err)
 
+	ns := env.Namespace().String()
+	query := "WorkflowType='simpleWorkflow'"
+
 	// Wait for workflows to be visible
-	s.EventuallyWithT(func(t *assert.CollectT) {
+	s.Await(func(s *AdminBatchRefreshWorkflowTasksTestSuite) {
 		resp, err := env.FrontendClient().CountWorkflowExecutions(s.Context(), &workflowservice.CountWorkflowExecutionsRequest{
-			Namespace: env.Namespace().String(),
-			Query:     "WorkflowType='simpleWorkflow'",
+			Namespace: ns,
+			Query:     query,
 		})
-		require.NoError(t, err)
-		require.GreaterOrEqual(t, resp.GetCount(), int64(2))
+		s.NoError(err)
+		s.GreaterOrEqual(resp.GetCount(), int64(2))
 	}, 10*time.Second, 500*time.Millisecond)
 
-	// Start admin batch operation using visibility query
-	resp, err := env.AdminClient().StartAdminBatchOperation(s.Context(), &adminservice.StartAdminBatchOperationRequest{
-		Namespace:       env.Namespace().String(),
-		VisibilityQuery: "WorkflowType='simpleWorkflow'",
-		JobId:           uuid.NewString(),
-		Reason:          "test refresh workflow tasks with query",
-		Identity:        "test-identity",
-		Operation: &adminservice.StartAdminBatchOperationRequest_RefreshTasksOperation{
-			RefreshTasksOperation: &adminservice.BatchOperationRefreshTasks{},
-		},
+	jobID := uuid.NewString()
+	s.NoError(s.runTdbg(env,
+		"--"+tdbg.FlagYes,
+		"--"+tdbg.FlagNamespace, ns,
+		"execution", "refresh-tasks",
+		"--"+tdbg.FlagVisibilityQuery, query,
+		"--"+tdbg.FlagReason, "test refresh workflow tasks with query",
+		"--"+tdbg.FlagJobID, jobID,
+	))
+
+	// tdbg qualifies the job ID with the namespace: the batch workflow runs in the system namespace,
+	// where job IDs from every namespace share one workflow ID space.
+	batchWorkflowID := jobID + ":" + ns
+	resp, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+		Namespace: primitives.SystemLocalNamespace,
+		Execution: &commonpb.WorkflowExecution{WorkflowId: batchWorkflowID},
 	})
 	s.NoError(err)
-	s.NotNil(resp)
+	s.Equal(batchWorkflowID, resp.GetWorkflowExecutionInfo().GetExecution().GetWorkflowId())
+	s.Equal(primitives.PerNSWorkerTaskQueue, resp.GetExecutionConfig().GetTaskQueue().GetName())
+
+	_, err = env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+		Namespace: ns,
+		Execution: &commonpb.WorkflowExecution{WorkflowId: batchWorkflowID},
+	})
+	var notFound *serviceerror.NotFound
+	s.ErrorAs(err, &notFound)
 }
 
 func (s *AdminBatchRefreshWorkflowTasksTestSuite) TestStartAdminBatchOperation_InvalidArgument_NoOperation() {

--- a/tests/xdc/admin_batch_refresh_workflow_tasks_test.go
+++ b/tests/xdc/admin_batch_refresh_workflow_tasks_test.go
@@ -40,7 +40,7 @@ func (s *AdminBatchRefreshWorkflowTasksTestSuite) SetupSuite() {
 	if s.dynamicConfigOverrides == nil {
 		s.dynamicConfigOverrides = make(map[dynamicconfig.Key]any)
 	}
-	s.dynamicConfigOverrides[dynamicconfig.FrontendMaxConcurrentAdminBatchOperationPerNamespace.Key()] = 10
+	s.dynamicConfigOverrides[dynamicconfig.FrontendMaxConcurrentAdminBatchOperation.Key()] = 10
 	s.setupSuite()
 }
 

--- a/tests/xdc/admin_batch_refresh_workflow_tasks_test.go
+++ b/tests/xdc/admin_batch_refresh_workflow_tasks_test.go
@@ -1,0 +1,222 @@
+package xdc
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	sdkclient "go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/workflow"
+	"go.temporal.io/server/api/adminservice/v1"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/primitives"
+	"go.temporal.io/server/common/testing/await"
+	"go.temporal.io/server/service/worker/batcher"
+	"go.temporal.io/server/tests/testcore"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+type AdminBatchRefreshWorkflowTasksTestSuite struct {
+	xdcBaseSuite
+}
+
+func TestAdminBatchRefreshWorkflowTasksTestSuite(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, &AdminBatchRefreshWorkflowTasksTestSuite{})
+}
+
+func (s *AdminBatchRefreshWorkflowTasksTestSuite) SetupSuite() {
+	if s.dynamicConfigOverrides == nil {
+		s.dynamicConfigOverrides = make(map[dynamicconfig.Key]any)
+	}
+	s.dynamicConfigOverrides[dynamicconfig.FrontendMaxConcurrentAdminBatchOperationPerNamespace.Key()] = 10
+	s.setupSuite()
+}
+
+func (s *AdminBatchRefreshWorkflowTasksTestSuite) SetupTest() {
+	s.setupTest()
+}
+
+func (s *AdminBatchRefreshWorkflowTasksTestSuite) TearDownSuite() {
+	s.tearDownSuite()
+}
+
+// TestRefreshWorkflowTasks_ActiveAndPassiveCluster runs an admin batch refresh-tasks job in both
+// the active and the passive cluster of a global namespace. The passive cluster is the case the
+// feature exists for: it has no per-namespace worker for a namespace that is not active there, and
+// api.GetActiveNamespace would reject starting the batch workflow in that namespace.
+func (s *AdminBatchRefreshWorkflowTasksTestSuite) TestRefreshWorkflowTasks_ActiveAndPassiveCluster() {
+	ctx := testcore.NewContext()
+	ns := s.createGlobalNamespace()
+
+	// The premise of this test: cluster 0 is active for ns, cluster 1 is passive. DescribeNamespace
+	// is a local API, so each cluster reports its own view.
+	for _, cluster := range s.clusters {
+		resp, err := cluster.FrontendClient().DescribeNamespace(ctx, &workflowservice.DescribeNamespaceRequest{Namespace: ns})
+		s.NoError(err)
+		s.Equal(s.clusters[0].ClusterName(), resp.GetReplicationConfig().GetActiveClusterName(),
+			"%s should see %s as active for %s", cluster.ClusterName(), s.clusters[0].ClusterName(), ns)
+	}
+
+	taskQueue := "admin-batch-refresh-tq"
+	workflowTypeName := "admin-batch-refresh-wf-type-" + uuid.NewString()
+	visibilityQuery := fmt.Sprintf("WorkflowType = '%s'", workflowTypeName)
+
+	// Two workflows with no worker on the task queue, so each keeps a pending workflow task.
+	executions := make([]*commonpb.WorkflowExecution, 0, 2)
+	for i := range 2 {
+		workflowID := fmt.Sprintf("admin-batch-refresh-%d-%s", i, uuid.NewString())
+		resp, err := s.clusters[0].FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
+			RequestId:          uuid.NewString(),
+			Namespace:          ns,
+			WorkflowId:         workflowID,
+			WorkflowType:       &commonpb.WorkflowType{Name: workflowTypeName},
+			TaskQueue:          &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+			Identity:           "test",
+			WorkflowRunTimeout: durationpb.New(time.Hour),
+		})
+		s.NoError(err)
+		executions = append(executions, &commonpb.WorkflowExecution{WorkflowId: workflowID, RunId: resp.GetRunId()})
+	}
+
+	s.waitForVisibility(ctx, s.clusters[0], ns, visibilityQuery, 2, 20*time.Second, 500*time.Millisecond)
+
+	// The passive cluster must hold the executions locally: RefreshWorkflowTasks there resolves the
+	// shard from the local namespace ID, so DescribeMutableState is the check that matters. It goes
+	// through the admin service, which is not subject to DC redirection.
+	for _, execution := range executions {
+		await.RequireTruef(s.T(), func() bool {
+			_, err := s.clusters[1].AdminClient().DescribeMutableState(ctx, &adminservice.DescribeMutableStateRequest{
+				Namespace: ns,
+				Execution: execution,
+			})
+			return err == nil
+		}, replicationWaitTime, replicationCheckInterval, "execution %s should replicate to the passive cluster", execution.GetWorkflowId())
+	}
+	s.waitForVisibility(ctx, s.clusters[1], ns, visibilityQuery, 2, replicationWaitTime, replicationCheckInterval)
+
+	for _, cluster := range s.clusters {
+		s.refreshTasksInCluster(ctx, cluster, ns, visibilityQuery)
+	}
+
+	// Both executions still have a dispatchable workflow task after being refreshed in both clusters.
+	sdkClient, worker := s.newClientAndWorker(s.clusters[0].Host().FrontendGRPCAddress(), ns, taskQueue, "worker0")
+	defer sdkClient.Close()
+	worker.RegisterWorkflowWithOptions(
+		func(workflow.Context) error { return nil },
+		workflow.RegisterOptions{Name: workflowTypeName},
+	)
+	s.NoError(worker.Start())
+	defer worker.Stop()
+
+	for _, execution := range executions {
+		s.NoError(sdkClient.GetWorkflow(ctx, execution.GetWorkflowId(), execution.GetRunId()).Get(ctx, nil))
+	}
+}
+
+func (s *AdminBatchRefreshWorkflowTasksTestSuite) refreshTasksInCluster(
+	ctx context.Context,
+	cluster *testcore.TestCluster,
+	ns string,
+	visibilityQuery string,
+) {
+	clusterName := cluster.ClusterName()
+	jobID := "refresh-" + clusterName + "-" + uuid.NewString()
+
+	_, err := cluster.AdminClient().StartAdminBatchOperation(ctx, &adminservice.StartAdminBatchOperationRequest{
+		Namespace:       ns,
+		VisibilityQuery: visibilityQuery,
+		JobId:           jobID,
+		Reason:          "xdc admin batch refresh tasks",
+		Identity:        "test",
+		Operation: &adminservice.StartAdminBatchOperationRequest_RefreshTasksOperation{
+			RefreshTasksOperation: &adminservice.BatchOperationRefreshTasks{},
+		},
+	})
+	s.NoError(err, "StartAdminBatchOperation should be accepted in %s", clusterName)
+
+	// StartAdminBatchOperation uses the job ID as the workflow ID.
+	batchWorkflowID := jobID
+
+	// The batch workflow lives in the system namespace, not in the namespace it operates on, and its
+	// tasks go to the system namespace's per-namespace worker task queue.
+	var describeResp *workflowservice.DescribeWorkflowExecutionResponse
+	await.Requiref(ctx, s.T(), func(t *await.T) {
+		resp, err := cluster.FrontendClient().DescribeWorkflowExecution(t.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: primitives.SystemLocalNamespace,
+			Execution: &commonpb.WorkflowExecution{WorkflowId: batchWorkflowID},
+		})
+		require.NoError(t, err)
+		require.Equal(t, enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, resp.GetWorkflowExecutionInfo().GetStatus())
+		describeResp = resp
+	}, 60*time.Second, time.Second, "%s: batch workflow %s should complete in %s", clusterName, batchWorkflowID, primitives.SystemLocalNamespace)
+
+	s.Equal(primitives.PerNSWorkerTaskQueue, describeResp.GetExecutionConfig().GetTaskQueue().GetName(),
+		"%s: batch workflow must run on the %s task queue", clusterName, primitives.PerNSWorkerTaskQueue)
+
+	// Only the system namespace's per-namespace worker polls that queue for this workflow type.
+	taskQueueResp, err := cluster.FrontendClient().DescribeTaskQueue(ctx, &workflowservice.DescribeTaskQueueRequest{
+		Namespace:     primitives.SystemLocalNamespace,
+		TaskQueue:     &taskqueuepb.TaskQueue{Name: primitives.PerNSWorkerTaskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		TaskQueueType: enumspb.TASK_QUEUE_TYPE_WORKFLOW,
+	})
+	s.NoError(err)
+	// Identity is "temporal-system@<host>@<namespace>", set by the per-namespace worker manager.
+	hasSystemNamespacePoller := slices.ContainsFunc(taskQueueResp.GetPollers(), func(poller *taskqueuepb.PollerInfo) bool {
+		return strings.HasSuffix(poller.GetIdentity(), "@"+primitives.SystemLocalNamespace)
+	})
+	s.True(hasSystemNamespacePoller,
+		"%s: the %s per-namespace worker must poll %s, got pollers %v",
+		clusterName, primitives.SystemLocalNamespace, primitives.PerNSWorkerTaskQueue, taskQueueResp.GetPollers())
+
+	_, err = cluster.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+		Namespace: ns,
+		Execution: &commonpb.WorkflowExecution{WorkflowId: batchWorkflowID},
+	})
+	var notFound *serviceerror.NotFound
+	s.ErrorAs(err, &notFound, "%s: batch workflow must not exist in %s", clusterName, ns)
+
+	// The job worked on the target namespace: both of its executions were counted and refreshed.
+	// Had it read visibility in the system namespace, the query would have matched nothing.
+	systemClient, err := sdkclient.Dial(sdkclient.Options{
+		HostPort:  cluster.Host().FrontendGRPCAddress(),
+		Namespace: primitives.SystemLocalNamespace,
+	})
+	s.NoError(err)
+	defer systemClient.Close()
+
+	var hbd batcher.HeartBeatDetails
+	s.NoError(systemClient.GetWorkflow(ctx, batchWorkflowID, "").Get(ctx, &hbd))
+	s.Equal(int64(2), hbd.TotalEstimate, "%s: estimate must come from %s", clusterName, ns)
+	s.Equal(2, hbd.SuccessCount, "%s: both executions must be refreshed", clusterName)
+	s.Equal(0, hbd.ErrorCount, "%s: no execution should fail to refresh", clusterName)
+}
+
+func (s *AdminBatchRefreshWorkflowTasksTestSuite) waitForVisibility(
+	ctx context.Context,
+	cluster *testcore.TestCluster,
+	ns string,
+	query string,
+	expected int64,
+	timeout time.Duration,
+	interval time.Duration,
+) {
+	await.RequireTruef(s.T(), func() bool {
+		resp, err := cluster.FrontendClient().CountWorkflowExecutions(ctx, &workflowservice.CountWorkflowExecutionsRequest{
+			Namespace: ns,
+			Query:     query,
+		})
+		return err == nil && resp.GetCount() == expected
+	}, timeout, interval, "%s should index %d executions for query %s", cluster.ClusterName(), expected, query)
+}

--- a/tools/tdbg/commands.go
+++ b/tools/tdbg/commands.go
@@ -769,6 +769,7 @@ func AdminBatchRefreshWorkflowTasks(c *cli.Context, clientFactory ClientFactory,
 	if jobID == "" {
 		jobID = fmt.Sprintf("batch-refresh-%d", time.Now().UnixNano())
 	}
+	jobIDWithNS := fmt.Sprintf("%s:%s", jobID, nsName)
 
 	ctx, cancel := newContext(c)
 	defer cancel()
@@ -782,14 +783,14 @@ func AdminBatchRefreshWorkflowTasks(c *cli.Context, clientFactory ClientFactory,
 		return fmt.Errorf("unable to count workflow executions: %w", err)
 	}
 
-	msg := fmt.Sprintf("Will refresh tasks for %d execution(s) matching query %q in namespace %q. Continue Y/N?",
+	msg := fmt.Sprintf("A workflow will be started in temporal-system to refresh tasks for %d execution(s) matching query %q in namespace %q. Continue Y/N?",
 		countResp.GetCount(), query, nsName)
 	prompter.Prompt(msg)
 
 	_, err = adminClient.StartAdminBatchOperation(ctx, &adminservice.StartAdminBatchOperationRequest{
 		Namespace:       nsName,
 		VisibilityQuery: query,
-		JobId:           jobID,
+		JobId:           jobIDWithNS,
 		Reason:          reason,
 		Identity:        getCurrentUserFromEnv(),
 		Operation: &adminservice.StartAdminBatchOperationRequest_RefreshTasksOperation{
@@ -801,7 +802,7 @@ func AdminBatchRefreshWorkflowTasks(c *cli.Context, clientFactory ClientFactory,
 	}
 
 	// nolint:errcheck // assuming that write will succeed.
-	fmt.Fprintf(c.App.Writer, "Batch Refresh Workflow Tasks started successfully for Job ID: %s\n", jobID)
+	fmt.Fprintf(c.App.Writer, "Batch Refresh Workflow Tasks started successfully for Job ID: %s\n", jobIDWithNS)
 	return nil
 }
 

--- a/tools/tdbg/commands.go
+++ b/tools/tdbg/commands.go
@@ -769,7 +769,7 @@ func AdminBatchRefreshWorkflowTasks(c *cli.Context, clientFactory ClientFactory,
 	if jobID == "" {
 		jobID = fmt.Sprintf("batch-refresh-%d", time.Now().UnixNano())
 	}
-	jobIDWithNS := fmt.Sprintf("%s:%s", jobID, nsName)
+	jobIDWithNS := fmt.Sprintf("%s:%s", nsName, jobID)
 
 	ctx, cancel := newContext(c)
 	defer cancel()


### PR DESCRIPTION
## What changed?

- updated batch administration operations to run in the system namespace while continuing to use per-namespace task queues and workers.
- allow batch activities running in the system namespace operating on other target namespaces
- add ns to jobID and print all previous changes in tdbg prompts

## Why?
to run refresh tasks in passive clusters of user global namespaces

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [x] added new functional test(s)

## Potential risks
need solid validation of the security for cross ns operation refer to analysis of this feature