### PR TITLE
Plan test retries from canonical results

### DIFF
--- a/tools/testrunner/attempt_result.go
+++ b/tools/testrunner/attempt_result.go
@@ -166,6 +166,25 @@ func (r attemptResult) observed(id testID) bool {
 	return false
 }
 
+// packageBlockedObservation reports whether a package-level failure makes an
+// absent targeted test inconclusive rather than a retry-plan violation.
+func (r attemptResult) packageBlockedObservation(packageName string) bool {
+	if r.process.state != processExited {
+		return true
+	}
+	for _, pkg := range r.packages {
+		if pkg.name != packageName {
+			continue
+		}
+		if pkg.failedBuild != "" || len(pkg.meaningfulIncompleteExecutions()) > 0 || r.packageHasTimeout(packageName) {
+			return true
+		}
+		return pkg.outcome == packageFailed &&
+			!slices.ContainsFunc(pkg.executions, testExecution.isAttributableFailure)
+	}
+	return false
+}
+
 func (p packageResult) meaningfulIncompleteExecutions() []testExecution {
 	if p.outcome != packageFailed && p.outcome != packageIncomplete {
 		return nil

--- a/tools/testrunner/retry.go
+++ b/tools/testrunner/retry.go
@@ -1,0 +1,127 @@
+package testrunner
+
+import (
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+)
+
+type retryMode uint8
+
+const (
+	retryStop retryMode = iota
+	retryRepeatScope
+	retryTargeted
+)
+
+type retryPolicy struct {
+	targetedThreshold int
+}
+
+type retryPlan struct {
+	mode     retryMode
+	reason   string
+	expected []testID
+}
+
+func (p retryPolicy) plan(result attemptResult) retryPlan {
+	if result.successful() {
+		return retryPlan{mode: retryStop, reason: "test attempt succeeded"}
+	}
+	if result.process.state != processExited ||
+		slices.ContainsFunc(result.diagnostics, func(diagnostic diagnostic) bool {
+			return diagnostic.kind == diagnosticTimeout
+		}) {
+		return retryPlan{mode: retryStop, reason: "test attempt cannot be retried safely"}
+	}
+	if result.unexplainedProcessFailure() {
+		return retryPlan{mode: retryStop, reason: "test attempt failed without any attributable failure"}
+	}
+	// A package abort can leave both incomplete tests and tests that never
+	// started, so observed test names cannot safely narrow the rerun. This also
+	// applies when a panic caused the abort.
+	if !result.canTargetFailures() {
+		return retryPlan{mode: retryRepeatScope, reason: "failure is not safely attributable to individual tests"}
+	}
+	failed := result.failedLeafTests()
+	if len(failed) > p.targetedThreshold {
+		return retryPlan{
+			mode:   retryRepeatScope,
+			reason: fmt.Sprintf("%d failures exceed targeted retry threshold %d", len(failed), p.targetedThreshold),
+		}
+	}
+	return retryPlan{
+		mode:     retryTargeted,
+		reason:   fmt.Sprintf("retrying %d failed test(s)", len(failed)),
+		expected: failed,
+	}
+}
+
+func (p retryPlan) apply(args []string) []string {
+	args = slices.Clone(args)
+	if p.mode != retryTargeted {
+		return args
+	}
+	args = stripRunFromArgs(args)
+	names := make([]string, 0, len(p.expected))
+	for _, id := range p.expected {
+		names = append(names, id.testName)
+	}
+	slices.Sort(names)
+	names = slices.Compact(names)
+	for i := range names {
+		names[i] = goTestNameToRunFlagRegexp(names[i])
+	}
+	runArgs := []string{"-run", strings.Join(names, "|")}
+	// -args has special semantics in Go.
+	if argsIndex := slices.Index(args, "-args"); argsIndex >= 0 {
+		return slices.Insert(args, argsIndex, runArgs...)
+	}
+	return append(args, runArgs...)
+}
+
+func (p retryPlan) validate(result attemptResult) error {
+	if p.mode != retryTargeted {
+		return nil
+	}
+	for _, expected := range p.expected {
+		if result.observed(expected) || result.packageBlockedObservation(expected.packageName) {
+			continue
+		}
+		return fmt.Errorf("expected targeted rerun was not observed: %s.%s", expected.packageName, expected.testName)
+	}
+	return nil
+}
+
+func stripRunFromArgs(args []string) (argsNoRun []string) {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "-args" {
+			return append(argsNoRun, args[i:]...)
+		}
+		if arg == "-run" {
+			i++
+			continue
+		}
+		if strings.HasPrefix(arg, "-run=") {
+			continue
+		}
+		argsNoRun = append(argsNoRun, arg)
+	}
+	return
+}
+
+func goTestNameToRunFlagRegexp(test string) string {
+	parts := strings.Split(test, "/")
+	var expression strings.Builder
+	for i, part := range parts {
+		if i > 0 {
+			expression.WriteByte('/')
+		}
+		expression.WriteByte('^')
+		expression.WriteString(regexp.QuoteMeta(part))
+		expression.WriteByte('$')
+	}
+	return expression.String()
+}

--- a/tools/testrunner/retry_test.go
+++ b/tools/testrunner/retry_test.go
@@ -1,0 +1,189 @@
+package testrunner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetryPolicyPlansTargetedPackageAwareRetry(t *testing.T) {
+	result := attemptResult{
+		packages: []packageResult{
+			{name: "example.com/one", outcome: packageFailed, executions: []testExecution{{id: testID{"example.com/one", "TestSuite/TestA"}, outcome: testFailed}}},
+			{name: "example.com/two", outcome: packageFailed, executions: []testExecution{{id: testID{"example.com/two", "TestSuite/TestA"}, outcome: testFailed}}},
+		},
+		process: processResult{state: processExited, exitCode: 1},
+	}
+	plan := (retryPolicy{targetedThreshold: 20}).plan(result)
+
+	require.Equal(t, retryTargeted, plan.mode)
+	require.Equal(t, []testID{
+		{"example.com/one", "TestSuite/TestA"},
+		{"example.com/two", "TestSuite/TestA"},
+	}, plan.expected)
+	require.Equal(t, []string{
+		"./...", "-run", "^TestSuite$/^TestA$", "-args", "-persistenceType=sql",
+	}, plan.apply([]string{"./...", "-run=old", "-args", "-persistenceType=sql"}))
+}
+
+func TestRetryPlanPreservesTestBinaryRunFlag(t *testing.T) {
+	plan := retryPlan{
+		mode:     retryTargeted,
+		expected: []testID{{"example.com/tests", "TestFailed"}},
+	}
+
+	require.Equal(t, []string{
+		"./...", "-run", "^TestFailed$", "-args", "-run", "binary-pattern",
+	}, plan.apply([]string{"./...", "-run=old", "-args", "-run", "binary-pattern"}))
+}
+
+func TestRetryPolicyRepeatsScopeForUnsafeFailuresAndThreshold(t *testing.T) {
+	aborted := attemptResult{
+		packages: []packageResult{{
+			name:       "example.com/tests",
+			outcome:    packageFailed,
+			executions: []testExecution{{id: testID{"example.com/tests", "TestIncomplete"}, outcome: testIncomplete}},
+		}},
+		process: processResult{state: processExited, exitCode: 1},
+	}
+	plan := (retryPolicy{targetedThreshold: 20}).plan(aborted)
+	require.Equal(t, retryRepeatScope, plan.mode)
+	require.Equal(t, []string{"./...", "-run=old"}, plan.apply([]string{"./...", "-run=old"}))
+
+	var executions []testExecution
+	for i := range 3 {
+		executions = append(executions, testExecution{
+			id:      testID{"example.com/tests", "Test" + string(rune('A'+i))},
+			outcome: testFailed,
+		})
+	}
+	threshold := attemptResult{
+		packages: []packageResult{{name: "example.com/tests", outcome: packageFailed, executions: executions}},
+		process:  processResult{state: processExited, exitCode: 1},
+	}
+	require.Equal(t, retryRepeatScope, (retryPolicy{targetedThreshold: 2}).plan(threshold).mode)
+}
+
+func TestRetryPolicyStopsForSuccessAndTimeout(t *testing.T) {
+	success := attemptResult{process: processResult{state: processExited}}
+	require.Equal(t, retryStop, (retryPolicy{targetedThreshold: 20}).plan(success).mode)
+
+	timedOut := attemptResult{
+		diagnostics: []diagnostic{{kind: diagnosticTimeout}},
+		process:     processResult{state: processExited, exitCode: 1},
+	}
+	require.Equal(t, retryStop, (retryPolicy{targetedThreshold: 20}).plan(timedOut).mode)
+}
+
+func TestRetryPlanValidatesEveryPackageAwareTarget(t *testing.T) {
+	one := testID{"example.com/one", "TestSame"}
+	two := testID{"example.com/two", "TestSame"}
+	plan := retryPlan{mode: retryTargeted, expected: []testID{one, two}}
+	next := attemptResult{
+		packages: []packageResult{
+			{name: one.packageName, executions: []testExecution{{id: one, outcome: testPassed}}},
+			{name: two.packageName, outcome: packageFailed, failedBuild: "example.com/two.test"},
+		},
+		builds:  []buildResult{{importPath: "example.com/two.test", failed: true}},
+		process: processResult{state: processExited, exitCode: 1},
+	}
+	require.NoError(t, plan.validate(next))
+
+	next.packages[1].failedBuild = ""
+	next.packages[1].outcome = packagePassed
+	next.builds = nil
+	require.EqualError(t, plan.validate(next), "expected targeted rerun was not observed: example.com/two.TestSame")
+}
+
+func TestRetryPlanDoesNotLetAnotherPackageBlockObservation(t *testing.T) {
+	expected := testID{"example.com/expected", "TestMissing"}
+	plan := retryPlan{mode: retryTargeted, expected: []testID{expected}}
+	next := attemptResult{
+		packages: []packageResult{{
+			name:        "example.com/other",
+			outcome:     packageFailed,
+			failedBuild: "example.com/other.test",
+		}},
+		builds:  []buildResult{{importPath: "example.com/other.test", failed: true}},
+		process: processResult{state: processExited, exitCode: 1},
+	}
+
+	require.EqualError(t, plan.validate(next), "expected targeted rerun was not observed: example.com/expected.TestMissing")
+}
+
+func TestRetryPolicyHandlesNonTargetableFailures(t *testing.T) {
+	tests := []struct {
+		name string
+		give attemptResult
+		want retryMode
+	}{
+		{
+			name: "build",
+			give: attemptResult{
+				builds:  []buildResult{{importPath: "example.com/tests.test", failed: true}},
+				process: processResult{state: processExited, exitCode: 1},
+			},
+			want: retryRepeatScope,
+		},
+		{
+			name: "runtime",
+			give: attemptResult{
+				packages: []packageResult{{name: "example.com/tests", outcome: packageFailed}},
+				process:  processResult{state: processExited, exitCode: 1},
+			},
+			want: retryRepeatScope,
+		},
+		{
+			name: "unexplained process",
+			give: attemptResult{process: processResult{state: processExited, exitCode: 1}},
+			want: retryStop,
+		},
+		{
+			name: "deadline",
+			give: attemptResult{process: processResult{state: processDeadlineExceeded, exitCode: 1}},
+			want: retryStop,
+		},
+		{
+			name: "start failure",
+			give: attemptResult{process: processResult{state: processStartFailed, exitCode: 1}},
+			want: retryStop,
+		},
+		{
+			name: "signaled",
+			give: attemptResult{process: processResult{state: processSignaled, exitCode: 1}},
+			want: retryStop,
+		},
+		{
+			name: "wait failure",
+			give: attemptResult{process: processResult{state: processWaitFailed, exitCode: 1}},
+			want: retryStop,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, (retryPolicy{targetedThreshold: 20}).plan(test.give).mode)
+		})
+	}
+}
+
+func TestRetryPolicyRepeatsScopeWhenDiagnosticAlsoNamesPassingTest(t *testing.T) {
+	failed := testID{"example.com/tests", "TestFailed"}
+	passed := testID{"example.com/tests", "TestPassed"}
+	result := attemptResult{
+		packages: []packageResult{{
+			name:    "example.com/tests",
+			outcome: packageFailed,
+			executions: []testExecution{
+				{id: failed, outcome: testFailed},
+				{id: passed, outcome: testPassed},
+			},
+		}},
+		diagnostics: []diagnostic{{
+			kind:  diagnosticDataRace,
+			tests: []testID{failed, passed},
+		}},
+		process: processResult{state: processExited, exitCode: 1},
+	}
+
+	require.Equal(t, retryRepeatScope, (retryPolicy{targetedThreshold: 20}).plan(result).mode)
+}

