### PR TITLE
Track process-lifetime object leak baselines

### DIFF
--- a/common/testing/objectleak/leakcheck.go
+++ b/common/testing/objectleak/leakcheck.go
@@ -19,21 +19,27 @@ const (
 // ObjectLeakCheck tracks objects reachable from roots and reports objects
 // that remain reachable after GC.
 type ObjectLeakCheck struct {
-	tracked         trackedObjects
-	baselineByID    map[objectIdentity]trackedObject
+	objects         []trackedObject
+	roots           int
+	baseline        objectBaseline
 	expected        patterns
 	pruneTypes      patterns
 	gcSettleTimeout time.Duration
 }
 
-type trackedObjects struct {
-	objects []trackedObject
-	roots   int
+type objectBaseline struct {
+	objects       []trackedObject
+	collectedByID map[objectIdentity]*atomic.Bool
 }
 
 type objectIdentity struct {
 	addr     uintptr
 	typeName string
+}
+
+func (b objectBaseline) contains(obj trackedObject) bool {
+	collected, ok := b.collectedByID[obj.identity()]
+	return ok && !collected.Load()
 }
 
 type Option func(*ObjectLeakCheck) error
@@ -57,8 +63,8 @@ func WithPruneType(pattern string) Option {
 	}
 }
 
-// WithGCSettleTimeout sets the maximum time Check spends forcing GC and waiting
-// for retained-object counts to settle.
+// WithGCSettleTimeout sets the maximum time Check and IgnoreCurrent spend
+// forcing GC and waiting for retained-object counts to settle.
 func WithGCSettleTimeout(timeout time.Duration) Option {
 	return func(t *ObjectLeakCheck) error {
 		if timeout <= 0 {
@@ -87,7 +93,7 @@ func NewObjectLeakCheck(opts ...Option) (ObjectLeakCheck, error) {
 func (t *ObjectLeakCheck) IgnoreCurrent() {
 	settleGC(t.gcSettleTimeout, func() [3]int {
 		retained := 0
-		for _, obj := range t.tracked.objects {
+		for _, obj := range t.objects {
 			if !obj.collected.Load() {
 				retained++
 			}
@@ -95,51 +101,34 @@ func (t *ObjectLeakCheck) IgnoreCurrent() {
 		return [3]int{retained}
 	})
 
-	if t.baselineByID == nil {
-		t.baselineByID = make(map[objectIdentity]trackedObject)
+	baseline := objectBaseline{
+		collectedByID: make(map[objectIdentity]*atomic.Bool),
 	}
-	for _, obj := range t.tracked.objects {
+	for _, obj := range t.objects {
 		if !obj.collected.Load() {
 			identity := obj.identity()
-			baseline, ok := t.baselineByID[identity]
-			if !ok || baseline.collected.Load() {
-				t.baselineByID[identity] = obj
-				continue
+			if collected, ok := baseline.collectedByID[identity]; ok {
+				obj.cleanup.Stop()
+				obj.collected = collected
+			} else {
+				baseline.collectedByID[identity] = obj.collected
 			}
+			baseline.objects = append(baseline.objects, obj)
+			continue
 		}
 		obj.cleanup.Stop()
 	}
-	t.tracked = trackedObjects{}
+	t.baseline = baseline
+	t.objects = nil
+	t.roots = 0
 }
 
 // Track walks all values reachable from root and tracks pointer objects it finds.
 func (t *ObjectLeakCheck) Track(root any) {
-	objects := t.tracked.track(root, t.pruneTypes)
-	for i := range objects {
-		objects[i].baselineCollected = t.baselineCollected(objects[i])
-	}
-}
-
-func (t *trackedObjects) track(root any, pruneTypes patterns) []trackedObject {
-	walker := newObjectWalker(pruneTypes)
+	walker := newObjectWalker(t.pruneTypes)
 	walker.track(root)
 	t.roots++
-	start := len(t.objects)
 	t.objects = append(t.objects, walker.objects...)
-	return t.objects[start:]
-}
-
-func (t *ObjectLeakCheck) baselineCollected(obj trackedObject) *atomic.Bool {
-	identity := obj.identity()
-	baseline, ok := t.baselineByID[identity]
-	if !ok {
-		return nil
-	}
-	if baseline.collected.Load() {
-		delete(t.baselineByID, identity)
-		return nil
-	}
-	return baseline.collected
 }
 
 // Check settles GC, then returns a full retained-object report and an error for
@@ -148,13 +137,11 @@ func (t *ObjectLeakCheck) baselineCollected(obj trackedObject) *atomic.Bool {
 // tracking.
 func (t *ObjectLeakCheck) Check() (string, error) {
 	var report report
-	var err error
 	settleGC(t.gcSettleTimeout, func() [3]int {
-		report = newReport(t.tracked.objects, t.tracked.roots, t.expected, t.pruneTypes)
-		err = report.failures()
+		report = newReport(t.objects, t.baseline, t.roots, t.expected, t.pruneTypes)
 		return report.totals()
 	})
-	return report.string(), err
+	return report.string(), report.failures()
 }
 
 func settleGC(timeout time.Duration, totals func() [3]int) {

--- a/common/testing/objectleak/leakcheck.go
+++ b/common/testing/objectleak/leakcheck.go
@@ -5,7 +5,6 @@ import (
 	"iter"
 	"runtime"
 	runtimedebug "runtime/debug"
-	"slices"
 	"sync/atomic"
 	"time"
 )
@@ -28,26 +27,23 @@ type ObjectLeakCheck struct {
 	gcSettleTimeout time.Duration
 }
 
-// Baseline contains the retained objects captured by IgnoreCurrent.
+// Baseline contains the retained objects captured by IgnoreCurrent. Its zero
+// value represents no ignored objects.
 type Baseline struct {
-	objects       []trackedObject
-	collectedByID map[objectIdentity]*atomic.Bool
-}
-
-type objectIdentity struct {
-	addr     uintptr
-	typeName string
+	objects         []trackedObject
+	collectedByAddr map[uintptr]*atomic.Bool
+	settleTimedOut  bool
 }
 
 func (b Baseline) contains(obj trackedObject) bool {
-	collected, ok := b.collectedByID[obj.identity()]
+	collected, ok := b.collectedByAddr[obj.addr]
 	return ok && !collected.Load()
 }
 
 type Option func(*ObjectLeakCheck) error
 
-// WithExpected marks retained objects whose reflected path or type name matches
-// pattern as expected. A trailing '*' matches any suffix.
+// WithExpected marks non-baseline retained objects whose reflected path or type
+// name matches pattern as expected. A trailing '*' matches any suffix.
 func WithExpected(pattern string) Option {
 	return func(t *ObjectLeakCheck) error {
 		t.expected = append(t.expected, newPattern(pattern))
@@ -65,8 +61,10 @@ func WithPruneType(pattern string) Option {
 	}
 }
 
-// WithGCSettleTimeout sets the maximum time [Check] and [IgnoreCurrent] spend
-// forcing GC and waiting for retained-object counts to settle.
+// WithGCSettleTimeout sets the timeout [ObjectLeakCheck.Check] and
+// [ObjectLeakCheck.IgnoreCurrent] use while forcing GC and waiting for
+// retained-object counts to settle. An in-progress GC pass may finish after the
+// timeout. A timeout shorter than the normal minimum wait takes precedence.
 func WithGCSettleTimeout(timeout time.Duration) Option {
 	return func(t *ObjectLeakCheck) error {
 		if timeout <= 0 {
@@ -91,22 +89,24 @@ func NewObjectLeakCheck(opts ...Option) (ObjectLeakCheck, error) {
 }
 
 // IgnoreCurrent waits for currently tracked objects to settle, returns the
-// retained objects as a baseline, and resets tracked roots.
+// retained objects as a baseline, and resets tracked roots. If settling times
+// out, [ObjectLeakCheck.Check] reports the timeout when passed the returned
+// baseline.
 func (t *ObjectLeakCheck) IgnoreCurrent() Baseline {
-	settleGC(t.gcSettleTimeout, func() int {
-		return len(slices.Collect(retainedObjects(t.objects)))
+	settled := settleGC(t.gcSettleTimeout, func() int {
+		return countRetained(t.objects)
 	})
 
 	baseline := Baseline{
-		collectedByID: make(map[objectIdentity]*atomic.Bool),
+		collectedByAddr: make(map[uintptr]*atomic.Bool),
+		settleTimedOut:  !settled,
 	}
 	for obj := range retainedObjects(t.objects) {
-		identity := obj.identity()
-		if canonicalCollected, ok := baseline.collectedByID[identity]; ok {
+		if canonicalCollected, ok := baseline.collectedByAddr[obj.addr]; ok {
 			obj.cleanup.Stop()
 			obj.collected = canonicalCollected
 		} else {
-			baseline.collectedByID[identity] = obj.collected
+			baseline.collectedByAddr[obj.addr] = obj.collected
 		}
 		baseline.objects = append(baseline.objects, obj)
 	}
@@ -125,15 +125,25 @@ func (t *ObjectLeakCheck) Track(root any) {
 
 // Check settles GC, then returns a full retained-object report and an error for
 // retained objects not covered by expected patterns, expected patterns that no
-// longer match any tracked object, or prune rules that did not match during
-// tracking.
+// longer match any tracked object, prune rules that did not match during
+// tracking, GC settling that timed out during Check, or a timeout recorded in
+// the supplied baseline.
 func (t *ObjectLeakCheck) Check(baseline Baseline) (string, error) {
-	settleGC(t.gcSettleTimeout, func() int {
-		return len(slices.Collect(retainedObjects(t.objects))) +
-			len(slices.Collect(retainedObjects(baseline.objects)))
+	settled := settleGC(t.gcSettleTimeout, func() int {
+		return countRetained(t.objects, baseline.objects)
 	})
-	report := newReport(t.objects, baseline, t.roots, t.expected, t.pruneTypes)
+	report := newReport(t.objects, baseline, !settled, t.roots, t.expected, t.pruneTypes)
 	return report.string(), report.failures()
+}
+
+func countRetained(objectSets ...[]trackedObject) int {
+	count := 0
+	for _, objects := range objectSets {
+		for range retainedObjects(objects) {
+			count++
+		}
+	}
+	return count
 }
 
 func retainedObjects(objects []trackedObject) iter.Seq[trackedObject] {
@@ -146,7 +156,7 @@ func retainedObjects(objects []trackedObject) iter.Seq[trackedObject] {
 	}
 }
 
-func settleGC(timeout time.Duration, snapshot func() int) {
+func settleGC(timeout time.Duration, snapshot func() int) bool {
 	start := time.Now()
 	minWaitDeadline := start.Add(checkGCMinWait)
 	deadline := start.Add(timeout)
@@ -180,11 +190,15 @@ func settleGC(timeout time.Duration, snapshot func() int) {
 			}
 		}
 
-		// The minimum wait gives cleanup callbacks several GC cycles to run. The
-		// quiet window then handles normal cleanup latency; the timeout bounds a
-		// genuinely stuck object graph so the test can still report diagnostics.
-		if now.After(settledDeadline) || now.After(deadline) {
-			return
+		// Unless the timeout expires first, the minimum wait gives cleanup
+		// callbacks several GC cycles to run. The quiet window then handles
+		// normal cleanup latency; the timeout bounds the wait.
+		if deadline.Before(settledDeadline) {
+			if now.After(deadline) {
+				return false
+			}
+		} else if now.After(settledDeadline) {
+			return true
 		}
 		time.Sleep(checkGCPause)
 	}

--- a/common/testing/objectleak/leakcheck.go
+++ b/common/testing/objectleak/leakcheck.go
@@ -26,7 +26,8 @@ type ObjectLeakCheck struct {
 	gcSettleTimeout time.Duration
 }
 
-type objectBaseline struct {
+// Baseline contains the retained objects captured by IgnoreCurrent.
+type Baseline struct {
 	objects       []trackedObject
 	collectedByID map[objectIdentity]*atomic.Bool
 }
@@ -36,19 +37,12 @@ type objectIdentity struct {
 	typeName string
 }
 
-func (b objectBaseline) contains(obj trackedObject) bool {
+func (b Baseline) contains(obj trackedObject) bool {
 	collected, ok := b.collectedByID[obj.identity()]
 	return ok && !collected.Load()
 }
 
 type Option func(*ObjectLeakCheck) error
-
-// CheckOption configures a single Check call.
-type CheckOption func(*checkOptions)
-
-type checkOptions struct {
-	baseline objectBaseline
-}
 
 // WithExpected marks retained objects whose reflected path or type name matches
 // pattern as expected. A trailing '*' matches any suffix.
@@ -94,10 +88,9 @@ func NewObjectLeakCheck(opts ...Option) (ObjectLeakCheck, error) {
 	return t, nil
 }
 
-// IgnoreCurrent waits for currently tracked objects to settle and returns a
-// CheckOption that ignores the retained objects when passed to future Check
-// calls. It also resets tracked roots.
-func (t *ObjectLeakCheck) IgnoreCurrent() CheckOption {
+// IgnoreCurrent waits for currently tracked objects to settle, returns the
+// retained objects as a baseline, and resets tracked roots.
+func (t *ObjectLeakCheck) IgnoreCurrent() Baseline {
 	settleGC(t.gcSettleTimeout, func() [3]int {
 		retained := 0
 		for _, obj := range t.objects {
@@ -108,7 +101,7 @@ func (t *ObjectLeakCheck) IgnoreCurrent() CheckOption {
 		return [3]int{retained}
 	})
 
-	baseline := objectBaseline{
+	baseline := Baseline{
 		collectedByID: make(map[objectIdentity]*atomic.Bool),
 	}
 	for _, obj := range t.objects {
@@ -127,9 +120,7 @@ func (t *ObjectLeakCheck) IgnoreCurrent() CheckOption {
 	}
 	t.objects = nil
 	t.roots = 0
-	return func(opts *checkOptions) {
-		opts.baseline = baseline
-	}
+	return baseline
 }
 
 // Track walks all values reachable from root and tracks pointer objects it finds.
@@ -144,15 +135,10 @@ func (t *ObjectLeakCheck) Track(root any) {
 // retained objects not covered by expected patterns, expected patterns that no
 // longer match any tracked object, or prune rules that did not match during
 // tracking.
-func (t *ObjectLeakCheck) Check(opts ...CheckOption) (string, error) {
-	checkOpts := checkOptions{}
-	for _, opt := range opts {
-		opt(&checkOpts)
-	}
-
+func (t *ObjectLeakCheck) Check(baseline Baseline) (string, error) {
 	var report report
 	settleGC(t.gcSettleTimeout, func() [3]int {
-		report = newReport(t.objects, checkOpts.baseline, t.roots, t.expected, t.pruneTypes)
+		report = newReport(t.objects, baseline, t.roots, t.expected, t.pruneTypes)
 		return report.totals()
 	})
 	return report.string(), report.failures()

--- a/common/testing/objectleak/leakcheck.go
+++ b/common/testing/objectleak/leakcheck.go
@@ -98,12 +98,7 @@ func (t *ObjectLeakCheck) IgnoreCurrent() Baseline {
 	baseline := Baseline{
 		collectedByID: make(map[objectIdentity]*atomic.Bool),
 	}
-	for _, obj := range t.objects {
-		if obj.collected.Load() {
-			obj.cleanup.Stop()
-			continue
-		}
-
+	forEachRetained(t.objects, func(obj trackedObject) {
 		identity := obj.identity()
 		if canonicalCollected, ok := baseline.collectedByID[identity]; ok {
 			obj.cleanup.Stop()
@@ -112,7 +107,7 @@ func (t *ObjectLeakCheck) IgnoreCurrent() Baseline {
 			baseline.collectedByID[identity] = obj.collected
 		}
 		baseline.objects = append(baseline.objects, obj)
-	}
+	})
 	t.objects = nil
 	t.roots = 0
 	return baseline
@@ -140,12 +135,18 @@ func (t *ObjectLeakCheck) Check(baseline Baseline) (string, error) {
 
 func retainedCount(objects []trackedObject) int {
 	retained := 0
+	forEachRetained(objects, func(trackedObject) {
+		retained++
+	})
+	return retained
+}
+
+func forEachRetained(objects []trackedObject, visit func(trackedObject)) {
 	for _, obj := range objects {
 		if !obj.collected.Load() {
-			retained++
+			visit(obj)
 		}
 	}
-	return retained
 }
 
 func settleGC(timeout time.Duration, snapshot func() int) {

--- a/common/testing/objectleak/leakcheck.go
+++ b/common/testing/objectleak/leakcheck.go
@@ -65,7 +65,7 @@ func WithPruneType(pattern string) Option {
 	}
 }
 
-// WithGCSettleTimeout sets the maximum time Check and IgnoreCurrent spend
+// WithGCSettleTimeout sets the maximum time [Check] and [IgnoreCurrent] spend
 // forcing GC and waiting for retained-object counts to settle.
 func WithGCSettleTimeout(timeout time.Duration) Option {
 	return func(t *ObjectLeakCheck) error {

--- a/common/testing/objectleak/leakcheck.go
+++ b/common/testing/objectleak/leakcheck.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"runtime"
 	runtimedebug "runtime/debug"
+	"sync/atomic"
 	"time"
 )
 
@@ -18,11 +19,21 @@ const (
 // ObjectLeakCheck tracks objects reachable from roots and reports objects
 // that remain reachable after GC.
 type ObjectLeakCheck struct {
-	objects         []trackedObject
-	roots           int
+	tracked         trackedObjects
+	baselineByID    map[objectIdentity]trackedObject
 	expected        patterns
 	pruneTypes      patterns
 	gcSettleTimeout time.Duration
+}
+
+type trackedObjects struct {
+	objects []trackedObject
+	roots   int
+}
+
+type objectIdentity struct {
+	addr     uintptr
+	typeName string
 }
 
 type Option func(*ObjectLeakCheck) error
@@ -71,12 +82,64 @@ func NewObjectLeakCheck(opts ...Option) (ObjectLeakCheck, error) {
 	return t, nil
 }
 
+// IgnoreCurrent waits for currently tracked objects to settle, records the
+// identities that remain reachable as the baseline, and resets tracked roots.
+func (t *ObjectLeakCheck) IgnoreCurrent() {
+	settleGC(t.gcSettleTimeout, func() [3]int {
+		retained := 0
+		for _, obj := range t.tracked.objects {
+			if !obj.collected.Load() {
+				retained++
+			}
+		}
+		return [3]int{retained}
+	})
+
+	if t.baselineByID == nil {
+		t.baselineByID = make(map[objectIdentity]trackedObject)
+	}
+	for _, obj := range t.tracked.objects {
+		if !obj.collected.Load() {
+			identity := obj.identity()
+			baseline, ok := t.baselineByID[identity]
+			if !ok || baseline.collected.Load() {
+				t.baselineByID[identity] = obj
+				continue
+			}
+		}
+		obj.cleanup.Stop()
+	}
+	t.tracked = trackedObjects{}
+}
+
 // Track walks all values reachable from root and tracks pointer objects it finds.
 func (t *ObjectLeakCheck) Track(root any) {
-	walker := newObjectWalker(t.pruneTypes)
+	objects := t.tracked.track(root, t.pruneTypes)
+	for i := range objects {
+		objects[i].baselineCollected = t.baselineCollected(objects[i])
+	}
+}
+
+func (t *trackedObjects) track(root any, pruneTypes patterns) []trackedObject {
+	walker := newObjectWalker(pruneTypes)
 	walker.track(root)
 	t.roots++
+	start := len(t.objects)
 	t.objects = append(t.objects, walker.objects...)
+	return t.objects[start:]
+}
+
+func (t *ObjectLeakCheck) baselineCollected(obj trackedObject) *atomic.Bool {
+	identity := obj.identity()
+	baseline, ok := t.baselineByID[identity]
+	if !ok {
+		return nil
+	}
+	if baseline.collected.Load() {
+		delete(t.baselineByID, identity)
+		return nil
+	}
+	return baseline.collected
 }
 
 // Check settles GC, then returns a full retained-object report and an error for
@@ -84,15 +147,24 @@ func (t *ObjectLeakCheck) Track(root any) {
 // longer match any tracked object, or prune rules that did not match during
 // tracking.
 func (t *ObjectLeakCheck) Check() (string, error) {
+	var report report
+	var err error
+	settleGC(t.gcSettleTimeout, func() [3]int {
+		report = newReport(t.tracked.objects, t.tracked.roots, t.expected, t.pruneTypes)
+		err = report.failures()
+		return report.totals()
+	})
+	return report.string(), err
+}
+
+func settleGC(timeout time.Duration, totals func() [3]int) {
 	start := time.Now()
 	minWaitDeadline := start.Add(checkGCMinWait)
-	deadline := start.Add(t.gcSettleTimeout)
+	deadline := start.Add(timeout)
 	settledDeadline := minWaitDeadline
 
 	var lastTotals [3]int
 	var haveLastTotals bool
-	var report report
-	var err error
 	for {
 		// AddCleanup callbacks run after GC proves tracked objects are
 		// unreachable. Run a small burst and yield so callbacks can mark tracked
@@ -105,15 +177,13 @@ func (t *ObjectLeakCheck) Check() (string, error) {
 		runtimedebug.FreeOSMemory()
 		runtime.Gosched()
 
-		report = newReport(t.objects, t.roots, t.expected, t.pruneTypes)
-		err = report.failures()
 		now := time.Now()
 
 		// Wait for the report totals to stop changing instead of returning on
 		// the first passing report. This lets delayed cleanup callbacks remove
 		// both unexpected objects and now-stale expected patterns before we decide.
-		if totals := report.totals(); !haveLastTotals || totals != lastTotals {
-			lastTotals = totals
+		if currentTotals := totals(); !haveLastTotals || currentTotals != lastTotals {
+			lastTotals = currentTotals
 			haveLastTotals = true
 			settledDeadline = now.Add(checkGCQuiet)
 			if minWaitDeadline.After(settledDeadline) {
@@ -125,7 +195,7 @@ func (t *ObjectLeakCheck) Check() (string, error) {
 		// quiet window then handles normal cleanup latency; the timeout bounds a
 		// genuinely stuck object graph so the test can still report diagnostics.
 		if now.After(settledDeadline) || now.After(deadline) {
-			return report.string(), err
+			return
 		}
 		time.Sleep(checkGCPause)
 	}

--- a/common/testing/objectleak/leakcheck.go
+++ b/common/testing/objectleak/leakcheck.go
@@ -91,14 +91,14 @@ func NewObjectLeakCheck(opts ...Option) (ObjectLeakCheck, error) {
 // IgnoreCurrent waits for currently tracked objects to settle, returns the
 // retained objects as a baseline, and resets tracked roots.
 func (t *ObjectLeakCheck) IgnoreCurrent() Baseline {
-	settleGC(t.gcSettleTimeout, func() [3]int {
+	settleGC(t.gcSettleTimeout, func() int {
 		retained := 0
 		for _, obj := range t.objects {
 			if !obj.collected.Load() {
 				retained++
 			}
 		}
-		return [3]int{retained}
+		return retained
 	})
 
 	baseline := Baseline{
@@ -144,14 +144,14 @@ func (t *ObjectLeakCheck) Check(baseline Baseline) (string, error) {
 	return report.string(), report.failures()
 }
 
-func settleGC(timeout time.Duration, totals func() [3]int) {
+func settleGC[T comparable](timeout time.Duration, snapshot func() T) {
 	start := time.Now()
 	minWaitDeadline := start.Add(checkGCMinWait)
 	deadline := start.Add(timeout)
 	settledDeadline := minWaitDeadline
 
-	var lastTotals [3]int
-	var haveLastTotals bool
+	var lastSnapshot T
+	var haveLastSnapshot bool
 	for {
 		// AddCleanup callbacks run after GC proves tracked objects are
 		// unreachable. Run a small burst and yield so callbacks can mark tracked
@@ -166,12 +166,12 @@ func settleGC(timeout time.Duration, totals func() [3]int) {
 
 		now := time.Now()
 
-		// Wait for the report totals to stop changing instead of returning on
-		// the first passing report. This lets delayed cleanup callbacks remove
-		// both unexpected objects and now-stale expected patterns before we decide.
-		if currentTotals := totals(); !haveLastTotals || currentTotals != lastTotals {
-			lastTotals = currentTotals
-			haveLastTotals = true
+		// Wait for the snapshot to stop changing instead of returning on the
+		// first passing state. This lets delayed cleanup callbacks finish before
+		// we decide.
+		if currentSnapshot := snapshot(); !haveLastSnapshot || currentSnapshot != lastSnapshot {
+			lastSnapshot = currentSnapshot
+			haveLastSnapshot = true
 			settledDeadline = now.Add(checkGCQuiet)
 			if minWaitDeadline.After(settledDeadline) {
 				settledDeadline = minWaitDeadline

--- a/common/testing/objectleak/leakcheck.go
+++ b/common/testing/objectleak/leakcheck.go
@@ -105,18 +105,19 @@ func (t *ObjectLeakCheck) IgnoreCurrent() Baseline {
 		collectedByID: make(map[objectIdentity]*atomic.Bool),
 	}
 	for _, obj := range t.objects {
-		if !obj.collected.Load() {
-			identity := obj.identity()
-			if collected, ok := baseline.collectedByID[identity]; ok {
-				obj.cleanup.Stop()
-				obj.collected = collected
-			} else {
-				baseline.collectedByID[identity] = obj.collected
-			}
-			baseline.objects = append(baseline.objects, obj)
+		if obj.collected.Load() {
+			obj.cleanup.Stop()
 			continue
 		}
-		obj.cleanup.Stop()
+
+		identity := obj.identity()
+		if canonicalCollected, ok := baseline.collectedByID[identity]; ok {
+			obj.cleanup.Stop()
+			obj.collected = canonicalCollected
+		} else {
+			baseline.collectedByID[identity] = obj.collected
+		}
+		baseline.objects = append(baseline.objects, obj)
 	}
 	t.objects = nil
 	t.roots = 0

--- a/common/testing/objectleak/leakcheck.go
+++ b/common/testing/objectleak/leakcheck.go
@@ -92,13 +92,7 @@ func NewObjectLeakCheck(opts ...Option) (ObjectLeakCheck, error) {
 // retained objects as a baseline, and resets tracked roots.
 func (t *ObjectLeakCheck) IgnoreCurrent() Baseline {
 	settleGC(t.gcSettleTimeout, func() int {
-		retained := 0
-		for _, obj := range t.objects {
-			if !obj.collected.Load() {
-				retained++
-			}
-		}
-		return retained
+		return retainedCount(t.objects)
 	})
 
 	baseline := Baseline{
@@ -137,21 +131,30 @@ func (t *ObjectLeakCheck) Track(root any) {
 // longer match any tracked object, or prune rules that did not match during
 // tracking.
 func (t *ObjectLeakCheck) Check(baseline Baseline) (string, error) {
-	var report report
-	settleGC(t.gcSettleTimeout, func() [3]int {
-		report = newReport(t.objects, baseline, t.roots, t.expected, t.pruneTypes)
-		return report.totals()
+	settleGC(t.gcSettleTimeout, func() int {
+		return retainedCount(t.objects) + retainedCount(baseline.objects)
 	})
+	report := newReport(t.objects, baseline, t.roots, t.expected, t.pruneTypes)
 	return report.string(), report.failures()
 }
 
-func settleGC[T comparable](timeout time.Duration, snapshot func() T) {
+func retainedCount(objects []trackedObject) int {
+	retained := 0
+	for _, obj := range objects {
+		if !obj.collected.Load() {
+			retained++
+		}
+	}
+	return retained
+}
+
+func settleGC(timeout time.Duration, snapshot func() int) {
 	start := time.Now()
 	minWaitDeadline := start.Add(checkGCMinWait)
 	deadline := start.Add(timeout)
 	settledDeadline := minWaitDeadline
 
-	var lastSnapshot T
+	var lastSnapshot int
 	var haveLastSnapshot bool
 	for {
 		// AddCleanup callbacks run after GC proves tracked objects are

--- a/common/testing/objectleak/leakcheck.go
+++ b/common/testing/objectleak/leakcheck.go
@@ -5,6 +5,7 @@ import (
 	"iter"
 	"runtime"
 	runtimedebug "runtime/debug"
+	"slices"
 	"sync/atomic"
 	"time"
 )
@@ -93,7 +94,7 @@ func NewObjectLeakCheck(opts ...Option) (ObjectLeakCheck, error) {
 // retained objects as a baseline, and resets tracked roots.
 func (t *ObjectLeakCheck) IgnoreCurrent() Baseline {
 	settleGC(t.gcSettleTimeout, func() int {
-		return retainedCount(t.objects)
+		return len(slices.Collect(retainedObjects(t.objects)))
 	})
 
 	baseline := Baseline{
@@ -128,18 +129,11 @@ func (t *ObjectLeakCheck) Track(root any) {
 // tracking.
 func (t *ObjectLeakCheck) Check(baseline Baseline) (string, error) {
 	settleGC(t.gcSettleTimeout, func() int {
-		return retainedCount(t.objects) + retainedCount(baseline.objects)
+		return len(slices.Collect(retainedObjects(t.objects))) +
+			len(slices.Collect(retainedObjects(baseline.objects)))
 	})
 	report := newReport(t.objects, baseline, t.roots, t.expected, t.pruneTypes)
 	return report.string(), report.failures()
-}
-
-func retainedCount(objects []trackedObject) int {
-	retained := 0
-	for range retainedObjects(objects) {
-		retained++
-	}
-	return retained
 }
 
 func retainedObjects(objects []trackedObject) iter.Seq[trackedObject] {

--- a/common/testing/objectleak/leakcheck.go
+++ b/common/testing/objectleak/leakcheck.go
@@ -26,6 +26,8 @@ type ObjectLeakCheck struct {
 	expected        patterns
 	pruneTypes      patterns
 	gcSettleTimeout time.Duration
+	gcSettleMinWait time.Duration
+	gcSettleQuiet   time.Duration
 }
 
 // Baseline contains the retained objects captured by IgnoreCurrent. Its zero
@@ -80,6 +82,8 @@ func WithGCSettleTimeout(timeout time.Duration) Option {
 func NewObjectLeakCheck(opts ...Option) (ObjectLeakCheck, error) {
 	t := ObjectLeakCheck{
 		gcSettleTimeout: defaultGCSettleTimeout,
+		gcSettleMinWait: checkGCMinWait,
+		gcSettleQuiet:   checkGCQuiet,
 	}
 	for _, opt := range opts {
 		if err := opt(&t); err != nil {
@@ -94,7 +98,7 @@ func NewObjectLeakCheck(opts ...Option) (ObjectLeakCheck, error) {
 // out, [ObjectLeakCheck.Check] reports the timeout when passed the returned
 // baseline.
 func (t *ObjectLeakCheck) IgnoreCurrent() Baseline {
-	settled := settleGC(t.gcSettleTimeout, func() int {
+	settled := settleGC(t.gcSettleTimeout, t.gcSettleMinWait, t.gcSettleQuiet, func() int {
 		return countRetained(t.objects)
 	})
 
@@ -130,7 +134,7 @@ func (t *ObjectLeakCheck) Track(root any) {
 // tracking, GC settling that timed out during Check, or a timeout recorded in
 // the supplied baseline.
 func (t *ObjectLeakCheck) Check(baseline Baseline) (string, error) {
-	settled := settleGCToZero(t.gcSettleTimeout, func() int {
+	settled := settleGCToZero(t.gcSettleTimeout, t.gcSettleMinWait, t.gcSettleQuiet, func() int {
 		return countUnexpected(t.objects, baseline, t.expected)
 	})
 	report := newReport(t.objects, baseline, !settled, t.roots, t.expected, t.pruneTypes)
@@ -141,19 +145,17 @@ func countUnexpected(objects []trackedObject, baseline Baseline, expected patter
 	activeExpected := slices.Clone(expected)
 	count := 0
 	for obj := range retainedObjects(objects) {
-		if classifyRetention(obj, baseline, activeExpected) == retentionUnexpected {
+		if classifyRetention(obj, obj.path.normalized(), baseline, activeExpected) == retentionUnexpected {
 			count++
 		}
 	}
 	return count
 }
 
-func countRetained(objectSets ...[]trackedObject) int {
+func countRetained(objects []trackedObject) int {
 	count := 0
-	for _, objects := range objectSets {
-		for range retainedObjects(objects) {
-			count++
-		}
+	for range retainedObjects(objects) {
+		count++
 	}
 	return count
 }
@@ -168,23 +170,28 @@ func retainedObjects(objects []trackedObject) iter.Seq[trackedObject] {
 	}
 }
 
-func settleGC(timeout time.Duration, snapshot func() int) bool {
-	return settleGCWhen(timeout, snapshot, false)
+func settleGC(timeout time.Duration, minWait time.Duration, quiet time.Duration, snapshot func() int) bool {
+	return settleGCWhen(timeout, minWait, quiet, snapshot, false)
 }
 
-func settleGCToZero(timeout time.Duration, snapshot func() int) bool {
-	return settleGCWhen(timeout, snapshot, true)
+func settleGCToZero(timeout time.Duration, minWait time.Duration, quiet time.Duration, snapshot func() int) bool {
+	return settleGCWhen(timeout, minWait, quiet, snapshot, true)
 }
 
-func settleGCWhen(timeout time.Duration, snapshot func() int, requireZero bool) bool {
+func settleGCWhen(
+	timeout time.Duration,
+	minWait time.Duration,
+	quiet time.Duration,
+	snapshot func() int,
+	requireZero bool,
+) bool {
 	start := time.Now()
-	minWaitDeadline := start.Add(checkGCMinWait)
+	minWaitDeadline := start.Add(minWait)
 	deadline := start.Add(timeout)
 	settledDeadline := minWaitDeadline
 
 	var lastSnapshot int
 	var haveLastSnapshot bool
-	var hadUnexpected bool
 	for {
 		// AddCleanup callbacks run after GC proves tracked objects are
 		// unreachable. Run a small burst and yield so callbacks can mark tracked
@@ -203,16 +210,10 @@ func settleGCWhen(timeout time.Duration, snapshot func() int, requireZero bool) 
 		// first passing state. This lets delayed cleanup callbacks finish before
 		// we decide.
 		currentSnapshot := snapshot()
-		if requireZero {
-			if currentSnapshot == 0 && hadUnexpected {
-				return true
-			}
-			hadUnexpected = hadUnexpected || currentSnapshot != 0
-		}
 		if !haveLastSnapshot || currentSnapshot != lastSnapshot {
 			lastSnapshot = currentSnapshot
 			haveLastSnapshot = true
-			settledDeadline = now.Add(checkGCQuiet)
+			settledDeadline = now.Add(quiet)
 			if minWaitDeadline.After(settledDeadline) {
 				settledDeadline = minWaitDeadline
 			}

--- a/common/testing/objectleak/leakcheck.go
+++ b/common/testing/objectleak/leakcheck.go
@@ -5,6 +5,7 @@ import (
 	"iter"
 	"runtime"
 	runtimedebug "runtime/debug"
+	"slices"
 	"sync/atomic"
 	"time"
 )
@@ -129,11 +130,22 @@ func (t *ObjectLeakCheck) Track(root any) {
 // tracking, GC settling that timed out during Check, or a timeout recorded in
 // the supplied baseline.
 func (t *ObjectLeakCheck) Check(baseline Baseline) (string, error) {
-	settled := settleGC(t.gcSettleTimeout, func() int {
-		return countRetained(t.objects, baseline.objects)
+	settled := settleGCToZero(t.gcSettleTimeout, func() int {
+		return countUnexpected(t.objects, baseline, t.expected)
 	})
 	report := newReport(t.objects, baseline, !settled, t.roots, t.expected, t.pruneTypes)
 	return report.string(), report.failures()
+}
+
+func countUnexpected(objects []trackedObject, baseline Baseline, expected patterns) int {
+	activeExpected := slices.Clone(expected)
+	count := 0
+	for obj := range retainedObjects(objects) {
+		if classifyRetention(obj, baseline, activeExpected) == retentionUnexpected {
+			count++
+		}
+	}
+	return count
 }
 
 func countRetained(objectSets ...[]trackedObject) int {
@@ -157,6 +169,14 @@ func retainedObjects(objects []trackedObject) iter.Seq[trackedObject] {
 }
 
 func settleGC(timeout time.Duration, snapshot func() int) bool {
+	return settleGCWhen(timeout, snapshot, false)
+}
+
+func settleGCToZero(timeout time.Duration, snapshot func() int) bool {
+	return settleGCWhen(timeout, snapshot, true)
+}
+
+func settleGCWhen(timeout time.Duration, snapshot func() int, requireZero bool) bool {
 	start := time.Now()
 	minWaitDeadline := start.Add(checkGCMinWait)
 	deadline := start.Add(timeout)
@@ -164,6 +184,7 @@ func settleGC(timeout time.Duration, snapshot func() int) bool {
 
 	var lastSnapshot int
 	var haveLastSnapshot bool
+	var hadUnexpected bool
 	for {
 		// AddCleanup callbacks run after GC proves tracked objects are
 		// unreachable. Run a small burst and yield so callbacks can mark tracked
@@ -181,13 +202,30 @@ func settleGC(timeout time.Duration, snapshot func() int) bool {
 		// Wait for the snapshot to stop changing instead of returning on the
 		// first passing state. This lets delayed cleanup callbacks finish before
 		// we decide.
-		if currentSnapshot := snapshot(); !haveLastSnapshot || currentSnapshot != lastSnapshot {
+		currentSnapshot := snapshot()
+		if requireZero {
+			if currentSnapshot == 0 && hadUnexpected {
+				return true
+			}
+			hadUnexpected = hadUnexpected || currentSnapshot != 0
+		}
+		if !haveLastSnapshot || currentSnapshot != lastSnapshot {
 			lastSnapshot = currentSnapshot
 			haveLastSnapshot = true
 			settledDeadline = now.Add(checkGCQuiet)
 			if minWaitDeadline.After(settledDeadline) {
 				settledDeadline = minWaitDeadline
 			}
+		}
+		if requireZero && currentSnapshot != 0 {
+			// Unexpected objects can remain reachable while asynchronous shutdown
+			// callbacks drain. Give them the full configured timeout, but still
+			// distinguish a stable leak from GC settling that never became quiet.
+			if now.After(deadline) {
+				return haveLastSnapshot && now.After(settledDeadline)
+			}
+			time.Sleep(checkGCPause)
+			continue
 		}
 
 		// Unless the timeout expires first, the minimum wait gives cleanup

--- a/common/testing/objectleak/leakcheck.go
+++ b/common/testing/objectleak/leakcheck.go
@@ -21,7 +21,6 @@ const (
 type ObjectLeakCheck struct {
 	objects         []trackedObject
 	roots           int
-	baseline        objectBaseline
 	expected        patterns
 	pruneTypes      patterns
 	gcSettleTimeout time.Duration
@@ -43,6 +42,13 @@ func (b objectBaseline) contains(obj trackedObject) bool {
 }
 
 type Option func(*ObjectLeakCheck) error
+
+// CheckOption configures a single Check call.
+type CheckOption func(*checkOptions)
+
+type checkOptions struct {
+	baseline objectBaseline
+}
 
 // WithExpected marks retained objects whose reflected path or type name matches
 // pattern as expected. A trailing '*' matches any suffix.
@@ -88,9 +94,10 @@ func NewObjectLeakCheck(opts ...Option) (ObjectLeakCheck, error) {
 	return t, nil
 }
 
-// IgnoreCurrent waits for currently tracked objects to settle, records the
-// identities that remain reachable as the baseline, and resets tracked roots.
-func (t *ObjectLeakCheck) IgnoreCurrent() {
+// IgnoreCurrent waits for currently tracked objects to settle and returns a
+// CheckOption that ignores the retained objects when passed to future Check
+// calls. It also resets tracked roots.
+func (t *ObjectLeakCheck) IgnoreCurrent() CheckOption {
 	settleGC(t.gcSettleTimeout, func() [3]int {
 		retained := 0
 		for _, obj := range t.objects {
@@ -118,9 +125,11 @@ func (t *ObjectLeakCheck) IgnoreCurrent() {
 		}
 		obj.cleanup.Stop()
 	}
-	t.baseline = baseline
 	t.objects = nil
 	t.roots = 0
+	return func(opts *checkOptions) {
+		opts.baseline = baseline
+	}
 }
 
 // Track walks all values reachable from root and tracks pointer objects it finds.
@@ -135,10 +144,15 @@ func (t *ObjectLeakCheck) Track(root any) {
 // retained objects not covered by expected patterns, expected patterns that no
 // longer match any tracked object, or prune rules that did not match during
 // tracking.
-func (t *ObjectLeakCheck) Check() (string, error) {
+func (t *ObjectLeakCheck) Check(opts ...CheckOption) (string, error) {
+	checkOpts := checkOptions{}
+	for _, opt := range opts {
+		opt(&checkOpts)
+	}
+
 	var report report
 	settleGC(t.gcSettleTimeout, func() [3]int {
-		report = newReport(t.objects, t.baseline, t.roots, t.expected, t.pruneTypes)
+		report = newReport(t.objects, checkOpts.baseline, t.roots, t.expected, t.pruneTypes)
 		return report.totals()
 	})
 	return report.string(), report.failures()

--- a/common/testing/objectleak/leakcheck.go
+++ b/common/testing/objectleak/leakcheck.go
@@ -219,9 +219,9 @@ func settleGCWhen(
 			}
 		}
 		if requireZero && currentSnapshot != 0 {
-			// Unexpected objects can remain reachable while asynchronous shutdown
-			// callbacks drain. Give them the full configured timeout, but still
-			// distinguish a stable leak from GC settling that never became quiet.
+			// Nonzero snapshots can persist while asynchronous shutdown callbacks
+			// drain. Give them the full configured timeout, but still distinguish a
+			// stable value from GC settling that never became quiet.
 			if now.After(deadline) {
 				return haveLastSnapshot && now.After(settledDeadline)
 			}

--- a/common/testing/objectleak/leakcheck.go
+++ b/common/testing/objectleak/leakcheck.go
@@ -2,6 +2,7 @@ package objectleak
 
 import (
 	"errors"
+	"iter"
 	"runtime"
 	runtimedebug "runtime/debug"
 	"sync/atomic"
@@ -98,7 +99,7 @@ func (t *ObjectLeakCheck) IgnoreCurrent() Baseline {
 	baseline := Baseline{
 		collectedByID: make(map[objectIdentity]*atomic.Bool),
 	}
-	forEachRetained(t.objects, func(obj trackedObject) {
+	for obj := range retainedObjects(t.objects) {
 		identity := obj.identity()
 		if canonicalCollected, ok := baseline.collectedByID[identity]; ok {
 			obj.cleanup.Stop()
@@ -107,7 +108,7 @@ func (t *ObjectLeakCheck) IgnoreCurrent() Baseline {
 			baseline.collectedByID[identity] = obj.collected
 		}
 		baseline.objects = append(baseline.objects, obj)
-	})
+	}
 	t.objects = nil
 	t.roots = 0
 	return baseline
@@ -135,16 +136,18 @@ func (t *ObjectLeakCheck) Check(baseline Baseline) (string, error) {
 
 func retainedCount(objects []trackedObject) int {
 	retained := 0
-	forEachRetained(objects, func(trackedObject) {
+	for range retainedObjects(objects) {
 		retained++
-	})
+	}
 	return retained
 }
 
-func forEachRetained(objects []trackedObject, visit func(trackedObject)) {
-	for _, obj := range objects {
-		if !obj.collected.Load() {
-			visit(obj)
+func retainedObjects(objects []trackedObject) iter.Seq[trackedObject] {
+	return func(yield func(trackedObject) bool) {
+		for _, obj := range objects {
+			if !obj.collected.Load() && !yield(obj) {
+				return
+			}
 		}
 	}
 }

--- a/common/testing/objectleak/leakcheck_test.go
+++ b/common/testing/objectleak/leakcheck_test.go
@@ -9,6 +9,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	testGCSettleTimeout = 100 * time.Millisecond
+	testGCSettleMinWait = 5 * time.Millisecond
+	testGCSettleQuiet   = 5 * time.Millisecond
+)
+
 type graphRoot struct {
 	Node *graphNode
 }
@@ -37,6 +43,7 @@ type aliasOuter struct {
 
 type aliasInner struct {
 	Value int
+	_     [8]byte
 }
 
 func TestObjectLeak_Check(t *testing.T) {
@@ -244,8 +251,8 @@ baseline retained objects:
 			gcSettleTimeout: time.Nanosecond,
 			setup: func(check *ObjectLeakCheck, roots []any) Baseline {
 				check.Track(roots[0])
-				baseline := check.IgnoreCurrent()                    // records the baseline settle timeout
-				check.gcSettleTimeout = checkGCMinWait + time.Second // lets Check settle normally
+				baseline := check.IgnoreCurrent()           // records the baseline settle timeout
+				check.gcSettleTimeout = testGCSettleTimeout // lets Check settle normally
 				check.Track(roots[1])
 				return baseline
 			},
@@ -366,12 +373,14 @@ baseline retained objects:
 			opts := append([]Option{}, tc.opts...)
 			gcSettleTimeout := tc.gcSettleTimeout
 			if gcSettleTimeout == 0 {
-				gcSettleTimeout = checkGCMinWait + time.Second
+				gcSettleTimeout = testGCSettleTimeout
 			}
 			opts = append(opts, WithGCSettleTimeout(gcSettleTimeout))
 
 			check, err := NewObjectLeakCheck(opts...)
 			require.NoError(t, err)
+			check.gcSettleMinWait = testGCSettleMinWait
+			check.gcSettleQuiet = testGCSettleQuiet
 
 			var baseline Baseline
 			if tc.setup != nil {
@@ -403,8 +412,10 @@ func TestObjectLeak_CheckSkipsTinyPointerFreeObjects(t *testing.T) {
 		new(tinyValue),
 		new(tinyZeroLengthPointerArrayValue),
 	}
-	check, err := NewObjectLeakCheck(WithGCSettleTimeout(checkGCMinWait + time.Second))
+	check, err := NewObjectLeakCheck(WithGCSettleTimeout(testGCSettleTimeout))
 	require.NoError(t, err)
+	check.gcSettleMinWait = testGCSettleMinWait
+	check.gcSettleQuiet = testGCSettleQuiet
 	for _, value := range values {
 		check.Track(value)
 	}
@@ -430,10 +441,22 @@ baseline retained objects:
 
 func TestSettleGCToZeroSucceedsWhenObjectsDrainNearTimeout(t *testing.T) {
 	start := time.Now()
-	require.True(t, settleGCToZero(checkGCMinWait+100*time.Millisecond, func() int {
-		if time.Since(start) < checkGCMinWait {
+	require.True(t, settleGCToZero(testGCSettleTimeout, testGCSettleMinWait, testGCSettleQuiet, func() int {
+		if time.Since(start) < testGCSettleMinWait {
 			return 1
 		}
 		return 0
 	}))
+}
+
+func TestSettleGCToZeroWaitsForQuietAfterObjectsDrain(t *testing.T) {
+	calls := 0
+	require.True(t, settleGCToZero(testGCSettleTimeout, testGCSettleMinWait, testGCSettleQuiet, func() int {
+		calls++
+		if calls == 1 {
+			return 1
+		}
+		return 0
+	}))
+	require.Greater(t, calls, 2)
 }

--- a/common/testing/objectleak/leakcheck_test.go
+++ b/common/testing/objectleak/leakcheck_test.go
@@ -20,10 +20,19 @@ type graphNode struct {
 
 type graphLeaf struct {
 	Value int
+	_     [8]byte
+}
+
+type tinyValue byte
+
+type tinyZeroLengthPointerArrayValue struct {
+	Pointers [0]*byte
+	Value    byte
 }
 
 type aliasOuter struct {
 	aliasInner
+	_ [8]byte
 }
 
 type aliasInner struct {
@@ -387,4 +396,44 @@ baseline retained objects:
 			require.Equal(t, tc.wantReport, report)
 		})
 	}
+}
+
+func TestObjectLeak_CheckSkipsTinyPointerFreeObjects(t *testing.T) {
+	values := []any{
+		new(tinyValue),
+		new(tinyZeroLengthPointerArrayValue),
+	}
+	check, err := NewObjectLeakCheck(WithGCSettleTimeout(checkGCMinWait + time.Second))
+	require.NoError(t, err)
+	for _, value := range values {
+		check.Track(value)
+	}
+
+	report, err := check.Check(Baseline{})
+	runtime.KeepAlive(values)
+	require.NoError(t, err)
+	require.Equal(t, `object leak report
+
+tracked root objects: 2
+retained paths: 0 total, 0 baseline, 0 expected, 0 unexpected
+retained objects: 0 total, 0 baseline, 0 expected, 0 unexpected
+
+unexpected retained objects:
+  none
+
+expected retained objects:
+  none
+
+baseline retained objects:
+  none`, report)
+}
+
+func TestSettleGCToZeroSucceedsWhenObjectsDrainNearTimeout(t *testing.T) {
+	start := time.Now()
+	require.True(t, settleGCToZero(checkGCMinWait+100*time.Millisecond, func() int {
+		if time.Since(start) < checkGCMinWait {
+			return 1
+		}
+		return 0
+	}))
 }

--- a/common/testing/objectleak/leakcheck_test.go
+++ b/common/testing/objectleak/leakcheck_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.temporal.io/server/common/testing/await"
 )
 
 type graphRoot struct {
@@ -39,8 +38,8 @@ func TestObjectLeak_Check(t *testing.T) {
 			wantReport: `object leak report
 
 tracked root objects: 2
-retained paths: 6 total, 0 expected, 6 unexpected
-retained objects: 4 total, 0 expected, 4 unexpected
+retained paths: 6 total, 0 baseline, 0 expected, 6 unexpected
+retained objects: 4 total, 0 baseline, 0 expected, 4 unexpected
 
 unexpected retained objects:
   2 objects: *objectleak.graphRoot
@@ -48,6 +47,9 @@ unexpected retained objects:
   2 paths, 1 object: Node.Leaf (*objectleak.graphLeaf)
 
 expected retained objects:
+  none
+
+baseline retained objects:
   none`,
 		},
 		{
@@ -61,8 +63,8 @@ expected retained objects:
 			wantReport: `object leak report
 
 tracked root objects: 2
-retained paths: 6 total, 6 expected, 0 unexpected
-retained objects: 4 total, 4 expected, 0 unexpected
+retained paths: 6 total, 0 baseline, 6 expected, 0 unexpected
+retained objects: 4 total, 0 baseline, 4 expected, 0 unexpected
 
 unexpected retained objects:
   none
@@ -70,7 +72,10 @@ unexpected retained objects:
 expected retained objects:
   2 objects: *objectleak.graphRoot
   2 paths, 1 object: Node (*objectleak.graphNode)
-  2 paths, 1 object: Node.Leaf (*objectleak.graphLeaf)`,
+  2 paths, 1 object: Node.Leaf (*objectleak.graphLeaf)
+
+baseline retained objects:
+  none`,
 		},
 		{
 			name: "fails stale expected pattern",
@@ -85,8 +90,8 @@ expected retained objects:
 			wantReport: `object leak report
 
 tracked root objects: 2
-retained paths: 6 total, 6 expected, 0 unexpected
-retained objects: 4 total, 4 expected, 0 unexpected
+retained paths: 6 total, 0 baseline, 6 expected, 0 unexpected
+retained objects: 4 total, 0 baseline, 4 expected, 0 unexpected
 
 unexpected retained objects:
   none
@@ -95,6 +100,9 @@ expected retained objects:
   2 objects: *objectleak.graphRoot
   2 paths, 1 object: Node (*objectleak.graphNode)
   2 paths, 1 object: Node.Leaf (*objectleak.graphLeaf)
+
+baseline retained objects:
+  none
 
 stale expected patterns:
   does.not.match`,
@@ -112,8 +120,8 @@ stale expected patterns:
 			wantReport: `object leak report
 
 tracked root objects: 2
-retained paths: 6 total, 6 expected, 0 unexpected
-retained objects: 4 total, 4 expected, 0 unexpected
+retained paths: 6 total, 0 baseline, 6 expected, 0 unexpected
+retained objects: 4 total, 0 baseline, 4 expected, 0 unexpected
 
 unexpected retained objects:
   none
@@ -122,6 +130,9 @@ expected retained objects:
   2 objects: *objectleak.graphRoot
   2 paths, 1 object: Node (*objectleak.graphNode)
   2 paths, 1 object: Node.Leaf (*objectleak.graphLeaf)
+
+baseline retained objects:
+  none
 
 stale prunes:
   does.not.Match`,
@@ -136,15 +147,18 @@ stale prunes:
 			wantReport: `object leak report
 
 tracked root objects: 2
-retained paths: 4 total, 4 expected, 0 unexpected
-retained objects: 3 total, 3 expected, 0 unexpected
+retained paths: 4 total, 0 baseline, 4 expected, 0 unexpected
+retained objects: 3 total, 0 baseline, 3 expected, 0 unexpected
 
 unexpected retained objects:
   none
 
 expected retained objects:
   2 objects: *objectleak.graphRoot
-  2 paths, 1 object: Node (*objectleak.graphNode)`,
+  2 paths, 1 object: Node (*objectleak.graphNode)
+
+baseline retained objects:
+  none`,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -184,78 +198,64 @@ expected retained objects:
 }
 
 func TestObjectLeak_IgnoreCurrent(t *testing.T) {
-	sharedLeaf := &graphLeaf{Value: 2}
 	baselineRoot := &graphRoot{
-		Node: &graphNode{Leaf: sharedLeaf},
+		Node: &graphNode{Leaf: &graphLeaf{Value: 2}},
 	}
 
-	check, err := NewObjectLeakCheck(WithGCSettleTimeout(10 * time.Millisecond))
+	check, err := NewObjectLeakCheck(
+		WithExpected("*objectleak.graphLeaf"),
+		WithGCSettleTimeout(10*time.Millisecond),
+	)
 	require.NoError(t, err)
 	check.Track(baselineRoot)
-	baselineRoot = nil
 	check.IgnoreCurrent()
 
-	root := &graphRoot{
-		Node: &graphNode{Leaf: sharedLeaf},
-	}
+	root := &graphRoot{}
 	check.Track(root)
 
 	report, err := check.Check()
+	runtime.KeepAlive(baselineRoot)
 	runtime.KeepAlive(root)
 	require.Error(t, err)
 	require.Equal(t, `object leak report
 
 tracked root objects: 1
-retained paths: 3 total, 1 baseline, 0 expected, 2 unexpected
-retained objects: 3 total, 1 baseline, 0 expected, 2 unexpected
+retained paths: 4 total, 3 baseline, 0 expected, 1 unexpected
+retained objects: 4 total, 3 baseline, 0 expected, 1 unexpected
 
 unexpected retained objects:
   1 object: *objectleak.graphRoot
-  1 object: Node (*objectleak.graphNode)
 
 expected retained objects:
   none
 
 baseline retained objects:
+  1 object: *objectleak.graphRoot
+  1 object: Node (*objectleak.graphNode)
   1 object: Node.Leaf (*objectleak.graphLeaf)`, report)
 }
 
-func TestObjectLeak_IgnoreCurrentObjectCollectedAfterSnapshot(t *testing.T) {
-	root := &graphRoot{}
-	check, err := NewObjectLeakCheck(WithGCSettleTimeout(10 * time.Millisecond))
-	require.NoError(t, err)
-	check.Track(root)
-	check.IgnoreCurrent()
-	runtime.KeepAlive(root)
-
-	require.Len(t, check.baselineByID, 1)
-	var identity objectIdentity
-	var baseline trackedObject
-	for identity, baseline = range check.baselineByID {
-	}
-
-	root = nil
-	await.RequireTrue(t, func() bool {
-		runtime.GC()
-		return baseline.collected.Load()
-	}, time.Second, 10*time.Millisecond)
-	require.Nil(t, check.baselineCollected(trackedObject{
-		addr:     identity.addr,
-		typeName: identity.typeName,
-	}))
-}
-
-func TestObjectLeak_IgnoreCurrentCollectionAfterTrack(t *testing.T) {
+func TestNewReport_CollectedBaselineIsUnexpected(t *testing.T) {
 	baselineCollected := &atomic.Bool{}
+	baselineObj := trackedObject{
+		addr:      1,
+		typeName:  "*objectleak.graphRoot",
+		collected: baselineCollected,
+	}
 	obj := trackedObject{
-		addr:              1,
-		typeName:          "*objectleak.graphRoot",
-		baselineCollected: baselineCollected,
-		collected:         &atomic.Bool{},
+		addr:      1,
+		typeName:  "*objectleak.graphRoot",
+		collected: &atomic.Bool{},
+	}
+	baseline := objectBaseline{
+		objects: []trackedObject{baselineObj},
+		collectedByID: map[objectIdentity]*atomic.Bool{
+			baselineObj.identity(): baselineCollected,
+		},
 	}
 	baselineCollected.Store(true)
 
-	report := newReport([]trackedObject{obj}, 1, nil, nil)
+	report := newReport([]trackedObject{obj}, baseline, 1, nil, nil)
 	require.Zero(t, report.baselineRetainedObjects)
 	require.Equal(t, 1, report.unexpectedRetainedObjects)
 }

--- a/common/testing/objectleak/leakcheck_test.go
+++ b/common/testing/objectleak/leakcheck_test.go
@@ -208,12 +208,12 @@ func TestObjectLeak_IgnoreCurrent(t *testing.T) {
 	)
 	require.NoError(t, err)
 	check.Track(baselineRoot)
-	check.IgnoreCurrent()
+	baseline := check.IgnoreCurrent()
 
 	root := &graphRoot{}
 	check.Track(root)
 
-	report, err := check.Check()
+	report, err := check.Check(baseline)
 	runtime.KeepAlive(baselineRoot)
 	runtime.KeepAlive(root)
 	require.Error(t, err)

--- a/common/testing/objectleak/leakcheck_test.go
+++ b/common/testing/objectleak/leakcheck_test.go
@@ -195,12 +195,6 @@ baseline retained objects:
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			opts := append([]Option{}, tc.opts...)
-			opts = append(opts, WithGCSettleTimeout(10*time.Millisecond))
-
-			check, err := NewObjectLeakCheck(opts...)
-			require.NoError(t, err)
-
 			node := &graphNode{
 				Leaf:  &graphLeaf{Value: 2},
 				Value: 1,
@@ -209,6 +203,13 @@ baseline retained objects:
 				&graphRoot{Node: node},
 				&graphRoot{Node: node},
 			}
+
+			opts := append([]Option{}, tc.opts...)
+			opts = append(opts, WithGCSettleTimeout(10*time.Millisecond))
+
+			check, err := NewObjectLeakCheck(opts...)
+			require.NoError(t, err)
+
 			var baseline Baseline
 			if tc.setup != nil {
 				baseline = tc.setup(&check, roots)

--- a/common/testing/objectleak/leakcheck_test.go
+++ b/common/testing/objectleak/leakcheck_test.go
@@ -26,7 +26,7 @@ func TestObjectLeak_Check(t *testing.T) {
 	for _, tc := range []struct {
 		name            string
 		opts            []Option
-		setup           func(*ObjectLeakCheck) ([]any, Baseline)
+		setup           func(*ObjectLeakCheck, []any) Baseline
 		wantErrContains []string
 		wantReport      string
 	}{
@@ -165,16 +165,11 @@ baseline retained objects:
 			opts: []Option{
 				WithExpected("*objectleak.graphLeaf"),
 			},
-			setup: func(check *ObjectLeakCheck) ([]any, Baseline) {
-				baselineRoot := &graphRoot{
-					Node: &graphNode{Leaf: &graphLeaf{Value: 2}},
-				}
-				check.Track(baselineRoot)
+			setup: func(check *ObjectLeakCheck, roots []any) Baseline {
+				check.Track(roots[0])
 				baseline := check.IgnoreCurrent()
-
-				root := &graphRoot{}
-				check.Track(root)
-				return []any{baselineRoot, root}, baseline
+				check.Track(roots[1])
+				return baseline
 			},
 			wantErrContains: []string{
 				"unexpected retained objects",
@@ -206,19 +201,18 @@ baseline retained objects:
 			check, err := NewObjectLeakCheck(opts...)
 			require.NoError(t, err)
 
-			var roots []any
+			node := &graphNode{
+				Leaf:  &graphLeaf{Value: 2},
+				Value: 1,
+			}
+			roots := []any{
+				&graphRoot{Node: node},
+				&graphRoot{Node: node},
+			}
 			var baseline Baseline
 			if tc.setup != nil {
-				roots, baseline = tc.setup(&check)
+				baseline = tc.setup(&check, roots)
 			} else {
-				node := &graphNode{
-					Leaf:  &graphLeaf{Value: 2},
-					Value: 1,
-				}
-				roots = []any{
-					&graphRoot{Node: node},
-					&graphRoot{Node: node},
-				}
 				for _, root := range roots {
 					check.Track(root)
 				}

--- a/common/testing/objectleak/leakcheck_test.go
+++ b/common/testing/objectleak/leakcheck_test.go
@@ -3,7 +3,6 @@ package objectleak
 import (
 	"reflect"
 	"runtime"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -27,6 +26,7 @@ func TestObjectLeak_Check(t *testing.T) {
 	for _, tc := range []struct {
 		name            string
 		opts            []Option
+		setup           func(*ObjectLeakCheck) ([]any, []CheckOption)
 		wantErrContains []string
 		wantReport      string
 	}{
@@ -160,64 +160,26 @@ expected retained objects:
 baseline retained objects:
   none`,
 		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
+		{
+			name: "ignores current objects",
+			opts: []Option{
+				WithExpected("*objectleak.graphLeaf"),
+			},
+			setup: func(check *ObjectLeakCheck) ([]any, []CheckOption) {
+				baselineRoot := &graphRoot{
+					Node: &graphNode{Leaf: &graphLeaf{Value: 2}},
+				}
+				check.Track(baselineRoot)
+				baseline := check.IgnoreCurrent()
 
-			node := &graphNode{
-				Leaf:  &graphLeaf{Value: 2},
-				Value: 1,
-			}
-			roots := []any{
-				&graphRoot{Node: node},
-				&graphRoot{Node: node},
-			}
-			opts := append([]Option{}, tc.opts...)
-			opts = append(opts, WithGCSettleTimeout(10*time.Millisecond))
-
-			check, err := NewObjectLeakCheck(opts...)
-			require.NoError(t, err)
-			for _, root := range roots {
+				root := &graphRoot{}
 				check.Track(root)
-			}
-
-			report, err := check.Check()
-			runtime.KeepAlive(roots) // prevent GC from reclaiming roots
-
-			if len(tc.wantErrContains) > 0 {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
-			for _, expected := range tc.wantErrContains {
-				require.Contains(t, err.Error(), expected)
-			}
-			require.Equal(t, tc.wantReport, report)
-		})
-	}
-}
-
-func TestObjectLeak_IgnoreCurrent(t *testing.T) {
-	baselineRoot := &graphRoot{
-		Node: &graphNode{Leaf: &graphLeaf{Value: 2}},
-	}
-
-	check, err := NewObjectLeakCheck(
-		WithExpected("*objectleak.graphLeaf"),
-		WithGCSettleTimeout(10*time.Millisecond),
-	)
-	require.NoError(t, err)
-	check.Track(baselineRoot)
-	baseline := check.IgnoreCurrent()
-
-	root := &graphRoot{}
-	check.Track(root)
-
-	report, err := check.Check(baseline)
-	runtime.KeepAlive(baselineRoot)
-	runtime.KeepAlive(root)
-	require.Error(t, err)
-	require.Equal(t, `object leak report
+				return []any{baselineRoot, root}, []CheckOption{baseline}
+			},
+			wantErrContains: []string{
+				"unexpected retained objects",
+			},
+			wantReport: `object leak report
 
 tracked root objects: 1
 retained paths: 4 total, 3 baseline, 0 expected, 1 unexpected
@@ -232,30 +194,48 @@ expected retained objects:
 baseline retained objects:
   1 object: *objectleak.graphRoot
   1 object: Node (*objectleak.graphNode)
-  1 object: Node.Leaf (*objectleak.graphLeaf)`, report)
-}
-
-func TestNewReport_CollectedBaselineIsUnexpected(t *testing.T) {
-	baselineCollected := &atomic.Bool{}
-	baselineObj := trackedObject{
-		addr:      1,
-		typeName:  "*objectleak.graphRoot",
-		collected: baselineCollected,
-	}
-	obj := trackedObject{
-		addr:      1,
-		typeName:  "*objectleak.graphRoot",
-		collected: &atomic.Bool{},
-	}
-	baseline := objectBaseline{
-		objects: []trackedObject{baselineObj},
-		collectedByID: map[objectIdentity]*atomic.Bool{
-			baselineObj.identity(): baselineCollected,
+  1 object: Node.Leaf (*objectleak.graphLeaf)`,
 		},
-	}
-	baselineCollected.Store(true)
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	report := newReport([]trackedObject{obj}, baseline, 1, nil, nil)
-	require.Zero(t, report.baselineRetainedObjects)
-	require.Equal(t, 1, report.unexpectedRetainedObjects)
+			opts := append([]Option{}, tc.opts...)
+			opts = append(opts, WithGCSettleTimeout(10*time.Millisecond))
+
+			check, err := NewObjectLeakCheck(opts...)
+			require.NoError(t, err)
+
+			var roots []any
+			var checkOpts []CheckOption
+			if tc.setup != nil {
+				roots, checkOpts = tc.setup(&check)
+			} else {
+				node := &graphNode{
+					Leaf:  &graphLeaf{Value: 2},
+					Value: 1,
+				}
+				roots = []any{
+					&graphRoot{Node: node},
+					&graphRoot{Node: node},
+				}
+				for _, root := range roots {
+					check.Track(root)
+				}
+			}
+
+			report, err := check.Check(checkOpts...)
+			runtime.KeepAlive(roots) // prevent GC from reclaiming roots
+
+			if len(tc.wantErrContains) > 0 {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			for _, expected := range tc.wantErrContains {
+				require.Contains(t, err.Error(), expected)
+			}
+			require.Equal(t, tc.wantReport, report)
+		})
+	}
 }

--- a/common/testing/objectleak/leakcheck_test.go
+++ b/common/testing/objectleak/leakcheck_test.go
@@ -26,7 +26,7 @@ func TestObjectLeak_Check(t *testing.T) {
 	for _, tc := range []struct {
 		name            string
 		opts            []Option
-		setup           func(*ObjectLeakCheck) ([]any, []CheckOption)
+		setup           func(*ObjectLeakCheck) ([]any, Baseline)
 		wantErrContains []string
 		wantReport      string
 	}{
@@ -165,7 +165,7 @@ baseline retained objects:
 			opts: []Option{
 				WithExpected("*objectleak.graphLeaf"),
 			},
-			setup: func(check *ObjectLeakCheck) ([]any, []CheckOption) {
+			setup: func(check *ObjectLeakCheck) ([]any, Baseline) {
 				baselineRoot := &graphRoot{
 					Node: &graphNode{Leaf: &graphLeaf{Value: 2}},
 				}
@@ -174,7 +174,7 @@ baseline retained objects:
 
 				root := &graphRoot{}
 				check.Track(root)
-				return []any{baselineRoot, root}, []CheckOption{baseline}
+				return []any{baselineRoot, root}, baseline
 			},
 			wantErrContains: []string{
 				"unexpected retained objects",
@@ -207,9 +207,9 @@ baseline retained objects:
 			require.NoError(t, err)
 
 			var roots []any
-			var checkOpts []CheckOption
+			var baseline Baseline
 			if tc.setup != nil {
-				roots, checkOpts = tc.setup(&check)
+				roots, baseline = tc.setup(&check)
 			} else {
 				node := &graphNode{
 					Leaf:  &graphLeaf{Value: 2},
@@ -224,7 +224,7 @@ baseline retained objects:
 				}
 			}
 
-			report, err := check.Check(checkOpts...)
+			report, err := check.Check(baseline)
 			runtime.KeepAlive(roots) // prevent GC from reclaiming roots
 
 			if len(tc.wantErrContains) > 0 {

--- a/common/testing/objectleak/leakcheck_test.go
+++ b/common/testing/objectleak/leakcheck_test.go
@@ -22,11 +22,20 @@ type graphLeaf struct {
 	Value int
 }
 
+type aliasOuter struct {
+	aliasInner
+}
+
+type aliasInner struct {
+	Value int
+}
+
 func TestObjectLeak_Check(t *testing.T) {
 	for _, tc := range []struct {
 		name            string
 		opts            []Option
 		setup           func(*ObjectLeakCheck, []any) Baseline
+		gcSettleTimeout time.Duration
 		wantErrContains []string
 		wantReport      string
 	}{
@@ -143,6 +152,7 @@ stale prunes:
 				WithExpected("*objectleak.graphRoot"),
 				WithExpected("*objectleak.graphNode"),
 				WithPruneType(reflect.TypeFor[graphNode]().PkgPath() + ".graphNode"),
+				WithPruneType(reflect.TypeFor[graphNode]().PkgPath() + ".graphN*"),
 			},
 			wantReport: `object leak report
 
@@ -161,18 +171,19 @@ baseline retained objects:
   none`,
 		},
 		{
-			name: "ignores current objects",
+			name: "reports baseline-only expected patterns stale",
 			opts: []Option{
 				WithExpected("*objectleak.graphLeaf"),
 			},
 			setup: func(check *ObjectLeakCheck, roots []any) Baseline {
 				check.Track(roots[0])
 				baseline := check.IgnoreCurrent()
-				check.Track(roots[1])
+				check.Track(roots[1]) // shared node and leaf remain baseline-covered
 				return baseline
 			},
 			wantErrContains: []string{
 				"unexpected retained objects",
+				"stale expected patterns",
 			},
 			wantReport: `object leak report
 
@@ -188,6 +199,145 @@ expected retained objects:
 
 baseline retained objects:
   1 object: *objectleak.graphRoot
+  1 object: Node (*objectleak.graphNode)
+  1 object: Node.Leaf (*objectleak.graphLeaf)
+
+stale expected patterns:
+  *objectleak.graphLeaf`,
+		},
+		{
+			name:            "reports check GC settle timeout",
+			gcSettleTimeout: time.Nanosecond,
+			wantErrContains: []string{
+				"check GC settling timed out",
+				"unexpected retained objects",
+			},
+			wantReport: `object leak report
+
+tracked root objects: 2
+check GC settling timed out
+retained paths: 6 total, 0 baseline, 0 expected, 6 unexpected
+retained objects: 4 total, 0 baseline, 0 expected, 4 unexpected
+
+unexpected retained objects:
+  2 objects: *objectleak.graphRoot
+  2 paths, 1 object: Node (*objectleak.graphNode)
+  2 paths, 1 object: Node.Leaf (*objectleak.graphLeaf)
+
+expected retained objects:
+  none
+
+baseline retained objects:
+  none`,
+		},
+		{
+			name:            "reports baseline GC settle timeout",
+			gcSettleTimeout: time.Nanosecond,
+			setup: func(check *ObjectLeakCheck, roots []any) Baseline {
+				check.Track(roots[0])
+				baseline := check.IgnoreCurrent()                    // records the baseline settle timeout
+				check.gcSettleTimeout = checkGCMinWait + time.Second // lets Check settle normally
+				check.Track(roots[1])
+				return baseline
+			},
+			wantErrContains: []string{
+				"baseline GC settling timed out",
+				"unexpected retained objects",
+			},
+			wantReport: `object leak report
+
+tracked root objects: 1
+baseline GC settling timed out
+retained paths: 4 total, 3 baseline, 0 expected, 1 unexpected
+retained objects: 4 total, 3 baseline, 0 expected, 1 unexpected
+
+unexpected retained objects:
+  1 object: *objectleak.graphRoot
+
+expected retained objects:
+  none
+
+baseline retained objects:
+  1 object: *objectleak.graphRoot
+  1 object: Node (*objectleak.graphNode)
+  1 object: Node.Leaf (*objectleak.graphLeaf)`,
+		},
+		{
+			name: "deduplicates baseline objects across roots",
+			setup: func(check *ObjectLeakCheck, roots []any) Baseline {
+				check.Track(roots[0])
+				check.Track(roots[1]) // duplicates the shared node and leaf across Track calls
+				baseline := check.IgnoreCurrent()
+				check.Track(roots[0]) // all objects remain covered by the deduplicated baseline
+				return baseline
+			},
+			wantReport: `object leak report
+
+tracked root objects: 1
+retained paths: 6 total, 6 baseline, 0 expected, 0 unexpected
+retained objects: 4 total, 4 baseline, 0 expected, 0 unexpected
+
+unexpected retained objects:
+  none
+
+expected retained objects:
+  none
+
+baseline retained objects:
+  2 objects: *objectleak.graphRoot
+  2 paths, 1 object: Node (*objectleak.graphNode)
+  2 paths, 1 object: Node.Leaf (*objectleak.graphLeaf)`,
+		},
+		{
+			name: "matches baseline objects by address",
+			setup: func(check *ObjectLeakCheck, roots []any) Baseline {
+				outer := &aliasOuter{}
+				roots[0] = outer
+				check.Track(outer)
+				baseline := check.IgnoreCurrent()
+				check.Track(&outer.aliasInner) // same address as outer, but a different pointer type
+				return baseline
+			},
+			wantReport: `object leak report
+
+tracked root objects: 1
+retained paths: 1 total, 1 baseline, 0 expected, 0 unexpected
+retained objects: 1 total, 1 baseline, 0 expected, 0 unexpected
+
+unexpected retained objects:
+  none
+
+expected retained objects:
+  none
+
+baseline retained objects:
+  1 object: *objectleak.aliasOuter`,
+		},
+		{
+			name: "drops collected baseline objects",
+			setup: func(check *ObjectLeakCheck, roots []any) Baseline {
+				check.Track(roots[0])
+				baseline := check.IgnoreCurrent()
+				roots[0] = nil // allows the baselined root to be collected before Check
+				check.Track(roots[1])
+				return baseline
+			},
+			wantErrContains: []string{
+				"unexpected retained objects",
+			},
+			wantReport: `object leak report
+
+tracked root objects: 1
+retained paths: 3 total, 2 baseline, 0 expected, 1 unexpected
+retained objects: 3 total, 2 baseline, 0 expected, 1 unexpected
+
+unexpected retained objects:
+  1 object: *objectleak.graphRoot
+
+expected retained objects:
+  none
+
+baseline retained objects:
   1 object: Node (*objectleak.graphNode)
   1 object: Node.Leaf (*objectleak.graphLeaf)`,
 		},
@@ -205,7 +355,11 @@ baseline retained objects:
 			}
 
 			opts := append([]Option{}, tc.opts...)
-			opts = append(opts, WithGCSettleTimeout(10*time.Millisecond))
+			gcSettleTimeout := tc.gcSettleTimeout
+			if gcSettleTimeout == 0 {
+				gcSettleTimeout = checkGCMinWait + time.Second
+			}
+			opts = append(opts, WithGCSettleTimeout(gcSettleTimeout))
 
 			check, err := NewObjectLeakCheck(opts...)
 			require.NoError(t, err)

--- a/common/testing/objectleak/leakcheck_test.go
+++ b/common/testing/objectleak/leakcheck_test.go
@@ -3,10 +3,12 @@ package objectleak
 import (
 	"reflect"
 	"runtime"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/testing/await"
 )
 
 type graphRoot struct {
@@ -179,4 +181,81 @@ expected retained objects:
 			require.Equal(t, tc.wantReport, report)
 		})
 	}
+}
+
+func TestObjectLeak_IgnoreCurrent(t *testing.T) {
+	sharedLeaf := &graphLeaf{Value: 2}
+	baselineRoot := &graphRoot{
+		Node: &graphNode{Leaf: sharedLeaf},
+	}
+
+	check, err := NewObjectLeakCheck(WithGCSettleTimeout(10 * time.Millisecond))
+	require.NoError(t, err)
+	check.Track(baselineRoot)
+	baselineRoot = nil
+	check.IgnoreCurrent()
+
+	root := &graphRoot{
+		Node: &graphNode{Leaf: sharedLeaf},
+	}
+	check.Track(root)
+
+	report, err := check.Check()
+	runtime.KeepAlive(root)
+	require.Error(t, err)
+	require.Equal(t, `object leak report
+
+tracked root objects: 1
+retained paths: 3 total, 1 baseline, 0 expected, 2 unexpected
+retained objects: 3 total, 1 baseline, 0 expected, 2 unexpected
+
+unexpected retained objects:
+  1 object: *objectleak.graphRoot
+  1 object: Node (*objectleak.graphNode)
+
+expected retained objects:
+  none
+
+baseline retained objects:
+  1 object: Node.Leaf (*objectleak.graphLeaf)`, report)
+}
+
+func TestObjectLeak_IgnoreCurrentObjectCollectedAfterSnapshot(t *testing.T) {
+	root := &graphRoot{}
+	check, err := NewObjectLeakCheck(WithGCSettleTimeout(10 * time.Millisecond))
+	require.NoError(t, err)
+	check.Track(root)
+	check.IgnoreCurrent()
+	runtime.KeepAlive(root)
+
+	require.Len(t, check.baselineByID, 1)
+	var identity objectIdentity
+	var baseline trackedObject
+	for identity, baseline = range check.baselineByID {
+	}
+
+	root = nil
+	await.RequireTrue(t, func() bool {
+		runtime.GC()
+		return baseline.collected.Load()
+	}, time.Second, 10*time.Millisecond)
+	require.Nil(t, check.baselineCollected(trackedObject{
+		addr:     identity.addr,
+		typeName: identity.typeName,
+	}))
+}
+
+func TestObjectLeak_IgnoreCurrentCollectionAfterTrack(t *testing.T) {
+	baselineCollected := &atomic.Bool{}
+	obj := trackedObject{
+		addr:              1,
+		typeName:          "*objectleak.graphRoot",
+		baselineCollected: baselineCollected,
+		collected:         &atomic.Bool{},
+	}
+	baselineCollected.Store(true)
+
+	report := newReport([]trackedObject{obj}, 1, nil, nil)
+	require.Zero(t, report.baselineRetainedObjects)
+	require.Equal(t, 1, report.unexpectedRetainedObjects)
 }

--- a/common/testing/objectleak/pattern.go
+++ b/common/testing/objectleak/pattern.go
@@ -2,7 +2,6 @@ package objectleak
 
 import (
 	"reflect"
-	"slices"
 	"strings"
 )
 
@@ -43,14 +42,15 @@ func (ps patterns) matchObject(path string, typeName string) bool {
 	return matched
 }
 
-func (ps patterns) matchAny(values ...string) bool {
+func (ps patterns) matchValue(value string) bool {
+	matched := false
 	for i := range ps {
-		if slices.ContainsFunc(values, ps[i].matches) {
+		if ps[i].matches(value) {
 			ps[i].matched = true
-			return true
+			matched = true
 		}
 	}
-	return false
+	return matched
 }
 
 func (ps patterns) matchType(t reflect.Type) bool {
@@ -58,9 +58,9 @@ func (ps patterns) matchType(t reflect.Type) bool {
 		t = t.Elem()
 	}
 	if t.Name() != "" {
-		return ps.matchAny(t.PkgPath() + "." + t.Name())
+		return ps.matchValue(t.PkgPath() + "." + t.Name())
 	}
-	return ps.matchAny(t.String())
+	return ps.matchValue(t.String())
 }
 
 func (ps patterns) unmatched() []string {

--- a/common/testing/objectleak/pattern.go
+++ b/common/testing/objectleak/pattern.go
@@ -28,19 +28,19 @@ func (p pattern) matches(value string) bool {
 	return value == p.value
 }
 
-func (p pattern) matchesObject(obj trackedObject) bool {
-	return p.matches(obj.path.normalized()) || p.matches(obj.typeName)
+func (p pattern) matchesObject(path string, typeName string) bool {
+	return p.matches(path) || p.matches(typeName)
 }
 
-func (ps patterns) matchObject(obj trackedObject) []string {
-	var matches []string
+func (ps patterns) matchObject(path string, typeName string) bool {
+	matched := false
 	for i := range ps {
-		if ps[i].matchesObject(obj) {
+		if ps[i].matchesObject(path, typeName) {
 			ps[i].matched = true
-			matches = append(matches, ps[i].String())
+			matched = true
 		}
 	}
-	return matches
+	return matched
 }
 
 func (ps patterns) matchAny(values ...string) bool {

--- a/common/testing/objectleak/report.go
+++ b/common/testing/objectleak/report.go
@@ -8,21 +8,33 @@ import (
 	"strings"
 )
 
+type retentionClass int
+
+const (
+	retentionUnexpected retentionClass = iota
+	retentionExpected
+	retentionBaseline
+	retentionClassCount
+)
+
 type report struct {
-	unexpectedObjects         []objectGroup
-	expectedObjects           []objectGroup
-	baselineObjects           []objectGroup
-	trackedRoots              int
-	totalRetainedPaths        int
-	totalRetainedObjects      int
-	baselineRetainedPaths     int
-	baselineRetainedObjects   int
-	expectedRetainedPaths     int
-	expectedRetainedObjects   int
-	unexpectedRetainedPaths   int
-	unexpectedRetainedObjects int
-	unmatchedExpected         []string
-	unmatchedPrunes           []string
+	retained             [retentionClassCount]retentionStats
+	trackedRoots         int
+	totalRetainedObjects int
+	unmatchedExpected    []string
+	unmatchedPrunes      []string
+}
+
+type retentionStats struct {
+	groups      []objectGroup
+	paths       int
+	addresses   map[uintptr]struct{}
+	groupsByKey map[objectGroupKey]*objectGroup
+}
+
+type objectGroupKey struct {
+	path     string
+	typeName string
 }
 
 type objectGroup struct {
@@ -46,76 +58,33 @@ func newReport(
 	// Matching mutates pattern.matched for stale-expected pattern detection.
 	activeExpected := slices.Clone(expected)
 
-	type retentionClass int
-	const (
-		retentionUnexpected retentionClass = iota
-		retentionExpected
-		retentionBaseline
-	)
-	type groupKey struct {
-		path     string
-		typeName string
-		class    retentionClass
+	for class := retentionClass(0); class < retentionClassCount; class++ {
+		report.retained[class] = newRetentionStats()
 	}
-	groupByKey := make(map[groupKey]*objectGroup)
 	retainedAddresses := make(map[uintptr]struct{})
-	baselineAddresses := make(map[uintptr]struct{})
-	expectedAddresses := make(map[uintptr]struct{})
-	unexpectedAddresses := make(map[uintptr]struct{})
 
 	// Classify each retained object and fold equivalent normalized paths into
 	// a single report row.
 	addRetained := func(obj trackedObject, class retentionClass) {
-		report.totalRetainedPaths++
 		retainedAddresses[obj.addr] = struct{}{}
-		switch class {
-		case retentionBaseline:
-			report.baselineRetainedPaths++
-			baselineAddresses[obj.addr] = struct{}{}
-		case retentionExpected:
-			report.expectedRetainedPaths++
-			expectedAddresses[obj.addr] = struct{}{}
-		case retentionUnexpected:
-			report.unexpectedRetainedPaths++
-			unexpectedAddresses[obj.addr] = struct{}{}
-		}
-
-		key := groupKey{
-			path:     obj.path.normalized(),
-			typeName: obj.typeName,
-			class:    class,
-		}
-		group := groupByKey[key]
-		if group == nil {
-			group = &objectGroup{
-				path:      key.path,
-				typeName:  key.typeName,
-				addresses: make(map[uintptr]struct{}),
-			}
-			groupByKey[key] = group
-		}
-		group.paths++
-		group.addresses[obj.addr] = struct{}{}
+		report.retained[class].add(obj)
 	}
-	forEachRetained(baseline.objects, func(obj trackedObject) {
+	for obj := range retainedObjects(baseline.objects) {
 		activeExpected.matchObject(obj)
 		addRetained(obj, retentionBaseline)
-	})
-	forEachRetained(objects, func(obj trackedObject) {
+	}
+	for obj := range retainedObjects(objects) {
 		expectedBy := activeExpected.matchObject(obj)
 		if baseline.contains(obj) {
-			return
+			continue
 		}
 		if len(expectedBy) > 0 {
 			addRetained(obj, retentionExpected)
 		} else {
 			addRetained(obj, retentionUnexpected)
 		}
-	})
+	}
 	report.totalRetainedObjects = len(retainedAddresses)
-	report.baselineRetainedObjects = len(baselineAddresses)
-	report.expectedRetainedObjects = len(expectedAddresses)
-	report.unexpectedRetainedObjects = len(unexpectedAddresses)
 
 	// Expected patterns that never matched any tracked object are stale and
 	// should be removed with the fix that made them unnecessary.
@@ -123,41 +92,64 @@ func newReport(
 	report.unmatchedPrunes = pruneTypes.unmatched()
 
 	// Keep report output stable across map iteration order and repeated runs.
-	for key, group := range groupByKey {
-		switch key.class {
-		case retentionBaseline:
-			report.baselineObjects = append(report.baselineObjects, *group)
-		case retentionExpected:
-			report.expectedObjects = append(report.expectedObjects, *group)
-		case retentionUnexpected:
-			report.unexpectedObjects = append(report.unexpectedObjects, *group)
-		}
+	for class := retentionClass(0); class < retentionClassCount; class++ {
+		report.retained[class].finish()
 	}
-	sortGroups := func(groups []objectGroup) {
-		slices.SortFunc(groups, func(a objectGroup, b objectGroup) int {
-			if c := cmp.Compare(b.objectCount(), a.objectCount()); c != 0 {
-				return c
-			}
-			if c := cmp.Compare(b.paths, a.paths); c != 0 {
-				return c
-			}
-			if c := cmp.Compare(a.path, b.path); c != 0 {
-				return c
-			}
-			return cmp.Compare(a.typeName, b.typeName)
-		})
-	}
-	sortGroups(report.unexpectedObjects)
-	sortGroups(report.expectedObjects)
-	sortGroups(report.baselineObjects)
 	slices.Sort(report.unmatchedExpected)
 	slices.Sort(report.unmatchedPrunes)
 	return report
 }
 
+func newRetentionStats() retentionStats {
+	return retentionStats{
+		addresses:   make(map[uintptr]struct{}),
+		groupsByKey: make(map[objectGroupKey]*objectGroup),
+	}
+}
+
+func (s *retentionStats) add(obj trackedObject) {
+	s.paths++
+	s.addresses[obj.addr] = struct{}{}
+
+	key := objectGroupKey{
+		path:     obj.path.normalized(),
+		typeName: obj.typeName,
+	}
+	group := s.groupsByKey[key]
+	if group == nil {
+		group = &objectGroup{
+			path:      key.path,
+			typeName:  key.typeName,
+			addresses: make(map[uintptr]struct{}),
+		}
+		s.groupsByKey[key] = group
+	}
+	group.paths++
+	group.addresses[obj.addr] = struct{}{}
+}
+
+func (s *retentionStats) finish() {
+	for _, group := range s.groupsByKey {
+		s.groups = append(s.groups, *group)
+	}
+	s.groupsByKey = nil
+	slices.SortFunc(s.groups, func(a objectGroup, b objectGroup) int {
+		if c := cmp.Compare(b.objectCount(), a.objectCount()); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(b.paths, a.paths); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(a.path, b.path); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.typeName, b.typeName)
+	})
+}
+
 func (r report) failures() error {
 	var failures []error
-	if len(r.unexpectedObjects) > 0 {
+	if len(r.retained[retentionUnexpected].groups) > 0 {
 		failures = append(failures, errors.New("unexpected retained objects"))
 	}
 	if len(r.unmatchedExpected) > 0 {
@@ -184,11 +176,11 @@ func (r report) string() string {
 		}
 	}
 	out.WriteByte('\n')
-	writeGroups("unexpected retained objects", r.unexpectedObjects)
+	writeGroups("unexpected retained objects", r.retained[retentionUnexpected].groups)
 	out.WriteByte('\n')
-	writeGroups("expected retained objects", r.expectedObjects)
+	writeGroups("expected retained objects", r.retained[retentionExpected].groups)
 	out.WriteByte('\n')
-	writeGroups("baseline retained objects", r.baselineObjects)
+	writeGroups("baseline retained objects", r.retained[retentionBaseline].groups)
 
 	if len(r.unmatchedExpected) > 0 {
 		out.WriteString("\nstale expected patterns:\n")
@@ -207,23 +199,28 @@ func (r report) string() string {
 }
 
 func (r report) writeSummary(out *strings.Builder) {
+	baseline := r.retained[retentionBaseline]
+	expected := r.retained[retentionExpected]
+	unexpected := r.retained[retentionUnexpected]
+	totalPaths := baseline.paths + expected.paths + unexpected.paths
+
 	out.WriteString("object leak report\n\n")
 	fmt.Fprintf(out, "tracked root objects: %d\n", r.trackedRoots)
 	fmt.Fprintf(
 		out,
 		"retained paths: %d total, %d baseline, %d expected, %d unexpected\n",
-		r.totalRetainedPaths,
-		r.baselineRetainedPaths,
-		r.expectedRetainedPaths,
-		r.unexpectedRetainedPaths,
+		totalPaths,
+		baseline.paths,
+		expected.paths,
+		unexpected.paths,
 	)
 	fmt.Fprintf(
 		out,
 		"retained objects: %d total, %d baseline, %d expected, %d unexpected\n",
 		r.totalRetainedObjects,
-		r.baselineRetainedObjects,
-		r.expectedRetainedObjects,
-		r.unexpectedRetainedObjects,
+		len(baseline.addresses),
+		len(expected.addresses),
+		len(unexpected.addresses),
 	)
 }
 

--- a/common/testing/objectleak/report.go
+++ b/common/testing/objectleak/report.go
@@ -32,7 +32,13 @@ type objectGroup struct {
 	addresses map[uintptr]struct{}
 }
 
-func newReport(objects []trackedObject, trackedRoots int, expected patterns, pruneTypes patterns) report {
+func newReport(
+	objects []trackedObject,
+	baseline objectBaseline,
+	trackedRoots int,
+	expected patterns,
+	pruneTypes patterns,
+) report {
 	report := report{
 		trackedRoots: trackedRoots,
 	}
@@ -54,20 +60,23 @@ func newReport(objects []trackedObject, trackedRoots int, expected patterns, pru
 
 	// Classify each retained object and fold equivalent normalized paths into
 	// a single report row.
-	for _, obj := range objects {
+	addRetained := func(obj trackedObject, isBaseline bool) {
 		if obj.collected.Load() {
-			continue
+			return
 		}
 
+		expectedBy := activeExpected.matchObject(obj)
+		if !isBaseline && baseline.contains(obj) {
+			return
+		}
 		report.totalRetainedPaths++
 		retainedAddresses[obj.addr] = struct{}{}
-		baseline := obj.baselineCollected != nil && !obj.baselineCollected.Load()
-		expected := false
-		if baseline {
+		isExpected := false
+		if isBaseline {
 			report.baselineRetainedPaths++
 			baselineAddresses[obj.addr] = struct{}{}
-		} else if expectedBy := activeExpected.matchObject(obj); len(expectedBy) > 0 {
-			expected = true
+		} else if len(expectedBy) > 0 {
+			isExpected = true
 			report.expectedRetainedPaths++
 			expectedAddresses[obj.addr] = struct{}{}
 		} else {
@@ -78,8 +87,8 @@ func newReport(objects []trackedObject, trackedRoots int, expected patterns, pru
 		key := groupKey{
 			path:     obj.path.normalized(),
 			typeName: obj.typeName,
-			baseline: baseline,
-			expected: expected,
+			baseline: isBaseline,
+			expected: isExpected,
 		}
 		group := groupByKey[key]
 		if group == nil {
@@ -92,6 +101,12 @@ func newReport(objects []trackedObject, trackedRoots int, expected patterns, pru
 		}
 		group.paths++
 		group.addresses[obj.addr] = struct{}{}
+	}
+	for _, obj := range baseline.objects {
+		addRetained(obj, true)
+	}
+	for _, obj := range objects {
+		addRetained(obj, false)
 	}
 	report.totalRetainedObjects = len(retainedAddresses)
 	report.baselineRetainedObjects = len(baselineAddresses)
@@ -175,10 +190,8 @@ func (r report) string() string {
 	writeGroups("unexpected retained objects", r.unexpectedObjects)
 	out.WriteByte('\n')
 	writeGroups("expected retained objects", r.expectedObjects)
-	if len(r.baselineObjects) > 0 {
-		out.WriteByte('\n')
-		writeGroups("baseline retained objects", r.baselineObjects)
-	}
+	out.WriteByte('\n')
+	writeGroups("baseline retained objects", r.baselineObjects)
 
 	if len(r.unmatchedExpected) > 0 {
 		out.WriteString("\nstale expected patterns:\n")
@@ -199,36 +212,19 @@ func (r report) string() string {
 func (r report) writeSummary(out *strings.Builder) {
 	out.WriteString("object leak report\n\n")
 	fmt.Fprintf(out, "tracked root objects: %d\n", r.trackedRoots)
-	if r.baselineRetainedPaths > 0 {
-		fmt.Fprintf(
-			out,
-			"retained paths: %d total, %d baseline, %d expected, %d unexpected\n",
-			r.totalRetainedPaths,
-			r.baselineRetainedPaths,
-			r.expectedRetainedPaths,
-			r.unexpectedRetainedPaths,
-		)
-		fmt.Fprintf(
-			out,
-			"retained objects: %d total, %d baseline, %d expected, %d unexpected\n",
-			r.totalRetainedObjects,
-			r.baselineRetainedObjects,
-			r.expectedRetainedObjects,
-			r.unexpectedRetainedObjects,
-		)
-		return
-	}
 	fmt.Fprintf(
 		out,
-		"retained paths: %d total, %d expected, %d unexpected\n",
+		"retained paths: %d total, %d baseline, %d expected, %d unexpected\n",
 		r.totalRetainedPaths,
+		r.baselineRetainedPaths,
 		r.expectedRetainedPaths,
 		r.unexpectedRetainedPaths,
 	)
 	fmt.Fprintf(
 		out,
-		"retained objects: %d total, %d expected, %d unexpected\n",
+		"retained objects: %d total, %d baseline, %d expected, %d unexpected\n",
 		r.totalRetainedObjects,
+		r.baselineRetainedObjects,
 		r.expectedRetainedObjects,
 		r.unexpectedRetainedObjects,
 	)

--- a/common/testing/objectleak/report.go
+++ b/common/testing/objectleak/report.go
@@ -44,24 +44,21 @@ func newReport(
 	// Matching mutates pattern.matched for stale-expected pattern detection.
 	activeExpected := slices.Clone(expected)
 
-	var retained [retentionClassCount]retentionAccumulator
 	retainedAddresses := make(map[uintptr]struct{})
 
 	// Record each classified retained object and fold equivalent normalized
 	// path and type pairs into a single report row.
-	addRetained := func(obj trackedObject, path string, class retentionClass) {
-		retainedAddresses[obj.addr] = struct{}{}
-		retained[class].add(obj, path)
-	}
 	for obj := range retainedObjects(baseline.objects) {
 		path := obj.path.normalized()
-		addRetained(obj, path, retentionBaseline)
+		retainedAddresses[obj.addr] = struct{}{}
+		r.retained[retentionBaseline].add(obj, path)
 	}
 	for obj := range retainedObjects(objects) {
 		path := obj.path.normalized()
-		class := classifyRetention(obj, baseline, activeExpected)
+		class := classifyRetention(obj, path, baseline, activeExpected)
 		if class != retentionBaseline {
-			addRetained(obj, path, class)
+			retainedAddresses[obj.addr] = struct{}{}
+			r.retained[class].add(obj, path)
 		}
 	}
 	r.totalRetainedObjects = len(retainedAddresses)
@@ -73,18 +70,23 @@ func newReport(
 
 	// Keep report output stable across map iteration order and repeated runs.
 	for class := range retentionClassCount {
-		r.retained[class] = retained[class].finalize()
+		r.retained[class].sortGroups()
 	}
 	slices.Sort(r.unmatchedExpected)
 	slices.Sort(r.unmatchedPrunes)
 	return r
 }
 
-func classifyRetention(obj trackedObject, baseline Baseline, expected patterns) retentionClass {
+func classifyRetention(
+	obj trackedObject,
+	path string,
+	baseline Baseline,
+	expected patterns,
+) retentionClass {
 	if baseline.contains(obj) {
 		return retentionBaseline
 	}
-	if expected.matchObject(obj.path.normalized(), obj.typeName) {
+	if expected.matchObject(path, obj.typeName) {
 		return retentionExpected
 	}
 	return retentionUnexpected
@@ -173,9 +175,9 @@ func (r report) writeSummary(out *strings.Builder) {
 		out,
 		"retained objects: %d total, %d baseline, %d expected, %d unexpected\n",
 		r.totalRetainedObjects,
-		baseline.objects,
-		expected.objects,
-		unexpected.objects,
+		baseline.objectCount(),
+		expected.objectCount(),
+		unexpected.objectCount(),
 	)
 }
 
@@ -185,64 +187,42 @@ type objectGroupKey struct {
 }
 
 type retentionStats struct {
-	groups  []objectGroup
-	paths   int
-	objects int
+	groups     []objectGroup
+	groupByKey map[objectGroupKey]int
+	paths      int
+	addresses  map[uintptr]struct{}
 }
 
-type retentionAccumulator struct {
-	groups    map[objectGroupKey]*objectGroupAccumulator
-	paths     int
-	addresses map[uintptr]struct{}
-}
-
-type objectGroupAccumulator struct {
-	path      string
-	typeName  string
-	paths     int
-	addresses map[uintptr]struct{}
-}
-
-func (a *retentionAccumulator) add(obj trackedObject, path string) {
-	a.paths++
-	if a.addresses == nil {
-		a.addresses = make(map[uintptr]struct{})
-		a.groups = make(map[objectGroupKey]*objectGroupAccumulator)
+func (s *retentionStats) add(obj trackedObject, path string) {
+	s.paths++
+	if s.addresses == nil {
+		s.addresses = make(map[uintptr]struct{})
+		s.groupByKey = make(map[objectGroupKey]int)
 	}
-	a.addresses[obj.addr] = struct{}{}
+	s.addresses[obj.addr] = struct{}{}
 
 	key := objectGroupKey{
 		path:     path,
 		typeName: obj.typeName,
 	}
-	group := a.groups[key]
-	if group == nil {
-		group = &objectGroupAccumulator{
+	groupIndex, ok := s.groupByKey[key]
+	if !ok {
+		groupIndex = len(s.groups)
+		s.groupByKey[key] = groupIndex
+		s.groups = append(s.groups, objectGroup{
 			path:      key.path,
 			typeName:  key.typeName,
 			addresses: make(map[uintptr]struct{}),
-		}
-		a.groups[key] = group
+		})
 	}
+	group := &s.groups[groupIndex]
 	group.paths++
 	group.addresses[obj.addr] = struct{}{}
 }
 
-func (a retentionAccumulator) finalize() retentionStats {
-	stats := retentionStats{
-		paths:   a.paths,
-		objects: len(a.addresses),
-	}
-	for _, group := range a.groups {
-		stats.groups = append(stats.groups, objectGroup{
-			path:     group.path,
-			typeName: group.typeName,
-			paths:    group.paths,
-			objects:  len(group.addresses),
-		})
-	}
-	slices.SortFunc(stats.groups, func(a objectGroup, b objectGroup) int {
-		if c := cmp.Compare(b.objects, a.objects); c != 0 {
+func (s *retentionStats) sortGroups() {
+	slices.SortFunc(s.groups, func(a objectGroup, b objectGroup) int {
+		if c := cmp.Compare(b.objectCount(), a.objectCount()); c != 0 {
 			return c
 		}
 		if c := cmp.Compare(b.paths, a.paths); c != 0 {
@@ -253,14 +233,17 @@ func (a retentionAccumulator) finalize() retentionStats {
 		}
 		return cmp.Compare(a.typeName, b.typeName)
 	})
-	return stats
+}
+
+func (s retentionStats) objectCount() int {
+	return len(s.addresses)
 }
 
 type objectGroup struct {
-	path     string
-	typeName string
-	paths    int
-	objects  int
+	path      string
+	typeName  string
+	paths     int
+	addresses map[uintptr]struct{}
 }
 
 func (g objectGroup) name() string {
@@ -271,10 +254,15 @@ func (g objectGroup) name() string {
 }
 
 func (g objectGroup) counts() string {
-	if g.paths == g.objects {
-		return formatCount(g.objects, "object")
+	objects := g.objectCount()
+	if g.paths == objects {
+		return formatCount(objects, "object")
 	}
-	return fmt.Sprintf("%s, %s", formatCount(g.paths, "path"), formatCount(g.objects, "object"))
+	return fmt.Sprintf("%s, %s", formatCount(g.paths, "path"), formatCount(objects, "object"))
+}
+
+func (g objectGroup) objectCount() int {
+	return len(g.addresses)
 }
 
 func formatCount(count int, label string) string {

--- a/common/testing/objectleak/report.go
+++ b/common/testing/objectleak/report.go
@@ -34,7 +34,7 @@ type objectGroup struct {
 
 func newReport(
 	objects []trackedObject,
-	baseline objectBaseline,
+	baseline Baseline,
 	trackedRoots int,
 	expected patterns,
 	pruneTypes patterns,

--- a/common/testing/objectleak/report.go
+++ b/common/testing/objectleak/report.go
@@ -20,19 +20,47 @@ const (
 type report struct {
 	retained               [retentionClassCount]retentionStats
 	trackedRoots           int
+	totalRetainedObjects   int
+	baselineSettleTimedOut bool
+	checkSettleTimedOut    bool
+	unmatchedExpected      []string
+	unmatchedPrunes        []string
+}
+
+func newReport(
+	objects []trackedObject,
+	baseline Baseline,
+	checkSettleTimedOut bool,
+	trackedRoots int,
+	expected patterns,
+	pruneTypes patterns,
+) report {
+	r := report{
+		trackedRoots:           trackedRoots,
+		baselineSettleTimedOut: baseline.settleTimedOut,
+		checkSettleTimedOut:    checkSettleTimedOut,
+	}
+
+	// Matching mutates pattern.matched for stale-expected pattern detection.
+	activeExpected := slices.Clone(expected)
+
+	retainedAddresses := make(map[uintptr]struct{})
+
 	// Record each classified retained object and fold equivalent normalized
 	// path and type pairs into a single report row.
 	for obj := range retainedObjects(baseline.objects) {
+		path := obj.path.normalized()
 		retainedAddresses[obj.addr] = struct{}{}
-		retained[retentionBaseline].add(obj)
+		r.retained[retentionBaseline].add(obj, path)
 	}
 	for obj := range retainedObjects(objects) {
-		class := classifyRetention(obj, baseline, activeExpected)
+		path := obj.path.normalized()
+		class := classifyRetention(obj, path, baseline, activeExpected)
 		if class == retentionBaseline {
 			continue
 		}
 		retainedAddresses[obj.addr] = struct{}{}
-		retained[class].add(obj)
+		r.retained[class].add(obj, path)
 	}
 	r.totalRetainedObjects = len(retainedAddresses)
 

--- a/common/testing/objectleak/report.go
+++ b/common/testing/objectleak/report.go
@@ -46,11 +46,16 @@ func newReport(
 	// Matching mutates pattern.matched for stale-expected pattern detection.
 	activeExpected := slices.Clone(expected)
 
+	type retentionClass int
+	const (
+		retentionUnexpected retentionClass = iota
+		retentionExpected
+		retentionBaseline
+	)
 	type groupKey struct {
 		path     string
 		typeName string
-		baseline bool
-		expected bool
+		class    retentionClass
 	}
 	groupByKey := make(map[groupKey]*objectGroup)
 	retainedAddresses := make(map[uintptr]struct{})
@@ -60,26 +65,17 @@ func newReport(
 
 	// Classify each retained object and fold equivalent normalized paths into
 	// a single report row.
-	addRetained := func(obj trackedObject, isBaseline bool) {
-		if obj.collected.Load() {
-			return
-		}
-
-		expectedBy := activeExpected.matchObject(obj)
-		if !isBaseline && baseline.contains(obj) {
-			return
-		}
+	addRetained := func(obj trackedObject, class retentionClass) {
 		report.totalRetainedPaths++
 		retainedAddresses[obj.addr] = struct{}{}
-		isExpected := false
-		if isBaseline {
+		switch class {
+		case retentionBaseline:
 			report.baselineRetainedPaths++
 			baselineAddresses[obj.addr] = struct{}{}
-		} else if len(expectedBy) > 0 {
-			isExpected = true
+		case retentionExpected:
 			report.expectedRetainedPaths++
 			expectedAddresses[obj.addr] = struct{}{}
-		} else {
+		case retentionUnexpected:
 			report.unexpectedRetainedPaths++
 			unexpectedAddresses[obj.addr] = struct{}{}
 		}
@@ -87,8 +83,7 @@ func newReport(
 		key := groupKey{
 			path:     obj.path.normalized(),
 			typeName: obj.typeName,
-			baseline: isBaseline,
-			expected: isExpected,
+			class:    class,
 		}
 		group := groupByKey[key]
 		if group == nil {
@@ -102,12 +97,21 @@ func newReport(
 		group.paths++
 		group.addresses[obj.addr] = struct{}{}
 	}
-	for _, obj := range baseline.objects {
-		addRetained(obj, true)
-	}
-	for _, obj := range objects {
-		addRetained(obj, false)
-	}
+	forEachRetained(baseline.objects, func(obj trackedObject) {
+		activeExpected.matchObject(obj)
+		addRetained(obj, retentionBaseline)
+	})
+	forEachRetained(objects, func(obj trackedObject) {
+		expectedBy := activeExpected.matchObject(obj)
+		if baseline.contains(obj) {
+			return
+		}
+		if len(expectedBy) > 0 {
+			addRetained(obj, retentionExpected)
+		} else {
+			addRetained(obj, retentionUnexpected)
+		}
+	})
 	report.totalRetainedObjects = len(retainedAddresses)
 	report.baselineRetainedObjects = len(baselineAddresses)
 	report.expectedRetainedObjects = len(expectedAddresses)
@@ -120,11 +124,12 @@ func newReport(
 
 	// Keep report output stable across map iteration order and repeated runs.
 	for key, group := range groupByKey {
-		if key.baseline {
+		switch key.class {
+		case retentionBaseline:
 			report.baselineObjects = append(report.baselineObjects, *group)
-		} else if key.expected {
+		case retentionExpected:
 			report.expectedObjects = append(report.expectedObjects, *group)
-		} else {
+		case retentionUnexpected:
 			report.unexpectedObjects = append(report.unexpectedObjects, *group)
 		}
 	}
@@ -148,6 +153,14 @@ func newReport(
 	slices.Sort(report.unmatchedExpected)
 	slices.Sort(report.unmatchedPrunes)
 	return report
+}
+
+func forEachRetained(objects []trackedObject, visit func(trackedObject)) {
+	for _, obj := range objects {
+		if !obj.collected.Load() {
+			visit(obj)
+		}
+	}
 }
 
 func (r report) failures() error {

--- a/common/testing/objectleak/report.go
+++ b/common/testing/objectleak/report.go
@@ -17,72 +17,6 @@ const (
 	retentionClassCount
 )
 
-type retentionStats struct {
-	groups      []objectGroup
-	paths       int
-	addresses   map[uintptr]struct{}
-	groupsByKey map[objectGroupKey]*objectGroup
-}
-
-func newRetentionStats() retentionStats {
-	return retentionStats{
-		addresses:   make(map[uintptr]struct{}),
-		groupsByKey: make(map[objectGroupKey]*objectGroup),
-	}
-}
-
-type objectGroupKey struct {
-	path     string
-	typeName string
-}
-
-type objectGroup struct {
-	path      string
-	typeName  string
-	paths     int
-	addresses map[uintptr]struct{}
-}
-
-func (s *retentionStats) add(obj trackedObject) {
-	s.paths++
-	s.addresses[obj.addr] = struct{}{}
-
-	key := objectGroupKey{
-		path:     obj.path.normalized(),
-		typeName: obj.typeName,
-	}
-	group := s.groupsByKey[key]
-	if group == nil {
-		group = &objectGroup{
-			path:      key.path,
-			typeName:  key.typeName,
-			addresses: make(map[uintptr]struct{}),
-		}
-		s.groupsByKey[key] = group
-	}
-	group.paths++
-	group.addresses[obj.addr] = struct{}{}
-}
-
-func (s *retentionStats) finish() {
-	for _, group := range s.groupsByKey {
-		s.groups = append(s.groups, *group)
-	}
-	s.groupsByKey = nil
-	slices.SortFunc(s.groups, func(a objectGroup, b objectGroup) int {
-		if c := cmp.Compare(b.objectCount(), a.objectCount()); c != 0 {
-			return c
-		}
-		if c := cmp.Compare(b.paths, a.paths); c != 0 {
-			return c
-		}
-		if c := cmp.Compare(a.path, b.path); c != 0 {
-			return c
-		}
-		return cmp.Compare(a.typeName, b.typeName)
-	})
-}
-
 type report struct {
 	retained             [retentionClassCount]retentionStats
 	trackedRoots         int
@@ -222,6 +156,72 @@ func (r report) writeSummary(out *strings.Builder) {
 		len(expected.addresses),
 		len(unexpected.addresses),
 	)
+}
+
+type retentionStats struct {
+	groups      []objectGroup
+	paths       int
+	addresses   map[uintptr]struct{}
+	groupsByKey map[objectGroupKey]*objectGroup
+}
+
+func newRetentionStats() retentionStats {
+	return retentionStats{
+		addresses:   make(map[uintptr]struct{}),
+		groupsByKey: make(map[objectGroupKey]*objectGroup),
+	}
+}
+
+type objectGroupKey struct {
+	path     string
+	typeName string
+}
+
+func (s *retentionStats) add(obj trackedObject) {
+	s.paths++
+	s.addresses[obj.addr] = struct{}{}
+
+	key := objectGroupKey{
+		path:     obj.path.normalized(),
+		typeName: obj.typeName,
+	}
+	group := s.groupsByKey[key]
+	if group == nil {
+		group = &objectGroup{
+			path:      key.path,
+			typeName:  key.typeName,
+			addresses: make(map[uintptr]struct{}),
+		}
+		s.groupsByKey[key] = group
+	}
+	group.paths++
+	group.addresses[obj.addr] = struct{}{}
+}
+
+func (s *retentionStats) finish() {
+	for _, group := range s.groupsByKey {
+		s.groups = append(s.groups, *group)
+	}
+	s.groupsByKey = nil
+	slices.SortFunc(s.groups, func(a objectGroup, b objectGroup) int {
+		if c := cmp.Compare(b.objectCount(), a.objectCount()); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(b.paths, a.paths); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(a.path, b.path); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.typeName, b.typeName)
+	})
+}
+
+type objectGroup struct {
+	path      string
+	typeName  string
+	paths     int
+	addresses map[uintptr]struct{}
 }
 
 func (g objectGroup) name() string {

--- a/common/testing/objectleak/report.go
+++ b/common/testing/objectleak/report.go
@@ -58,15 +58,10 @@ func newReport(
 		addRetained(obj, path, retentionBaseline)
 	}
 	for obj := range retainedObjects(objects) {
-		if baseline.contains(obj) {
-			continue
-		}
 		path := obj.path.normalized()
-		isExpected := activeExpected.matchObject(path, obj.typeName)
-		if isExpected {
-			addRetained(obj, path, retentionExpected)
-		} else {
-			addRetained(obj, path, retentionUnexpected)
+		class := classifyRetention(obj, baseline, activeExpected)
+		if class != retentionBaseline {
+			addRetained(obj, path, class)
 		}
 	}
 	r.totalRetainedObjects = len(retainedAddresses)
@@ -83,6 +78,16 @@ func newReport(
 	slices.Sort(r.unmatchedExpected)
 	slices.Sort(r.unmatchedPrunes)
 	return r
+}
+
+func classifyRetention(obj trackedObject, baseline Baseline, expected patterns) retentionClass {
+	if baseline.contains(obj) {
+		return retentionBaseline
+	}
+	if expected.matchObject(obj.path.normalized(), obj.typeName) {
+		return retentionExpected
+	}
+	return retentionUnexpected
 }
 
 func (r report) failures() error {

--- a/common/testing/objectleak/report.go
+++ b/common/testing/objectleak/report.go
@@ -32,58 +32,60 @@ func newReport(
 	expected patterns,
 	pruneTypes patterns,
 ) report {
-	report := report{
+	r := report{
 		trackedRoots: trackedRoots,
 	}
 
 	// Matching mutates pattern.matched for stale-expected pattern detection.
 	activeExpected := slices.Clone(expected)
 
-	for class := range retentionClassCount {
-		report.retained[class] = newRetentionStats()
-	}
+	var retained [retentionClassCount]retentionAccumulator
 	retainedAddresses := make(map[uintptr]struct{})
 
-	// Classify each retained object and fold equivalent normalized paths into
-	// a single report row.
-	addRetained := func(obj trackedObject, class retentionClass) {
+	// Record each classified retained object and fold equivalent normalized
+	// paths into a single report row.
+	addRetained := func(obj trackedObject, path string, class retentionClass) {
 		retainedAddresses[obj.addr] = struct{}{}
-		report.retained[class].add(obj)
+		retained[class].add(obj, path)
 	}
 	for obj := range retainedObjects(baseline.objects) {
-		activeExpected.matchObject(obj)
-		addRetained(obj, retentionBaseline)
+		path := obj.path.normalized()
+		// Baseline objects still satisfy expected patterns so those patterns are
+		// not reported as stale.
+		activeExpected.matchObject(path, obj.typeName)
+		addRetained(obj, path, retentionBaseline)
 	}
 	for obj := range retainedObjects(objects) {
-		expectedBy := activeExpected.matchObject(obj)
+		path := obj.path.normalized()
+		isExpected := activeExpected.matchObject(path, obj.typeName)
 		if baseline.contains(obj) {
 			continue
 		}
-		if len(expectedBy) > 0 {
-			addRetained(obj, retentionExpected)
+		if isExpected {
+			addRetained(obj, path, retentionExpected)
 		} else {
-			addRetained(obj, retentionUnexpected)
+			addRetained(obj, path, retentionUnexpected)
 		}
 	}
-	report.totalRetainedObjects = len(retainedAddresses)
+	r.totalRetainedObjects = len(retainedAddresses)
 
 	// Expected patterns that never matched any tracked object are stale and
 	// should be removed with the fix that made them unnecessary.
-	report.unmatchedExpected = activeExpected.unmatched()
-	report.unmatchedPrunes = pruneTypes.unmatched()
+	r.unmatchedExpected = activeExpected.unmatched()
+	r.unmatchedPrunes = pruneTypes.unmatched()
 
 	// Keep report output stable across map iteration order and repeated runs.
 	for class := range retentionClassCount {
-		report.retained[class].finish()
+		r.retained[class] = retained[class].finalize()
 	}
-	slices.Sort(report.unmatchedExpected)
-	slices.Sort(report.unmatchedPrunes)
-	return report
+	slices.Sort(r.unmatchedExpected)
+	slices.Sort(r.unmatchedPrunes)
+	return r
 }
 
 func (r report) failures() error {
 	var failures []error
-	if len(r.retained[retentionUnexpected].groups) > 0 {
+	if r.retained[retentionUnexpected].paths > 0 {
 		failures = append(failures, errors.New("unexpected retained objects"))
 	}
 	if len(r.unmatchedExpected) > 0 {
@@ -152,9 +154,9 @@ func (r report) writeSummary(out *strings.Builder) {
 		out,
 		"retained objects: %d total, %d baseline, %d expected, %d unexpected\n",
 		r.totalRetainedObjects,
-		len(baseline.addresses),
-		len(expected.addresses),
-		len(unexpected.addresses),
+		baseline.objects,
+		expected.objects,
+		unexpected.objects,
 	)
 }
 
@@ -164,47 +166,64 @@ type objectGroupKey struct {
 }
 
 type retentionStats struct {
-	groups      []objectGroup
-	paths       int
-	addresses   map[uintptr]struct{}
-	groupsByKey map[objectGroupKey]*objectGroup
+	groups  []objectGroup
+	paths   int
+	objects int
 }
 
-func newRetentionStats() retentionStats {
-	return retentionStats{
-		addresses:   make(map[uintptr]struct{}),
-		groupsByKey: make(map[objectGroupKey]*objectGroup),
+type retentionAccumulator struct {
+	groups    map[objectGroupKey]*objectGroupAccumulator
+	paths     int
+	addresses map[uintptr]struct{}
+}
+
+type objectGroupAccumulator struct {
+	path      string
+	typeName  string
+	paths     int
+	addresses map[uintptr]struct{}
+}
+
+func (a *retentionAccumulator) add(obj trackedObject, path string) {
+	a.paths++
+	if a.addresses == nil {
+		a.addresses = make(map[uintptr]struct{})
+		a.groups = make(map[objectGroupKey]*objectGroupAccumulator)
 	}
-}
-
-func (s *retentionStats) add(obj trackedObject) {
-	s.paths++
-	s.addresses[obj.addr] = struct{}{}
+	a.addresses[obj.addr] = struct{}{}
 
 	key := objectGroupKey{
-		path:     obj.path.normalized(),
+		path:     path,
 		typeName: obj.typeName,
 	}
-	group := s.groupsByKey[key]
+	group := a.groups[key]
 	if group == nil {
-		group = &objectGroup{
+		group = &objectGroupAccumulator{
 			path:      key.path,
 			typeName:  key.typeName,
 			addresses: make(map[uintptr]struct{}),
 		}
-		s.groupsByKey[key] = group
+		a.groups[key] = group
 	}
 	group.paths++
 	group.addresses[obj.addr] = struct{}{}
 }
 
-func (s *retentionStats) finish() {
-	for _, group := range s.groupsByKey {
-		s.groups = append(s.groups, *group)
+func (a retentionAccumulator) finalize() retentionStats {
+	stats := retentionStats{
+		paths:   a.paths,
+		objects: len(a.addresses),
 	}
-	s.groupsByKey = nil
-	slices.SortFunc(s.groups, func(a objectGroup, b objectGroup) int {
-		if c := cmp.Compare(b.objectCount(), a.objectCount()); c != 0 {
+	for _, group := range a.groups {
+		stats.groups = append(stats.groups, objectGroup{
+			path:     group.path,
+			typeName: group.typeName,
+			paths:    group.paths,
+			objects:  len(group.addresses),
+		})
+	}
+	slices.SortFunc(stats.groups, func(a objectGroup, b objectGroup) int {
+		if c := cmp.Compare(b.objects, a.objects); c != 0 {
 			return c
 		}
 		if c := cmp.Compare(b.paths, a.paths); c != 0 {
@@ -215,13 +234,14 @@ func (s *retentionStats) finish() {
 		}
 		return cmp.Compare(a.typeName, b.typeName)
 	})
+	return stats
 }
 
 type objectGroup struct {
-	path      string
-	typeName  string
-	paths     int
-	addresses map[uintptr]struct{}
+	path     string
+	typeName string
+	paths    int
+	objects  int
 }
 
 func (g objectGroup) name() string {
@@ -231,16 +251,11 @@ func (g objectGroup) name() string {
 	return fmt.Sprintf("%s (%s)", g.path, g.typeName)
 }
 
-func (g objectGroup) objectCount() int {
-	return len(g.addresses)
-}
-
 func (g objectGroup) counts() string {
-	objects := g.objectCount()
-	if g.paths == objects {
-		return formatCount(objects, "object")
+	if g.paths == g.objects {
+		return formatCount(g.objects, "object")
 	}
-	return fmt.Sprintf("%s, %s", formatCount(g.paths, "path"), formatCount(objects, "object"))
+	return fmt.Sprintf("%s, %s", formatCount(g.paths, "path"), formatCount(g.objects, "object"))
 }
 
 func formatCount(count int, label string) string {

--- a/common/testing/objectleak/report.go
+++ b/common/testing/objectleak/report.go
@@ -17,19 +17,18 @@ const (
 	retentionClassCount
 )
 
-type report struct {
-	retained             [retentionClassCount]retentionStats
-	trackedRoots         int
-	totalRetainedObjects int
-	unmatchedExpected    []string
-	unmatchedPrunes      []string
-}
-
 type retentionStats struct {
 	groups      []objectGroup
 	paths       int
 	addresses   map[uintptr]struct{}
 	groupsByKey map[objectGroupKey]*objectGroup
+}
+
+func newRetentionStats() retentionStats {
+	return retentionStats{
+		addresses:   make(map[uintptr]struct{}),
+		groupsByKey: make(map[objectGroupKey]*objectGroup),
+	}
 }
 
 type objectGroupKey struct {
@@ -42,6 +41,54 @@ type objectGroup struct {
 	typeName  string
 	paths     int
 	addresses map[uintptr]struct{}
+}
+
+func (s *retentionStats) add(obj trackedObject) {
+	s.paths++
+	s.addresses[obj.addr] = struct{}{}
+
+	key := objectGroupKey{
+		path:     obj.path.normalized(),
+		typeName: obj.typeName,
+	}
+	group := s.groupsByKey[key]
+	if group == nil {
+		group = &objectGroup{
+			path:      key.path,
+			typeName:  key.typeName,
+			addresses: make(map[uintptr]struct{}),
+		}
+		s.groupsByKey[key] = group
+	}
+	group.paths++
+	group.addresses[obj.addr] = struct{}{}
+}
+
+func (s *retentionStats) finish() {
+	for _, group := range s.groupsByKey {
+		s.groups = append(s.groups, *group)
+	}
+	s.groupsByKey = nil
+	slices.SortFunc(s.groups, func(a objectGroup, b objectGroup) int {
+		if c := cmp.Compare(b.objectCount(), a.objectCount()); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(b.paths, a.paths); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(a.path, b.path); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.typeName, b.typeName)
+	})
+}
+
+type report struct {
+	retained             [retentionClassCount]retentionStats
+	trackedRoots         int
+	totalRetainedObjects int
+	unmatchedExpected    []string
+	unmatchedPrunes      []string
 }
 
 func newReport(
@@ -98,53 +145,6 @@ func newReport(
 	slices.Sort(report.unmatchedExpected)
 	slices.Sort(report.unmatchedPrunes)
 	return report
-}
-
-func newRetentionStats() retentionStats {
-	return retentionStats{
-		addresses:   make(map[uintptr]struct{}),
-		groupsByKey: make(map[objectGroupKey]*objectGroup),
-	}
-}
-
-func (s *retentionStats) add(obj trackedObject) {
-	s.paths++
-	s.addresses[obj.addr] = struct{}{}
-
-	key := objectGroupKey{
-		path:     obj.path.normalized(),
-		typeName: obj.typeName,
-	}
-	group := s.groupsByKey[key]
-	if group == nil {
-		group = &objectGroup{
-			path:      key.path,
-			typeName:  key.typeName,
-			addresses: make(map[uintptr]struct{}),
-		}
-		s.groupsByKey[key] = group
-	}
-	group.paths++
-	group.addresses[obj.addr] = struct{}{}
-}
-
-func (s *retentionStats) finish() {
-	for _, group := range s.groupsByKey {
-		s.groups = append(s.groups, *group)
-	}
-	s.groupsByKey = nil
-	slices.SortFunc(s.groups, func(a objectGroup, b objectGroup) int {
-		if c := cmp.Compare(b.objectCount(), a.objectCount()); c != 0 {
-			return c
-		}
-		if c := cmp.Compare(b.paths, a.paths); c != 0 {
-			return c
-		}
-		if c := cmp.Compare(a.path, b.path); c != 0 {
-			return c
-		}
-		return cmp.Compare(a.typeName, b.typeName)
-	})
 }
 
 func (r report) failures() error {

--- a/common/testing/objectleak/report.go
+++ b/common/testing/objectleak/report.go
@@ -58,7 +58,7 @@ func newReport(
 	// Matching mutates pattern.matched for stale-expected pattern detection.
 	activeExpected := slices.Clone(expected)
 
-	for class := retentionClass(0); class < retentionClassCount; class++ {
+	for class := range retentionClassCount {
 		report.retained[class] = newRetentionStats()
 	}
 	retainedAddresses := make(map[uintptr]struct{})
@@ -92,7 +92,7 @@ func newReport(
 	report.unmatchedPrunes = pruneTypes.unmatched()
 
 	// Keep report output stable across map iteration order and repeated runs.
-	for class := retentionClass(0); class < retentionClassCount; class++ {
+	for class := range retentionClassCount {
 		report.retained[class].finish()
 	}
 	slices.Sort(report.unmatchedExpected)

--- a/common/testing/objectleak/report.go
+++ b/common/testing/objectleak/report.go
@@ -158,6 +158,11 @@ func (r report) writeSummary(out *strings.Builder) {
 	)
 }
 
+type objectGroupKey struct {
+	path     string
+	typeName string
+}
+
 type retentionStats struct {
 	groups      []objectGroup
 	paths       int
@@ -170,11 +175,6 @@ func newRetentionStats() retentionStats {
 		addresses:   make(map[uintptr]struct{}),
 		groupsByKey: make(map[objectGroupKey]*objectGroup),
 	}
-}
-
-type objectGroupKey struct {
-	path     string
-	typeName string
 }
 
 func (s *retentionStats) add(obj trackedObject) {

--- a/common/testing/objectleak/report.go
+++ b/common/testing/objectleak/report.go
@@ -18,22 +18,27 @@ const (
 )
 
 type report struct {
-	retained             [retentionClassCount]retentionStats
-	trackedRoots         int
-	totalRetainedObjects int
-	unmatchedExpected    []string
-	unmatchedPrunes      []string
+	retained               [retentionClassCount]retentionStats
+	trackedRoots           int
+	totalRetainedObjects   int
+	baselineSettleTimedOut bool
+	checkSettleTimedOut    bool
+	unmatchedExpected      []string
+	unmatchedPrunes        []string
 }
 
 func newReport(
 	objects []trackedObject,
 	baseline Baseline,
+	checkSettleTimedOut bool,
 	trackedRoots int,
 	expected patterns,
 	pruneTypes patterns,
 ) report {
 	r := report{
-		trackedRoots: trackedRoots,
+		trackedRoots:           trackedRoots,
+		baselineSettleTimedOut: baseline.settleTimedOut,
+		checkSettleTimedOut:    checkSettleTimedOut,
 	}
 
 	// Matching mutates pattern.matched for stale-expected pattern detection.
@@ -43,24 +48,21 @@ func newReport(
 	retainedAddresses := make(map[uintptr]struct{})
 
 	// Record each classified retained object and fold equivalent normalized
-	// paths into a single report row.
+	// path and type pairs into a single report row.
 	addRetained := func(obj trackedObject, path string, class retentionClass) {
 		retainedAddresses[obj.addr] = struct{}{}
 		retained[class].add(obj, path)
 	}
 	for obj := range retainedObjects(baseline.objects) {
 		path := obj.path.normalized()
-		// Baseline objects still satisfy expected patterns so those patterns are
-		// not reported as stale.
-		activeExpected.matchObject(path, obj.typeName)
 		addRetained(obj, path, retentionBaseline)
 	}
 	for obj := range retainedObjects(objects) {
-		path := obj.path.normalized()
-		isExpected := activeExpected.matchObject(path, obj.typeName)
 		if baseline.contains(obj) {
 			continue
 		}
+		path := obj.path.normalized()
+		isExpected := activeExpected.matchObject(path, obj.typeName)
 		if isExpected {
 			addRetained(obj, path, retentionExpected)
 		} else {
@@ -69,8 +71,8 @@ func newReport(
 	}
 	r.totalRetainedObjects = len(retainedAddresses)
 
-	// Expected patterns that never matched any tracked object are stale and
-	// should be removed with the fix that made them unnecessary.
+	// Expected patterns that never matched a non-baseline retained object are
+	// stale and should be removed with the fix that made them unnecessary.
 	r.unmatchedExpected = activeExpected.unmatched()
 	r.unmatchedPrunes = pruneTypes.unmatched()
 
@@ -85,6 +87,12 @@ func newReport(
 
 func (r report) failures() error {
 	var failures []error
+	if r.baselineSettleTimedOut {
+		failures = append(failures, errors.New("baseline GC settling timed out"))
+	}
+	if r.checkSettleTimedOut {
+		failures = append(failures, errors.New("check GC settling timed out"))
+	}
 	if r.retained[retentionUnexpected].paths > 0 {
 		failures = append(failures, errors.New("unexpected retained objects"))
 	}
@@ -142,6 +150,12 @@ func (r report) writeSummary(out *strings.Builder) {
 
 	out.WriteString("object leak report\n\n")
 	fmt.Fprintf(out, "tracked root objects: %d\n", r.trackedRoots)
+	if r.baselineSettleTimedOut {
+		out.WriteString("baseline GC settling timed out\n")
+	}
+	if r.checkSettleTimedOut {
+		out.WriteString("check GC settling timed out\n")
+	}
 	fmt.Fprintf(
 		out,
 		"retained paths: %d total, %d baseline, %d expected, %d unexpected\n",

--- a/common/testing/objectleak/report.go
+++ b/common/testing/objectleak/report.go
@@ -20,46 +20,19 @@ const (
 type report struct {
 	retained               [retentionClassCount]retentionStats
 	trackedRoots           int
-	totalRetainedObjects   int
-	baselineSettleTimedOut bool
-	checkSettleTimedOut    bool
-	unmatchedExpected      []string
-	unmatchedPrunes        []string
-}
-
-func newReport(
-	objects []trackedObject,
-	baseline Baseline,
-	checkSettleTimedOut bool,
-	trackedRoots int,
-	expected patterns,
-	pruneTypes patterns,
-) report {
-	r := report{
-		trackedRoots:           trackedRoots,
-		baselineSettleTimedOut: baseline.settleTimedOut,
-		checkSettleTimedOut:    checkSettleTimedOut,
-	}
-
-	// Matching mutates pattern.matched for stale-expected pattern detection.
-	activeExpected := slices.Clone(expected)
-
-	retainedAddresses := make(map[uintptr]struct{})
-
 	// Record each classified retained object and fold equivalent normalized
 	// path and type pairs into a single report row.
 	for obj := range retainedObjects(baseline.objects) {
-		path := obj.path.normalized()
 		retainedAddresses[obj.addr] = struct{}{}
-		r.retained[retentionBaseline].add(obj, path)
+		retained[retentionBaseline].add(obj)
 	}
 	for obj := range retainedObjects(objects) {
-		path := obj.path.normalized()
-		class := classifyRetention(obj, path, baseline, activeExpected)
-		if class != retentionBaseline {
-			retainedAddresses[obj.addr] = struct{}{}
-			r.retained[class].add(obj, path)
+		class := classifyRetention(obj, baseline, activeExpected)
+		if class == retentionBaseline {
+			continue
 		}
+		retainedAddresses[obj.addr] = struct{}{}
+		retained[class].add(obj)
 	}
 	r.totalRetainedObjects = len(retainedAddresses)
 

--- a/common/testing/objectleak/report.go
+++ b/common/testing/objectleak/report.go
@@ -164,14 +164,6 @@ func (r report) failures() error {
 	return errors.Join(failures...)
 }
 
-func (r report) totals() [3]int {
-	return [3]int{
-		r.totalRetainedObjects,
-		r.unexpectedRetainedObjects,
-		len(r.unmatchedExpected) + len(r.unmatchedPrunes),
-	}
-}
-
 func (r report) string() string {
 	var out strings.Builder
 	r.writeSummary(&out)

--- a/common/testing/objectleak/report.go
+++ b/common/testing/objectleak/report.go
@@ -155,14 +155,6 @@ func newReport(
 	return report
 }
 
-func forEachRetained(objects []trackedObject, visit func(trackedObject)) {
-	for _, obj := range objects {
-		if !obj.collected.Load() {
-			visit(obj)
-		}
-	}
-}
-
 func (r report) failures() error {
 	var failures []error
 	if len(r.unexpectedObjects) > 0 {

--- a/common/testing/objectleak/report.go
+++ b/common/testing/objectleak/report.go
@@ -11,9 +11,12 @@ import (
 type report struct {
 	unexpectedObjects         []objectGroup
 	expectedObjects           []objectGroup
+	baselineObjects           []objectGroup
 	trackedRoots              int
 	totalRetainedPaths        int
 	totalRetainedObjects      int
+	baselineRetainedPaths     int
+	baselineRetainedObjects   int
 	expectedRetainedPaths     int
 	expectedRetainedObjects   int
 	unexpectedRetainedPaths   int
@@ -40,10 +43,12 @@ func newReport(objects []trackedObject, trackedRoots int, expected patterns, pru
 	type groupKey struct {
 		path     string
 		typeName string
+		baseline bool
 		expected bool
 	}
 	groupByKey := make(map[groupKey]*objectGroup)
 	retainedAddresses := make(map[uintptr]struct{})
+	baselineAddresses := make(map[uintptr]struct{})
 	expectedAddresses := make(map[uintptr]struct{})
 	unexpectedAddresses := make(map[uintptr]struct{})
 
@@ -54,11 +59,15 @@ func newReport(objects []trackedObject, trackedRoots int, expected patterns, pru
 			continue
 		}
 
-		expectedBy := activeExpected.matchObject(obj)
 		report.totalRetainedPaths++
 		retainedAddresses[obj.addr] = struct{}{}
-		expected := len(expectedBy) > 0
-		if expected {
+		baseline := obj.baselineCollected != nil && !obj.baselineCollected.Load()
+		expected := false
+		if baseline {
+			report.baselineRetainedPaths++
+			baselineAddresses[obj.addr] = struct{}{}
+		} else if expectedBy := activeExpected.matchObject(obj); len(expectedBy) > 0 {
+			expected = true
 			report.expectedRetainedPaths++
 			expectedAddresses[obj.addr] = struct{}{}
 		} else {
@@ -69,6 +78,7 @@ func newReport(objects []trackedObject, trackedRoots int, expected patterns, pru
 		key := groupKey{
 			path:     obj.path.normalized(),
 			typeName: obj.typeName,
+			baseline: baseline,
 			expected: expected,
 		}
 		group := groupByKey[key]
@@ -84,6 +94,7 @@ func newReport(objects []trackedObject, trackedRoots int, expected patterns, pru
 		group.addresses[obj.addr] = struct{}{}
 	}
 	report.totalRetainedObjects = len(retainedAddresses)
+	report.baselineRetainedObjects = len(baselineAddresses)
 	report.expectedRetainedObjects = len(expectedAddresses)
 	report.unexpectedRetainedObjects = len(unexpectedAddresses)
 
@@ -94,7 +105,9 @@ func newReport(objects []trackedObject, trackedRoots int, expected patterns, pru
 
 	// Keep report output stable across map iteration order and repeated runs.
 	for key, group := range groupByKey {
-		if key.expected {
+		if key.baseline {
+			report.baselineObjects = append(report.baselineObjects, *group)
+		} else if key.expected {
 			report.expectedObjects = append(report.expectedObjects, *group)
 		} else {
 			report.unexpectedObjects = append(report.unexpectedObjects, *group)
@@ -116,6 +129,7 @@ func newReport(objects []trackedObject, trackedRoots int, expected patterns, pru
 	}
 	sortGroups(report.unexpectedObjects)
 	sortGroups(report.expectedObjects)
+	sortGroups(report.baselineObjects)
 	slices.Sort(report.unmatchedExpected)
 	slices.Sort(report.unmatchedPrunes)
 	return report
@@ -161,6 +175,10 @@ func (r report) string() string {
 	writeGroups("unexpected retained objects", r.unexpectedObjects)
 	out.WriteByte('\n')
 	writeGroups("expected retained objects", r.expectedObjects)
+	if len(r.baselineObjects) > 0 {
+		out.WriteByte('\n')
+		writeGroups("baseline retained objects", r.baselineObjects)
+	}
 
 	if len(r.unmatchedExpected) > 0 {
 		out.WriteString("\nstale expected patterns:\n")
@@ -181,6 +199,25 @@ func (r report) string() string {
 func (r report) writeSummary(out *strings.Builder) {
 	out.WriteString("object leak report\n\n")
 	fmt.Fprintf(out, "tracked root objects: %d\n", r.trackedRoots)
+	if r.baselineRetainedPaths > 0 {
+		fmt.Fprintf(
+			out,
+			"retained paths: %d total, %d baseline, %d expected, %d unexpected\n",
+			r.totalRetainedPaths,
+			r.baselineRetainedPaths,
+			r.expectedRetainedPaths,
+			r.unexpectedRetainedPaths,
+		)
+		fmt.Fprintf(
+			out,
+			"retained objects: %d total, %d baseline, %d expected, %d unexpected\n",
+			r.totalRetainedObjects,
+			r.baselineRetainedObjects,
+			r.expectedRetainedObjects,
+			r.unexpectedRetainedObjects,
+		)
+		return
+	}
 	fmt.Fprintf(
 		out,
 		"retained paths: %d total, %d expected, %d unexpected\n",

--- a/common/testing/objectleak/walker.go
+++ b/common/testing/objectleak/walker.go
@@ -14,11 +14,19 @@ type objectWalker struct {
 }
 
 type trackedObject struct {
-	addr      uintptr
-	path      path
-	typeName  string
-	collected *atomic.Bool
-	cleanup   runtime.Cleanup
+	addr              uintptr
+	path              path
+	typeName          string
+	baselineCollected *atomic.Bool
+	collected         *atomic.Bool
+	cleanup           runtime.Cleanup
+}
+
+func (o trackedObject) identity() objectIdentity {
+	return objectIdentity{
+		addr:     o.addr,
+		typeName: o.typeName,
+	}
 }
 
 func newObjectWalker(pruneTypes patterns) objectWalker {

--- a/common/testing/objectleak/walker.go
+++ b/common/testing/objectleak/walker.go
@@ -14,12 +14,11 @@ type objectWalker struct {
 }
 
 type trackedObject struct {
-	addr              uintptr
-	path              path
-	typeName          string
-	baselineCollected *atomic.Bool
-	collected         *atomic.Bool
-	cleanup           runtime.Cleanup
+	addr      uintptr
+	path      path
+	typeName  string
+	collected *atomic.Bool
+	cleanup   runtime.Cleanup
 }
 
 func (o trackedObject) identity() objectIdentity {

--- a/common/testing/objectleak/walker.go
+++ b/common/testing/objectleak/walker.go
@@ -7,12 +7,6 @@ import (
 	"unsafe"
 )
 
-type objectWalker struct {
-	objects    []trackedObject
-	seen       map[uintptr]struct{}
-	pruneTypes patterns
-}
-
 type trackedObject struct {
 	addr      uintptr
 	path      path
@@ -26,6 +20,12 @@ func (o trackedObject) identity() objectIdentity {
 		addr:     o.addr,
 		typeName: o.typeName,
 	}
+}
+
+type objectWalker struct {
+	objects    []trackedObject
+	seen       map[uintptr]struct{}
+	pruneTypes patterns
 }
 
 func newObjectWalker(pruneTypes patterns) objectWalker {

--- a/common/testing/objectleak/walker.go
+++ b/common/testing/objectleak/walker.go
@@ -15,13 +15,6 @@ type trackedObject struct {
 	cleanup   runtime.Cleanup
 }
 
-func (o trackedObject) identity() objectIdentity {
-	return objectIdentity{
-		addr:     o.addr,
-		typeName: o.typeName,
-	}
-}
-
 type objectWalker struct {
 	objects    []trackedObject
 	seen       map[uintptr]struct{}

--- a/common/testing/objectleak/walker.go
+++ b/common/testing/objectleak/walker.go
@@ -7,6 +7,12 @@ import (
 	"unsafe"
 )
 
+// The runtime may batch pointer-free allocations smaller than 16 bytes into a
+// shared block. A cleanup attached to one of those allocations may not run
+// while any allocation in the block is reachable, so those objects cannot be
+// tracked individually.
+const runtimeTinyAllocationSize = 16
+
 type trackedObject struct {
 	addr      uintptr
 	path      path
@@ -53,8 +59,10 @@ func (w *objectWalker) walk(v reflect.Value, path path) {
 			return
 		}
 		w.seen[addr] = struct{}{}
-		if obj, ok := trackPointerObject(ptr, addr, path, v.Type().String()); ok {
-			w.objects = append(w.objects, obj)
+		if isTrackableObject(v.Type().Elem()) {
+			if obj, ok := trackPointerObject(ptr, addr, path, v.Type().String()); ok {
+				w.objects = append(w.objects, obj)
+			}
 		}
 		if w.shouldPrune(v.Type()) {
 			return
@@ -81,6 +89,29 @@ func (w *objectWalker) walk(v reflect.Value, path path) {
 	default:
 		return
 	}
+}
+
+func isTrackableObject(t reflect.Type) bool {
+	return t.Size() >= runtimeTinyAllocationSize || typeContainsPointers(t)
+}
+
+func typeContainsPointers(t reflect.Type) bool {
+	switch t.Kind() {
+	case reflect.Array:
+		return t.Len() > 0 && typeContainsPointers(t.Elem())
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer,
+		reflect.Slice, reflect.String, reflect.UnsafePointer:
+		return true
+	case reflect.Struct:
+		for field := range t.Fields() {
+			if typeContainsPointers(field.Type) {
+				return true
+			}
+		}
+	default:
+		return false
+	}
+	return false
 }
 
 func (w *objectWalker) shouldPrune(t reflect.Type) bool {

--- a/tests/leakcheck/leak_test.go
+++ b/tests/leakcheck/leak_test.go
@@ -83,8 +83,8 @@ func TestClusterShutdownLeak(t *testing.T) {
 
 	// Wait for warmup goroutines to drain before snapshotting the object and goroutine baselines.
 	_ = goleak.Find(goleakOpts...)
-	leakCheck.IgnoreCurrent()
-	baseline := goleak.IgnoreCurrent()
+	objleakBaseline := leakCheck.IgnoreCurrent()
+	goleakBaseline := goleak.IgnoreCurrent()
 
 	// Run the leak test: build, run, and tear down a cluster per iteration.
 	for i := range iters {
@@ -93,7 +93,7 @@ func TestClusterShutdownLeak(t *testing.T) {
 	}
 
 	// Verify that no goroutines leaked beyond the baseline.
-	goleakErr := goleak.Find(append(goleakOpts, baseline)...)
+	goleakErr := goleak.Find(append(goleakOpts, goleakBaseline)...)
 	goleakReport := "no unexpected goroutines\n"
 	if goleakErr != nil {
 		goleakReport = goleakErr.Error() + "\n"
@@ -103,7 +103,7 @@ func TestClusterShutdownLeak(t *testing.T) {
 
 	// Verify that no cluster references leaked.
 	leakCheckStart := time.Now()
-	leakReport, leakErr := leakCheck.Check()
+	leakReport, leakErr := leakCheck.Check(objleakBaseline)
 	t.Logf("object leak check settled in %s", time.Since(leakCheckStart).Round(time.Millisecond))
 	reportPath := filepath.Join(outputDir, "objectleak_report.txt")
 	writeReport(t, outputDir, "objectleak_report.txt", leakReport+"\n")

--- a/tests/leakcheck/leak_test.go
+++ b/tests/leakcheck/leak_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	sdkclient "go.temporal.io/sdk/client"
+	sdkworker "go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
 	"go.temporal.io/server/common/testing/objectleak"
 	"go.temporal.io/server/tests/testcore"
@@ -75,10 +76,14 @@ func TestClusterShutdownLeak(t *testing.T) {
 	leakCheck, err := objectleak.NewObjectLeakCheck(leakOpts...)
 	require.NoError(t, err)
 
+	// Keep the final stopped warmup worker reachable through Check so the SDK's
+	// process-wide workflow cache remains the same allocation across the baseline.
+	var worker sdkworker.Worker
+
 	// Warm up with a few clusters so process-lifetime singletons (gRPC resolver
 	// init, proto registries, ...) are created before we snapshot the baseline.
 	for range warmupIters {
-		buildRunTeardownCluster(t, &leakCheck)
+		worker = buildRunTeardownCluster(t, &leakCheck)
 	}
 
 	// Wait for warmup goroutines to drain before snapshotting the object and goroutine baselines.
@@ -88,7 +93,7 @@ func TestClusterShutdownLeak(t *testing.T) {
 
 	// Run the leak test: build, run, and tear down a cluster per iteration.
 	for i := range iters {
-		buildRunTeardownCluster(t, &leakCheck)
+		_ = buildRunTeardownCluster(t, &leakCheck)
 		t.Logf("cluster %2d: goroutines=%d", i, runtime.NumGoroutine())
 	}
 
@@ -104,6 +109,8 @@ func TestClusterShutdownLeak(t *testing.T) {
 	// Verify that no cluster references leaked.
 	leakCheckStart := time.Now()
 	leakReport, leakErr := leakCheck.Check(objleakBaseline)
+	runtime.KeepAlive(worker) // ensure worker is kept alive until leak check completes
+
 	t.Logf("object leak check settled in %s", time.Since(leakCheckStart).Round(time.Millisecond))
 	reportPath := filepath.Join(outputDir, "objectleak_report.txt")
 	writeReport(t, outputDir, "objectleak_report.txt", leakReport+"\n")
@@ -122,14 +129,16 @@ func TestClusterShutdownLeak(t *testing.T) {
 
 // buildRunTeardownCluster creates a dedicated cluster, runs a trivial
 // workflow on it to exercise the full server path, then tears it down.
-func buildRunTeardownCluster(t *testing.T, leakCheck *objectleak.ObjectLeakCheck) {
+func buildRunTeardownCluster(t *testing.T, leakCheck *objectleak.ObjectLeakCheck) sdkworker.Worker {
+	var worker sdkworker.Worker
 	// The subtest ensures all env cleanups complete before this returns.
 	t.Run("cluster", func(t *testing.T) {
 		env := testcore.NewEnv(t,
 			testcore.WithDedicatedCluster(),
 			testcore.WithWorkerService("leak regression test"))
 
-		env.SdkWorker().RegisterWorkflow(smokeWorkflow)
+		worker = env.SdkWorker()
+		worker.RegisterWorkflow(smokeWorkflow)
 		run, err := env.SdkClient().ExecuteWorkflow(
 			context.Background(),
 			sdkclient.StartWorkflowOptions{TaskQueue: env.WorkerTaskQueue()},
@@ -140,6 +149,7 @@ func buildRunTeardownCluster(t *testing.T, leakCheck *objectleak.ObjectLeakCheck
 
 		leakCheck.Track(env)
 	})
+	return worker
 }
 
 func smokeWorkflow(workflow.Context) error { return nil }

--- a/tests/leakcheck/leak_test.go
+++ b/tests/leakcheck/leak_test.go
@@ -34,8 +34,6 @@ var objectLeakOpts = []objectleak.Option{
 	objectleak.WithExpected("FunctionalTestBase.testCluster.host*"),
 	objectleak.WithExpected("FunctionalTestBase.testCluster.testBase*"),
 	objectleak.WithExpected("FunctionalTestBase.testClusterConfig"),
-	// TODO: This is not fully garbage collected because of the goroutine leak above. Nothing to be done here.
-	objectleak.WithExpected("sdkClient*"),
 }
 
 // TestClusterShutdownLeak is a goroutine-leak regression test for the functional
@@ -83,8 +81,9 @@ func TestClusterShutdownLeak(t *testing.T) {
 		buildRunTeardownCluster(t, &leakCheck)
 	}
 
-	// Wait for warmup goroutines to drain before snapshotting the baseline.
+	// Wait for warmup goroutines to drain before snapshotting the object and goroutine baselines.
 	_ = goleak.Find(goleakOpts...)
+	leakCheck.IgnoreCurrent()
 	baseline := goleak.IgnoreCurrent()
 
 	// Run the leak test: build, run, and tear down a cluster per iteration.

--- a/tests/leakcheck/leak_test.go
+++ b/tests/leakcheck/leak_test.go
@@ -93,7 +93,7 @@ func TestClusterShutdownLeak(t *testing.T) {
 
 	// Run the leak test: build, run, and tear down a cluster per iteration.
 	for i := range iters {
-		_ = buildRunTeardownCluster(t, &leakCheck)
+		buildRunTeardownCluster(t, &leakCheck)
 		t.Logf("cluster %2d: goroutines=%d", i, runtime.NumGoroutine())
 	}
 


### PR DESCRIPTION
## What changed?

Add process-lifetime baselines to `objectleak`, ignore tiny pointer-free allocations that the runtime cannot track individually, and allow asynchronous cleanup the full settle timeout.

## Why?

Make object leak reports actionable by distinguishing process-lifetime objects from leaks and avoiding runtime-induced false positives.

Replaces #11313.
