### PR TITLE
Use chasm context NamespaceEntry instead of injecting namespace registry for activity code

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -52,7 +52,6 @@ import (
 	"go.temporal.io/server/common/contextutil"
 	commonfailure "go.temporal.io/server/common/failure"
 	"go.temporal.io/server/common/metrics"
-	"go.temporal.io/server/common/namespace"
 	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/nexus/nexusrpc"
 	"go.temporal.io/server/common/payload"
@@ -592,10 +591,7 @@ func (a *Activity) HandleCompleted(
 	}
 
 	baseHandler := a.baseMetricsHandler(ctx, metrics.HistoryRespondActivityTaskCompletedScope)
-	enrichedHandler, err := a.enrichedMetricsHandler(ctx, metrics.HistoryRespondActivityTaskCompletedScope)
-	if err != nil {
-		return nil, err
-	}
+	enrichedHandler := a.enrichedMetricsHandler(ctx, metrics.HistoryRespondActivityTaskCompletedScope)
 
 	if err := TransitionCompleted.Apply(a, ctx, completeEvent{
 		req:             event.Request,
@@ -619,10 +615,7 @@ func (a *Activity) HandleFailed(
 	}
 
 	baseHandler := a.baseMetricsHandler(ctx, metrics.HistoryRespondActivityTaskFailedScope)
-	enrichedHandler, err := a.enrichedMetricsHandler(ctx, metrics.HistoryRespondActivityTaskFailedScope)
-	if err != nil {
-		return nil, err
-	}
+	enrichedHandler := a.enrichedMetricsHandler(ctx, metrics.HistoryRespondActivityTaskFailedScope)
 	failedRequest := event.Request.GetFailedRequest()
 	failure := failedRequest.GetFailure()
 
@@ -674,10 +667,7 @@ func (a *Activity) HandleCanceled(
 		return nil, consts.ErrActivityTaskNotCancelRequested
 	}
 
-	metricsHandler, err := a.enrichedMetricsHandler(ctx, metrics.HistoryRespondActivityTaskCanceledScope)
-	if err != nil {
-		return nil, err
-	}
+	metricsHandler := a.enrichedMetricsHandler(ctx, metrics.HistoryRespondActivityTaskCanceledScope)
 
 	if err := TransitionCanceled.Apply(a, ctx, cancelEvent{
 		details:        event.Request.GetCancelRequest().GetDetails(),
@@ -708,10 +698,7 @@ func (a *Activity) Terminate(
 		return chasm.TerminateComponentResponse{}, nil
 	}
 
-	metricsHandler, err := a.enrichedMetricsHandler(ctx, metrics.ActivityTerminatedScope)
-	if err != nil {
-		return chasm.TerminateComponentResponse{}, err
-	}
+	metricsHandler := a.enrichedMetricsHandler(ctx, metrics.ActivityTerminatedScope)
 	return chasm.TerminateComponentResponse{}, TransitionTerminated.Apply(a, ctx, terminateEvent{
 		request:        req,
 		metricsHandler: metricsHandler,
@@ -818,10 +805,7 @@ func (a *Activity) UpdateActivityExecutionOptions(
 		a.reissueDispatchAndScheduleToStart(ctx, attempt)
 	}
 
-	metricsHandler, err := a.enrichedMetricsHandler(ctx, metrics.ActivityUpdateOptionsScope)
-	if err != nil {
-		return nil, err
-	}
+	metricsHandler := a.enrichedMetricsHandler(ctx, metrics.ActivityUpdateOptionsScope)
 	a.emitOnUpdateOptionsMetrics(metricsHandler)
 
 	if requestID != "" {
@@ -978,11 +962,8 @@ func (a *Activity) handleCancellationRequested(ctx chasm.MutableContext, request
 
 	// Transition to Canceled if no attempt in progress; otherwise wait for worker response.
 	if !hasAttemptInProgress {
-		metricsHandler, err := a.enrichedMetricsHandler(ctx, metrics.HistoryRespondActivityTaskCanceledScope)
-		if err != nil {
-			return nil, err
-		}
-		err = TransitionCanceled.Apply(a, ctx, cancelEvent{
+		metricsHandler := a.enrichedMetricsHandler(ctx, metrics.HistoryRespondActivityTaskCanceledScope)
+		err := TransitionCanceled.Apply(a, ctx, cancelEvent{
 			metricsHandler: metricsHandler,
 			fromStatus:     originalStatus,
 			details: &commonpb.Payloads{
@@ -1016,10 +997,7 @@ func (a *Activity) handlePauseRequested(ctx chasm.MutableContext, req *activityp
 		return nil, serviceerror.NewFailedPreconditionf("activity is in non-pausable state %v", a.GetStatus())
 	}
 
-	metricsHandler, err := a.enrichedMetricsHandler(ctx, metrics.ActivityPausedScope)
-	if err != nil {
-		return nil, err
-	}
+	metricsHandler := a.enrichedMetricsHandler(ctx, metrics.ActivityPausedScope)
 
 	event := pauseEvent{req: req.GetFrontendRequest(), metricsHandler: metricsHandler}
 	if canPause {
@@ -1053,10 +1031,7 @@ func (a *Activity) handleUnpauseRequested(ctx chasm.MutableContext, req *activit
 	if a.isTerminal() {
 		return nil, serviceerror.NewFailedPreconditionf("activity is in terminal state %v", a.GetStatus())
 	}
-	metricsHandler, err := a.enrichedMetricsHandler(ctx, metrics.ActivityUnpausedScope)
-	if err != nil {
-		return nil, err
-	}
+	metricsHandler := a.enrichedMetricsHandler(ctx, metrics.ActivityUnpausedScope)
 
 	event := unpauseEvent{req: frontendReq, metricsHandler: metricsHandler}
 	switch {
@@ -1211,10 +1186,7 @@ func (a *Activity) handleReset(
 		}
 	}
 
-	metricsHandler, err := a.enrichedMetricsHandler(ctx, metrics.ActivityResetScope)
-	if err != nil {
-		return nil, err
-	}
+	metricsHandler := a.enrichedMetricsHandler(ctx, metrics.ActivityResetScope)
 
 	switch a.Status {
 	case activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED:
@@ -2082,14 +2054,11 @@ func (a *Activity) baseMetricsHandler(ctx chasm.Context, operation string) metri
 }
 
 // enrichedMetricsHandler adds standard activity tags in addition to the operation tag.
-func (a *Activity) enrichedMetricsHandler(ctx chasm.Context, operation string) (metrics.Handler, error) {
+func (a *Activity) enrichedMetricsHandler(ctx chasm.Context, operation string) metrics.Handler {
+	namespaceName := ctx.NamespaceEntry().Name()
 	// activityContextFromChasm panics if the context value is missing; this is intentional and
 	// indicates a library registration bug rather than a runtime error.
 	actCtx := activityContextFromChasm(ctx)
-	namespaceName, err := actCtx.namespaceRegistry.GetNamespaceName(namespace.ID(ctx.ExecutionKey().NamespaceID))
-	if err != nil {
-		return nil, err
-	}
 	breakdownMetricsByTaskQueue := actCtx.config.BreakdownMetricsByTaskQueue
 	taskQueueFamily := a.GetTaskQueue().GetName()
 	return metrics.GetPerTaskQueueFamilyScope(
@@ -2101,7 +2070,7 @@ func (a *Activity) enrichedMetricsHandler(ctx chasm.Context, operation string) (
 		metrics.ActivityTypeTag(a.GetActivityType().GetName()),
 		metrics.VersioningBehaviorTag(enumspb.VERSIONING_BEHAVIOR_UNSPECIFIED),
 		metrics.WorkflowTypeTag(WorkflowTypeTag),
-	), nil
+	)
 }
 
 func (a *Activity) emitOnAttemptTimedOutMetrics(metricsHandler metrics.Handler, timeoutType enumspb.TimeoutType) {

--- a/chasm/lib/activity/activity_tasks.go
+++ b/chasm/lib/activity/activity_tasks.go
@@ -102,10 +102,7 @@ func (h *scheduleToStartTimeoutTaskHandler) Execute(
 	_ chasm.TaskAttributes,
 	_ *activitypb.ScheduleToStartTimeoutTask,
 ) error {
-	metricsHandler, err := activity.enrichedMetricsHandler(ctx, metrics.TimerActiveTaskActivityTimeoutScope)
-	if err != nil {
-		return err
-	}
+	metricsHandler := activity.enrichedMetricsHandler(ctx, metrics.TimerActiveTaskActivityTimeoutScope)
 
 	event := timeoutEvent{
 		timeoutType:    enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START,
@@ -149,10 +146,7 @@ func (h *scheduleToCloseTimeoutTaskHandler) Execute(
 	_ chasm.TaskAttributes,
 	_ *activitypb.ScheduleToCloseTimeoutTask,
 ) error {
-	metricsHandler, err := activity.enrichedMetricsHandler(ctx, metrics.TimerActiveTaskActivityTimeoutScope)
-	if err != nil {
-		return err
-	}
+	metricsHandler := activity.enrichedMetricsHandler(ctx, metrics.TimerActiveTaskActivityTimeoutScope)
 	retryState := enumspb.RETRY_STATE_TIMEOUT
 	if activity.GetStatus() == activitypb.ACTIVITY_EXECUTION_STATUS_CANCEL_REQUESTED {
 		retryState = enumspb.RETRY_STATE_CANCEL_REQUESTED
@@ -202,10 +196,7 @@ func (h *startToCloseTimeoutTaskHandler) Execute(
 		return err
 	}
 
-	metricsHandler, err := activity.enrichedMetricsHandler(ctx, metrics.TimerActiveTaskActivityTimeoutScope)
-	if err != nil {
-		return err
-	}
+	metricsHandler := activity.enrichedMetricsHandler(ctx, metrics.TimerActiveTaskActivityTimeoutScope)
 
 	if retryState == enumspb.RETRY_STATE_IN_PROGRESS {
 		activity.emitOnAttemptTimedOutMetrics(metricsHandler, enumspb.TIMEOUT_TYPE_START_TO_CLOSE)
@@ -285,10 +276,7 @@ func (h *heartbeatTimeoutTaskHandler) Execute(
 		return err
 	}
 
-	metricsHandler, err := activity.enrichedMetricsHandler(ctx, metrics.TimerActiveTaskActivityTimeoutScope)
-	if err != nil {
-		return err
-	}
+	metricsHandler := activity.enrichedMetricsHandler(ctx, metrics.TimerActiveTaskActivityTimeoutScope)
 
 	if retryState == enumspb.RETRY_STATE_IN_PROGRESS {
 		activity.emitOnAttemptTimedOutMetrics(metricsHandler, enumspb.TIMEOUT_TYPE_HEARTBEAT)

--- a/chasm/lib/activity/activity_tasks_test.go
+++ b/chasm/lib/activity/activity_tasks_test.go
@@ -15,9 +15,7 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/metrics/metricstest"
-	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/retrypolicy"
-	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -136,10 +134,6 @@ func TestTimeoutTaskTerminalFailure(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			nsRegistry := namespace.NewMockRegistry(ctrl)
-			nsRegistry.EXPECT().GetNamespaceName(gomock.Any()).Return(namespace.Name("test-namespace"), nil)
-
 			metricsHandler := metricstest.NewCaptureHandler()
 			capture := metricsHandler.StartCapture()
 			defer metricsHandler.StopCapture(capture)
@@ -147,11 +141,11 @@ func TestTimeoutTaskTerminalFailure(t *testing.T) {
 				MockContext: chasm.MockContext{
 					HandleNow:            func(chasm.Component) time.Time { return defaultTime.Add(1500 * time.Millisecond) },
 					HandleMetricsHandler: func() metrics.Handler { return metricsHandler },
+					HandleNamespaceEntry: testNamespaceEntry,
 					GoCtx: context.WithValue(context.Background(), ctxKeyActivityContext, &activityContext{
 						config: &Config{
 							BreakdownMetricsByTaskQueue: dynamicconfig.GetBoolPropertyFnFilteredByTaskQueue(false),
 						},
-						namespaceRegistry: nsRegistry,
 					}),
 				},
 			}

--- a/chasm/lib/activity/activity_test.go
+++ b/chasm/lib/activity/activity_test.go
@@ -29,7 +29,6 @@ import (
 	"go.temporal.io/server/common/searchattribute/sadefs"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/common/testing/protorequire"
-	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -507,19 +506,14 @@ func TestActivityTerminate(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-			nsRegistry := namespace.NewMockRegistry(ctrl)
-			nsRegistry.EXPECT().GetNamespaceName(gomock.Any()).Return(namespace.Name("test-namespace"), nil).AnyTimes()
-
 			ctx := &chasm.MockMutableContext{
 				MockContext: chasm.MockContext{
-					HandleNow: func(chasm.Component) time.Time { return defaultTime },
+					HandleNow:            func(chasm.Component) time.Time { return defaultTime },
+					HandleNamespaceEntry: testNamespaceEntry,
 					GoCtx: context.WithValue(context.Background(), ctxKeyActivityContext, &activityContext{
 						config: &Config{
 							BreakdownMetricsByTaskQueue: dynamicconfig.GetBoolPropertyFnFilteredByTaskQueue(true),
 						},
-						namespaceRegistry: nsRegistry,
 					}),
 				},
 			}
@@ -702,11 +696,6 @@ func TestHandleCancellationRequestedDirectCancelMetrics(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-			nsRegistry := namespace.NewMockRegistry(ctrl)
-			nsRegistry.EXPECT().GetNamespaceName(gomock.Any()).Return(namespace.Name("test-namespace"), nil).AnyTimes()
-
 			metricsHandler := metricstest.NewCaptureHandler()
 			capture := metricsHandler.StartCapture()
 
@@ -714,11 +703,11 @@ func TestHandleCancellationRequestedDirectCancelMetrics(t *testing.T) {
 				MockContext: chasm.MockContext{
 					HandleNow:            func(chasm.Component) time.Time { return defaultTime },
 					HandleMetricsHandler: func() metrics.Handler { return metricsHandler },
+					HandleNamespaceEntry: testNamespaceEntry,
 					GoCtx: context.WithValue(context.Background(), ctxKeyActivityContext, &activityContext{
 						config: &Config{
 							BreakdownMetricsByTaskQueue: dynamicconfig.GetBoolPropertyFnFilteredByTaskQueue(true),
 						},
-						namespaceRegistry: nsRegistry,
 					}),
 				},
 			}
@@ -1139,19 +1128,14 @@ func TestActivityTaskTokenLegacyStampCompatibility(t *testing.T) {
 
 func TestUpdateStartedActivityExecutionOptionsDoesNotBumpStartedStamp(t *testing.T) {
 	testTime := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	nsRegistry := namespace.NewMockRegistry(ctrl)
-	nsRegistry.EXPECT().GetNamespaceName(gomock.Any()).Return(namespace.Name("test-namespace"), nil).AnyTimes()
-
 	ctx := &chasm.MockMutableContext{
 		MockContext: chasm.MockContext{
-			HandleNow: func(chasm.Component) time.Time { return testTime },
+			HandleNow:            func(chasm.Component) time.Time { return testTime },
+			HandleNamespaceEntry: testNamespaceEntry,
 			GoCtx: context.WithValue(context.Background(), ctxKeyActivityContext, &activityContext{
 				config: &Config{
 					BreakdownMetricsByTaskQueue: dynamicconfig.GetBoolPropertyFnFilteredByTaskQueue(true),
 				},
-				namespaceRegistry: nsRegistry,
 			}),
 		},
 	}
@@ -1419,17 +1403,14 @@ func TestUpdateActivityExecutionOptionsRequestID(t *testing.T) {
 
 func newOperatorCommandTestContext(t *testing.T) *chasm.MockMutableContext {
 	t.Helper()
-	ctrl := gomock.NewController(t)
-	nsRegistry := namespace.NewMockRegistry(ctrl)
-	nsRegistry.EXPECT().GetNamespaceName(gomock.Any()).Return(namespace.Name("test-namespace"), nil).AnyTimes()
 	return &chasm.MockMutableContext{
 		MockContext: chasm.MockContext{
-			HandleNow: func(chasm.Component) time.Time { return time.Unix(0, 0) },
+			HandleNow:            func(chasm.Component) time.Time { return time.Unix(0, 0) },
+			HandleNamespaceEntry: testNamespaceEntry,
 			GoCtx: context.WithValue(context.Background(), ctxKeyActivityContext, &activityContext{
 				config: &Config{
 					BreakdownMetricsByTaskQueue: dynamicconfig.GetBoolPropertyFnFilteredByTaskQueue(true),
 				},
-				namespaceRegistry: nsRegistry,
 			}),
 		},
 	}

--- a/chasm/lib/activity/library.go
+++ b/chasm/lib/activity/library.go
@@ -3,7 +3,6 @@ package activity
 import (
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/activity/gen/activitypb/v1"
-	"go.temporal.io/server/common/namespace"
 	"google.golang.org/grpc"
 )
 
@@ -13,8 +12,7 @@ var ctxKeyActivityContext = ctxKeyActivityContextType{}
 
 // activityContext holds dependencies injected into the chasm.Context for use by Activity methods.
 type activityContext struct {
-	config            *Config
-	namespaceRegistry namespace.Registry
+	config *Config
 }
 
 // activityContextFromChasm extracts the activityContext from a chasm.Context.
@@ -36,17 +34,14 @@ var (
 
 type componentOnlyLibrary struct {
 	chasm.UnimplementedLibrary
-	config            *Config
-	namespaceRegistry namespace.Registry
+	config *Config
 }
 
 func newComponentOnlyLibrary(
 	config *Config,
-	namespaceRegistry namespace.Registry,
 ) *componentOnlyLibrary {
 	return &componentOnlyLibrary{
-		config:            config,
-		namespaceRegistry: namespaceRegistry,
+		config: config,
 	}
 }
 
@@ -67,8 +62,7 @@ func (l *componentOnlyLibrary) Components() []*chasm.RegistrableComponent {
 			chasm.WithBusinessIDAlias("ActivityId"),
 			chasm.WithContextValues(map[any]any{
 				ctxKeyActivityContext: &activityContext{
-					config:            l.config,
-					namespaceRegistry: l.namespaceRegistry,
+					config: l.config,
 				},
 			}),
 		),
@@ -79,7 +73,7 @@ func (l *componentOnlyLibrary) Components() []*chasm.RegistrableComponent {
 // registration-only contexts like tdbg where no task execution is needed.
 func NewNilLibrary() chasm.Library {
 	return &library{
-		componentOnlyLibrary: *newComponentOnlyLibrary(nil, nil),
+		componentOnlyLibrary: *newComponentOnlyLibrary(nil),
 	}
 }
 
@@ -102,10 +96,9 @@ func newLibrary(
 	startToCloseTimeoutTaskHandler *startToCloseTimeoutTaskHandler,
 	heartbeatTimeoutTaskHandler *heartbeatTimeoutTaskHandler,
 	config *Config,
-	namespaceRegistry namespace.Registry,
 ) *library {
 	return &library{
-		componentOnlyLibrary:              *newComponentOnlyLibrary(config, namespaceRegistry),
+		componentOnlyLibrary:              *newComponentOnlyLibrary(config),
 		handler:                           handler,
 		activityDispatchTaskHandler:       activityDispatchTaskHandler,
 		scheduleToStartTimeoutTaskHandler: scheduleToStartTimeoutTaskHandler,

--- a/chasm/lib/activity/statemachine_test.go
+++ b/chasm/lib/activity/statemachine_test.go
@@ -47,6 +47,15 @@ var (
 // defaultFailureSizeLimit is the retained-failure size limit used by tests in this package.
 const defaultFailureSizeLimit = 1024
 
+// testNamespaceEntry is the namespace entry Activity methods read off the chasm context in tests.
+func testNamespaceEntry() *namespace.Namespace {
+	return namespace.NewLocalNamespaceForTest(
+		&persistencespb.NamespaceInfo{Id: "test-namespace-id", Name: "test-namespace"},
+		&persistencespb.NamespaceConfig{},
+		"test-cluster",
+	)
+}
+
 // injectActivityContext adds the dependencies that Activity methods read off the chasm context:
 // the activityContext (dynamic config) and the namespace entry.
 func injectActivityContext(t *testing.T, ctx *chasm.MockMutableContext) {
@@ -54,11 +63,7 @@ func injectActivityContext(t *testing.T, ctx *chasm.MockMutableContext) {
 		MutableStateActivityFailureSizeLimitError: dynamicconfig.GetIntPropertyFnFilteredByNamespace(defaultFailureSizeLimit),
 	}
 	ctx.GoCtx = context.WithValue(t.Context(), ctxKeyActivityContext, &activityContext{config: config})
-	ctx.HandleNamespaceEntry = func() *namespace.Namespace {
-		return namespace.NewLocalNamespaceForTest(
-			&persistencespb.NamespaceInfo{Name: "test-namespace"}, nil, "test-cluster",
-		)
-	}
+	ctx.HandleNamespaceEntry = testNamespaceEntry
 }
 
 func TestTransitionScheduled(t *testing.T) {


### PR DESCRIPTION
## What changed?

Updated the activity code to use a CHASM context API that was added after the original code was written.

## Why?

Prevent this pattern from being copied to other libraries.