### PR TITLE
Render JUnit from canonical attempt results

### DIFF
--- a/tools/common/junit/junit.go
+++ b/tools/common/junit/junit.go
@@ -24,6 +24,9 @@ type Testcase = junitxml.Testcase
 // Result is a JUnit test-case failure or error.
 type Result = junitxml.Result
 
+// Output is captured JUnit test output.
+type Output = junitxml.Output
+
 var errRead = errors.New("failed to read JUnit report file")
 
 // Read reads a JUnit XML file with either a testsuites or testsuite root.
@@ -93,6 +96,72 @@ func validateDocumentEnd(decoder *xml.Decoder) error {
 			return fmt.Errorf("unexpected trailing XML token %T", token)
 		}
 	}
+}
+
+// ValidateCounters verifies that suite and root counters describe the emitted
+// testcase tree exactly.
+func ValidateCounters(testsuites *Testsuites) error {
+	if testsuites == nil {
+		return errors.New("JUnit report is nil")
+	}
+
+	var rootTests, rootErrors, rootFailures, rootSkipped, rootDisabled int
+	for i := range testsuites.Suites {
+		suite := &testsuites.Suites[i]
+		tests := len(suite.Testcases)
+		var errorCount, failures, skipped int
+		for _, testcase := range suite.Testcases {
+			if testcase.Error != nil {
+				errorCount++
+			}
+			if testcase.Failure != nil {
+				failures++
+			}
+			if testcase.Skipped != nil {
+				skipped++
+			}
+		}
+		if err := validateCounter(fmt.Sprintf("suite %q tests", suite.Name), suite.Tests, tests); err != nil {
+			return err
+		}
+		if err := validateCounter(fmt.Sprintf("suite %q errors", suite.Name), suite.Errors, errorCount); err != nil {
+			return err
+		}
+		if err := validateCounter(fmt.Sprintf("suite %q failures", suite.Name), suite.Failures, failures); err != nil {
+			return err
+		}
+		if err := validateCounter(fmt.Sprintf("suite %q skipped", suite.Name), suite.Skipped, skipped); err != nil {
+			return err
+		}
+		rootTests += suite.Tests
+		rootErrors += suite.Errors
+		rootFailures += suite.Failures
+		rootSkipped += suite.Skipped
+		rootDisabled += suite.Disabled
+	}
+	for _, counter := range []struct {
+		name string
+		got  int
+		want int
+	}{
+		{"root tests", testsuites.Tests, rootTests},
+		{"root errors", testsuites.Errors, rootErrors},
+		{"root failures", testsuites.Failures, rootFailures},
+		{"root skipped", testsuites.Skipped, rootSkipped},
+		{"root disabled", testsuites.Disabled, rootDisabled},
+	} {
+		if err := validateCounter(counter.name, counter.got, counter.want); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateCounter(name string, got, want int) error {
+	if got != want {
+		return fmt.Errorf("%s counter is %d, want %d", name, got, want)
+	}
+	return nil
 }
 
 // Write atomically replaces a JUnit XML file.

--- a/tools/common/junit/junit_test.go
+++ b/tools/common/junit/junit_test.go
@@ -150,6 +150,37 @@ func TestWrite(t *testing.T) {
 `, string(content))
 }
 
+func TestValidateCounters(t *testing.T) {
+	report := &Testsuites{
+		Tests:    4,
+		Failures: 1,
+		Errors:   1,
+		Skipped:  1,
+		Disabled: 2,
+		Suites: []Testsuite{{
+			Name:     "suite",
+			Tests:    4,
+			Failures: 1,
+			Errors:   1,
+			Skipped:  1,
+			Disabled: 2,
+			Testcases: []Testcase{
+				{Name: "pass"},
+				{Name: "fail", Failure: &Result{}},
+				{Name: "error", Error: &Result{}},
+				{Name: "skip", Skipped: &Result{}},
+			},
+		}},
+	}
+	require.NoError(t, ValidateCounters(report))
+
+	report.Suites[0].Failures = 0
+	require.ErrorContains(t, ValidateCounters(report), `suite "suite" failures counter is 0, want 1`)
+	report.Suites[0].Failures = 1
+	report.Tests = 3
+	require.ErrorContains(t, ValidateCounters(report), "root tests counter is 3, want 4")
+}
+
 func TestWriteAtomicallyReplacesExistingTarget(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "junit.xml")

--- a/tools/optimize-test-sharding/main_test.go
+++ b/tools/optimize-test-sharding/main_test.go
@@ -1,0 +1,27 @@
+package optimizetestsharding
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/tools/common/junit"
+)
+
+func TestProcessJUnitReportReadsRenderedTestcaseShape(t *testing.T) {
+	suite := junit.Testsuite{Name: "example.com/tests", Time: "1.250000"}
+	suite.AddTestcase(junit.Testcase{
+		Name: "TestSuite/TestCase (retry 1) (final)",
+		Time: "1.250000",
+	})
+	report := &junit.Testsuites{Time: "1.250000"}
+	report.AddSuite(suite)
+	path := filepath.Join(t.TempDir(), "junit.xml")
+	require.NoError(t, junit.Write(path, report))
+
+	times := make(map[string][]float64)
+	require.NoError(t, processJUnitReport(path, times))
+	require.Equal(t, map[string][]float64{
+		"TestSuite/TestCase": {1.25},
+	}, times)
+}

--- a/tools/testrunner/attempt_integration_test.go
+++ b/tools/testrunner/attempt_integration_test.go
@@ -2,9 +2,11 @@ package testrunner
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/tools/common/junit"
 )
 
 func TestRunAttemptConsumesRealGoTestJSON(t *testing.T) {
@@ -23,6 +25,17 @@ func TestRunAttemptConsumesRealGoTestJSON(t *testing.T) {
 		packageName: "go.temporal.io/server/tools/testrunner/testdata/gotestfixture/passfail",
 		testName:    "TestFail",
 	}}, result.failedLeafTests())
+
+	report := renderJUnit([]attemptResult{result})
+	require.NoError(t, junit.ValidateCounters(&report))
+	path := filepath.Join(t.TempDir(), "junit.xml")
+	require.NoError(t, junit.Write(path, &report))
+	persisted, err := junit.Read(path)
+	require.NoError(t, err)
+	summary := newSummaryFromReports(persisted)
+	require.Len(t, summary.Rows, 1)
+	require.Equal(t, "TestFail", summary.Rows[0].Name)
+	require.NotEmpty(t, summary.Rows[0].Details)
 }
 
 func TestRunAttemptConsumesRealGoBuildFailureJSON(t *testing.T) {
@@ -35,6 +48,10 @@ func TestRunAttemptConsumesRealGoBuildFailureJSON(t *testing.T) {
 	require.True(t, result.builds[0].failed)
 	require.Contains(t, result.builds[0].output, "undefinedFixtureSymbol")
 	require.False(t, result.canTargetFailures())
+
+	report := renderJUnit([]attemptResult{result})
+	require.NoError(t, junit.ValidateCounters(&report))
+	require.NotZero(t, report.Errors)
 }
 
 func TestRunAttemptAttributesCleanupFailureFromRealGoTestJSON(t *testing.T) {
@@ -52,4 +69,11 @@ func TestRunAttemptAttributesCleanupFailureFromRealGoTestJSON(t *testing.T) {
 	}}, result.failedLeafTests())
 	require.Empty(t, result.abortedPackages())
 	require.True(t, result.canTargetFailures())
+
+	report := renderJUnit([]attemptResult{result})
+	require.NoError(t, junit.ValidateCounters(&report))
+	require.Equal(t, 1, report.Failures)
+	testcase := findJUnitTestcase(t, report, "TestCleanupFailure/Child")
+	require.NotNil(t, testcase.Failure)
+	require.Contains(t, testcase.Failure.Data, "fixture cleanup failure")
 }

--- a/tools/testrunner/attempt_result.go
+++ b/tools/testrunner/attempt_result.go
@@ -148,6 +148,15 @@ func (p packageResult) hasAttributableFailureDescendant(parent testExecution) bo
 	})
 }
 
+func (p packageResult) hasExecutionDescendant(parent testExecution) bool {
+	prefix := parent.id.testName + "/"
+	return slices.ContainsFunc(p.executions, func(execution testExecution) bool {
+		return execution.id.packageName == parent.id.packageName &&
+			execution.occurrence == parent.occurrence &&
+			strings.HasPrefix(execution.id.testName, prefix)
+	})
+}
+
 func compareTestID(a, b testID) int {
 	if byPackage := strings.Compare(a.packageName, b.packageName); byPackage != 0 {
 		return byPackage

--- a/tools/testrunner/junit.go
+++ b/tools/testrunner/junit.go
@@ -10,8 +10,7 @@ import (
 	"go.temporal.io/server/tools/common/junit"
 )
 
-// alertsSuiteName is the JUnit suite name used for structural alerts (data
-// races, panics, fatal errors).
+const testrunnerSuiteName = "testrunner"
 const alertsSuiteName = "ALERTS"
 
 const junitAlertDetailsMaxBytes = 64 * 1024
@@ -21,6 +20,7 @@ type failureType string
 const (
 	// failureTypeFailed marks a failed assertion.
 	failureTypeFailed   failureType = "Failed"
+	failureTypeAborted  failureType = "ABORTED"
 	failureTypeTimeout  failureType = "TIMEOUT"
 	failureTypeCrash    failureType = "CRASH"
 	failureTypeDataRace failureType = "DATA RACE"

--- a/tools/testrunner/legacy_diagnostics.go
+++ b/tools/testrunner/legacy_diagnostics.go
@@ -76,18 +76,3 @@ func parseFailureDetails(data string) string {
 	}
 	return evidence.details
 }
-
-func failureTypeForDiagnostic(kind diagnosticKind) failureType {
-	switch kind {
-	case diagnosticDataRace:
-		return failureTypeDataRace
-	case diagnosticPanic:
-		return failureTypePanic
-	case diagnosticFatal:
-		return failureTypeFatal
-	case diagnosticTimeout:
-		return failureTypeTimeout
-	default:
-		return failureTypeFailed
-	}
-}

--- a/tools/testrunner/render_junit.go
+++ b/tools/testrunner/render_junit.go
@@ -1,0 +1,446 @@
+package testrunner
+
+import (
+	"encoding/xml"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"go.temporal.io/server/tools/common/junit"
+)
+
+type junitRenderer struct {
+	history []attemptResult
+	report  junit.Testsuites
+}
+
+func renderJUnit(results []attemptResult) junit.Testsuites {
+	renderer := junitRenderer{
+		history: results,
+		report:  junit.Testsuites{XMLName: xml.Name{Local: "testsuites"}},
+	}
+	for attemptIndex := range results {
+		renderer.renderAttempt(attemptIndex)
+	}
+	var duration time.Duration
+	for _, result := range results {
+		duration += result.process.duration
+	}
+	renderer.report.Time = formatDuration(duration)
+	return renderer.report
+}
+
+func (r *junitRenderer) renderAttempt(attemptIndex int) {
+	result := r.history[attemptIndex]
+	suffix := attemptSuffix(attemptIndex, len(r.history))
+	runtimeFailures := make(map[string]struct{})
+	for _, pkg := range result.runtimeFailures() {
+		runtimeFailures[pkg.name] = struct{}{}
+	}
+	packages := slices.Clone(result.packages)
+	slices.SortFunc(packages, func(a, b packageResult) int { return strings.Compare(a.name, b.name) })
+	for _, pkg := range packages {
+		if suite, ok := r.renderPackage(attemptIndex, pkg, suffix, runtimeFailures); ok {
+			r.report.AddSuite(suite)
+		}
+	}
+	builds := slices.Clone(result.builds)
+	slices.SortFunc(builds, func(a, b buildResult) int { return strings.Compare(a.importPath, b.importPath) })
+	for _, build := range builds {
+		if build.failed || strings.TrimSpace(build.output) != "" {
+			r.report.AddSuite(renderBuildSuite(build, suffix, len(r.report.Suites)))
+		}
+	}
+	r.renderSyntheticFailures(result, suffix)
+}
+
+func (r *junitRenderer) renderPackage(
+	attemptIndex int,
+	pkg packageResult,
+	suffix string,
+	runtimeFailures map[string]struct{},
+) (junit.Testsuite, bool) {
+	suite := junit.Testsuite{
+		Name: pkg.name + suffix,
+		ID:   len(r.report.Suites),
+		Time: formatDuration(pkg.duration),
+	}
+	if !pkg.startedAt.IsZero() {
+		suite.Timestamp = pkg.startedAt.Format(time.RFC3339Nano)
+	}
+	if pkg.coverage != nil {
+		suite.AddProperty("coverage.statements.pct", fmt.Sprintf("%.2f", *pkg.coverage))
+	}
+
+	executions := slices.Clone(pkg.executions)
+	slices.SortFunc(executions, func(a, b testExecution) int {
+		if byName := strings.Compare(a.id.testName, b.id.testName); byName != 0 {
+			return byName
+		}
+		return a.occurrence - b.occurrence
+	})
+	var retainedParentOutput strings.Builder
+	for _, execution := range executions {
+		if testcase, parentOutput, ok := r.renderExecution(attemptIndex, pkg, execution, suffix); ok {
+			suite.AddTestcase(testcase)
+		} else if parentOutput != "" {
+			fmt.Fprintf(&retainedParentOutput, "[%s]\n%s\n", execution.id.testName, parentOutput)
+		}
+	}
+	if _, ok := runtimeFailures[pkg.name]; ok {
+		runtimeDetails := strings.TrimSpace(strings.Join([]string{
+			cleanPackageOutput(pkg.output),
+			r.history[attemptIndex].process.stderr,
+		}, "\n"))
+		suite.AddTestcase(junit.Testcase{
+			Name:      pkg.name + " [runtime failure]" + suffix,
+			Classname: pkg.name,
+			Time:      formatDuration(0),
+			Error: &junit.Result{
+				Message: "Package runtime error",
+				Type:    "ERROR",
+				Data:    sanitizeXML(truncateAlertDetails(runtimeDetails)),
+			},
+		})
+	}
+	packageOutput := strings.TrimSpace(cleanPackageOutput(pkg.output))
+	parentOutput := strings.TrimSpace(retainedParentOutput.String())
+	if packageOutput != "" || parentOutput != "" {
+		data := strings.TrimSpace(strings.Join([]string{packageOutput, parentOutput}, "\n"))
+		suite.SystemOut = &junit.Output{Data: sanitizeXML(data)}
+	}
+	return suite, len(suite.Testcases) > 0 || suite.SystemOut != nil || suite.Properties != nil
+}
+
+func (r *junitRenderer) renderExecution(
+	attemptIndex int,
+	pkg packageResult,
+	execution testExecution,
+	suffix string,
+) (junit.Testcase, string, bool) {
+	if execution.outcome == testIncomplete && !pkg.isFailedLeaf(execution) {
+		return junit.Testcase{}, "", false
+	}
+	hasDescendant := pkg.hasExecutionDescendant(execution)
+	if (execution.outcome == testPassed || execution.outcome == testSkipped) && hasDescendant {
+		return junit.Testcase{}, "", false
+	}
+	cleanedOutput := strings.TrimSpace(cleanTestOutput(execution.output))
+	if execution.outcome == testFailed && !pkg.isFailedLeaf(execution) {
+		return junit.Testcase{}, cleanedOutput, false
+	}
+	if execution.outcome == testFailed && r.isStructuralParent(execution.id) && !execution.failure.actionable &&
+		r.hasLaterTerminal(attemptIndex, execution.id) {
+		return junit.Testcase{}, cleanedOutput, false
+	}
+
+	testcase := junit.Testcase{
+		Name:      execution.id.testName + suffix,
+		Classname: execution.id.packageName,
+		Time:      formatDuration(execution.duration),
+	}
+	switch execution.outcome {
+	case testFailed, testIncomplete:
+		details := execution.failure.details
+		if details == "" {
+			details = cleanedOutput
+		}
+		if details == "" {
+			details = "test failed without attributable diagnostic output; no failed descendant supplied the cause"
+		}
+		testcase.Failure = generateFailure(failureTypeFailed, sanitizeXML(truncateAlertDetails(details)))
+	case testSkipped:
+		testcase.Skipped = &junit.Result{Message: "Skipped"}
+	default:
+	}
+	return testcase, "", true
+}
+
+func (r *junitRenderer) isStructuralParent(id testID) bool {
+	prefix := id.testName + "/"
+	for _, result := range r.history {
+		for _, pkg := range result.packages {
+			if pkg.name != id.packageName {
+				continue
+			}
+			if slices.ContainsFunc(pkg.executions, func(execution testExecution) bool {
+				return strings.HasPrefix(execution.id.testName, prefix)
+			}) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (r *junitRenderer) hasLaterTerminal(attemptIndex int, id testID) bool {
+	for _, result := range r.history[attemptIndex+1:] {
+		for _, pkg := range result.packages {
+			if slices.ContainsFunc(pkg.executions, func(execution testExecution) bool {
+				return execution.id == id && execution.outcome != testIncomplete
+			}) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func renderBuildSuite(build buildResult, suffix string, id int) junit.Testsuite {
+	suite := junit.Testsuite{Name: build.importPath + suffix, ID: id, Time: formatDuration(0)}
+	details := sanitizeXML(strings.TrimSpace(cleanPackageOutput(build.output)))
+	if build.failed {
+		suite.AddTestcase(junit.Testcase{
+			Name:      "[build failed]" + suffix,
+			Classname: build.importPath,
+			Time:      formatDuration(0),
+			Error: &junit.Result{
+				Message: "Build error",
+				Type:    "ERROR",
+				Data:    details,
+			},
+		})
+	} else {
+		suite.SystemOut = &junit.Output{Data: details}
+	}
+	return suite
+}
+
+func (r *junitRenderer) renderSyntheticFailures(result attemptResult, suffix string) {
+	var cases []junit.Testcase
+	if result.process.state != processDeadlineExceeded {
+		for _, pkg := range result.abortedPackages() {
+			cases = append(cases, junit.Testcase{
+				Name:    "testrunner.PackageAborted: " + pkg.name + suffix,
+				Time:    formatDuration(0),
+				Failure: generateFailure(failureTypeAborted, packageAbortDetails(result, pkg)),
+			})
+		}
+	}
+	for _, diagnostic := range result.diagnostics {
+		diagnostic.tests = slices.Clone(diagnostic.tests)
+		slices.SortFunc(diagnostic.tests, compareTestID)
+		kind := failureTypeForDiagnostic(diagnostic.kind)
+		details := diagnosticFailureDetails(diagnostic)
+		if diagnostic.kind == diagnosticTimeout && len(diagnostic.tests) > 0 {
+			for _, id := range diagnostic.tests {
+				cases = append(cases, junit.Testcase{
+					Name:      id.testName + " (timed out)" + suffix,
+					Classname: id.packageName,
+					Time:      formatDuration(0),
+					Failure:   generateFailure(kind, details),
+				})
+			}
+			continue
+		}
+		name := fmt.Sprintf("%s: %s", kind, diagnostic.summary)
+		if len(diagnostic.tests) > 0 {
+			name += " — in " + diagnostic.tests[0].testName
+		}
+		cases = append(cases, junit.Testcase{
+			Name:    name + suffix,
+			Time:    formatDuration(0),
+			Failure: generateFailure(kind, details),
+		})
+	}
+	if result.process.state == processDeadlineExceeded {
+		cases = append(cases, junit.Testcase{
+			Name:    "testrunner.TotalTimeout" + suffix,
+			Time:    formatDuration(0),
+			Failure: generateFailure(failureTypeTimeout, totalTimeoutDetails(result)),
+		})
+	} else if result.unexplainedProcessFailure() {
+		details := strings.TrimSpace(strings.Join([]string{
+			result.process.details,
+			result.process.stderr,
+			result.unstructuredOutput,
+		}, "\n"))
+		cases = append(cases, junit.Testcase{
+			Name:    "testrunner.ExecutionError" + suffix,
+			Time:    formatDuration(0),
+			Failure: generateFailure(failureTypeCrash, sanitizeXML(truncateAlertDetails(details))),
+		})
+	}
+	if len(cases) == 0 {
+		return
+	}
+	slices.SortFunc(cases, func(a, b junit.Testcase) int { return strings.Compare(a.Name, b.Name) })
+	suite := junit.Testsuite{Name: testrunnerSuiteName + suffix, ID: len(r.report.Suites), Time: formatDuration(0)}
+	for _, testcase := range cases {
+		suite.AddTestcase(testcase)
+	}
+	r.report.AddSuite(suite)
+}
+
+func diagnosticFailureDetails(diagnostic diagnostic) string {
+	var payload strings.Builder
+	diagnosticDetails := strings.TrimSpace(diagnostic.details)
+	if diagnostic.kind == diagnosticTimeout && diagnostic.summary != "" {
+		payload.WriteString(diagnostic.summary)
+		if diagnosticDetails != "" {
+			payload.WriteByte('\n')
+		}
+	}
+	payload.WriteString(diagnosticDetails)
+
+	var details strings.Builder
+	details.WriteString(truncateAlertDetails(payload.String()))
+	if len(diagnostic.tests) > 0 {
+		if details.Len() > 0 {
+			details.WriteString("\n\n")
+		}
+		details.WriteString("Detected in tests:")
+		for _, id := range diagnostic.tests {
+			fmt.Fprintf(&details, "\n\t%s.%s", id.packageName, id.testName)
+		}
+	}
+	return sanitizeXML(details.String())
+}
+
+func failureTypeForDiagnostic(kind diagnosticKind) failureType {
+	switch kind {
+	case diagnosticDataRace:
+		return failureTypeDataRace
+	case diagnosticPanic:
+		return failureTypePanic
+	case diagnosticFatal:
+		return failureTypeFatal
+	case diagnosticTimeout:
+		return failureTypeTimeout
+	default:
+		return failureTypeFailed
+	}
+}
+
+// packageAbortDetails summarizes a package that exited before its incomplete
+// tests produced terminal results.
+func packageAbortDetails(result attemptResult, pkg packageResult) string {
+	incomplete := pkg.meaningfulIncompleteExecutions()
+	testNodes := "test nodes"
+	if len(incomplete) == 1 {
+		testNodes = "test node"
+	}
+	var details strings.Builder
+	fmt.Fprintf(
+		&details,
+		"package %s aborted; %d %s had no final result, and others may not have started",
+		pkg.name,
+		len(incomplete),
+		testNodes,
+	)
+	details.WriteString("\n\nTests without final results:")
+	for _, execution := range incomplete {
+		fmt.Fprintf(&details, "\n- %s", execution.id.testName)
+		if execution.failure.details != "" {
+			details.WriteString("\n  Details:\n    ")
+			details.WriteString(strings.ReplaceAll(execution.failure.details, "\n", "\n    "))
+		}
+	}
+	for _, diagnostic := range result.diagnostics {
+		if diagnostic.packageName != pkg.name && !slices.ContainsFunc(diagnostic.tests, func(id testID) bool {
+			return id.packageName == pkg.name
+		}) {
+			continue
+		}
+		diagnosticDetails := diagnosticContextSummary(diagnostic)
+		if diagnosticDetails == "" || strings.Contains(details.String(), diagnosticDetails) {
+			continue
+		}
+		details.WriteString("\n\nDiagnostic context:\n")
+		details.WriteString(diagnosticDetails)
+	}
+	if (result.process.state != processExited || result.process.exitCode != 0) && result.process.details != "" {
+		details.WriteString("\n\nProcess termination:\n")
+		details.WriteString(strings.TrimSpace(result.process.details))
+	}
+	if processStderr := strings.TrimSpace(result.process.stderr); processStderr != "" {
+		details.WriteString("\n\nProcess stderr:\n")
+		details.WriteString(processStderr)
+	}
+	return sanitizeXML(truncateAlertDetails(details.String()))
+}
+
+func totalTimeoutDetails(result attemptResult) string {
+	details := []string{strings.TrimSpace(result.process.details)}
+	for _, pkg := range result.packages {
+		if len(pkg.meaningfulIncompleteExecutions()) > 0 {
+			details = append(details, packageAbortDetails(result, pkg))
+		}
+	}
+	return sanitizeXML(truncateAlertDetails(strings.TrimSpace(strings.Join(details, "\n\n"))))
+}
+
+func diagnosticContextSummary(diagnostic diagnostic) string {
+	for line := range strings.Lines(diagnostic.details) {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "panic:") ||
+			strings.HasPrefix(line, "fatal error:") ||
+			strings.HasPrefix(line, "WARNING: DATA RACE") {
+			return line
+		}
+	}
+	return strings.TrimSpace(diagnostic.summary)
+}
+
+func cleanTestOutput(output string) string {
+	var lines []string
+	for line := range strings.Lines(output) {
+		line = strings.TrimSuffix(line, "\n")
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "=== RUN   ") ||
+			strings.HasPrefix(trimmed, "=== PAUSE ") ||
+			strings.HasPrefix(trimmed, "=== CONT  ") ||
+			strings.HasPrefix(trimmed, "=== NAME  ") ||
+			strings.HasPrefix(trimmed, "--- PASS: ") ||
+			strings.HasPrefix(trimmed, "--- FAIL: ") ||
+			strings.HasPrefix(trimmed, "--- SKIP: ") {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func cleanPackageOutput(output string) string {
+	var lines []string
+	for line := range strings.Lines(output) {
+		line = strings.TrimSuffix(line, "\n")
+		if line == "FAIL" || line == "PASS" ||
+			strings.HasPrefix(line, "FAIL\t") ||
+			strings.HasPrefix(line, "ok  \t") ||
+			strings.HasPrefix(line, "?   \t") ||
+			coverageLine.MatchString(strings.TrimSpace(line)) {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func attemptSuffix(attemptIndex, attempts int) string {
+	if attemptIndex == 0 {
+		return ""
+	}
+	suffix := fmt.Sprintf(" (retry %d)", attemptIndex)
+	if attemptIndex == attempts-1 {
+		suffix += " (final)"
+	}
+	return suffix
+}
+
+func formatDuration(duration time.Duration) string {
+	return fmt.Sprintf("%.6f", duration.Seconds())
+}
+
+func renderCrashJUnit(name string) junit.Testsuites {
+	suite := junit.Testsuite{Name: "suite", Time: formatDuration(0)}
+	suite.AddTestcase(junit.Testcase{
+		Name:    name + " (crash)",
+		Time:    formatDuration(0),
+		Failure: generateFailure(failureTypeCrash, ""),
+	})
+	report := junit.Testsuites{XMLName: xml.Name{Local: "testsuites"}, Time: formatDuration(0)}
+	report.AddSuite(suite)
+	return report
+}

--- a/tools/testrunner/render_junit_test.go
+++ b/tools/testrunner/render_junit_test.go
@@ -1,0 +1,375 @@
+package testrunner
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/tools/common/junit"
+)
+
+func TestRenderJUnitSuppressesResolvedNoDetailParents(t *testing.T) {
+	id := func(name string) testID { return testID{"example.com/tests", name} }
+	first := attemptResult{
+		packages: []packageResult{{
+			name:    "example.com/tests",
+			outcome: packageFailed,
+			executions: []testExecution{
+				{id: id("TestEmptyParent"), outcome: testFailed},
+				{id: id("TestEmptyParent/Child"), outcome: testPassed},
+				{id: id("TestNoisyParent"), outcome: testFailed, output: "network dial warning\n"},
+				{id: id("TestNoisyParent/Child"), outcome: testPassed},
+				{id: id("TestCleanupParent"), outcome: testFailed, failure: failureEvidence{details: "Error Trace:\tparent_test.go:20\nError:\tcleanup failed", actionable: true}},
+				{id: id("TestCleanupParent/Child"), outcome: testPassed},
+			},
+		}},
+		process: processResult{state: processExited, exitCode: 1},
+	}
+	final := attemptResult{
+		packages: []packageResult{{
+			name:    "example.com/tests",
+			outcome: packageFailed,
+			executions: []testExecution{
+				{id: id("TestEmptyParent"), outcome: testPassed},
+				{id: id("TestEmptyParent/Child"), outcome: testPassed},
+				{id: id("TestNoisyParent"), outcome: testPassed},
+				{id: id("TestNoisyParent/Child"), outcome: testPassed},
+				{id: id("TestCleanupParent"), outcome: testPassed},
+				{id: id("TestCleanupParent/Child"), outcome: testPassed},
+				{id: id("TestFinalParent"), outcome: testFailed},
+				{id: id("TestFinalParent/Child"), outcome: testPassed},
+			},
+		}},
+		process: processResult{state: processExited, exitCode: 1},
+	}
+
+	report := renderJUnit([]attemptResult{first, final})
+	require.NoError(t, junit.ValidateCounters(&report))
+	names := collectJUnitTestNames(report.Suites)
+	require.NotContains(t, names, "TestEmptyParent")
+	require.NotContains(t, names, "TestNoisyParent")
+	require.Contains(t, names, "TestCleanupParent")
+	require.Contains(t, names, "TestFinalParent (retry 1) (final)")
+
+	finalFailure := findJUnitTestcase(t, report, "TestFinalParent (retry 1) (final)")
+	require.NotNil(t, finalFailure.Failure)
+	require.NotEmpty(t, finalFailure.Failure.Data)
+	summary := newSummaryFromReports(&report)
+	require.Len(t, summary.Rows, 2)
+	for _, row := range summary.Rows {
+		require.NotContains(t, row.Name, "TestEmptyParent")
+		require.NotContains(t, row.Name, "TestNoisyParent")
+		require.NotEmpty(t, row.Details)
+	}
+}
+
+func TestRenderJUnitSuppressesPropagatedParentUnlessActionable(t *testing.T) {
+	pkg := packageResult{
+		name:    "example.com/tests",
+		outcome: packageFailed,
+		executions: []testExecution{
+			{id: testID{"example.com/tests", "TestGeneric"}, outcome: testFailed, output: "ordinary parent log\n"},
+			{id: testID{"example.com/tests", "TestGeneric/Child"}, outcome: testFailed},
+			{id: testID{"example.com/tests", "TestActionable"}, outcome: testFailed, failure: failureEvidence{details: "Error Trace:\tparent_test.go:20", actionable: true}},
+			{id: testID{"example.com/tests", "TestActionable/Child"}, outcome: testFailed},
+		},
+	}
+	report := renderJUnit([]attemptResult{{
+		packages: []packageResult{pkg},
+		process:  processResult{state: processExited, exitCode: 1},
+	}})
+
+	require.NoError(t, junit.ValidateCounters(&report))
+	names := collectJUnitTestNames(report.Suites)
+	require.NotContains(t, names, "TestGeneric")
+	require.Contains(t, names, "TestGeneric/Child")
+	require.Contains(t, names, "TestActionable")
+	require.Contains(t, names, "TestActionable/Child")
+}
+
+func TestRenderJUnitRendersActionableIncompleteFailure(t *testing.T) {
+	report := renderJUnit([]attemptResult{{
+		packages: []packageResult{{
+			name:    "example.com/tests",
+			outcome: packageFailed,
+			executions: []testExecution{
+				{id: testID{"example.com/tests", "TestSuite"}, outcome: testFailed},
+				{
+					id:      testID{"example.com/tests", "TestSuite/TestCleanupFailure"},
+					outcome: testIncomplete,
+					failure: failureEvidence{details: "test exceeded timeout", actionable: true},
+				},
+				{id: testID{"example.com/tests", "TestSuite/TestCleanupFailure/Completed"}, outcome: testPassed},
+			},
+		}},
+		process: processResult{state: processExited, exitCode: 1},
+	}})
+
+	require.NoError(t, junit.ValidateCounters(&report))
+	require.Equal(t, []string{
+		"TestSuite/TestCleanupFailure",
+		"TestSuite/TestCleanupFailure/Completed",
+	}, collectJUnitTestNames(report.Suites))
+	testcase := findJUnitTestcase(t, report, "TestSuite/TestCleanupFailure")
+	require.NotNil(t, testcase.Failure)
+	require.Equal(t, "test exceeded timeout", testcase.Failure.Data)
+}
+
+func TestRenderJUnitBuildAbortDiagnosticAndCoverage(t *testing.T) {
+	coverage := 12.5
+	result := attemptResult{
+		packages: []packageResult{{
+			name:       "example.com/tests",
+			outcome:    packageFailed,
+			coverage:   &coverage,
+			executions: []testExecution{{id: testID{"example.com/tests", "TestIncomplete"}, outcome: testIncomplete}},
+		}},
+		builds: []buildResult{{importPath: "example.com/broken.test", failed: true, output: "compile failed"}},
+		diagnostics: []diagnostic{{
+			kind: diagnosticPanic, summary: "boom", details: "panic: boom",
+			tests: []testID{{"example.com/tests", "TestIncomplete"}},
+		}},
+		process: processResult{state: processExited, exitCode: 1},
+	}
+
+	report := renderJUnit([]attemptResult{result})
+	require.NoError(t, junit.ValidateCounters(&report))
+	require.Equal(t, 3, report.Tests)
+	require.Equal(t, 2, report.Failures)
+	require.Equal(t, 1, report.Errors)
+	requireJUnitTimesAreNumeric(t, report)
+}
+
+func TestRenderJUnitAbortIncludesDiagnosticAndProcessContext(t *testing.T) {
+	pkg := packageResult{
+		name:       "example.com/tests",
+		outcome:    packageIncomplete,
+		executions: []testExecution{{id: testID{"example.com/tests", "TestIncomplete"}, outcome: testIncomplete}},
+	}
+	result := attemptResult{
+		packages: []packageResult{pkg},
+		diagnostics: []diagnostic{{
+			kind:        diagnosticPanic,
+			summary:     "boom",
+			details:     "panic: boom",
+			packageName: pkg.name,
+		}},
+		process: processResult{
+			state:    processSignaled,
+			exitCode: 1,
+			details:  "killed",
+			stderr:   "process stderr",
+		},
+	}
+
+	report := renderJUnit([]attemptResult{result})
+	testcase := findJUnitTestcase(t, report, "testrunner.PackageAborted: example.com/tests")
+	require.NotNil(t, testcase.Failure)
+	require.Contains(t, testcase.Failure.Data, "panic: boom")
+	require.Contains(t, testcase.Failure.Data, "killed")
+	require.Contains(t, testcase.Failure.Data, "process stderr")
+
+	result.diagnostics = nil
+	result.process = processResult{state: processExited, exitCode: 1, details: "exit status 1"}
+	report = renderJUnit([]attemptResult{result})
+	testcase = findJUnitTestcase(t, report, "testrunner.PackageAborted: example.com/tests")
+	require.NotNil(t, testcase.Failure)
+	require.Contains(t, testcase.Failure.Data, "exit status 1")
+}
+
+func TestRenderJUnitTotalTimeoutIncludesIncompleteTests(t *testing.T) {
+	report := renderJUnit([]attemptResult{{
+		packages: []packageResult{{
+			name:    "example.com/tests",
+			outcome: packageIncomplete,
+			executions: []testExecution{
+				{id: testID{"example.com/tests", "TestHung"}, outcome: testIncomplete},
+				{id: testID{"example.com/tests", "TestAlsoHung"}, outcome: testIncomplete},
+			},
+		}},
+		process: processResult{state: processDeadlineExceeded, exitCode: 1, details: "context deadline exceeded"},
+	}})
+
+	testcase := findJUnitTestcase(t, report, "testrunner.TotalTimeout")
+	require.NotNil(t, testcase.Failure)
+	require.Contains(t, testcase.Failure.Data, "context deadline exceeded")
+	require.Contains(t, testcase.Failure.Data, "TestHung")
+	require.Contains(t, testcase.Failure.Data, "TestAlsoHung")
+	require.NotContains(t, collectJUnitTestNames(report.Suites), "testrunner.PackageAborted: example.com/tests")
+}
+
+func TestRenderJUnitBoundsFailurePayloads(t *testing.T) {
+	details := strings.Repeat("x", junitAlertDetailsMaxBytes+100)
+	tests := []struct {
+		name     string
+		result   attemptResult
+		caseName string
+	}{
+		{
+			name: "test failure",
+			result: attemptResult{
+				packages: []packageResult{{
+					name:       "example.com/tests",
+					outcome:    packageFailed,
+					executions: []testExecution{{id: testID{"example.com/tests", "TestFailed"}, outcome: testFailed, failure: failureEvidence{details: details}}},
+				}},
+				process: processResult{state: processExited, exitCode: 1},
+			},
+			caseName: "TestFailed",
+		},
+		{
+			name: "runtime failure",
+			result: attemptResult{
+				packages: []packageResult{{name: "example.com/runtime", outcome: packageFailed, output: details}},
+				process:  processResult{state: processExited, exitCode: 1},
+			},
+			caseName: "example.com/runtime [runtime failure]",
+		},
+		{
+			name:     "execution error",
+			result:   attemptResult{process: processResult{state: processExited, exitCode: 2, details: details}},
+			caseName: "testrunner.ExecutionError",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			testcase := findJUnitTestcase(t, renderJUnit([]attemptResult{test.result}), test.caseName)
+			if testcase.Failure != nil {
+				require.LessOrEqual(t, len(testcase.Failure.Data), junitAlertDetailsMaxBytes)
+				return
+			}
+			require.NotNil(t, testcase.Error)
+			require.LessOrEqual(t, len(testcase.Error.Data), junitAlertDetailsMaxBytes)
+		})
+	}
+}
+
+func TestRenderJUnitTimeoutDoesNotAlsoReportPackageAbort(t *testing.T) {
+	pkg := packageResult{
+		name:       "example.com/tests",
+		outcome:    packageFailed,
+		executions: []testExecution{{id: testID{"example.com/tests", "TestTimedOut"}, outcome: testIncomplete}},
+	}
+	report := renderJUnit([]attemptResult{{
+		packages: []packageResult{pkg},
+		diagnostics: []diagnostic{{
+			kind:        diagnosticTimeout,
+			summary:     "panic: test timed out after 5s",
+			details:     "abridged stacktrace",
+			packageName: pkg.name,
+			tests:       []testID{{pkg.name, "TestTimedOut"}},
+		}},
+		process: processResult{state: processExited, exitCode: 1},
+	}})
+
+	names := collectJUnitTestNames(report.Suites)
+	require.Contains(t, names, "TestTimedOut (timed out)")
+	require.NotContains(t, names, "testrunner.PackageAborted: example.com/tests")
+}
+
+func TestRenderJUnitIterationSuffixIsNotAParentRelationship(t *testing.T) {
+	result := attemptResult{
+		packages: []packageResult{{
+			name:    "example.com/tests",
+			outcome: packageFailed,
+			executions: []testExecution{
+				{id: testID{"example.com/tests", "TestRepeated"}, outcome: testFailed},
+				{id: testID{"example.com/tests", "TestRepeated#01"}, outcome: testFailed},
+			},
+		}},
+		process: processResult{state: processExited, exitCode: 1},
+	}
+
+	report := renderJUnit([]attemptResult{result})
+	require.NoError(t, junit.ValidateCounters(&report))
+	require.ElementsMatch(t, []string{"TestRepeated", "TestRepeated#01"}, collectJUnitTestNames(report.Suites))
+}
+
+func TestRenderJUnitPreservesSuccessfulBuildOutput(t *testing.T) {
+	report := renderJUnit([]attemptResult{{
+		builds:  []buildResult{{importPath: "example.com/generated", output: "generated warning\n"}},
+		process: processResult{state: processExited},
+	}})
+
+	require.NoError(t, junit.ValidateCounters(&report))
+	require.Len(t, report.Suites, 1)
+	require.Equal(t, "example.com/generated", report.Suites[0].Name)
+	require.Empty(t, report.Suites[0].Testcases)
+	require.NotNil(t, report.Suites[0].SystemOut)
+	require.Equal(t, "generated warning", report.Suites[0].SystemOut.Data)
+}
+
+func TestRenderJUnitIncludesStderrInRuntimeFailure(t *testing.T) {
+	report := renderJUnit([]attemptResult{{
+		packages: []packageResult{{name: "example.com/tests", outcome: packageFailed}},
+		process:  processResult{state: processExited, exitCode: 1, stderr: "runtime stderr\n"},
+	}})
+
+	testcase := findJUnitTestcase(t, report, "example.com/tests [runtime failure]")
+	require.NotNil(t, testcase.Error)
+	require.Contains(t, testcase.Error.Data, "runtime stderr")
+}
+
+func TestRenderJUnitKeepsEveryDiagnosticTestAssociation(t *testing.T) {
+	report := renderJUnit([]attemptResult{{
+		diagnostics: []diagnostic{{
+			kind:    diagnosticPanic,
+			summary: "boom",
+			details: "panic: boom",
+			tests: []testID{
+				{"example.com/one", "TestOne"},
+				{"example.com/two", "TestTwo"},
+			},
+		}},
+		process: processResult{state: processExited, exitCode: 1},
+	}})
+
+	testcase := findJUnitTestcase(t, report, "PANIC: boom — in TestOne")
+	require.NotNil(t, testcase.Failure)
+	require.Contains(t, testcase.Failure.Data, "example.com/one.TestOne")
+	require.Contains(t, testcase.Failure.Data, "example.com/two.TestTwo")
+}
+
+func TestRenderCrashJUnitUsesNumericTimes(t *testing.T) {
+	report := renderCrashJUnit("unit-test")
+	require.NoError(t, junit.ValidateCounters(&report))
+	requireJUnitTimesAreNumeric(t, report)
+}
+
+func collectJUnitTestNames(suites []junit.Testsuite) []string {
+	var names []string
+	for _, suite := range suites {
+		for _, testcase := range suite.Testcases {
+			names = append(names, testcase.Name)
+		}
+	}
+	return names
+}
+
+func findJUnitTestcase(t *testing.T, report junit.Testsuites, name string) junit.Testcase {
+	t.Helper()
+	for _, suite := range report.Suites {
+		for _, testcase := range suite.Testcases {
+			if testcase.Name == name {
+				return testcase
+			}
+		}
+	}
+	require.FailNowf(t, "testcase not found", "no testcase named %q, have %v", name, collectJUnitTestNames(report.Suites))
+	return junit.Testcase{}
+}
+
+func requireJUnitTimesAreNumeric(t *testing.T, report junit.Testsuites) {
+	t.Helper()
+	_, err := strconv.ParseFloat(report.Time, 64)
+	require.NoError(t, err)
+	for _, suite := range report.Suites {
+		_, err := strconv.ParseFloat(suite.Time, 64)
+		require.NoError(t, err)
+		for _, testcase := range suite.Testcases {
+			_, err := strconv.ParseFloat(testcase.Time, 64)
+			require.NoError(t, err)
+		}
+	}
+}

--- a/tools/testrunner/timeout_test.go
+++ b/tools/testrunner/timeout_test.go
@@ -5,21 +5,34 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/tools/common/junit"
 )
 
-func TestParseTestTimeouts(t *testing.T) {
-	logInput, err := os.ReadFile("testdata/timeout-input.log")
+func TestExtractTimeoutDiagnostic(t *testing.T) {
+	input, err := os.ReadFile("testdata/timeout-input.log")
 	require.NoError(t, err)
-	logOutput, err := os.ReadFile("testdata/timeout-output.log")
+	expected, err := os.ReadFile("testdata/timeout-output.log")
 	require.NoError(t, err)
 
-	stacktrace, tests := parseTestTimeouts(string(logInput))
-	require.Equal(t, []string{
-		"TestActivityApiResetClientTestSuite",
-		"TestNDCFuncTestSuite",
-		"TestActivityApiStateReplicationSuite",
-	}, tests)
-	require.Equal(t, string(logOutput), stacktrace)
+	timeout := extractTimeoutDiagnostic(outputScope{packageName: "example.com/tests"}, string(input))
+	require.NotNil(t, timeout)
+	require.Equal(t, diagnosticTimeout, timeout.kind)
+	require.Equal(t, string(expected), timeout.details)
+	require.Equal(t, []testID{
+		{"example.com/tests", "TestActivityApiResetClientTestSuite"},
+		{"example.com/tests", "TestNDCFuncTestSuite"},
+		{"example.com/tests", "TestActivityApiStateReplicationSuite"},
+	}, timeout.tests)
+
+	report := renderJUnit([]attemptResult{{
+		diagnostics: []diagnostic{*timeout},
+		process:     processResult{state: processExited, exitCode: 1},
+	}})
+	require.NoError(t, junit.ValidateCounters(&report))
+	testcase := findJUnitTestcase(t, report, "TestActivityApiResetClientTestSuite (timed out)")
+	require.NotNil(t, testcase.Failure)
+	require.Contains(t, testcase.Failure.Data, "panic: test timed out after 5s")
+	require.Contains(t, testcase.Failure.Data, "abridged stacktrace:")
 }
 
 func TestParseTestTimeoutsTruncatedAfterPanic(t *testing.T) {


### PR DESCRIPTION
Adds the pure canonical attempt-history renderer, including parent-failure suppression, diagnostics, timeouts, aborts, build errors, retry suffixes, crash reports, exact counters, and numeric durations. Integration coverage verifies the persisted JUnit shape and the downstream sharding consumer.

Stack: depends on #11516. The production cutover follows in #11518.
