### PR TITLE
Populate CallbackInfo Outcome and BlockedReason fields

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -17,7 +17,6 @@ import (
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/activity/gen/activitypb/v1"
 	"go.temporal.io/server/chasm/lib/callback"
-	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/contextutil"
 	"go.temporal.io/server/common/metrics"
@@ -331,9 +330,9 @@ func (a *Activity) addCompletionCallbacks(
 			return err
 		}
 
-		// requestID (unique per API call) + idx (position within the request) ensures unique,idempotent callback IDs.
+		// requestID (unique per API call) + idx (position within the request) ensures unique, idempotent callback IDs.
 		id := fmt.Sprintf("%s-%d", requestID, idx)
-		callbackObj := callback.NewCallback(requestID, registrationTime, &callbackspb.CallbackState{}, chasmCB)
+		callbackObj := callback.NewCallback(requestID, registrationTime, chasmCB)
 		a.Callbacks[id] = chasm.NewComponentField(ctx, callbackObj)
 	}
 	return nil

--- a/chasm/lib/activity/responses.go
+++ b/chasm/lib/activity/responses.go
@@ -4,15 +4,12 @@ import (
 	"fmt"
 
 	apiactivitypb "go.temporal.io/api/activity/v1" //nolint:importas
-	callbackpb "go.temporal.io/api/callback/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
-	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/activity/gen/activitypb/v1"
-	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -205,42 +202,16 @@ func (a *Activity) buildCallbackInfos(ctx chasm.Context) ([]*apiactivitypb.Callb
 	for _, field := range a.Callbacks {
 		cb := field.Get(ctx)
 
-		cbSpec, err := cb.ToAPICallback()
+		cbInfo, err := cb.ToAPICallbackInfo(ctx)
 		if err != nil {
 			return nil, err
-		}
-
-		var state enumspb.CallbackState
-		switch cb.Status {
-		case callbackspb.CALLBACK_STATUS_UNSPECIFIED:
-			return nil, serviceerror.NewInternal("callback with UNSPECIFIED state")
-		case callbackspb.CALLBACK_STATUS_STANDBY:
-			state = enumspb.CALLBACK_STATE_STANDBY
-		case callbackspb.CALLBACK_STATUS_SCHEDULED:
-			state = enumspb.CALLBACK_STATE_SCHEDULED
-		case callbackspb.CALLBACK_STATUS_BACKING_OFF:
-			state = enumspb.CALLBACK_STATE_BACKING_OFF
-		case callbackspb.CALLBACK_STATUS_FAILED:
-			state = enumspb.CALLBACK_STATE_FAILED
-		case callbackspb.CALLBACK_STATUS_SUCCEEDED:
-			state = enumspb.CALLBACK_STATE_SUCCEEDED
-		default:
-			return nil, serviceerror.NewInternalf("unknown callback state: %v", cb.Status)
 		}
 
 		cbInfos = append(cbInfos, &apiactivitypb.CallbackInfo{
 			Trigger: &apiactivitypb.CallbackInfo_Trigger{
 				Variant: &apiactivitypb.CallbackInfo_Trigger_ActivityClosed{},
 			},
-			Info: &callbackpb.CallbackInfo{
-				Callback:                cbSpec,
-				RegistrationTime:        cb.RegistrationTime,
-				State:                   state,
-				Attempt:                 cb.Attempt,
-				LastAttemptCompleteTime: cb.LastAttemptCompleteTime,
-				LastAttemptFailure:      cb.LastAttemptFailure,
-				NextAttemptScheduleTime: cb.NextAttemptScheduleTime,
-			},
+			Info: cbInfo,
 		})
 	}
 	return cbInfos, nil

--- a/chasm/lib/callback/component.go
+++ b/chasm/lib/callback/component.go
@@ -5,7 +5,9 @@ import (
 	"maps"
 	"time"
 
+	callbackpb "go.temporal.io/api/callback/v1"
 	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/chasm"
 	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
@@ -37,7 +39,6 @@ type Callback struct {
 func NewCallback(
 	requestID string,
 	registrationTime *timestamppb.Timestamp,
-	state *callbackspb.CallbackState,
 	cb *callbackspb.Callback,
 ) *Callback {
 	return &Callback{
@@ -87,6 +88,7 @@ func (c *Callback) loadInvocationArgs(
 		)
 	}
 
+	// Get the parent CHASM object's Nexus result to be delivered.
 	target := c.CompletionSource.Get(ctx)
 	completion, err := target.GetNexusCompletion(ctx, c.RequestId)
 	if err != nil {
@@ -174,6 +176,74 @@ func (c *Callback) ToAPICallback() (*commonpb.Callback, error) {
 	default:
 		return nil, serviceerror.NewInternalf("unsupported CHASM callback type: %T", variant)
 	}
+}
+
+// APIState converts the CHASM callback status to the API CallbackState enum along with the relevant
+// circuit breaker's blocking status.
+func (c *Callback) APIState(ctx chasm.Context) (enumspb.CallbackState, string, error) {
+	state, err := c.apiStatus()
+	if err != nil {
+		return enumspb.CALLBACK_STATE_UNSPECIFIED, "", err
+	}
+
+	// The circuit breaker is only relevant for scheduled callbacks.
+	if state != enumspb.CALLBACK_STATE_SCHEDULED {
+		return state, "", nil
+	}
+
+	cbCtx := callbackContextFromChasm(ctx)
+	destination, err := callbackDestination(c.GetCallback())
+	if err != nil {
+		return enumspb.CALLBACK_STATE_UNSPECIFIED, "", err
+	}
+	if !cbCtx.destinationBlocked(ctx.ExecutionKey().NamespaceID, destination) {
+		return state, "", nil
+	}
+	return enumspb.CALLBACK_STATE_BLOCKED, "The circuit breaker is open.", nil
+}
+
+func (c *Callback) apiStatus() (enumspb.CallbackState, error) {
+	switch c.Status {
+	case callbackspb.CALLBACK_STATUS_STANDBY:
+		return enumspb.CALLBACK_STATE_STANDBY, nil
+	case callbackspb.CALLBACK_STATUS_SCHEDULED:
+		return enumspb.CALLBACK_STATE_SCHEDULED, nil
+	case callbackspb.CALLBACK_STATUS_BACKING_OFF:
+		return enumspb.CALLBACK_STATE_BACKING_OFF, nil
+	case callbackspb.CALLBACK_STATUS_FAILED:
+		return enumspb.CALLBACK_STATE_FAILED, nil
+	case callbackspb.CALLBACK_STATUS_SUCCEEDED:
+		return enumspb.CALLBACK_STATE_SUCCEEDED, nil
+	case callbackspb.CALLBACK_STATUS_UNSPECIFIED:
+		return enumspb.CALLBACK_STATE_UNSPECIFIED, serviceerror.NewInternal("callback with UNSPECIFIED state")
+	default:
+		return enumspb.CALLBACK_STATE_UNSPECIFIED, serviceerror.NewInternalf("unknown callback state: %v", c.Status)
+	}
+}
+
+// ToAPICallbackInfo returns the API CallbackInfo based on the current state of the CHASM component.
+func (c *Callback) ToAPICallbackInfo(ctx chasm.Context) (*callbackpb.CallbackInfo, error) {
+	apiCb, err := c.ToAPICallback()
+	if err != nil {
+		return nil, err
+	}
+	apiState, blockedReason, err := c.APIState(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	info := &callbackpb.CallbackInfo{
+		Callback:                apiCb,
+		RegistrationTime:        common.CloneProto(c.RegistrationTime),
+		State:                   apiState,
+		BlockedReason:           blockedReason,
+		RequestId:               c.RequestId,
+		Attempt:                 c.Attempt,
+		LastAttemptCompleteTime: common.CloneProto(c.LastAttemptCompleteTime),
+		LastAttemptFailure:      common.CloneProto(c.LastAttemptFailure),
+		NextAttemptScheduleTime: common.CloneProto(c.NextAttemptScheduleTime),
+	}
+	return info, nil
 }
 
 // FromAPICallback converts an API callback into a CHASM callback proto.

--- a/chasm/lib/callback/component_test.go
+++ b/chasm/lib/callback/component_test.go
@@ -2,16 +2,23 @@ package callback
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	callbackpb "go.temporal.io/api/callback/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/chasm"
 	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
 	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/definition"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/testing/protorequire"
 	queueserrors "go.temporal.io/server/service/history/queues/errors"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestFromAPICallback(t *testing.T) {
@@ -151,4 +158,270 @@ func TestNexusHandlerCallbacksNotSupported(t *testing.T) {
 	require.ErrorAs(t, err, &unprocessableErr)
 	require.ErrorContains(t, err, "unprocessable callback variant")
 	require.ErrorContains(t, err, "Callback_NexusHandler_")
+}
+
+const (
+	testNamespaceID = "test-namespace-id"
+	testCallbackURL = "http://callback.example.com:8080/path?query=string"
+	// testDestination is what the outbound queue keys the callback's rate limiter and circuit
+	// breaker by the scheme and host of the callback URL. See [callbackDestination].
+	testDestination = "http://callback.example.com:8080"
+)
+
+// blockedQuery is one question the component asked the injected DestinationBlockedFn.
+type blockedQuery struct {
+	namespaceID string
+	destination string
+}
+
+// destinationBlockedStub is a fake for the History Service's outbound queue's circuit breakers.
+// It keeps track of the blocked/unblocked state.
+type destinationBlockedStub struct {
+	blocked bool
+	queries []blockedQuery
+}
+
+func (s *destinationBlockedStub) fn(namespaceID string, destination string) bool {
+	s.queries = append(s.queries, blockedQuery{namespaceID: namespaceID, destination: destination})
+	return s.blocked
+}
+
+func newTestContext(t *testing.T, lib *Library) chasm.Context {
+	t.Helper()
+
+	logger := log.NewTestLogger()
+	registry := chasm.NewRegistry(logger)
+	require.NoError(t, registry.Register(lib))
+
+	backend := &chasm.MockNodeBackend{
+		HandleGetWorkflowKey: func() definition.WorkflowKey {
+			return definition.NewWorkflowKey(testNamespaceID, "business-id", "run-id")
+		},
+	}
+	node := chasm.NewEmptyTree(
+		registry,
+		clock.NewEventTimeSource(),
+		backend,
+		chasm.DefaultPathEncoder,
+		logger,
+		metrics.NoopMetricsHandler,
+	)
+	return chasm.NewContext(t.Context(), node)
+}
+
+// newTestLibrary builds the library the way fx does, sans task handlers.
+func newTestLibrary(destinationBlocked DestinationBlockedFn) *Library {
+	return newLibrary(libraryParams{DestinationBlocked: destinationBlocked})
+}
+
+func newTestCallback(status callbackspb.CallbackStatus, variant *callbackspb.Callback) *Callback {
+	return &Callback{
+		CallbackState: &callbackspb.CallbackState{
+			Status:   status,
+			Callback: variant,
+		},
+	}
+}
+
+func nexusVariant(url string) *callbackspb.Callback {
+	return &callbackspb.Callback{
+		Variant: &callbackspb.Callback_Nexus_{Nexus: &callbackspb.Callback_Nexus{Url: url}},
+	}
+}
+
+// Only a SCHEDULED callback can be held back by an open circuit breaker. Tt is the one state in
+// which a delivery is waiting on the outbound queue. Every other state reports as itself and must
+// not consult the breaker at all.
+func TestAPIStateCircuitBreaker(t *testing.T) {
+	cases := []struct {
+		name      string
+		status    callbackspb.CallbackStatus
+		wantState enumspb.CallbackState
+		// blockable is true for the states an open breaker can turn into BLOCKED.
+		blockable bool
+	}{
+		{
+			name:      "standby",
+			status:    callbackspb.CALLBACK_STATUS_STANDBY,
+			wantState: enumspb.CALLBACK_STATE_STANDBY,
+		},
+		{
+			name:      "scheduled",
+			status:    callbackspb.CALLBACK_STATUS_SCHEDULED,
+			wantState: enumspb.CALLBACK_STATE_SCHEDULED,
+			blockable: true,
+		},
+		{
+			name:      "backing off",
+			status:    callbackspb.CALLBACK_STATUS_BACKING_OFF,
+			wantState: enumspb.CALLBACK_STATE_BACKING_OFF,
+		},
+		{
+			name:      "succeeded",
+			status:    callbackspb.CALLBACK_STATUS_SUCCEEDED,
+			wantState: enumspb.CALLBACK_STATE_SUCCEEDED,
+		},
+		{
+			name:      "failed",
+			status:    callbackspb.CALLBACK_STATUS_FAILED,
+			wantState: enumspb.CALLBACK_STATE_FAILED,
+		},
+	}
+
+	for _, tc := range cases {
+		for _, blocked := range []bool{false, true} {
+			name := tc.name
+			if blocked {
+				name += " with an open breaker"
+			}
+
+			t.Run(name, func(t *testing.T) {
+				stub := &destinationBlockedStub{blocked: blocked}
+				ctx := newTestContext(t, newTestLibrary(stub.fn))
+				cb := newTestCallback(tc.status, nexusVariant(testCallbackURL))
+
+				state, blockedReason, err := cb.APIState(ctx)
+				require.NoError(t, err)
+
+				if blocked && tc.blockable {
+					require.Equal(t, enumspb.CALLBACK_STATE_BLOCKED, state)
+					require.Equal(t, "The circuit breaker is open.", blockedReason)
+				} else {
+					require.Equal(t, tc.wantState, state)
+					require.Empty(t, blockedReason)
+				}
+
+				if tc.blockable {
+					require.Equal(t,
+						[]blockedQuery{{namespaceID: testNamespaceID, destination: testDestination}},
+						stub.queries)
+				} else {
+					require.Empty(t, stub.queries, "the breaker is only relevant to a scheduled callback")
+				}
+			})
+		}
+	}
+}
+
+func TestAPIStateQueriesCallbackDestination(t *testing.T) {
+	cases := []struct {
+		name            string
+		variant         *callbackspb.Callback
+		wantDestination string
+	}{
+		{
+			name:            "nexus",
+			variant:         nexusVariant(testCallbackURL),
+			wantDestination: testDestination,
+		},
+		{
+			name: "nexus handler",
+			variant: &callbackspb.Callback{
+				Variant: &callbackspb.Callback_NexusHandler_{
+					NexusHandler: &callbackspb.Callback_NexusHandler{TaskQueueName: "completions-task-queue"},
+				},
+			},
+			wantDestination: "nexus-handler://completions-task-queue",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stub := &destinationBlockedStub{}
+			ctx := newTestContext(t, newTestLibrary(stub.fn))
+			cb := newTestCallback(callbackspb.CALLBACK_STATUS_SCHEDULED, tc.variant)
+
+			_, _, err := cb.APIState(ctx)
+
+			// Confirm that calling APIState results in looking up the
+			// circuit breaker status for the given destination.
+			wantQuery := blockedQuery{
+				namespaceID: testNamespaceID,
+				destination: tc.wantDestination,
+			}
+			require.NoError(t, err)
+			require.Equal(t,
+				[]blockedQuery{wantQuery},
+				stub.queries)
+		})
+	}
+
+	// Assert that a failure computing the callback's destination will be surfaced from APIState.
+	t.Run("InvalidDestination", func(t *testing.T) {
+		stub := &destinationBlockedStub{blocked: true}
+		ctx := newTestContext(t, newTestLibrary(stub.fn))
+		cb := newTestCallback(callbackspb.CALLBACK_STATUS_SCHEDULED, nexusVariant("http://invalid url/path"))
+
+		state, blockedReason, err := cb.APIState(ctx)
+		require.ErrorContains(t, err, "failed to parse URL:")
+		require.Equal(t, enumspb.CALLBACK_STATE_UNSPECIFIED, state)
+		require.Empty(t, blockedReason)
+		require.Empty(t, stub.queries)
+	})
+}
+
+// Only the history service runs the outbound queue, so elsewhere the library is built without a
+// DestinationBlockedFn. Those processes must still be able to describe a callback.
+func TestAPIStateWithoutInjectedDestinationBlocked(t *testing.T) {
+	for name, lib := range map[string]*Library{
+		"no fn provided": newTestLibrary(nil),
+		"nil library":    NewNilLibrary(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx := newTestContext(t, lib)
+			cb := newTestCallback(callbackspb.CALLBACK_STATUS_SCHEDULED, nexusVariant(testCallbackURL))
+
+			state, blockedReason, err := cb.APIState(ctx)
+			require.NoError(t, err)
+			require.Equal(t, enumspb.CALLBACK_STATE_SCHEDULED, state)
+			require.Empty(t, blockedReason)
+		})
+	}
+}
+
+// ToAPICallbackInfo surfaces the blocked state and its reason alongside the rest of the callback's
+// state, which is what Describe returns to a caller.
+func TestToAPICallbackInfoReportsBlocked(t *testing.T) {
+	registrationTime := timestamppb.New(time.Now())
+
+	for _, blocked := range []bool{false, true} {
+		name := "scheduled"
+		if blocked {
+			name = "blocked by an open breaker"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			stub := &destinationBlockedStub{blocked: blocked}
+			ctx := newTestContext(t, newTestLibrary(stub.fn))
+
+			cb := newTestCallback(callbackspb.CALLBACK_STATUS_SCHEDULED, nexusVariant(testCallbackURL))
+			cb.RequestId = "request-id"
+			cb.RegistrationTime = registrationTime
+			cb.Attempt = 7
+
+			info, err := cb.ToAPICallbackInfo(ctx)
+			require.NoError(t, err)
+
+			wantState := enumspb.CALLBACK_STATE_SCHEDULED
+			wantReason := ""
+			if blocked {
+				wantState = enumspb.CALLBACK_STATE_BLOCKED
+				wantReason = "The circuit breaker is open."
+			}
+			want := &callbackpb.CallbackInfo{
+				Callback: &commonpb.Callback{
+					Variant: &commonpb.Callback_Nexus_{
+						Nexus: &commonpb.Callback_Nexus{Url: testCallbackURL},
+					},
+				},
+				RegistrationTime: registrationTime,
+				State:            wantState,
+				BlockedReason:    wantReason,
+				RequestId:        "request-id",
+				Attempt:          7,
+			}
+
+			protorequire.ProtoEqual(t, want, info)
+		})
+	}
 }

--- a/chasm/lib/callback/library.go
+++ b/chasm/lib/callback/library.go
@@ -2,10 +2,33 @@ package callback
 
 import (
 	"go.temporal.io/server/chasm"
+	"go.uber.org/fx"
 	"google.golang.org/grpc"
 )
 
+// InvocationTaskGroup is the outbound queue task group that callback invocation tasks are
+// scheduled under. The queue's per-destination rate limiters and circuit breakers are keyed by it.
 const InvocationTaskGroup = chasm.CallbackLibraryName + ".invoke"
+
+// DestinationBlockedFn reports whether the outbound queue is currently holding back callback
+// deliveries to the given destination, i.e. whether its circuit breaker is open.
+type DestinationBlockedFn func(namespaceID string, destination string) bool
+
+type ctxKeyCallbackContextType struct{}
+
+var ctxKeyCallbackContext = ctxKeyCallbackContextType{}
+
+// callbackContext holds the dependencies injected into the chasm.Context for use by Callback methods.
+type callbackContext struct {
+	destinationBlocked DestinationBlockedFn
+}
+
+// callbackContextFromChasm extracts the callbackContext from a chasm.Context.
+// Panics if the context value is missing, which indicates a library registration bug.
+func callbackContextFromChasm(ctx chasm.Context) *callbackContext {
+	//nolint:revive // unchecked-type-assertion: intentional panic on missing context value
+	return ctx.Value(ctxKeyCallbackContext).(*callbackContext)
+}
 
 type (
 	Library struct {
@@ -13,6 +36,8 @@ type (
 
 		InvocationTaskHandler *invocationTaskHandler
 		BackoffTaskHandler    *backoffTaskHandler
+
+		destinationBlocked DestinationBlockedFn
 	}
 )
 
@@ -22,13 +47,21 @@ func NewNilLibrary() *Library {
 	return &Library{}
 }
 
-func newLibrary(
-	InvocationTaskHandler *invocationTaskHandler,
-	BackoffTaskHandler *backoffTaskHandler,
-) *Library {
+type libraryParams struct {
+	fx.In
+
+	InvocationTaskHandler *invocationTaskHandler
+	BackoffTaskHandler    *backoffTaskHandler
+	// Only the history service runs the outbound queue, so only it provides this. Elsewhere it is
+	// absent and callbacks are simply never reported as blocked.
+	DestinationBlocked DestinationBlockedFn `optional:"true"`
+}
+
+func newLibrary(params libraryParams) *Library {
 	return &Library{
-		InvocationTaskHandler: InvocationTaskHandler,
-		BackoffTaskHandler:    BackoffTaskHandler,
+		InvocationTaskHandler: params.InvocationTaskHandler,
+		BackoffTaskHandler:    params.BackoffTaskHandler,
+		destinationBlocked:    params.DestinationBlocked,
 	}
 }
 
@@ -37,10 +70,20 @@ func (l *Library) Name() string {
 }
 
 func (l *Library) Components() []*chasm.RegistrableComponent {
+	destinationBlocked := l.destinationBlocked
+	if destinationBlocked == nil {
+		// Processes that don't run the outbound queue never report a destination as blocked.
+		destinationBlocked = func(string, string) bool { return false }
+	}
 	return []*chasm.RegistrableComponent{
 		chasm.NewRegistrableComponent[*Callback](
 			chasm.CallbackComponentName,
 			chasm.WithDetached(),
+			chasm.WithContextValues(map[any]any{
+				ctxKeyCallbackContext: &callbackContext{
+					destinationBlocked: destinationBlocked,
+				},
+			}),
 		),
 	}
 }

--- a/chasm/lib/workflow/workflow.go
+++ b/chasm/lib/workflow/workflow.go
@@ -173,7 +173,7 @@ func addCallbacksToMap(
 			// Already registered, skip to avoid overwriting.
 			continue
 		}
-		callbackObj := callback.NewCallback(requestID, eventTime, &callbackspb.CallbackState{}, chasmCB)
+		callbackObj := callback.NewCallback(requestID, eventTime, chasmCB)
 		target[id] = chasm.NewComponentField(ctx, callbackObj)
 	}
 	return nil

--- a/common/testing/await/report.go
+++ b/common/testing/await/report.go
@@ -42,10 +42,12 @@ func (r *timeoutReport) recordAttemptTimeout() {
 }
 
 func (r timeoutReport) reportAttemptErrors(tb testing.TB) {
+	tb.Helper()
 	reportAttemptErrors(tb, r.failures)
 }
 
 func (r timeoutReport) reportTimeout(tb testing.TB, funcName, timeoutMsg string) {
+	tb.Helper()
 	r.reportAttemptErrors(tb)
 	message := fmt.Sprintf("condition not satisfied after %v", r.effectiveTimeout)
 	if timeoutMsg != "" {
@@ -56,6 +58,7 @@ func (r timeoutReport) reportTimeout(tb testing.TB, funcName, timeoutMsg string)
 }
 
 func reportAttemptErrors(tb testing.TB, failures []attemptFailure) {
+	tb.Helper()
 	if len(failures) == 0 {
 		return
 	}

--- a/service/history/api/describeworkflow/api.go
+++ b/service/history/api/describeworkflow/api.go
@@ -19,7 +19,6 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/chasm"
 	chasmcallback "go.temporal.io/server/chasm/lib/callback"
-	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
 	"go.temporal.io/server/chasm/lib/nexusoperation"
 	chasmworkflow "go.temporal.io/server/chasm/lib/workflow"
 	"go.temporal.io/server/common"
@@ -278,13 +277,11 @@ func Invoke(
 			)
 		}
 		chasmCallbackInfos, err := buildCallbackInfosFromChasm(
-			ctx,
 			namespaceID,
 			wf,
 			chasmCtx,
 			executionInfo,
 			executionState,
-			outboundQueueCBPool,
 			shard.GetLogger(),
 		)
 		if err != nil {
@@ -502,13 +499,11 @@ func buildCallbackInfosFromHSM(
 // buildCallbackInfosFromChasm reads callbacks from the CHASM workflow component and converts them to API format.
 // TODO(long-nt-tran): move this to chasm/lib/workflow/workflow.go to be within the CHASM workflow context.
 func buildCallbackInfosFromChasm(
-	ctx context.Context,
 	namespaceID namespace.ID,
 	wf *chasmworkflow.Workflow,
 	chasmCtx chasm.Context,
 	executionInfo *persistencespb.WorkflowExecutionInfo,
 	executionState *persistencespb.WorkflowExecutionState,
-	outboundQueueCBPool *circuitbreakerpool.OutboundQueueCircuitBreakerPool,
 	logger log.Logger,
 ) ([]*workflowpb.CallbackInfo, error) {
 	result := make([]*workflowpb.CallbackInfo, 0, len(wf.Callbacks))
@@ -519,7 +514,7 @@ func buildCallbackInfosFromChasm(
 			Variant: &workflowpb.CallbackInfo_Trigger_WorkflowClosed{},
 		}
 
-		callbackInfo, err := buildCallbackInfoFromChasm(ctx, namespaceID, callback, trigger, outboundQueueCBPool)
+		callbackInfo, err := buildChasmCallbackInfo(chasmCtx, callback, trigger)
 		if err != nil {
 			logger.Error(
 				"failed to build callback info from CHASM callback",
@@ -550,7 +545,7 @@ func buildCallbackInfosFromChasm(
 				},
 			}
 
-			callbackInfo, err := buildCallbackInfoFromChasm(ctx, namespaceID, callback, trigger, outboundQueueCBPool)
+			callbackInfo, err := buildChasmCallbackInfo(chasmCtx, callback, trigger)
 			if err != nil {
 				logger.Error(
 					"failed to build callback info from CHASM update callback",
@@ -571,35 +566,12 @@ func buildCallbackInfosFromChasm(
 	return result, nil
 }
 
-// buildCallbackInfoFromChasm converts a single CHASM callback to API format.
-func buildCallbackInfoFromChasm(
-	ctx context.Context,
-	namespaceID namespace.ID,
-	callback *chasmcallback.Callback,
-	trigger *workflowpb.CallbackInfo_Trigger,
-	outboundQueueCBPool *circuitbreakerpool.OutboundQueueCircuitBreakerPool,
-) (*workflowpb.CallbackInfo, error) {
-	// Create a circuit breaker state checker function
-	circuitBreakerState := func(destination string) bool {
-		cb := outboundQueueCBPool.Get(tasks.TaskGroupNamespaceIDAndDestination{
-			TaskGroup:   callbacks.TaskTypeInvocation,
-			NamespaceID: namespaceID.String(),
-			Destination: destination,
-		})
-		return cb.State() != gobreaker.StateClosed
-	}
-
-	return buildChasmCallbackInfo(ctx, namespaceID.String(), callback, trigger, circuitBreakerState)
-}
-
 // buildChasmCallbackInfo converts a single CHASM callback to API CallbackInfo format.
 // Returns nil if the callback should not be included in the response.
 func buildChasmCallbackInfo(
-	ctx context.Context,
-	namespaceID string,
+	ctx chasm.Context,
 	cb *chasmcallback.Callback,
 	trigger *workflowpb.CallbackInfo_Trigger,
-	circuitBreakerState func(destination string) bool,
 ) (*workflowpb.CallbackInfo, error) {
 	nexusVariant := cb.GetCallback().GetNexus()
 	if nexusVariant == nil {
@@ -607,47 +579,26 @@ func buildChasmCallbackInfo(
 		return nil, nil
 	}
 
-	cbSpec, err := cb.ToAPICallback()
+	apiCb, err := cb.ToAPICallback()
+	if err != nil {
+		return nil, err
+	}
+	state, blockedReason, err := cb.APIState(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	var state enumspb.CallbackState
-	switch cb.Status {
-	case callbackspb.CALLBACK_STATUS_UNSPECIFIED:
-		return nil, serviceerror.NewInternal("callback with UNSPECIFIED state")
-	case callbackspb.CALLBACK_STATUS_STANDBY:
-		state = enumspb.CALLBACK_STATE_STANDBY
-	case callbackspb.CALLBACK_STATUS_SCHEDULED:
-		state = enumspb.CALLBACK_STATE_SCHEDULED
-	case callbackspb.CALLBACK_STATUS_BACKING_OFF:
-		state = enumspb.CALLBACK_STATE_BACKING_OFF
-	case callbackspb.CALLBACK_STATUS_FAILED:
-		state = enumspb.CALLBACK_STATE_FAILED
-	case callbackspb.CALLBACK_STATUS_SUCCEEDED:
-		state = enumspb.CALLBACK_STATE_SUCCEEDED
-	default:
-		return nil, serviceerror.NewInternalf("unknown callback state: %v", cb.Status)
-	}
-
-	blockedReason := ""
-	if state == enumspb.CALLBACK_STATE_SCHEDULED {
-		if circuitBreakerState(cbSpec.GetNexus().GetUrl()) {
-			state = enumspb.CALLBACK_STATE_BLOCKED
-			blockedReason = "The circuit breaker is open."
-		}
-	}
-
 	return &workflowpb.CallbackInfo{
-		Callback:                cbSpec,
+		Callback:                apiCb,
 		Trigger:                 trigger,
-		RegistrationTime:        cb.RegistrationTime,
+		RegistrationTime:        common.CloneProto(cb.RegistrationTime),
 		State:                   state,
 		Attempt:                 cb.Attempt,
-		LastAttemptCompleteTime: cb.LastAttemptCompleteTime,
-		LastAttemptFailure:      cb.LastAttemptFailure,
-		NextAttemptScheduleTime: cb.NextAttemptScheduleTime,
+		LastAttemptCompleteTime: common.CloneProto(cb.LastAttemptCompleteTime),
+		LastAttemptFailure:      common.CloneProto(cb.LastAttemptFailure),
+		NextAttemptScheduleTime: common.CloneProto(cb.NextAttemptScheduleTime),
 		BlockedReason:           blockedReason,
+		RequestId:               cb.GetRequestId(),
 	}, nil
 }
 

--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/nexus-rpc/sdk-go/nexus"
+	"github.com/sony/gobreaker"
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/activity"
@@ -41,6 +42,7 @@ import (
 	"go.temporal.io/server/service/history/api"
 	"go.temporal.io/server/service/history/api/workflowresend"
 	"go.temporal.io/server/service/history/archival"
+	"go.temporal.io/server/service/history/circuitbreakerpool"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/events"
@@ -50,6 +52,7 @@ import (
 	hsmnexusworkflow "go.temporal.io/server/service/history/hsm/nexusoperations/workflow"
 	"go.temporal.io/server/service/history/replication"
 	"go.temporal.io/server/service/history/shard"
+	"go.temporal.io/server/service/history/tasks"
 	"go.temporal.io/server/service/history/workflow"
 	"go.temporal.io/server/service/history/workflow/cache"
 	"go.temporal.io/server/service/worker/workerdeployment"
@@ -70,6 +73,7 @@ var Module = fx.Options(
 	archival.Module,
 	ChasmEngineModule,
 	chasmtests.Module,
+	fx.Provide(CallbackDestinationBlockedProvider),
 	fx.Provide(ConfigProvider), // might be worth just using provider for configs.Config directly
 	fx.Provide(workflow.NewCommandHandlerRegistry),
 	fx.Provide(ServiceErrorInterceptorProvider),
@@ -129,6 +133,22 @@ var Module = fx.Options(
 	chasmworkflow.Module,
 	chasmworkflow.HistoryHandlerModule,
 )
+
+// CallbackDestinationBlockedProvider lets the callback library report a callback as BLOCKED while
+// the outbound queue's circuit breaker for its destination is open. Only the history service runs
+// that queue, so only it can answer.
+func CallbackDestinationBlockedProvider(
+	outboundQueueCBPool *circuitbreakerpool.OutboundQueueCircuitBreakerPool,
+) callback.DestinationBlockedFn {
+	return func(namespaceID string, destination string) bool {
+		cb := outboundQueueCBPool.Get(tasks.TaskGroupNamespaceIDAndDestination{
+			TaskGroup:   callback.InvocationTaskGroup,
+			NamespaceID: namespaceID,
+			Destination: destination,
+		})
+		return cb.State() != gobreaker.StateClosed
+	}
+}
 
 func ServerProvider(grpcServerOptions []grpc.ServerOption) *grpc.Server {
 	return grpc.NewServer(grpcServerOptions...)

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nexus-rpc/sdk-go/nexus"
 	"github.com/stretchr/testify/require"
 	activitypb "go.temporal.io/api/activity/v1"
+	callbackpb "go.temporal.io/api/callback/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
@@ -10066,6 +10067,31 @@ func (env *standaloneActivityEnv) startActivityWithType(ctx context.Context, act
 	})
 }
 
+// awaitCallbackInfo polls DescribeActivityExecution until the activity's single completion
+// callback reaches wantState, and returns that CallbackInfo.
+func (env *standaloneActivityEnv) awaitCallbackInfo(
+	ctx context.Context,
+	t *testing.T,
+	activityID string,
+	wantState enumspb.CallbackState,
+) *callbackpb.CallbackInfo {
+	t.Helper()
+	var cbInfo *callbackpb.CallbackInfo
+	await.Require(ctx, t, func(c *await.T) {
+		descResp, err := env.FrontendClient().DescribeActivityExecution(c.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+		})
+		require.NoError(c, err)
+		require.Len(c, descResp.GetCallbacks(), 1)
+		cbInfo = descResp.GetCallbacks()[0].GetInfo()
+		require.NotNil(c, cbInfo)
+		require.Equal(c, wantState, cbInfo.GetState())
+	}, 10*time.Second, 100*time.Millisecond)
+	return cbInfo
+}
+
+// Tests verifying that completion callbacks attached to standalone Activities get triggered.
 func (s *standaloneActivityTestSuite) TestCallbacks() {
 	env := s.newTestEnv()
 	t := s.T()
@@ -10257,6 +10283,9 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		})
 		require.NoError(t, err)
 		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED, descResp.GetInfo().GetStatus())
+
+		// Wait for the callback to complete and confirm it has a Success result.
+		env.awaitCallbackInfo(s.Context(), t, activityID, enumspb.CALLBACK_STATE_SUCCEEDED)
 	})
 
 	t.Run("FailsWithCallbacks", func(t *testing.T) {
@@ -10323,6 +10352,9 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		})
 		require.NoError(t, err)
 		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_FAILED, descResp.GetInfo().GetStatus())
+
+		// The Activity may have failed, but the callback reporting the failure should be successful.
+		env.awaitCallbackInfo(s.Context(), t, activityID, enumspb.CALLBACK_STATE_SUCCEEDED)
 	})
 
 	t.Run("TerminatedWithCallbacks", func(t *testing.T) {
@@ -10390,6 +10422,9 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		})
 		require.NoError(t, err)
 		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_TERMINATED, descResp.GetInfo().GetStatus())
+
+		// The callback reporting the termination should be delivered successfully.
+		env.awaitCallbackInfo(s.Context(), t, activityID, enumspb.CALLBACK_STATE_SUCCEEDED)
 	})
 
 	t.Run("CanceledWithCallbacks", func(t *testing.T) {
@@ -10462,6 +10497,9 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		})
 		require.NoError(t, err)
 		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_CANCELED, descResp.GetInfo().GetStatus())
+
+		// The callback reporting the cancellation should be delivered successfully.
+		env.awaitCallbackInfo(s.Context(), t, activityID, enumspb.CALLBACK_STATE_SUCCEEDED)
 	})
 
 	// This test covers the timeout callback path using schedule-to-start, but the callback behavior
@@ -10517,6 +10555,99 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		})
 		require.NoError(t, err)
 		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT, descResp.GetInfo().GetStatus())
