### PR TITLE
Preserve UTF-8 in test summaries

### DIFF
--- a/tools/testrunner/summary.go
+++ b/tools/testrunner/summary.go
@@ -6,6 +6,7 @@ import (
 	"html"
 	"slices"
 	"strings"
+	"unicode/utf8"
 )
 
 const summaryMaxDetailBytes = 4 * 1024
@@ -93,7 +94,14 @@ func newSummaryRow(kind failureType, name string, details string) summaryRow {
 	if len(details) > summaryMaxDetailBytes {
 		headBytes := (summaryMaxDetailBytes - len(summaryTruncatedMarker)) / 2
 		tailBytes := summaryMaxDetailBytes - len(summaryTruncatedMarker) - headBytes
-		details = details[:headBytes] + summaryTruncatedMarker + details[len(details)-tailBytes:]
+		for headBytes > 0 && !utf8.RuneStart(details[headBytes]) {
+			headBytes--
+		}
+		tailStart := len(details) - tailBytes
+		for tailStart < len(details) && !utf8.RuneStart(details[tailStart]) {
+			tailStart++
+		}
+		details = details[:headBytes] + summaryTruncatedMarker + details[tailStart:]
 	}
 	return summaryRow{
 		Kind:    kind,

--- a/tools/testrunner/summary_test.go
+++ b/tools/testrunner/summary_test.go
@@ -90,6 +90,14 @@ func TestNewSummaryRow_TruncatesOversizedDetail(t *testing.T) {
 	require.Contains(t, row.Details, summaryTruncatedMarker)
 }
 
+func TestNewSummaryRow_TruncatesUTF8DetailAtRuneBoundaries(t *testing.T) {
+	detail := strings.Repeat("é", summaryMaxDetailBytes)
+
+	row := newSummaryRow(failureTypeFailed, "TestStandalone", detail)
+	require.Equal(t, strings.ToValidUTF8(row.Details, ""), row.Details)
+	require.LessOrEqual(t, len(row.Details), summaryMaxDetailBytes)
+}
+
 func TestRenderSummaryFromReports_Markdown_RendersFailureRows(t *testing.T) {
 	failureReport := mustReadReportFixture(t, "testdata/junit-single-failure.xml")
 	failureReport.Suites[0].Testcases[0].Name = "TestFoo"


### PR DESCRIPTION
Test summary details are truncated to byte budgets before being written to Markdown and JSON. Ensure the retained head and tail start at UTF-8 rune boundaries so multibyte failure output remains valid after truncation.

The regression test uses multibyte input whose previous tail boundary split a rune.