--- a/tools/testrunner/testrunner.go
+++ b/tools/testrunner/testrunner.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -457,35 +456,4 @@ func (r *runner) runTests(ctx context.Context, args []string) {
 		log.Printf("exiting with failure: total timeout (%s) reached", r.totalTimeout)
 		os.Exit(1)
 	}
-}
-
-func stripRunFromArgs(args []string) (argsNoRun []string) {
-	var skipNext bool
-	for _, arg := range args {
-		if skipNext {
-			skipNext = false
-			continue
-		} else if arg == "-run" {
-			skipNext = true
-			continue
-		} else if strings.HasPrefix(arg, "-run=") {
-			continue
-		}
-		argsNoRun = append(argsNoRun, arg)
-	}
-	return
-}
-
-func goTestNameToRunFlagRegexp(test string) string {
-	parts := strings.Split(test, "/")
-	var sb strings.Builder
-	for i, p := range parts {
-		if i > 0 {
-			sb.WriteByte('/')
-		}
-		sb.WriteByte('^')
-		sb.WriteString(regexp.QuoteMeta(p))
-		sb.WriteByte('$')
-	}
-	return sb.String()
 }


### PR DESCRIPTION
Moves retry selection, argument rewriting, and missing-rerun validation into a focused policy over canonical attempt results. The current runner still owns orchestration, so this PR changes the decision module without switching the reporting pipeline.

Stack: depends on #11515. Canonical JUnit rendering follows in #11517.
