### PR TITLE
Enable Claude reviews for OSS Matching

### DIFF
--- a/.github/workflows/claude-review-teams.yml
+++ b/.github/workflows/claude-review-teams.yml
@@ -14,7 +14,7 @@ env:
   # Space- or newline-separated list of temporalio team slugs whose
   # members' PRs should receive an automated Claude review. Empty means only
   # PRs labeled with REVIEW_OPT_IN_LABEL by a temporalio org member are reviewed.
-  REVIEW_TEAMS: "nexus act"
+  REVIEW_TEAMS: "nexus act oss-matching"
   REVIEW_OPT_IN_LABEL: request-claude-review
   REVIEW_OPT_OUT_LABEL: skip-claude-review
 


### PR DESCRIPTION
## Summary

- Enable automated Claude PR reviews for members of `temporalio/oss-matching`.

## Impact

Members of the OSS Matching team will receive automated Claude reviews after the workflow's existing organization membership, repository permission, and label checks pass.

## Validation

- `git diff --check`
- Confirmed the branch contains a single workflow-only commit based on the latest `origin/main`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single workflow env change; no application or security logic is modified, only which GitHub team triggers an existing gated review job.
> 
> **Overview**
> Extends automated Claude PR reviews to **`temporalio/oss-matching`** by adding `oss-matching` to the `REVIEW_TEAMS` list in `.github/workflows/claude-review-teams.yml` (alongside existing `nexus` and `act`).
> 
> PRs from active members of that team still go through the same eligibility path as other configured teams: org membership, repo write access, and no `skip-claude-review` label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86e1e13fd74a1afd781e690288d93e1a4e770956. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->