### PR TITLE
Record canonical Go test attempt results

### DIFF
--- a/tools/testrunner/attempt.go
+++ b/tools/testrunner/attempt.go
@@ -1,0 +1,108 @@
+package testrunner
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"slices"
+	"strings"
+	"syscall"
+	"time"
+)
+
+type attemptSpec struct {
+	number           int
+	args             []string
+	coverProfilePath string
+}
+
+func runAttempt(ctx context.Context, spec attemptSpec) attemptResult {
+	args := spec.goTestArgs()
+	log.Printf("starting test attempt #%d: go test %v", spec.number, strings.Join(args, " "))
+
+	cmd := exec.CommandContext(ctx, "go", append([]string{"test"}, args...)...)
+	// Bound the post-kill wait on output pipes so a leaked descendant that
+	// inherited them cannot outlive the deadline meant to end this attempt.
+	cmd.WaitDelay = 10 * time.Second
+	recorder := newGoTestRecorder(os.Stdout)
+	var stderr strings.Builder
+	cmd.Stdout = recorder
+	cmd.Stderr = io.MultiWriter(os.Stderr, &stderr)
+	cmd.Stdin = os.Stdin
+
+	startedAt := time.Now()
+	err := cmd.Run()
+	process := classifyProcessResult(ctx, cmd, err, startedAt, time.Since(startedAt), stderr.String())
+	return recorder.finish(process)
+}
+
+func (s attemptSpec) goTestArgs() []string {
+	args := slices.Clone(s.args)
+	hasJSON := false
+	for i, arg := range args {
+		if arg == "-args" {
+			break
+		}
+		switch {
+		case arg == "-json":
+			hasJSON = true
+		case strings.HasPrefix(arg, coverProfileFlag):
+			// Each attempt writes a separate coverage profile for later merging.
+			args[i] = coverProfileFlag + s.coverProfilePath
+		default:
+		}
+	}
+	if !hasJSON {
+		args = append([]string{"-json"}, args...)
+	}
+	return args
+}
+
+func classifyProcessResult(
+	ctx context.Context,
+	cmd *exec.Cmd,
+	err error,
+	startedAt time.Time,
+	duration time.Duration,
+	stderr string,
+) processResult {
+	result := processResult{
+		state:     processExited,
+		startedAt: startedAt,
+		duration:  duration,
+		stderr:    stderr,
+	}
+	if err == nil {
+		return result
+	}
+	result.exitCode = 1
+	result.details = err.Error()
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		result.state = processDeadlineExceeded
+		result.details = ctx.Err().Error()
+		return result
+	}
+	var exitError *exec.ExitError
+	if errors.As(err, &exitError) {
+		result.exitCode = exitError.ExitCode()
+		if waitStatus, ok := exitError.Sys().(syscall.WaitStatus); ok && waitStatus.Signaled() {
+			result.state = processSignaled
+			result.details = waitStatus.Signal().String()
+		}
+		return result
+	}
+	if cmd.Process == nil {
+		result.state = processStartFailed
+		return result
+	}
+	if ctx.Err() != nil {
+		result.state = processSignaled
+		result.details = ctx.Err().Error()
+		return result
+	}
+	result.state = processWaitFailed
+	return result
+}

--- a/tools/testrunner/attempt_integration_test.go
+++ b/tools/testrunner/attempt_integration_test.go
@@ -1,0 +1,55 @@
+package testrunner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunAttemptConsumesRealGoTestJSON(t *testing.T) {
+	t.Setenv("TEMPORAL_TESTRUNNER_FIXTURE_FAILURE", "1")
+	result := runAttempt(context.Background(), attemptSpec{
+		number: 1,
+		args: []string{
+			"./testdata/gotestfixture/passfail",
+			"-run", "TestPass|TestFail",
+		},
+	})
+	require.Equal(t, 1, result.process.exitCode)
+	require.Len(t, result.packages, 1)
+	require.Equal(t, packageFailed, result.packages[0].outcome)
+	require.Equal(t, []testID{{
+		packageName: "go.temporal.io/server/tools/testrunner/testdata/gotestfixture/passfail",
+		testName:    "TestFail",
+	}}, result.failedLeafTests())
+}
+
+func TestRunAttemptConsumesRealGoBuildFailureJSON(t *testing.T) {
+	result := runAttempt(context.Background(), attemptSpec{
+		number: 1,
+		args:   []string{"./testdata/gotestfixture/buildfail"},
+	})
+	require.Equal(t, 1, result.process.exitCode)
+	require.NotEmpty(t, result.builds)
+	require.True(t, result.builds[0].failed)
+	require.Contains(t, result.builds[0].output, "undefinedFixtureSymbol")
+	require.False(t, result.canTargetFailures())
+}
+
+func TestRunAttemptAttributesCleanupFailureFromRealGoTestJSON(t *testing.T) {
+	t.Setenv("TEMPORAL_TESTRUNNER_FIXTURE_CLEANUP_FAILURE", "1")
+	result := runAttempt(context.Background(), attemptSpec{
+		number: 1,
+		args: []string{
+			"./testdata/gotestfixture/passfail",
+			"-run", "TestCleanupFailure",
+		},
+	})
+	require.Equal(t, []testID{{
+		packageName: "go.temporal.io/server/tools/testrunner/testdata/gotestfixture/passfail",
+		testName:    "TestCleanupFailure/Child",
+	}}, result.failedLeafTests())
+	require.Empty(t, result.abortedPackages())
+	require.True(t, result.canTargetFailures())
+}

