### PR TITLE
Use generic JUnit documents at runner boundaries

### DIFF
--- a/tools/testrunner/summary.go
+++ b/tools/testrunner/summary.go
@@ -6,6 +6,8 @@ import (
 	"html"
 	"slices"
 	"strings"
+
+	"go.temporal.io/server/tools/common/junit"
 )
 
 const summaryMaxDetailBytes = 4 * 1024
@@ -16,7 +18,7 @@ type summary struct {
 	Rows []summaryRow `json:"rows"`
 }
 
-func newSummaryFromReports(reports []*junitReport) summary {
+func newSummaryFromReports(reports ...*junit.Testsuites) summary {
 	return summary{
 		Rows: newSummaryRowsFromReports(reports),
 	}
@@ -65,7 +67,7 @@ type summaryRow struct {
 	Final   bool        `json:"final,omitempty"`
 }
 
-func newSummaryRowsFromReports(reports []*junitReport) []summaryRow {
+func newSummaryRowsFromReports(reports []*junit.Testsuites) []summaryRow {
 	var rows []summaryRow
 	for _, report := range reports {
 		for _, suite := range report.Suites {

--- a/tools/testrunner/summary_test.go
+++ b/tools/testrunner/summary_test.go
@@ -20,7 +20,8 @@ func TestNewSummaryFromReports_RendersAssertionFailureRow(t *testing.T) {
 }
 
 func TestNewSummaryFromReports_EmptyWhenNoFailures(t *testing.T) {
-	s := newSummaryFromReports([]*junitReport{mustReadReportFixture(t, "testdata/junit-empty.xml")})
+	report := mustReadReportFixture(t, "testdata/junit-empty.xml")
+	s := newSummaryFromReports(&report.Testsuites)
 	require.Empty(t, s.Rows)
 }
 
@@ -52,7 +53,7 @@ func TestNewSummaryFromReports_RendersTrimmedFailureBodyRow(t *testing.T) {
 func TestNewSummaryFromReports_RendersAlertRow(t *testing.T) {
 	report := mustReadReportFixture(t, "testdata/junit-alert-data-race.xml")
 
-	s := newSummaryFromReports([]*junitReport{report})
+	s := newSummaryFromReports(&report.Testsuites)
 	require.Equal(t, []summaryRow{{
 		Kind:    failureTypeDataRace,
 		Name:    "DATA RACE: Data race detected in TestFoo",
@@ -71,7 +72,7 @@ func TestNewSummaryFromReports_MergesMultipleReports(t *testing.T) {
 	reportNew.Suites[0].Testcases[0].Name = "TestNew"
 	reportNew.Suites[0].Testcases[0].Failure.Data = "new failure"
 
-	summary := newSummaryFromReports([]*junitReport{reportOld, reportNew})
+	summary := newSummaryFromReports(&reportOld.Testsuites, &reportNew.Testsuites)
 	require.Equal(t, []summaryRow{
 		{Kind: failureTypeFailed, Name: "TestNew", Details: "new failure"},
 		{Kind: failureTypeFailed, Name: "TestOld", Details: "old failure"},
@@ -119,13 +120,14 @@ func TestRenderSummaryFromReports_Markdown_RendersTrimmedFailureBody(t *testing.
 func TestRenderSummaryFromReports_Markdown_RendersAlertRow(t *testing.T) {
 	report := mustReadReportFixture(t, "testdata/junit-alert-data-race.xml")
 
-	rendered := newSummaryFromReports([]*junitReport{report}).Markdown()
+	rendered := newSummaryFromReports(&report.Testsuites).Markdown()
 	require.Contains(t, rendered, failureTypeDataRace)
 	require.Contains(t, rendered, "Write at 0x00c000123456 by goroutine 7")
 }
 
 func TestRenderSummaryFromReports_Markdown_EmptyWhenNoFailures(t *testing.T) {
-	s := newSummaryFromReports([]*junitReport{mustReadReportFixture(t, "testdata/junit-empty.xml")})
+	report := mustReadReportFixture(t, "testdata/junit-empty.xml")
+	s := newSummaryFromReports(&report.Testsuites)
 	require.Empty(t, s.Markdown())
 }
 
@@ -191,5 +193,5 @@ func mustNewMergedSummary(t *testing.T, reports ...*junitReport) summary {
 	t.Helper()
 	merged, err := mergeReports(reports)
 	require.NoError(t, err)
-	return newSummaryFromReports([]*junitReport{merged})
+	return newSummaryFromReports(&merged.Testsuites)
 }

--- a/tools/testrunner/testrunner.go
+++ b/tools/testrunner/testrunner.go
@@ -250,7 +250,7 @@ func Main() {
 // nolint:revive,deep-exit
 func (r *runner) reportCrash() {
 	jr := generateReport([]string{r.crashName}, "crash", failureTypeCrash)
-	if err := r.writeReport(jr); err != nil {
+	if err := r.writeReport(&jr.Testsuites); err != nil {
 		log.Fatal(err)
 	}
 }
@@ -262,16 +262,16 @@ func (r *runner) generateSummary() error {
 	}
 	slices.Sort(paths)
 
-	reports := make([]*junitReport, 0, len(paths))
+	reports := make([]*junit.Testsuites, 0, len(paths))
 	for _, path := range paths {
-		report, err := readReport(path)
+		report, err := junit.Read(path)
 		if err != nil {
-			return fmt.Errorf("failed to read junit report %q: %w", path, err)
+			return err
 		}
 		reports = append(reports, report)
 	}
 
-	summary := newSummaryFromReports(reports)
+	summary := newSummaryFromReports(reports...)
 	if len(summary.Rows) == 0 {
 		fmt.Println("no failed tests found in junit reports; skipping test summary")
 		return nil
@@ -295,8 +295,8 @@ func (r *runner) generateSummary() error {
 	return nil
 }
 
-func (r *runner) writeReport(report *junitReport) error {
-	if err := junit.Write(r.junitOutputPath, &report.Testsuites); err != nil {
+func (r *runner) writeReport(report *junit.Testsuites) error {
+	if err := junit.Write(r.junitOutputPath, report); err != nil {
 		return err
 	}
 	log.Printf("wrote junit report to %s", r.junitOutputPath)
@@ -321,7 +321,7 @@ func (r *runner) writeCurrentReport() {
 	if len(r.alerts) > 0 {
 		merged.appendAlertsSuite(r.alerts)
 	}
-	if err := r.writeReport(merged); err != nil {
+	if err := r.writeReport(&merged.Testsuites); err != nil {
 		log.Printf("warning: failed to write intermediate report: %v", err)
 	}
 }
@@ -436,7 +436,7 @@ func (r *runner) runTests(ctx context.Context, args []string) {
 	if len(r.alerts) > 0 {
 		mergedReport.appendAlertsSuite(r.alerts)
 	}
-	if err = r.writeReport(mergedReport); err != nil {
+	if err = r.writeReport(&mergedReport.Testsuites); err != nil {
 		log.Fatal(err)
 	}
 


### PR DESCRIPTION
Moves testrunner report inputs, outputs, and summaries onto the shared JUnit document types. The existing reporting behavior remains unchanged behind that seam.

Stack: depends on #11513. Parser separation follows in #11487.
