### PR TITLE
Reduce worker deployment log spam

### DIFF
--- a/service/worker/workerdeployment/workflow.go
+++ b/service/worker/workerdeployment/workflow.go
@@ -269,15 +269,6 @@ func (d *WorkflowRunner) updateVersionSummary(summary *deploymentspb.WorkerDeplo
 }
 
 func (d *WorkflowRunner) run(ctx workflow.Context) error {
-	// TODO(carlydf): remove verbose logging
-	d.logger.Info("Raw workflow state at start",
-		"state_nil", d.State == nil,
-		"create_time_nil", d.GetState().GetCreateTime() == nil,
-		"routing_config_nil", d.GetState().GetRoutingConfig() == nil,
-		"raw_state", d.State,
-		"workflow_id", workflow.GetInfo(ctx).WorkflowExecution.ID,
-		"run_id", workflow.GetInfo(ctx).WorkflowExecution.RunID)
-
 	if d.GetState().GetCreateTime() == nil ||
 		d.GetState().GetRoutingConfig() == nil ||
 		d.GetState().GetConflictToken() == nil {
@@ -304,15 +295,6 @@ func (d *WorkflowRunner) run(ctx workflow.Context) error {
 	if d.State.Versions == nil {
 		d.State.Versions = make(map[string]*deploymentspb.WorkerDeploymentVersionSummary)
 	}
-
-	// TODO(carlydf): remove verbose logging
-	d.logger.Info("Starting workflow run",
-		"create_time", d.State.GetCreateTime(),
-		"routing_config", d.State.GetRoutingConfig(),
-		//nolint:staticcheck // SA1019: worker versioning v0.31
-		"current_version", d.State.GetRoutingConfig().GetCurrentVersion(),
-		//nolint:staticcheck // SA1019: worker versioning v0.31
-		"ramping_version", d.State.GetRoutingConfig().GetRampingVersion())
 
 	err := workflow.SetQueryHandler(ctx, QueryDescribeDeployment, func() (*deploymentspb.QueryDescribeWorkerDeploymentResponse, error) {
 		if d.deleteDeployment {
@@ -437,19 +419,6 @@ func (d *WorkflowRunner) run(ctx workflow.Context) error {
 			(!d.signalHandler.signalSelector.HasPending() && d.signalHandler.processingSignals == 0 && workflow.AllHandlersFinished(ctx) &&
 				(d.forceCAN || d.stateChanged || workflow.GetInfo(ctx).GetContinueAsNewSuggested()))
 
-		// TODO(carlydf): remove verbose logging
-		if canContinue {
-			d.logger.Info("Workflow can continue as new",
-				"workflow_id", workflow.GetInfo(ctx).WorkflowExecution.ID,
-				"run_id", workflow.GetInfo(ctx).WorkflowExecution.RunID,
-				"delete_deployment", d.deleteDeployment,
-				"has_pending_signals", d.signalHandler.signalSelector.HasPending(),
-				"processing_signals", d.signalHandler.processingSignals,
-				"all_handlers_finished", workflow.AllHandlersFinished(ctx),
-				"force_can", d.forceCAN,
-				"state_changed", d.stateChanged,
-				"routing_config", d.State.GetRoutingConfig())
-		}
 		return canContinue
 	})
 	if err != nil {
@@ -459,19 +428,6 @@ func (d *WorkflowRunner) run(ctx workflow.Context) error {
 	if d.deleteDeployment {
 		return nil
 	}
-
-	// TODO(carlydf): remove verbose logging
-	d.logger.Info("Continuing workflow as new",
-		"create_time", d.State.GetCreateTime(),
-		"routing_config", d.State.GetRoutingConfig(),
-		//nolint:staticcheck // SA1019: worker versioning v0.31
-		"current_version", d.State.GetRoutingConfig().GetCurrentVersion(),
-		//nolint:staticcheck // SA1019: worker versioning v0.31
-		"ramping_version", d.State.GetRoutingConfig().GetRampingVersion(),
-		"state_changed", d.stateChanged,
-		"force_can", d.forceCAN,
-		"workflow_id", workflow.GetInfo(ctx).WorkflowExecution.ID,
-		"run_id", workflow.GetInfo(ctx).WorkflowExecution.RunID)
 
 	// We perform a continue-as-new after each update and signal is handled to ensure compatibility
 	// even if the server rolls back to a previous minor version. By continuing-as-new,
@@ -1346,14 +1302,6 @@ func (d *WorkflowRunner) handleSetCurrent(ctx workflow.Context, args *deployment
 		d.lock.Unlock()
 	}()
 
-	// Log state before update
-	// TODO(carlydf): remove verbose logging
-	d.logger.Info("Starting SetCurrent update",
-		//nolint:staticcheck // SA1019: worker versioning v0.31
-		"current_version", d.State.GetRoutingConfig().GetCurrentVersion(),
-		"new_version", args.Version,
-		"routing_config", d.State.GetRoutingConfig())
-
 	// Validating the state before starting the SetCurrent operation. This is required due to the following reason:
 	// The validator accepts/rejects updates based on the state of the deployment workflow. Theoretically, two concurrent update requests
 	// might be accepted by the validator since the state of the workflow, at that point in time, is valid for the updates to take place. Since this update handler
@@ -1784,14 +1732,6 @@ func (d *WorkflowRunner) newUUID(ctx workflow.Context) string {
 }
 
 func (d *WorkflowRunner) updateMemo(ctx workflow.Context) error {
-	// TODO(carlydf): remove verbose logging
-	d.logger.Info("Updating workflow memo",
-		"routing_config", d.State.GetRoutingConfig(),
-		//nolint:staticcheck // SA1019: worker versioning v0.31
-		"current_version", d.State.GetRoutingConfig().GetCurrentVersion(),
-		//nolint:staticcheck // SA1019: worker versioning v0.31
-		"ramping_version", d.State.GetRoutingConfig().GetRampingVersion())
-
 	return workflow.UpsertMemo(ctx, map[string]any{
 		WorkerDeploymentMemoField: &deploymentspb.WorkerDeploymentWorkflowMemo{
 			DeploymentName:        d.DeploymentName,


### PR DESCRIPTION
Remove temporary worker deployment workflow logs to reduce log spam.

Checks: `go test -tags test_dep ./service/worker/workerdeployment`; `make lint-code`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only deletion with no control-flow or state changes in the deployment workflow.
> 
> **Overview**
> Removes temporary **Info**-level debug logging from the worker deployment workflow in `workflow.go` to cut log volume in steady state and during continue-as-new.
> 
> Deleted log sites include workflow startup (raw state dump), run start, continue-as-new eligibility, the continue-as-new transition itself, **SetCurrent** update entry, and **updateMemo**—each previously tagged for removal. Workflow logic, metrics, and existing error/info paths are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17d70832a604132536bec962e4203cd6fc1d087f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->