--- a/tools/testrunner/attempt_test.go
+++ b/tools/testrunner/attempt_test.go
@@ -1,0 +1,75 @@
+package testrunner
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAttemptSpecGoTestArgs(t *testing.T) {
+	spec := attemptSpec{
+		args:             []string{"./...", "-coverprofile=old.cover.out", "-args", "value"},
+		coverProfilePath: "attempt.cover.out",
+	}
+	require.Equal(t, []string{
+		"-json", "./...", "-coverprofile=attempt.cover.out", "-args", "value",
+	}, spec.goTestArgs())
+	require.Equal(t, []string{"./...", "-coverprofile=old.cover.out", "-args", "value"}, spec.args)
+}
+
+func TestAttemptSpecGoTestArgsIgnoresTestBinaryFlags(t *testing.T) {
+	spec := attemptSpec{
+		args:             []string{"./...", "-args", "-json", "-coverprofile=binary.out"},
+		coverProfilePath: "attempt.cover.out",
+	}
+
+	require.Equal(t, []string{
+		"-json", "./...", "-args", "-json", "-coverprofile=binary.out",
+	}, spec.goTestArgs())
+}
+
+func TestAttemptSpecGoTestArgsKeepsExistingJSONFlag(t *testing.T) {
+	spec := attemptSpec{args: []string{"-json", "./..."}}
+	require.Equal(t, []string{"-json", "./..."}, spec.goTestArgs())
+}
+
+func TestClassifyProcessResult(t *testing.T) {
+	startedAt := time.Now()
+	duration := time.Second
+
+	result := classifyProcessResult(context.Background(), &exec.Cmd{}, nil, startedAt, duration, "stderr")
+	require.Equal(t, processResult{
+		state:     processExited,
+		startedAt: startedAt,
+		duration:  duration,
+		stderr:    "stderr",
+	}, result)
+
+	deadlineContext, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+	result = classifyProcessResult(deadlineContext, &exec.Cmd{}, context.DeadlineExceeded, startedAt, duration, "")
+	require.Equal(t, processDeadlineExceeded, result.state)
+	require.Equal(t, 1, result.exitCode)
+
+	result = classifyProcessResult(context.Background(), &exec.Cmd{}, errors.New("start failed"), startedAt, duration, "")
+	require.Equal(t, processStartFailed, result.state)
+	require.Equal(t, "start failed", result.details)
+
+	command := exec.Command("sh", "-c", "exit 7")
+	err := command.Run()
+	require.Error(t, err)
+	result = classifyProcessResult(context.Background(), command, err, startedAt, duration, "")
+	require.Equal(t, processExited, result.state)
+	require.Equal(t, 7, result.exitCode)
+
+	command = exec.Command("sh", "-c", "kill -TERM $$")
+	err = command.Run()
+	require.Error(t, err)
+	result = classifyProcessResult(context.Background(), command, err, startedAt, duration, "")
+	require.Equal(t, processSignaled, result.state)
+	require.Equal(t, "terminated", result.details)
+}