+
+		// The callback delivering the timeout failure should itself succeed.
+		env.awaitCallbackInfo(s.Context(), t, activityID, enumspb.CALLBACK_STATE_SUCCEEDED)
+	})
+
+	// Verify that if the callback fails to be delivered for some reason, that the failure is
+	// persisted correctly and available from the Describe operation.
+	t.Run("CallbackDeliveryFailure", func(t *testing.T) {
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+
+		ch, callbackAddress := newNexusCompletionHandler(t)
+
+		// Start and successfully complete a standalone Activity.
+		_, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
+			Namespace:    env.Namespace().String(),
+			ActivityId:   activityID,
+			ActivityType: env.Tv().ActivityType(),
+			Identity:     env.Tv().WorkerIdentity(),
+			Input:        defaultInput,
+			TaskQueue: &taskqueuepb.TaskQueue{
+				Name: taskQueue,
+			},
+			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
+			RequestId:           env.Tv().Any().String(),
+			CompletionCallbacks: []*commonpb.Callback{{
+				Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: callbackAddress}},
+			}},
+		})
+		require.NoError(t, err)
+
+		pollResp, err := env.FrontendClient().PollActivityTaskQueue(s.Context(), &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
+			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+			Identity:  env.Tv().WorkerIdentity(),
+		})
+		require.NoError(t, err)
+
+		_, err = env.FrontendClient().RespondActivityTaskCompleted(s.Context(), &workflowservice.RespondActivityTaskCompletedRequest{
+			Namespace: env.Namespace().String(),
+			TaskToken: pollResp.TaskToken,
+			Result:    defaultResult,
+			Identity:  defaultIdentity,
+		})
+		require.NoError(t, err)
+
+		// Simulate the completion handler returning a retryable error followed by
+		// an unretryable error. Confirm the SAA's CallbackInfo includes the terminal
+		// failure.
+		for deliveryAttempt := 1; deliveryAttempt <= 2; deliveryAttempt++ {
+			select {
+			case completion := <-ch.requestCh:
+				// Pull the completion request from the channel.
+				require.Equal(t, nexus.OperationStateSucceeded, completion.State)
+				if deliveryAttempt == 1 {
+					// The first attempt to deliver the Activity's completion callback reports a retryable error.
+					// Call Describe and confirm the Callback has just been scheduled.
+					cbInfo := env.awaitCallbackInfo(s.Context(), t, activityID, enumspb.CALLBACK_STATE_SCHEDULED)
+					require.EqualValues(t, 0, cbInfo.GetAttempt()) // zero attempts so far.
+					require.Nil(t, cbInfo.GetLastAttemptFailure())
+
+					// Retryable error.
+					ch.requestCompleteCh <- nexus.NewHandlerErrorf(nexus.HandlerErrorTypeUnavailable, "delivery #1")
+				} else {
+					// The second attempt to deliver the Activity's completion callback should report a
+					// non-retryable error.
+					// Call Describe and confirm the CallbackInfo describes the previous delivery attempt.
+					cbInfo := env.awaitCallbackInfo(s.Context(), t, activityID, enumspb.CALLBACK_STATE_SCHEDULED)
+					require.EqualValues(t, 1, cbInfo.GetAttempt()) // 1 attempt so far, the 2nd is in-progress.
+					require.NotNil(t, cbInfo.GetLastAttemptFailure())
+					require.Contains(t, cbInfo.GetLastAttemptFailure().GetMessage(), "delivery #1")
+
+					// Unretryable error.
+					ch.requestCompleteCh <- nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "delivery #2")
+				}
+
+			case <-s.Context().Done():
+				require.Fail(t, "timed out waiting for completion callback")
+			}
+		}
+
+		// Verify the Activity is in completed state.
+		descResp, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+		})
+		require.NoError(t, err)
+		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED, descResp.GetInfo().GetStatus())
+
+		// Verify the completion callback delivery has failed.
+		cbInfo := env.awaitCallbackInfo(s.Context(), t, activityID, enumspb.CALLBACK_STATE_FAILED)
+		const lastDeliveryFailureMessage = "handler error (BAD_REQUEST): delivery #2"
+		require.Equal(t, lastDeliveryFailureMessage, cbInfo.GetLastAttemptFailure().GetMessage())
 	})
 }
 

