### PR TITLE
Harden shared JUnit report IO

### DIFF
--- a/tools/common/junit/junit.go
+++ b/tools/common/junit/junit.go
@@ -4,7 +4,10 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
+	"strings"
 
 	junitxml "github.com/jstemmer/go-junit-report/v2/junit"
 )
@@ -27,7 +30,7 @@ var errRead = errors.New("failed to read JUnit report file")
 func Read(path string) (*Testsuites, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open JUnit report file: %w", err)
+		return nil, fmt.Errorf("failed to open JUnit report file %q: %w", path, err)
 	}
 	defer func() { _ = f.Close() }()
 
@@ -35,7 +38,7 @@ func Read(path string) (*Testsuites, error) {
 	for {
 		token, err := decoder.Token()
 		if err != nil {
-			return nil, fmt.Errorf("%w: %w", errRead, err)
+			return nil, fmt.Errorf("%w %q: %w", errRead, path, err)
 		}
 		root, ok := token.(xml.StartElement)
 		if !ok {
@@ -46,35 +49,84 @@ func Read(path string) (*Testsuites, error) {
 		case "testsuites":
 			var testsuites Testsuites
 			if err := decoder.DecodeElement(&testsuites, &root); err != nil {
-				return nil, fmt.Errorf("%w: %w", errRead, err)
+				return nil, fmt.Errorf("%w %q: %w", errRead, path, err)
+			}
+			if err := validateDocumentEnd(decoder); err != nil {
+				return nil, fmt.Errorf("%w %q: %w", errRead, path, err)
 			}
 			return &testsuites, nil
 		case "testsuite":
 			var testsuite Testsuite
 			if err := decoder.DecodeElement(&testsuite, &root); err != nil {
-				return nil, fmt.Errorf("%w: %w", errRead, err)
+				return nil, fmt.Errorf("%w %q: %w", errRead, path, err)
+			}
+			if err := validateDocumentEnd(decoder); err != nil {
+				return nil, fmt.Errorf("%w %q: %w", errRead, path, err)
 			}
 			testsuites := &Testsuites{Time: testsuite.Time}
 			testsuites.AddSuite(testsuite)
 			return testsuites, nil
 		default:
-			return nil, fmt.Errorf("%w: unexpected root element %q", errRead, root.Name.Local)
+			return nil, fmt.Errorf("%w %q: unexpected root element %q", errRead, path, root.Name.Local)
 		}
 	}
 }
 
-// Write writes a JUnit XML file.
-func Write(path string, testsuites *Testsuites) error {
-	f, err := os.Create(path)
-	if err != nil {
-		return fmt.Errorf("failed to create JUnit report file: %w", err)
+func validateDocumentEnd(decoder *xml.Decoder) error {
+	for {
+		token, err := decoder.Token()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		switch token := token.(type) {
+		case xml.CharData:
+			if strings.TrimSpace(string(token)) != "" {
+				return fmt.Errorf("unexpected trailing XML data %q", strings.TrimSpace(string(token)))
+			}
+		case xml.Comment, xml.ProcInst:
+		case xml.StartElement:
+			return fmt.Errorf("unexpected trailing XML element %q", token.Name.Local)
+		default:
+			return fmt.Errorf("unexpected trailing XML token %T", token)
+		}
 	}
-	defer func() { _ = f.Close() }()
+}
+
+// Write atomically replaces a JUnit XML file.
+func Write(path string, testsuites *Testsuites) error {
+	dir := filepath.Dir(path)
+	f, err := os.CreateTemp(dir, "."+filepath.Base(path)+"-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary JUnit report file for %q: %w", path, err)
+	}
+	tempPath := f.Name()
+	defer func() {
+		_ = f.Close()
+		_ = os.Remove(tempPath)
+	}()
+	if err := f.Chmod(0o644); err != nil {
+		return fmt.Errorf("failed to set permissions on temporary JUnit report file for %q: %w", path, err)
+	}
 
 	encoder := xml.NewEncoder(f)
 	encoder.Indent("", "    ")
 	if err := encoder.Encode(testsuites); err != nil {
-		return fmt.Errorf("failed to write JUnit report file: %w", err)
+		return fmt.Errorf("failed to encode JUnit report file %q: %w", path, err)
+	}
+	if _, err := f.WriteString("\n"); err != nil {
+		return fmt.Errorf("failed to finish JUnit report file %q: %w", path, err)
+	}
+	if err := f.Sync(); err != nil {
+		return fmt.Errorf("failed to sync JUnit report file %q: %w", path, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("failed to close JUnit report file %q: %w", path, err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return fmt.Errorf("failed to replace JUnit report file %q: %w", path, err)
 	}
 	return nil
 }

--- a/tools/common/junit/junit_test.go
+++ b/tools/common/junit/junit_test.go
@@ -101,6 +101,11 @@ func TestReadErrors(t *testing.T) {
 			content: `<testsuite>`,
 			wantErr: "failed to read JUnit report file",
 		},
+		{
+			name:    "trailing data",
+			content: `<testsuites></testsuites><testsuite></testsuite>`,
+			wantErr: `unexpected trailing XML element "testsuite"`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -110,6 +115,7 @@ func TestReadErrors(t *testing.T) {
 
 			_, err := Read(path)
 			require.ErrorContains(t, err, tt.wantErr)
+			require.ErrorContains(t, err, path)
 			require.ErrorIs(t, err, errRead)
 		})
 	}
@@ -140,5 +146,24 @@ func TestWrite(t *testing.T) {
     <testsuite name="suite" tests="1" failures="0" errors="0" id="0" time="">
         <testcase name="TestOne" classname="example.com/tests"></testcase>
     </testsuite>
-</testsuites>`, string(content))
+</testsuites>
+`, string(content))
+}
+
+func TestWriteAtomicallyReplacesExistingTarget(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "junit.xml")
+	require.NoError(t, os.WriteFile(path, []byte("previous report"), 0o600))
+	report := &Testsuites{}
+
+	require.NoError(t, Write(path, report))
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, "<testsuites></testsuites>\n", string(content))
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o644), info.Mode().Perm())
+	temps, err := filepath.Glob(filepath.Join(dir, ".junit.xml-*"))
+	require.NoError(t, err)
+	require.Empty(t, temps)
 }

--- a/tools/testrunner/junit_test.go
+++ b/tools/testrunner/junit_test.go
@@ -228,7 +228,7 @@ func requireReportEquals(t *testing.T, expectedFile, actualFile string) {
 
 	actualReport, err := os.ReadFile(actualFile)
 	require.NoError(t, err)
-	require.Equal(t, strings.TrimSuffix(string(expectedReport), "\n"), string(actualReport))
+	require.Equal(t, string(expectedReport), string(actualReport))
 }
 
 func TestJUnitXMLWellFormed(t *testing.T) {


### PR DESCRIPTION
Strengthens shared JUnit reads and writes. Reads reject trailing XML and include the source path in errors. Writes atomically replace the destination so interrupted writes cannot corrupt an existing report.

This is the bottom of the testrunner reporting stack.