--- a/tools/testrunner/console.go
+++ b/tools/testrunner/console.go
@@ -1,0 +1,110 @@
+package testrunner
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+type goTestConsole struct {
+	output io.Writer
+}
+
+func newGoTestConsole(output io.Writer) *goTestConsole {
+	return &goTestConsole{output: output}
+}
+
+func (c *goTestConsole) packageOutput(output string) {
+	_, _ = fmt.Fprint(c.output, output)
+}
+
+func (c *goTestConsole) unstructuredOutput(output string) {
+	_, _ = fmt.Fprintln(c.output, output)
+}
+
+func (c *goTestConsole) completeTest(execution testExecution, hasFailedDescendant bool) {
+	// Only failing tests are shown; passing and skipped test output is hidden
+	// from the live console, since their framing and body add no signal there.
+	if execution.outcome != testFailed || hasFailedDescendant && !execution.failure.actionable {
+		return
+	}
+	_, _ = fmt.Fprint(c.output, goTestLiveOutput(execution.output))
+}
+
+func (c *goTestConsole) incompleteDiagnostics(execution testExecution, diagnostics []diagnostic) {
+	if len(diagnostics) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintf(c.output, "=== RUN   %s\n", execution.id.testName)
+	for _, diagnostic := range diagnostics {
+		_, _ = fmt.Fprintln(c.output, strings.TrimRight(diagnostic.details, "\n"))
+	}
+}
+
+func (c *goTestConsole) finish(result attemptResult) {
+	var tests, skipped, failures, buildErrors int
+	for _, pkg := range result.packages {
+		packageHasFailedTest := false
+		for _, execution := range pkg.executions {
+			if execution.outcome == testIncomplete {
+				continue
+			}
+			tests++
+			switch execution.outcome {
+			case testFailed:
+				failures++
+				packageHasFailedTest = true
+			case testSkipped:
+				skipped++
+			default:
+			}
+		}
+		if pkg.outcome == packageFailed && !packageHasFailedTest {
+			failures++
+		}
+	}
+	for _, build := range result.builds {
+		if build.failed {
+			buildErrors++
+		}
+	}
+	if len(result.packages) == 0 && len(result.builds) == 0 {
+		return
+	}
+
+	var summary strings.Builder
+	fmt.Fprintf(&summary, "\nDONE %d tests", tests)
+	if skipped > 0 {
+		fmt.Fprintf(&summary, ", %d skipped", skipped)
+	}
+	if failures > 0 {
+		label := "failure"
+		if failures > 1 {
+			label = "failures"
+		}
+		fmt.Fprintf(&summary, ", %d %s", failures, label)
+	}
+	if buildErrors > 0 {
+		label := "error"
+		if buildErrors > 1 {
+			label = "errors"
+		}
+		fmt.Fprintf(&summary, ", %d %s", buildErrors, label)
+	}
+	fmt.Fprintf(&summary, " in %.3fs\n", result.process.duration.Seconds())
+	_, _ = fmt.Fprint(c.output, summary.String())
+}
+
+func goTestLiveOutput(output string) string {
+	var live strings.Builder
+	for line := range strings.Lines(output) {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "=== PAUSE ") ||
+			strings.HasPrefix(trimmed, "=== CONT  ") ||
+			strings.HasPrefix(trimmed, "=== NAME  ") {
+			continue
+		}
+		live.WriteString(line)
+	}
+	return live.String()
+}

--- a/tools/testrunner/diagnostics.go
+++ b/tools/testrunner/diagnostics.go
@@ -186,6 +186,28 @@ func diagnosticTestIDs(scope outputScope, names []string) []testID {
 	return ids
 }
 
+func collectAttemptDiagnostics(result attemptResult) []diagnostic {
+	var diagnostics []diagnostic
+	for _, pkg := range result.packages {
+		for _, execution := range pkg.executions {
+			id := execution.id
+			diagnostics = append(diagnostics, extractDiagnostics(outputScope{
+				packageName: pkg.name,
+				test:        &id,
+			}, execution.output)...)
+		}
+		diagnostics = append(diagnostics, extractDiagnostics(outputScope{packageName: pkg.name}, pkg.output)...)
+	}
+	diagnostics = append(diagnostics, extractDiagnostics(outputScope{}, result.process.stderr)...)
+	diagnostics = append(diagnostics, extractDiagnostics(outputScope{}, result.unstructuredOutput)...)
+	for i := range diagnostics {
+		diagnostics[i].tests = slices.DeleteFunc(diagnostics[i].tests, func(id testID) bool {
+			return !result.observed(id)
+		})
+	}
+	return dedupeDiagnostics(diagnostics)
+}
+
 func dedupeDiagnostics(diagnostics []diagnostic) []diagnostic {
 	seen := make(map[string]struct{}, len(diagnostics))
 	result := make([]diagnostic, 0, len(diagnostics))

--- a/tools/testrunner/diagnostics_test.go
+++ b/tools/testrunner/diagnostics_test.go
@@ -103,3 +103,29 @@ func TestExtractFailureEvidence(t *testing.T) {
 		})
 	}
 }
+
+func TestCollectAttemptDiagnosticsScopesFiltersAndDeduplicates(t *testing.T) {
+	observed := testID{"example.com/tests", "TestObserved"}
+	testRace := "WARNING: DATA RACE\nexample.TestObserved()\nFAIL\n"
+	packageRace := "WARNING: DATA RACE\nexample.TestUnobserved()\nFAIL\n"
+	duplicatePanic := "panic: duplicate\nFAIL\n"
+	result := attemptResult{
+		packages: []packageResult{{
+			name: "example.com/tests",
+			executions: []testExecution{{
+				id:      observed,
+				outcome: testFailed,
+				output:  testRace,
+			}},
+			output: packageRace,
+		}},
+		process:            processResult{stderr: duplicatePanic},
+		unstructuredOutput: duplicatePanic,
+	}
+
+	diagnostics := collectAttemptDiagnostics(result)
+	require.Len(t, diagnostics, 3)
+	require.Equal(t, []testID{observed}, diagnostics[0].tests)
+	require.Empty(t, diagnostics[1].tests)
+	require.Equal(t, diagnosticPanic, diagnostics[2].kind)
+}