--- a/tests/comp_callbacks.go
+++ b/tests/comp_callbacks.go
@@ -29,8 +29,8 @@ import (
 type completionCallbackTarget interface {
 	// newCallback returns a new completion callback addressed to this destination.
 	newCallback() *commonpb.Callback
-	// stopFailing makes every delivery from here on succeed moving forward.
-	stopFailing()
+	// changeBehavior updates the way the callback target operates moving forward.
+	changeBehavior(completionCallbackBehavior)
 	// deliveries reports how many deliveries have reached the destination so far.
 	deliveries() int
 }
@@ -56,8 +56,8 @@ func (ct *baseCompletionCallbackTarget) deliveries() int {
 	return int(ct.deliveryCount.Load())
 }
 
-func (ct *baseCompletionCallbackTarget) stopFailing() {
-	ct.behavior.Store(int32(completionCallbackBehaviorSuccess))
+func (ct *baseCompletionCallbackTarget) changeBehavior(newBehavior completionCallbackBehavior) {
+	ct.behavior.Store(int32(newBehavior))
 }
 
 func (ct *baseCompletionCallbackTarget) CompleteOperation(_ context.Context, _ *nexusrpc.CompletionRequest) error {

--- a/tests/comp_callbacks_test.go
+++ b/tests/comp_callbacks_test.go
@@ -15,6 +15,10 @@ import (
 	"go.temporal.io/server/tests/testcore"
 )
 
+// circuitBreakerFailureThreshold is how many failures are encountered before the circuit breaker
+// opens, and starts skipping deliveries.
+const circuitBreakerFailureThreshold = 5
+
 // CompletionCallbacksSuite tests completion callback behavior.
 //
 // There are several layers of abstraction so that the test suite can run the same test against
@@ -45,6 +49,12 @@ func (s *CompletionCallbacksSuite) newTestEnv() *testcore.TestEnv {
 			[]any{map[string]any{"Pattern": "*", "AllowInsecure": true}}),
 		testcore.WithDynamicConfig(callback.RetryPolicyInitialInterval, 10*time.Millisecond),
 		testcore.WithDynamicConfig(callback.RetryPolicyMaximumInterval, 20*time.Millisecond),
+		// Circuit breaker. Timeout is how long the breaker stays open before half-opening
+		// (and trying to send a request again). It defaults to 60s which is too long for a
+		// unit test to observe. But 1s is too short, and tests couldn't detect the BLOCKED
+		// or BACKING_OFF state. 3s seems to be the sweet spot.
+		testcore.WithDynamicConfig(dynamicconfig.OutboundQueueCircuitBreakerSettings,
+			dynamicconfig.CircuitBreakerSettings{MaxRequests: 1, Timeout: 3 * time.Second}),
 	}
 	return testcore.NewEnv(s.T(), opts...)
 }
@@ -174,5 +184,101 @@ func (s *CompletionCallbacksSuite) TestUnsupportedVariants() {
 					require.ErrorContains(t, gotErr, tc.WantErr)
 				})
 			}
