### PR TITLE
Eliminate expected object leak suppressions

### DIFF
--- a/common/membership/grpc_resolver.go
+++ b/common/membership/grpc_resolver.go
@@ -1,11 +1,14 @@
 package membership
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"go.temporal.io/server/common/primitives"
 	"go.uber.org/fx"
@@ -22,12 +25,13 @@ const (
 type (
 	// grpcBuilder implements grpc/resolver.Builder. This is a singleton that's registered with grpc.
 	grpcBuilder struct {
-		resolvers sync.Map // pointer as string -> *GRPCResolver
+		resolvers sync.Map // registration ID string -> *GRPCResolver
 	}
 
 	// GRPCResolver and the resolvers map in grpcBuilder is used to pass a Monitor through a string url.
 	GRPCResolver struct {
-		monitor Monitor
+		monitor        Monitor
+		registrationID string
 	}
 
 	// grpcResolver is a single instance of a resolver.
@@ -47,6 +51,7 @@ var (
 	_ resolver.Builder = (*grpcBuilder)(nil)
 
 	globalGrpcBuilder grpcBuilder
+	grpcResolverID    atomic.Uint64
 
 	errInvalidUrl     = errors.New("invalid grpc resolver url")
 	errNotInitialized = errors.New("grpc resolver has not been initialized yet")
@@ -66,17 +71,53 @@ func GetServiceResolverFromURL(u *url.URL) (ServiceResolver, error) {
 // This should only be used in unit tests. For normal code, use the *GRPCResolver provided by fx.
 // Monitor may be nil if it's not needed, but then note that GetServiceResolverFromURL will panic.
 func GRPCResolverURLForTesting(monitor Monitor, service primitives.ServiceName) string {
-	return newGRPCResolver(monitor).MakeURL(service)
+	res, register, _ := newGRPCResolverRegistration(monitor)
+	register()
+	return res.MakeURL(service)
 }
 
-func newGRPCResolver(monitor Monitor) *GRPCResolver {
-	res := &GRPCResolver{monitor: monitor}
-	globalGrpcBuilder.resolvers.Store(fmt.Sprintf("%p", res), res)
+// GRPCResolverURLForTestingWithCleanup registers monitor and returns its URL
+// together with a function that removes the registration.
+func GRPCResolverURLForTestingWithCleanup(monitor Monitor, service primitives.ServiceName) (string, func()) {
+	res, register, cleanup := newGRPCResolverRegistration(monitor)
+	register()
+	return res.MakeURL(service), cleanup
+}
+
+func newGRPCResolver(lifecycle fx.Lifecycle, monitor Monitor) *GRPCResolver {
+	res, register, cleanup := newGRPCResolverRegistration(monitor)
+	lifecycle.Append(fx.Hook{
+		OnStart: func(context.Context) error {
+			register()
+			return nil
+		},
+		OnStop: func(context.Context) error {
+			cleanup()
+			return nil
+		},
+	})
 	return res
 }
 
+func newGRPCResolverRegistration(monitor Monitor) (
+	grpcResolver *GRPCResolver,
+	register func(),
+	cleanup func(),
+) {
+	registrationID := strconv.FormatUint(grpcResolverID.Add(1), 10)
+	res := &GRPCResolver{
+		monitor:        monitor,
+		registrationID: registrationID,
+	}
+	return res, func() {
+			globalGrpcBuilder.resolvers.Store(registrationID, res)
+		}, func() {
+			globalGrpcBuilder.resolvers.Delete(registrationID)
+		}
+}
+
 func (g *GRPCResolver) MakeURL(service primitives.ServiceName) string {
-	return fmt.Sprintf("%s://%s%s%p", grpcResolverScheme, string(service), delim, g)
+	return fmt.Sprintf("%s://%s%s%s", grpcResolverScheme, string(service), delim, g.registrationID)
 }
 
 func (m *grpcBuilder) Scheme() string {

--- a/common/membership/grpc_resolver_test.go
+++ b/common/membership/grpc_resolver_test.go
@@ -3,6 +3,7 @@ package membership
 import (
 	"context"
 	"net"
+	"net/url"
 	"testing"
 	"time"
 
@@ -10,10 +11,75 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/testing/nettest"
+	"go.uber.org/fx/fxtest"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
+
+func TestGRPCResolverUnregistersOnStop(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	serviceResolver := NewMockServiceResolver(ctrl)
+	monitor := NewMockMonitor(ctrl)
+	monitor.EXPECT().GetResolver(primitives.FrontendService).Return(serviceResolver, nil)
+
+	lifecycle := fxtest.NewLifecycle(t)
+	grpcResolver := newGRPCResolver(lifecycle, monitor)
+	resolverURL, err := url.Parse(grpcResolver.MakeURL(primitives.FrontendService))
+	require.NoError(t, err)
+	_, err = GetServiceResolverFromURL(resolverURL)
+	require.ErrorIs(t, err, errNotInitialized)
+
+	require.NoError(t, lifecycle.Start(context.Background()))
+	resolved, err := GetServiceResolverFromURL(resolverURL)
+	require.NoError(t, err)
+	require.Equal(t, serviceResolver, resolved)
+
+	require.NoError(t, lifecycle.Stop(context.Background()))
+	_, err = GetServiceResolverFromURL(resolverURL)
+	require.ErrorIs(t, err, errNotInitialized)
+}
+
+func TestGRPCResolverDoesNotRegisterBeforeStart(t *testing.T) {
+	lifecycle := fxtest.NewLifecycle(t)
+	grpcResolver := newGRPCResolver(lifecycle, nil)
+	resolverURL, err := url.Parse(grpcResolver.MakeURL(primitives.FrontendService))
+	require.NoError(t, err)
+
+	_, err = GetServiceResolverFromURL(resolverURL)
+	require.ErrorIs(t, err, errNotInitialized)
+}
+
+func TestGRPCResolverURLForTestingWithCleanup(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	serviceResolver := NewMockServiceResolver(ctrl)
+	replacementServiceResolver := NewMockServiceResolver(ctrl)
+	monitor := NewMockMonitor(ctrl)
+	replacementMonitor := NewMockMonitor(ctrl)
+	monitor.EXPECT().GetResolver(primitives.FrontendService).Return(serviceResolver, nil)
+	replacementMonitor.EXPECT().GetResolver(primitives.FrontendService).Return(replacementServiceResolver, nil)
+
+	resolverURLString, cleanup := GRPCResolverURLForTestingWithCleanup(monitor, primitives.FrontendService)
+	resolverURL, err := url.Parse(resolverURLString)
+	require.NoError(t, err)
+	resolved, err := GetServiceResolverFromURL(resolverURL)
+	require.NoError(t, err)
+	require.Equal(t, serviceResolver, resolved)
+
+	cleanup()
+	_, err = GetServiceResolverFromURL(resolverURL)
+	require.ErrorIs(t, err, errNotInitialized)
+
+	replacementURLString, replacementCleanup := GRPCResolverURLForTestingWithCleanup(replacementMonitor, primitives.FrontendService)
+	t.Cleanup(replacementCleanup)
+	replacementURL, err := url.Parse(replacementURLString)
+	require.NoError(t, err)
+	replacement, err := GetServiceResolverFromURL(replacementURL)
+	require.NoError(t, err)
+	require.Equal(t, replacementServiceResolver, replacement)
+	_, err = GetServiceResolverFromURL(resolverURL)
+	require.ErrorIs(t, err, errNotInitialized)
+}
 
 func TestGRPCBuilder(t *testing.T) {
 	t.Parallel()

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"slices"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -970,6 +972,79 @@ type SpanExporterInputs struct {
 	Config     *config.Config `optional:"true"`
 }
 
+type otelLoggerErrorHandler struct {
+	mu            sync.RWMutex
+	registrations []*otelLoggerErrorHandlerRegistration
+}
+
+type otelLoggerErrorHandlerRegistration struct {
+	tracingReady *atomic.Bool
+	logger       atomic.Pointer[otelLoggerErrorHandlerState]
+}
+
+type otelLoggerErrorHandlerState struct {
+	logger log.Logger
+}
+
+func (h *otelLoggerErrorHandler) Handle(err error) {
+	state := h.currentState()
+	if state != nil {
+		state.logger.Warn("OTEL error", tag.Error(err), tag.ServiceErrorType(err))
+	}
+}
+
+func (h *otelLoggerErrorHandler) currentState() *otelLoggerErrorHandlerState {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	for i := len(h.registrations) - 1; i >= 0; i-- {
+		registration := h.registrations[i]
+		state := registration.logger.Load()
+		if state != nil && registration.tracingReady.Load() { // ignore errors during startup and shutdown
+			return state
+		}
+	}
+	return nil
+}
+
+func (h *otelLoggerErrorHandler) add(registration *otelLoggerErrorHandlerRegistration) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.registrations = append(h.registrations, registration)
+}
+
+func (h *otelLoggerErrorHandler) remove(registration *otelLoggerErrorHandlerRegistration) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for i, candidate := range h.registrations {
+		if candidate == registration {
+			h.registrations = slices.Delete(h.registrations, i, i+1)
+			return
+		}
+	}
+}
+
+var globalOTELLoggerErrorHandler otelLoggerErrorHandler
+
+func installOTELLoggerErrorHandler(lifecycle fx.Lifecycle, logger log.Logger, tracingReady *atomic.Bool) {
+	registration := &otelLoggerErrorHandlerRegistration{
+		tracingReady: tracingReady,
+	}
+	registration.logger.Store(&otelLoggerErrorHandlerState{logger: logger})
+	lifecycle.Append(fx.Hook{
+		OnStart: func(context.Context) error {
+			globalOTELLoggerErrorHandler.add(registration)
+			otel.SetErrorHandler(&globalOTELLoggerErrorHandler)
+			return nil
+		},
+		OnStop: func(context.Context) error {
+			registration.tracingReady.Store(false)
+			registration.logger.Store(nil)
+			globalOTELLoggerErrorHandler.remove(registration)
+			return nil
+		},
+	})
+}
+
 // TraceExportModule holds process-global telemetry fx state defining the set of
 // OTEL trace/span exporters used by tracing instrumentation. The following
 // types can be overriden/augmented with fx.Replace/fx.Decorate:
@@ -977,13 +1052,6 @@ type SpanExporterInputs struct {
 // - []go.opentelemetry.io/otel/sdk/trace.SpanExporter
 var TraceExportModule = fx.Options(
 	fx.Provide(func(inputs SpanExporterInputs) ([]otelsdktrace.SpanExporter, error) {
-		var tracingReady atomic.Bool
-		otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
-			if tracingReady.Load() { // ignore errors during startup
-				inputs.Logger.Warn("OTEL error", tag.Error(err), tag.ServiceErrorType(err))
-			}
-		}))
-
 		// (1) Exporters from config.
 		exportersByType := map[telemetry.SpanExporterType]otelsdktrace.SpanExporter{}
 		if inputs.Config != nil {
@@ -1007,6 +1075,7 @@ var TraceExportModule = fx.Options(
 		maps.Copy(exportersByType, exportersByTypeFromEnv) // env overrides config
 		maps.Copy(exportersByType, customExportersByType)  // custom overrides all
 		exporters := expmaps.Values(exportersByType)
+		tracingReady := &atomic.Bool{}
 
 		// Configure exporters' lifecycle hooks.
 		inputs.Lifecycyle.Append(fx.Hook{
@@ -1017,6 +1086,7 @@ var TraceExportModule = fx.Options(
 			},
 			OnStop: shutdownAll(exporters),
 		})
+		installOTELLoggerErrorHandler(inputs.Lifecycyle, inputs.Logger, tracingReady)
 		return exporters, nil
 	}),
 )
@@ -1084,10 +1154,6 @@ var ServiceTracingModule = fx.Options(
 		tp := otelsdktrace.NewTracerProvider(opts...)
 		lc.Append(fx.Hook{
 			OnStop: func(ctx context.Context) error {
-				otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
-					// ignore errors during shutdown
-				}))
-
 				shutdownCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 				defer cancel()
 

--- a/temporal/fx_test.go
+++ b/temporal/fx_test.go
@@ -3,9 +3,11 @@ package temporal
 import (
 	"context"
 	"path"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
 	enumspb "go.temporal.io/api/enums/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/archiver"
@@ -14,8 +16,47 @@ import (
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/service/history/tasks"
 	"go.temporal.io/server/tests/testutils"
+	"go.uber.org/fx/fxtest"
 	"go.uber.org/mock/gomock"
 )
+
+func TestOTELLoggerErrorHandlerReleasesLoggerOnStop(t *testing.T) {
+	t.Cleanup(func() { otel.SetErrorHandler(otel.ErrorHandlerFunc(func(error) {})) })
+	lifecycle := fxtest.NewLifecycle(t)
+	tracingReady := &atomic.Bool{}
+	tracingReady.Store(true)
+
+	installOTELLoggerErrorHandler(lifecycle, log.NewNoopLogger(), tracingReady)
+	require.Nil(t, globalOTELLoggerErrorHandler.currentState())
+	require.NoError(t, lifecycle.Start(context.Background()))
+	require.Equal(t, &globalOTELLoggerErrorHandler, otel.GetErrorHandler())
+	require.NotNil(t, globalOTELLoggerErrorHandler.currentState())
+
+	require.NoError(t, lifecycle.Stop(context.Background()))
+	require.Nil(t, globalOTELLoggerErrorHandler.currentState())
+}
+
+func TestOTELLoggerErrorHandlerRestoresPreviousRegistrationOnStop(t *testing.T) {
+	t.Cleanup(func() { otel.SetErrorHandler(otel.ErrorHandlerFunc(func(error) {})) })
+	firstLifecycle := fxtest.NewLifecycle(t)
+	firstReady := &atomic.Bool{}
+	firstReady.Store(true)
+	installOTELLoggerErrorHandler(firstLifecycle, log.NewNoopLogger(), firstReady)
+	require.NoError(t, firstLifecycle.Start(context.Background()))
+	firstState := globalOTELLoggerErrorHandler.currentState()
+	require.NotNil(t, firstState)
+
+	secondLifecycle := fxtest.NewLifecycle(t)
+	secondReady := &atomic.Bool{}
+	secondReady.Store(true)
+	installOTELLoggerErrorHandler(secondLifecycle, log.NewNoopLogger(), secondReady)
+	require.NoError(t, secondLifecycle.Start(context.Background()))
+	require.NotSame(t, firstState, globalOTELLoggerErrorHandler.currentState())
+
+	require.NoError(t, secondLifecycle.Stop(context.Background()))
+	require.Same(t, firstState, globalOTELLoggerErrorHandler.currentState())
+	require.NoError(t, firstLifecycle.Stop(context.Background()))
+}
 
 func TestInitCurrentClusterMetadataRecord(t *testing.T) {
 	configDir := path.Join(testutils.GetRepoRootDirectory(), "config")

--- a/tests/leakcheck/leak_test.go
+++ b/tests/leakcheck/leak_test.go
@@ -28,14 +28,6 @@ var goleakOpts = []goleak.Option{
 
 var objectLeakOpts = []objectleak.Option{
 	objectleak.WithPruneType("google.golang.org/protobuf/internal/impl.*"),
-	objectleak.WithExpected("FunctionalTestBase"),
-	objectleak.WithExpected("FunctionalTestBase.Logger*"),
-	objectleak.WithExpected("FunctionalTestBase.Suite*"),
-	objectleak.WithExpected("FunctionalTestBase.testCluster.host*"),
-	objectleak.WithExpected("FunctionalTestBase.testCluster.testBase*"),
-	objectleak.WithExpected("FunctionalTestBase.testClusterConfig"),
-	// TODO: This is not fully garbage collected because of the goroutine leak above. Nothing to be done here.
-	objectleak.WithExpected("sdkClient*"),
 }
 
 // TestClusterShutdownLeak is a goroutine-leak regression test for the functional

--- a/tests/testcore/clients.go
+++ b/tests/testcore/clients.go
@@ -66,8 +66,9 @@ type historyClients struct {
 }
 
 type matchingClient struct {
-	once   sync.Once
-	client matchingservice.MatchingServiceClient
+	once    sync.Once
+	client  matchingservice.MatchingServiceClient
+	cleanup func()
 }
 
 func newClients(
@@ -164,7 +165,10 @@ func (c *clients) ensureMatching() {
 
 		monitor := static.NewMonitor(c.hostsByService)
 		monitor.Start()
-		frontendMembershipAddress := membership.GRPCResolverURLForTesting(monitor, primitives.FrontendService)
+		frontendMembershipAddress, unregisterResolver := membership.GRPCResolverURLForTestingWithCleanup(
+			monitor,
+			primitives.FrontendService,
+		)
 		rpcFactory := rpc.NewFactory(
 			&config.Config{},
 			primitives.FrontendService,
@@ -203,9 +207,15 @@ func (c *clients) ensureMatching() {
 			matchingclient.DefaultLongPollTimeout,
 		)
 		if err != nil {
+			rpcFactory.Close()
+			unregisterResolver()
 			c.logger.Fatal("unable to create matching test client", tag.Error(err))
 		}
 		c.matching.client = matchingClient
+		c.matching.cleanup = func() {
+			rpcFactory.Close()
+			unregisterResolver()
+		}
 	})
 }
 
@@ -221,6 +231,11 @@ func (c *clients) close() []error {
 	}
 	c.frontend.conn = nil
 	c.history.conn = nil
+	if c.matching.cleanup != nil {
+		c.matching.cleanup()
+		c.matching.cleanup = nil
+		c.matching.client = nil
+	}
 	return errs
 }
 

--- a/tests/testcore/cluster_poison_test.go
+++ b/tests/testcore/cluster_poison_test.go
@@ -2,13 +2,17 @@ package testcore
 
 import (
 	"fmt"
+	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/softassert"
+	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/common/testing/testlogger"
 )
 
@@ -84,6 +88,26 @@ func TestSharedClusterT_LogfForwardsWhileLocked(t *testing.T) {
 
 	close(sub.release)
 	<-done
+}
+
+func TestSharedClusterT_RemoveTestReleasesTest(t *testing.T) {
+	s := &sharedClusterT{name: t.Name()}
+	collected := &atomic.Bool{}
+
+	func() {
+		sub := &mockSubtestT{T: t}
+		runtime.AddCleanup(sub, func(collected *atomic.Bool) {
+			collected.Store(true)
+		}, collected)
+		s.addTest(sub)
+		require.True(t, s.removeTest(sub))
+	}()
+
+	await.RequireTrue(t, func() bool {
+		runtime.GC()
+		return collected.Load()
+	}, time.Second, 10*time.Millisecond)
+	runtime.KeepAlive(s)
 }
 
 func TestSharedClusterPoison(t *testing.T) {

--- a/tests/testcore/shared_cluster_t.go
+++ b/tests/testcore/shared_cluster_t.go
@@ -3,6 +3,7 @@ package testcore
 import (
 	"fmt"
 	"os"
+	"slices"
 	"sync"
 	"sync/atomic"
 
@@ -39,7 +40,7 @@ func (s *sharedClusterT) removeTest(t testlogger.CleanupCapableT) (wasLast bool)
 	defer s.mu.Unlock()
 	for i, x := range s.activeTests {
 		if x == t {
-			s.activeTests = append(s.activeTests[:i], s.activeTests[i+1:]...)
+			s.activeTests = slices.Delete(s.activeTests, i, i+1)
 			break
 		}
 	}


### PR DESCRIPTION
## What changed?

- Unregister process-global gRPC resolver and OpenTelemetry logger state during lifecycle shutdown.
- Close the test matching client RPC factory and clear removed test references.
- Remove every `WithExpected` entry from `objectLeakOpts`.

## Why?

The leak test was suppressing the cluster graph instead of enforcing that cluster-owned objects become collectible. These lifecycle fixes leave only the protobuf traversal prune.

## Testing

- `go test -count=1 -tags test_dep ./common/membership -run 'TestGRPCResolver'`
- `go test -count=1 ./temporal`
- `go test -count=1 ./tests/testcore -run 'TestSharedClusterT_RemoveTestReleasesTest'`
- `go test -count=1 ./tests/leakcheck -run '^$'`

Replaces #11503.