--- a/tools/testrunner/gotestjson.go
+++ b/tools/testrunner/gotestjson.go
@@ -1,0 +1,324 @@
+package testrunner
+
+import (
+	"encoding/json"
+	"io"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var coverageLine = regexp.MustCompile(`^coverage: ([0-9]+(?:\.[0-9]+)?)% of statements`)
+
+type goTestJSONEvent struct {
+	Time        time.Time `json:"Time"`
+	Action      string    `json:"Action"`
+	Package     string    `json:"Package"`
+	Test        string    `json:"Test"`
+	Elapsed     float64   `json:"Elapsed"`
+	Output      string    `json:"Output"`
+	ImportPath  string    `json:"ImportPath"`
+	FailedBuild string    `json:"FailedBuild"`
+}
+
+type goTestRecorder struct {
+	line         strings.Builder
+	console      *goTestConsole
+	packages     map[string]*goTestPackageBuilder
+	packageOrder []string
+	builds       map[string]*goTestBuildBuilder
+	buildOrder   []string
+	unstructured strings.Builder
+}
+
+type goTestPackageBuilder struct {
+	name               string
+	startedAt          time.Time
+	duration           time.Duration
+	outcome            packageOutcome
+	coverage           *float64
+	output             strings.Builder
+	excludedTestOutput strings.Builder
+	failedBuild        string
+	executions         []*goTestExecutionBuilder
+	active             map[testID]*goTestExecutionBuilder
+	occurrences        map[testID]int
+}
+
+type goTestExecutionBuilder struct {
+	id         testID
+	occurrence int
+	outcome    testOutcome
+	terminal   bool
+	duration   time.Duration
+	output     strings.Builder
+}
+
+type goTestBuildBuilder struct {
+	importPath string
+	failed     bool
+	output     strings.Builder
+}
+
+func newGoTestRecorder(consoleOutput io.Writer) *goTestRecorder {
+	return &goTestRecorder{
+		console:  newGoTestConsole(consoleOutput),
+		packages: make(map[string]*goTestPackageBuilder),
+		builds:   make(map[string]*goTestBuildBuilder),
+	}
+}
+
+func (r *goTestRecorder) Write(p []byte) (int, error) {
+	for _, b := range p {
+		r.line.WriteByte(b)
+		if b == '\n' {
+			r.recordLine(strings.TrimSuffix(r.line.String(), "\n"))
+			r.line.Reset()
+		}
+	}
+	return len(p), nil
+}
+
+func (r *goTestRecorder) recordLine(line string) {
+	var event goTestJSONEvent
+	if err := json.Unmarshal([]byte(line), &event); err != nil {
+		r.unstructured.WriteString(line)
+		r.unstructured.WriteByte('\n')
+		r.console.unstructuredOutput(line)
+		return
+	}
+	r.record(event)
+}
+
+func (r *goTestRecorder) record(event goTestJSONEvent) {
+	if event.Action == "build-output" || event.Action == "build-fail" {
+		build := r.build(event.ImportPath)
+		if event.Output != "" {
+			build.output.WriteString(event.Output)
+			r.console.packageOutput(event.Output)
+		}
+		if event.Action == "build-fail" {
+			build.failed = true
+		}
+		return
+	}
+
+	if event.Package == "" {
+		if event.Output != "" {
+			r.unstructured.WriteString(event.Output)
+			r.console.packageOutput(event.Output)
+		}
+		return
+	}
+	pkg := r.pkg(event.Package)
+	if event.Test != "" {
+		if strings.HasPrefix(event.Test, "Benchmark") {
+			if event.Output != "" {
+				pkg.excludedTestOutput.WriteString(event.Output)
+			}
+			return
+		}
+		r.recordTestEvent(pkg, event)
+		return
+	}
+
+	if event.Output != "" {
+		pkg.output.WriteString(event.Output)
+		if match := coverageLine.FindStringSubmatch(strings.TrimSpace(event.Output)); match != nil {
+			coverage, err := strconv.ParseFloat(match[1], 64)
+			if err == nil {
+				pkg.coverage = &coverage
+			}
+		}
+		r.console.packageOutput(event.Output)
+	}
+	switch event.Action {
+	case "start":
+		pkg.startedAt = event.Time
+	case "pass":
+		pkg.outcome = packagePassed
+		pkg.duration = durationSeconds(event.Elapsed)
+	case "fail":
+		pkg.outcome = packageFailed
+		pkg.duration = durationSeconds(event.Elapsed)
+		pkg.failedBuild = event.FailedBuild
+	case "skip":
+		pkg.outcome = packageSkipped
+		pkg.duration = durationSeconds(event.Elapsed)
+	default:
+	}
+}
+
+func (r *goTestRecorder) recordTestEvent(pkg *goTestPackageBuilder, event goTestJSONEvent) {
+	id := testID{packageName: event.Package, testName: event.Test}
+	execution := pkg.active[id]
+	if execution == nil ||
+		execution.terminal && (event.Action == "run" || isTerminalTestAction(event.Action)) {
+		execution = pkg.open(id)
+	} else if execution.terminal {
+		if event.Output != "" {
+			execution.output.WriteString(event.Output)
+		}
+		return
+	}
+	if event.Output != "" {
+		execution.output.WriteString(event.Output)
+	}
+
+	switch event.Action {
+	case "pass", "fail", "skip":
+		execution.terminal = true
+		execution.duration = durationSeconds(event.Elapsed)
+		switch event.Action {
+		case "fail":
+			execution.outcome = testFailed
+		case "skip":
+			execution.outcome = testSkipped
+		default:
+			execution.outcome = testPassed
+		}
+		if execution.outcome == testFailed {
+			finished := execution.finish()
+			r.console.completeTest(finished, packageBuilderHasFailedDescendant(pkg, finished))
+		}
+	default:
+	}
+}
+
+func isTerminalTestAction(action string) bool {
+	switch action {
+	case "pass", "fail", "skip":
+		return true
+	default:
+		return false
+	}
+}
+
+func (r *goTestRecorder) pkg(name string) *goTestPackageBuilder {
+	if pkg := r.packages[name]; pkg != nil {
+		return pkg
+	}
+	pkg := &goTestPackageBuilder{
+		name:        name,
+		active:      make(map[testID]*goTestExecutionBuilder),
+		occurrences: make(map[testID]int),
+	}
+	r.packages[name] = pkg
+	r.packageOrder = append(r.packageOrder, name)
+	return pkg
+}
+
+func (r *goTestRecorder) build(importPath string) *goTestBuildBuilder {
+	if build := r.builds[importPath]; build != nil {
+		return build
+	}
+	build := &goTestBuildBuilder{importPath: importPath}
+	r.builds[importPath] = build
+	r.buildOrder = append(r.buildOrder, importPath)
+	return build
+}
+
+func (p *goTestPackageBuilder) open(id testID) *goTestExecutionBuilder {
+	rootID := testID{packageName: id.packageName, testName: strings.SplitN(id.testName, "/", 2)[0]}
+	occurrence := p.occurrences[id]
+	if id != rootID {
+		if root := p.active[rootID]; root != nil && !root.terminal {
+			occurrence = root.occurrence
+			p.occurrences[id] = max(p.occurrences[id], occurrence+1)
+		} else {
+			p.occurrences[id]++
+		}
+	} else {
+		p.occurrences[id]++
+	}
+	execution := &goTestExecutionBuilder{
+		id:         id,
+		occurrence: occurrence,
+		outcome:    testIncomplete,
+	}
+	p.active[id] = execution
+	p.executions = append(p.executions, execution)
+	return execution
+}
+
+func (b *goTestExecutionBuilder) finish() testExecution {
+	output := b.output.String()
+	return testExecution{
+		id:         b.id,
+		occurrence: b.occurrence,
+		outcome:    b.outcome,
+		duration:   b.duration,
+		output:     output,
+		failure:    extractFailureEvidence(output),
+	}
+}
+
+func packageBuilderHasFailedDescendant(pkg *goTestPackageBuilder, parent testExecution) bool {
+	prefix := parent.id.testName + "/"
+	for _, execution := range pkg.executions {
+		if execution.id.packageName == parent.id.packageName &&
+			execution.occurrence == parent.occurrence && execution.terminal &&
+			execution.outcome == testFailed && strings.HasPrefix(execution.id.testName, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func durationSeconds(seconds float64) time.Duration {
+	return time.Duration(seconds * float64(time.Second))
+}
+
+func (r *goTestRecorder) finish(process processResult) attemptResult {
+	if r.line.Len() > 0 {
+		r.recordLine(r.line.String())
+		r.line.Reset()
+	}
+	result := attemptResult{
+		process:            process,
+		unstructuredOutput: r.unstructured.String(),
+	}
+	for _, name := range r.packageOrder {
+		builder := r.packages[name]
+		pkg := packageResult{
+			name:        builder.name,
+			startedAt:   builder.startedAt,
+			duration:    builder.duration,
+			outcome:     builder.outcome,
+			coverage:    builder.coverage,
+			output:      builder.output.String(),
+			failedBuild: builder.failedBuild,
+		}
+		if builder.outcome == packageFailed {
+			pkg.output += builder.excludedTestOutput.String()
+		}
+		for _, execution := range builder.executions {
+			finished := execution.finish()
+			pkg.executions = append(pkg.executions, finished)
+			if finished.outcome == testIncomplete {
+				// A package abort leaves scheduler framing buffered for every unfinished
+				// test. Surface high-priority diagnostics without presenting ordinary
+				// output from unfinished tests as live failures, while retaining the full
+				// event-owned output in the canonical result.
+				diagnostics := extractDiagnostics(outputScope{
+					packageName: name,
+					test:        &finished.id,
+				}, finished.output)
+				r.console.incompleteDiagnostics(finished, diagnostics)
+			}
+		}
+		result.packages = append(result.packages, pkg)
+	}
+	for _, importPath := range r.buildOrder {
+		build := r.builds[importPath]
+		result.builds = append(result.builds, buildResult{
+			importPath: build.importPath,
+			failed:     build.failed,
+			output:     build.output.String(),
+		})
+	}
+	result.diagnostics = collectAttemptDiagnostics(result)
+	r.console.finish(result)
+	return result
+}

--- a/tools/testrunner/recorder_test.go
+++ b/tools/testrunner/recorder_test.go
@@ -1,0 +1,215 @@
+package testrunner
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGoTestRecorderBuildsPackageAwareAttemptResult(t *testing.T) {
+	input := `{"Time":"2026-08-11T01:00:00Z","Action":"start","Package":"example.com/one"}
+{"Action":"run","Package":"example.com/one","Test":"TestSame"}
+{"Action":"run","Package":"example.com/two","Test":"TestSame"}
+{"Action":"output","Package":"example.com/two","Test":"TestSame","Output":"two output\n"}
+{"Action":"output","Package":"example.com/one","Test":"TestSame","Output":"one output\n"}
+{"Action":"pass","Package":"example.com/two","Test":"TestSame","Elapsed":0.25}
+{"Action":"fail","Package":"example.com/one","Test":"TestSame","Elapsed":0.5}
+{"Action":"pass","Package":"example.com/two","Elapsed":0.3}
+{"Action":"fail","Package":"example.com/one","Elapsed":0.6}
+`
+	var console bytes.Buffer
+	recorder := newGoTestRecorder(&console)
+	_, err := recorder.Write([]byte(input))
+	require.NoError(t, err)
+	result := recorder.finish(processResult{state: processExited, exitCode: 1, duration: time.Second})
+
+	require.Equal(t, []packageResult{
+		{
+			name:      "example.com/one",
+			startedAt: time.Date(2026, 8, 11, 1, 0, 0, 0, time.UTC),
+			duration:  600 * time.Millisecond,
+			outcome:   packageFailed,
+			executions: []testExecution{{
+				id:       testID{"example.com/one", "TestSame"},
+				outcome:  testFailed,
+				duration: 500 * time.Millisecond,
+				output:   "one output\n",
+			}},
+		},
+		{
+			name:     "example.com/two",
+			duration: 300 * time.Millisecond,
+			outcome:  packagePassed,
+			executions: []testExecution{{
+				id:       testID{"example.com/two", "TestSame"},
+				outcome:  testPassed,
+				duration: 250 * time.Millisecond,
+				output:   "two output\n",
+			}},
+		},
+	}, result.packages)
+	require.Contains(t, console.String(), "one output")
+	require.NotContains(t, console.String(), "two output")
+}
+
+func TestGoTestRecorderRetainsOccurrencesBuildsAndCoverage(t *testing.T) {
+	input := `{"Action":"run","Package":"example.com/tests","Test":"TestRepeated"}
+{"Action":"pass","Package":"example.com/tests","Test":"TestRepeated","Elapsed":0.1}
+{"Action":"run","Package":"example.com/tests","Test":"TestRepeated"}
+{"Action":"fail","Package":"example.com/tests","Test":"TestRepeated","Elapsed":0.2}
+{"Action":"output","Package":"example.com/tests","Output":"coverage: 0.0% of statements\n"}
+{"ImportPath":"example.com/broken.test","Action":"build-output","Output":"compile failed\n"}
+{"ImportPath":"example.com/broken.test","Action":"build-fail"}
+{"Action":"fail","Package":"example.com/tests","FailedBuild":"example.com/broken.test"}
+`
+	recorder := newGoTestRecorder(&bytes.Buffer{})
+	_, err := recorder.Write([]byte(input))
+	require.NoError(t, err)
+	result := recorder.finish(processResult{state: processExited, exitCode: 1})
+
+	require.Len(t, result.packages, 1)
+	require.Equal(t, 0, result.packages[0].executions[0].occurrence)
+	require.Equal(t, 1, result.packages[0].executions[1].occurrence)
+	require.NotNil(t, result.packages[0].coverage)
+	require.InDelta(t, 0, *result.packages[0].coverage, 0)
+	require.Equal(t, "example.com/broken.test", result.packages[0].failedBuild)
+	require.Equal(t, []buildResult{{
+		importPath: "example.com/broken.test",
+		failed:     true,
+		output:     "compile failed\n",
+	}}, result.builds)
+}
+
+func TestGoTestRecorderFinalizesPartialAndMalformedLines(t *testing.T) {
+	var console bytes.Buffer
+	recorder := newGoTestRecorder(&console)
+	_, err := recorder.Write([]byte("not json\n"))
+	require.NoError(t, err)
+	_, err = recorder.Write([]byte(`{"Action":"run","Package":"example.com/tests","Test":"TestPartial"}`))
+	require.NoError(t, err)
+	result := recorder.finish(processResult{state: processExited, exitCode: 1})
+
+	require.Equal(t, "not json\n", result.unstructuredOutput)
+	require.Equal(t, testIncomplete, result.packages[0].executions[0].outcome)
+	require.Contains(t, console.String(), "not json")
+}
+
+func TestGoTestRecorderExcludesBenchmarks(t *testing.T) {
+	input := `{"Action":"run","Package":"example.com/tests","Test":"BenchmarkExample"}
+{"Action":"output","Package":"example.com/tests","Test":"BenchmarkExample","Output":"BenchmarkExample-12  1  100 ns/op\n"}
+{"Action":"pass","Package":"example.com/tests"}
+`
+	recorder := newGoTestRecorder(&bytes.Buffer{})
+	_, err := recorder.Write([]byte(input))
+	require.NoError(t, err)
+	result := recorder.finish(processResult{state: processExited})
+
+	require.Empty(t, result.packages[0].executions)
+	require.True(t, result.successful())
+
+	failing := newGoTestRecorder(&bytes.Buffer{})
+	_, err = failing.Write([]byte(`{"Action":"run","Package":"example.com/tests","Test":"BenchmarkFailure"}
+{"Action":"output","Package":"example.com/tests","Test":"BenchmarkFailure","Output":"benchmark failure detail\n"}
+{"Action":"fail","Package":"example.com/tests","Test":"BenchmarkFailure"}
+{"Action":"fail","Package":"example.com/tests"}
+`))
+	require.NoError(t, err)
+	failedResult := failing.finish(processResult{state: processExited, exitCode: 1})
+	require.Empty(t, failedResult.packages[0].executions)
+	require.Contains(t, failedResult.packages[0].output, "benchmark failure detail")
+	require.Len(t, failedResult.runtimeFailures(), 1)
+}
+
+func TestGoTestRecorderCreatesOccurrenceForTerminalWithoutRun(t *testing.T) {
+	recorder := newGoTestRecorder(&bytes.Buffer{})
+	_, err := recorder.Write([]byte(`{"Action":"skip","Package":"example.com/tests","Test":"TestCached","Elapsed":0.1}`))
+	require.NoError(t, err)
+	result := recorder.finish(processResult{state: processExited})
+
+	require.Equal(t, []testExecution{{
+		id:       testID{"example.com/tests", "TestCached"},
+		outcome:  testSkipped,
+		duration: 100 * time.Millisecond,
+	}}, result.packages[0].executions)
+}
+
+func TestGoTestRecorderCorrelatesConditionalChildWithParentOccurrence(t *testing.T) {
+	input := `{"Action":"run","Package":"example.com/tests","Test":"TestRepeated"}
+{"Action":"pass","Package":"example.com/tests","Test":"TestRepeated"}
+{"Action":"run","Package":"example.com/tests","Test":"TestRepeated"}
+{"Action":"run","Package":"example.com/tests","Test":"TestRepeated/ConditionalChild"}
+{"Action":"fail","Package":"example.com/tests","Test":"TestRepeated/ConditionalChild"}
+{"Action":"fail","Package":"example.com/tests","Test":"TestRepeated"}
+{"Action":"fail","Package":"example.com/tests"}
+`
+	recorder := newGoTestRecorder(&bytes.Buffer{})
+	_, err := recorder.Write([]byte(input))
+	require.NoError(t, err)
+	result := recorder.finish(processResult{state: processExited, exitCode: 1})
+
+	require.Equal(t, 1, result.packages[0].executions[1].occurrence)
+	require.Equal(t, 1, result.packages[0].executions[2].occurrence)
+	require.Equal(t, []testID{{"example.com/tests", "TestRepeated/ConditionalChild"}}, result.failedLeafTests())
+}
+
+func TestGoTestRecorderAttributesCleanupFailureWithoutTerminalTestEvent(t *testing.T) {
+	input := `{"Action":"run","Package":"example.com/tests","Test":"TestSuite"}
+{"Action":"run","Package":"example.com/tests","Test":"TestSuite/TestCleanupFailure"}
+{"Action":"output","Package":"example.com/tests","Test":"TestSuite/TestCleanupFailure","Output":"    context.go:132: \n"}
+{"Action":"output","Package":"example.com/tests","Test":"TestSuite/TestCleanupFailure","Output":"        Error Trace: cleanup_test.go:42\n"}
+{"Action":"output","Package":"example.com/tests","Test":"TestSuite/TestCleanupFailure","Output":"        Error: test exceeded timeout\n"}
+{"Action":"fail","Package":"example.com/tests","Test":"TestSuite"}
+{"Action":"fail","Package":"example.com/tests"}
+`
+	recorder := newGoTestRecorder(&bytes.Buffer{})
+	_, err := recorder.Write([]byte(input))
+	require.NoError(t, err)
+	result := recorder.finish(processResult{state: processExited, exitCode: 1})
+
+	require.Equal(t, []testID{{"example.com/tests", "TestSuite/TestCleanupFailure"}}, result.failedLeafTests())
+	require.Empty(t, result.abortedPackages())
+	require.True(t, result.canTargetFailures())
+}
+
+func TestGoTestRecorderDoesNotInventOccurrenceForPostTerminalMetadata(t *testing.T) {
+	input := `{"Action":"run","Package":"example.com/tests","Test":"TestFinished"}
+{"Action":"pass","Package":"example.com/tests","Test":"TestFinished"}
+{"Action":"attr","Package":"example.com/tests","Test":"TestFinished"}
+{"Action":"artifacts","Package":"example.com/tests","Test":"TestFinished"}
+{"Action":"fail","Package":"example.com/tests"}
+`
+	recorder := newGoTestRecorder(&bytes.Buffer{})
+	_, err := recorder.Write([]byte(input))
+	require.NoError(t, err)
+	result := recorder.finish(processResult{state: processExited, exitCode: 1})
+
+	require.Len(t, result.packages[0].executions, 1)
+	require.Equal(t, testPassed, result.packages[0].executions[0].outcome)
+	require.Empty(t, result.abortedPackages())
+}
+
+func TestGoTestRecorderFindsDiagnosticInHiddenPassingOutputAndStderr(t *testing.T) {
+	input := `{"Action":"run","Package":"example.com/tests","Test":"TestPass"}
+{"Action":"output","Package":"example.com/tests","Test":"TestPass","Output":"panic: hidden panic\n"}
+{"Action":"pass","Package":"example.com/tests","Test":"TestPass"}
+{"Action":"pass","Package":"example.com/tests"}
+`
+	var console bytes.Buffer
+	recorder := newGoTestRecorder(&console)
+	_, err := recorder.Write([]byte(input))
+	require.NoError(t, err)
+	result := recorder.finish(processResult{
+		state:    processExited,
+		exitCode: 1,
+		stderr:   "fatal error: stderr failure\n",
+	})
+
+	require.Len(t, result.diagnostics, 2)
+	require.Equal(t, diagnosticPanic, result.diagnostics[0].kind)
+	require.Equal(t, []testID{{"example.com/tests", "TestPass"}}, result.diagnostics[0].tests)
+	require.Equal(t, diagnosticFatal, result.diagnostics[1].kind)
+	require.Empty(t, result.diagnostics[1].tests)
+	require.NotContains(t, console.String(), "hidden panic")
+}

--- a/tools/testrunner/testdata/gotestfixture/buildfail/buildfail.go
+++ b/tools/testrunner/testdata/gotestfixture/buildfail/buildfail.go
@@ -1,0 +1,5 @@
+package buildfail
+
+func doesNotCompile() {
+	undefinedFixtureSymbol()
+}

--- a/tools/testrunner/testdata/gotestfixture/passfail/passfail_test.go
+++ b/tools/testrunner/testdata/gotestfixture/passfail/passfail_test.go
@@ -1,0 +1,26 @@
+package passfail
+
+import (
+	"os"
+	"testing"
+)
+
+func TestPass(t *testing.T) {}
+
+func TestFail(t *testing.T) {
+	if os.Getenv("TEMPORAL_TESTRUNNER_FIXTURE_FAILURE") == "" {
+		return
+	}
+	t.Errorf("fixture failure")
+}
+
+func TestCleanupFailure(t *testing.T) {
+	if os.Getenv("TEMPORAL_TESTRUNNER_FIXTURE_CLEANUP_FAILURE") == "" {
+		return
+	}
+	t.Run("Child", func(t *testing.T) {
+		t.Cleanup(func() {
+			t.Errorf("fixture cleanup failure")
+		})
+	})
+}


### PR DESCRIPTION
Runs Go tests directly with JSON output and records package-aware canonical attempt results. The recorder owns event attribution, build failures, diagnostics, timeouts, console output, process state, and coverage-path handling, with focused unit and subprocess tests.

Stack: depends on #11488. Retry policy follows in #11516.