+		})
+}
+
+// TestBlockedWhenCircuitBreakerOpens covers deliveries that keep failing against the same
+// destination: its breaker opens and Describe reports the callback as BLOCKED.
+func (s *CompletionCallbacksSuite) TestBlockedWhenCircuitBreakerOpens() {
+	env := s.newTestEnv()
+
+	s.forEachTestCombination(
+		func(
+			s *CompletionCallbacksSuite,
+			exec executionWithCallbacks,
+			newCompCallbackTargetFn newCompletionCallbackTargetFn,
+		) {
+			t := s.T()
+
+			// Create a callback target that will always fail with a retryable error.
+			alwaysFailingCallbackTarget := newCompCallbackTargetFn(t, env, completionCallbackBehaviorRetryableFailure)
+			executionID, err := exec.startAndCompleteEx(t, env, alwaysFailingCallbackTarget.newCallback())
+			require.NoError(t, err)
+
+			// Deliveries are retried until enough have failed to open the breaker, so the callback passes
+			// through SCHEDULED and BACKING_OFF on the way to BLOCKED.
+			callbackInfo := exec.awaitCallbackState(t, executionID, env, enumspb.CALLBACK_STATE_BLOCKED, nil)
+			require.Equal(t, "The circuit breaker is open.", callbackInfo.GetBlockedReason())
+
+			require.Equal(t, "The circuit breaker is open.", callbackInfo.GetBlockedReason())
+			require.Greater(t, callbackInfo.GetAttempt(), int32(circuitBreakerFailureThreshold),
+				"the breaker should not open before the failure threshold is exceeded")
+		})
+}
+
+// TestBreakerIsPerDestination covers the isolation the per-destination key buys: one dead
+// destination must not hold back deliveries to a healthy one.
+//
+// The two executions are deliberately sequential. Attaching both callbacks to one execution does
+// not test anything: the healthy delivery succeeds immediately, long before the failing one has
+// accumulated enough failures for there to be an open breaker to be affected by.
+func (s *CompletionCallbacksSuite) TestBreakerIsPerDestination() {
+	env := s.newTestEnv()
+
+	s.forEachTestCombination(
+		func(
+			s *CompletionCallbacksSuite,
+			exec executionWithCallbacks,
+			newCompCallbackTargetFn newCompletionCallbackTargetFn,
+		) {
+			t := s.T()
+
+			// Create an execution trying to deliver a callback to an unavailable target.
+			alwaysFailingCallbackTarget := newCompCallbackTargetFn(t, env, completionCallbackBehaviorRetryableFailure)
+			failingExecutionID, err := exec.startAndCompleteEx(t, env, alwaysFailingCallbackTarget.newCallback())
+			require.NoError(t, err)
+
+			exec.awaitCallbackState(t, failingExecutionID, env, enumspb.CALLBACK_STATE_BLOCKED, nil)
+
+			// Start another execution with a callback targeting a _different_ destination for the same
+			// variant of callback. (e.g. a different Nexus handler.)
+			alwaysSucceedCallbackTarget := newCompCallbackTargetFn(t, env, completionCallbackBehaviorSuccess)
+			successfulExecutionID, err := exec.startAndCompleteEx(t, env, alwaysSucceedCallbackTarget.newCallback())
+			require.NoError(t, err)
+
+			errorStates := []enumspb.CallbackState{enumspb.CALLBACK_STATE_BLOCKED, enumspb.CALLBACK_STATE_BACKING_OFF}
+			successfulCallbackInfo := exec.awaitCallbackState(t, successfulExecutionID, env, enumspb.CALLBACK_STATE_SUCCEEDED, errorStates)
+			require.EqualValues(t, 1, successfulCallbackInfo.GetAttempt())
+		})
+}
+
+// TestRecoversFromBlocked covers BLOCKED not being terminal: once the breaker's open period elapses
+// it half-opens, and the destination, healthy again by then, gets the delivery.
+func (s *CompletionCallbacksSuite) TestRecoversFromBlocked() {
+	env := s.newTestEnv()
+
+	s.forEachTestCombination(
+		func(
+			s *CompletionCallbacksSuite,
+			exec executionWithCallbacks,
+			newCompCallbackTargetFn newCompletionCallbackTargetFn,
+		) {
+			t := s.T()
+
+			// Have the callback target always start where each request fails with a retryable error.
+			testCallbackTarget := newCompCallbackTargetFn(t, env, completionCallbackBehaviorRetryableFailure)
+			executionID, err := exec.startAndCompleteEx(t, env, testCallbackTarget.newCallback())
+			require.NoError(t, err)
+
+			blockedCbi := exec.awaitCallbackState(t, executionID, env, enumspb.CALLBACK_STATE_BLOCKED, nil)
+
+			// Simulate the destination recovering. The breaker half-opens, lets a delivery through, and it succeeds.
+			testCallbackTarget.changeBehavior(completionCallbackBehaviorSuccess)
+			successfulCbi := exec.awaitCallbackState(t, executionID, env, enumspb.CALLBACK_STATE_SUCCEEDED, nil)
+
+			// Confirm the updated CallbackInfo reflects the state change.
+			require.Equal(t, blockedCbi.GetRequestId(), successfulCbi.GetRequestId())
+			require.Less(t, blockedCbi.GetAttempt(), successfulCbi.GetAttempt())
+			require.Empty(t, successfulCbi.GetBlockedReason())
 		})
 }


### PR DESCRIPTION
⚠️ This is part of a stacked PR set, to be merged into `chrsmith/wc-add-worker-cb-variant`. This will not go directly into `main`.

This was originally sent out as https://github.com/temporalio/temporal/pull/11413, which also persisted the terminal failure of CHASM Callback components. This new version does not do that, and instead just includes the various refactorings and cleanups.

---

## What changed?

The [worker callbacks API changes](https://github.com/temporalio/api/compare/feature/worker-callbacks?expand=1) adds the result of a Callback invocation to the `CallbackInfo` object.

This PR wires it through for the Describe- response for Standalone Activities. (We already have tests that the completion callbacks were triggered for standalone activities, we now just verify the `CallbackInfo`'s returned have the right `outcome` data as well.)

As part of this, various refactorings were applied to consolidate the conversion logic for `callback.Callback` and other types. (e.g. getting the API Status enum value, or the `commonpb.Callback` proto.)

**_Update_**
As part of slimming down later PRs in this stack, this was also extended to include populating the `BlockedReason` field which previously wasn't set. This required wiring a new CHASM Callback context field, and injecting the outbound queue circuit breaker pool.

## Why?

This wiring and the associated refactorings are all part of adding worker callbacks, and making that easier to land. (Worker callbacks will need to wire the `CallbackInfo` objects to the Describe- endpoint, covered in a subsequent PR.)

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

None that I can think of.
