### PR TITLE
Index GitHub Actions runs for flake bisecting

### DIFF
--- a/tools/flakereport/bisect.go
+++ b/tools/flakereport/bisect.go
@@ -61,14 +61,12 @@ func logSumExpNormalize(logWeights []float64) []float64 {
 }
 
 type testRunIndex struct {
-	commitOrder []string
-	tests       map[string]*indexedTestRuns
+	tests map[string]*indexedTestRuns
 }
 
 type indexedTestRuns struct {
 	totalRuns int
 	failures  int
-	byCommit  map[int]commitRunCounts
 }
 
 type commitRunCounts struct {
@@ -76,19 +74,11 @@ type commitRunCounts struct {
 	fails  int
 }
 
-func buildTestRunIndex(
-	allRuns []TestRun,
-	commitOrder []string,
-	runToSHA map[int64]string,
-) *testRunIndex {
-	commitIndexes := make(map[string]int, len(commitOrder))
-	for i, sha := range commitOrder {
-		commitIndexes[sha] = i
-	}
-
+// buildTestRunIndex aggregates non-skipped runs by normalized test name.
+// totalRuns and failures count every run, including ones outside the commit range.
+func buildTestRunIndex(allRuns []TestRun) *testRunIndex {
 	index := &testRunIndex{
-		commitOrder: commitOrder,
-		tests:       make(map[string]*indexedTestRuns),
+		tests: make(map[string]*indexedTestRuns),
 	}
 	for _, run := range allRuns {
 		if run.Skipped {
@@ -97,14 +87,44 @@ func buildTestRunIndex(
 		testName := normalizeTestName(run.Name)
 		testRuns := index.tests[testName]
 		if testRuns == nil {
-			testRuns = &indexedTestRuns{byCommit: make(map[int]commitRunCounts)}
+			testRuns = &indexedTestRuns{}
 			index.tests[testName] = testRuns
 		}
 		testRuns.totalRuns++
 		if run.Failed {
 			testRuns.failures++
 		}
+	}
+	return index
+}
 
+// buildObservationsByTest aggregates selected tests by commit. commitOrder lists
+// SHAs oldest to newest; runs with commits outside that range are excluded.
+func buildObservationsByTest(
+	allRuns []TestRun,
+	testNames []string,
+	commitOrder []string,
+	runToSHA map[int64]string,
+) map[string][]CommitObservation {
+	selectedTests := make(map[string]struct{}, len(testNames))
+	for _, testName := range testNames {
+		selectedTests[testName] = struct{}{}
+	}
+
+	commitIndexes := make(map[string]int, len(commitOrder))
+	for i, sha := range commitOrder {
+		commitIndexes[sha] = i
+	}
+
+	countsByTest := make(map[string]map[int]commitRunCounts, len(testNames))
+	for _, run := range allRuns {
+		if run.Skipped {
+			continue
+		}
+		testName := normalizeTestName(run.Name)
+		if _, ok := selectedTests[testName]; !ok {
+			continue
+		}
 		commitSHA, ok := runToSHA[run.RunID]
 		if !ok || commitSHA == "" {
 			continue
@@ -113,41 +133,42 @@ func buildTestRunIndex(
 		if !ok {
 			continue
 		}
-		counts := testRuns.byCommit[commitIndex]
+		countsByCommit := countsByTest[testName]
+		if countsByCommit == nil {
+			countsByCommit = make(map[int]commitRunCounts)
+			countsByTest[testName] = countsByCommit
+		}
+		counts := countsByCommit[commitIndex]
 		if run.Failed {
 			counts.fails++
 		} else {
 			counts.passes++
 		}
-		testRuns.byCommit[commitIndex] = counts
-	}
-	return index
-}
-
-func buildObservations(testName string, index *testRunIndex) []CommitObservation {
-	testRuns := index.tests[testName]
-	if testRuns == nil {
-		return nil
+		countsByCommit[commitIndex] = counts
 	}
 
-	commitIndexes := make([]int, 0, len(testRuns.byCommit))
-	for commitIndex := range testRuns.byCommit {
-		commitIndexes = append(commitIndexes, commitIndex)
-	}
-	sort.Ints(commitIndexes)
+	observationsByTest := make(map[string][]CommitObservation, len(countsByTest))
+	for testName, countsByCommit := range countsByTest {
+		commitIndexes := make([]int, 0, len(countsByCommit))
+		for commitIndex := range countsByCommit {
+			commitIndexes = append(commitIndexes, commitIndex)
+		}
+		sort.Ints(commitIndexes)
 
-	observations := make([]CommitObservation, 0, len(commitIndexes))
-	for _, commitIndex := range commitIndexes {
-		counts := testRuns.byCommit[commitIndex]
-		observations = append(observations, CommitObservation{
-			CommitSHA: index.commitOrder[commitIndex],
-			CommitIdx: commitIndex,
-			Prior:     1.0,
-			Passes:    counts.passes,
-			Fails:     counts.fails,
-		})
+		observations := make([]CommitObservation, 0, len(commitIndexes))
+		for _, commitIndex := range commitIndexes {
+			counts := countsByCommit[commitIndex]
+			observations = append(observations, CommitObservation{
+				CommitSHA: commitOrder[commitIndex],
+				CommitIdx: commitIndex,
+				Prior:     1.0,
+				Passes:    counts.passes,
+				Fails:     counts.fails,
+			})
+		}
+		observationsByTest[testName] = observations
 	}
-	return observations
+	return observationsByTest
 }
 
 // runBisect computes posterior probability for each candidate culprit commit.
@@ -276,8 +297,7 @@ func allFilesMatchSuffixes(files, suffixes []string) bool {
 // commitMetas is a pre-populated, read-only cache of commit metadata (SHA → github.Commit).
 //
 //nolint:revive // Keep the bisect pipeline linear so the filtering steps remain reviewable.
-func runBisectForTest(cfg BisectConfig, testName string, index *testRunIndex, commitMetas map[string]github.Commit) TestBisectReport {
-	obs := buildObservations(testName, index)
+func runBisectForTest(cfg BisectConfig, testName string, obs []CommitObservation, commitMetas map[string]github.Commit) TestBisectReport {
 
 	totalPasses, totalFails := 0, 0
 	for _, o := range obs {
@@ -451,7 +471,7 @@ func runBisectAnalysis(ctx context.Context, cfg BisectConfig, allRuns []TestRun,
 		return nil, fmt.Errorf("commit order is empty for anchor %s: SHA may not be an ancestor of HEAD (force-push or unrelated branch?)", oldestSHA[:7])
 	}
 	fmt.Printf("Commit range: %d commits\n", len(commitOrderSlice))
-	testRuns := buildTestRunIndex(allRuns, commitOrderSlice, runToSHA)
+	testRuns := buildTestRunIndex(allRuns)
 
 	// Select qualifying flaky tests
 	targetTests := selectTopFlakyTests(testRuns, cfg)
@@ -463,7 +483,10 @@ func runBisectAnalysis(ctx context.Context, cfg BisectConfig, allRuns []TestRun,
 			len(targetTests), cfg.MinFailures, cfg.MinRuns)
 	}
 
-	// Pre-fetch commit metadata for all unique GitHub Actions commit SHAs.
+	observationsByTest := buildObservationsByTest(allRuns, targetTests, commitOrderSlice, runToSHA)
+
+	// Fetching once here, deduplicated and in parallel, avoids O(tests × commits)
+	// serial subprocess calls.
 	uniqueSHAs := make([]string, 0, len(runToSHA))
 	seenSHA := make(map[string]struct{}, len(runToSHA))
 	for _, sha := range runToSHA {
@@ -479,7 +502,7 @@ func runBisectAnalysis(ctx context.Context, cfg BisectConfig, allRuns []TestRun,
 	reports := make([]TestBisectReport, 0, len(targetTests))
 	for _, testName := range targetTests {
 		start := time.Now()
-		report := runBisectForTest(cfg, testName, testRuns, commitMetas)
+		report := runBisectForTest(cfg, testName, observationsByTest[testName], commitMetas)
 		fmt.Printf("  Bisected %s in %s (skipped=%v)\n", testName, time.Since(start).Round(time.Millisecond), report.Skipped)
 		reports = append(reports, report)
 	}

--- a/tools/flakereport/bisect.go
+++ b/tools/flakereport/bisect.go
@@ -60,61 +60,94 @@ func logSumExpNormalize(logWeights []float64) []float64 {
 	return probs
 }
 
-// buildObservations groups TestRun records for a single (normalized) test name by commit SHA
-// and returns them sorted chronologically using the commit order slice.
-// runToSHA maps workflow RunID → commit SHA.
-// commitOrder lists SHAs from oldest to newest.
-// Runs whose SHA is not in commitOrder are skipped (e.g. from force-pushes or unrelated branches).
-func buildObservations(testName string, runs []TestRun, commitOrderSlice []string, runToSHA map[int64]string) []CommitObservation {
-	// Build commit index map: SHA → index
-	commitIdx := make(map[string]int, len(commitOrderSlice))
-	for i, sha := range commitOrderSlice {
-		commitIdx[sha] = i
+type testRunIndex struct {
+	commitOrder []string
+	tests       map[string]*indexedTestRuns
+}
+
+type indexedTestRuns struct {
+	totalRuns int
+	failures  int
+	byCommit  map[int]commitRunCounts
+}
+
+type commitRunCounts struct {
+	passes int
+	fails  int
+}
+
+func buildTestRunIndex(
+	allTestRuns []TestRun,
+	commitOrder []string,
+	githubActionsRunIDToCommitSHA map[int64]string,
+) *testRunIndex {
+	commitIndexes := make(map[string]int, len(commitOrder))
+	for i, sha := range commitOrder {
+		commitIndexes[sha] = i
 	}
 
-	// Aggregate pass/fail counts per commit SHA for this test
-	type counts struct{ passes, fails int }
-	bySHA := make(map[string]*counts)
-
-	for _, run := range runs {
+	index := &testRunIndex{
+		commitOrder: commitOrder,
+		tests:       make(map[string]*indexedTestRuns),
+	}
+	for _, run := range allTestRuns {
 		if run.Skipped {
 			continue
 		}
-		if normalizeTestName(run.Name) != testName {
-			continue
+		testName := normalizeTestName(run.Name)
+		testRuns := index.tests[testName]
+		if testRuns == nil {
+			testRuns = &indexedTestRuns{byCommit: make(map[int]commitRunCounts)}
+			index.tests[testName] = testRuns
 		}
-		sha, ok := runToSHA[run.RunID]
-		if !ok || sha == "" {
-			continue
-		}
-		if _, inOrder := commitIdx[sha]; !inOrder {
-			continue
-		}
-		if bySHA[sha] == nil {
-			bySHA[sha] = &counts{}
-		}
+		testRuns.totalRuns++
 		if run.Failed {
-			bySHA[sha].fails++
-		} else {
-			bySHA[sha].passes++
+			testRuns.failures++
 		}
+
+		commitSHA, ok := githubActionsRunIDToCommitSHA[run.RunID]
+		if !ok || commitSHA == "" {
+			continue
+		}
+		commitIndex, ok := commitIndexes[commitSHA]
+		if !ok {
+			continue
+		}
+		counts := testRuns.byCommit[commitIndex]
+		if run.Failed {
+			counts.fails++
+		} else {
+			counts.passes++
+		}
+		testRuns.byCommit[commitIndex] = counts
+	}
+	return index
+}
+
+func buildObservations(testName string, index *testRunIndex) []CommitObservation {
+	testRuns := index.tests[testName]
+	if testRuns == nil {
+		return nil
 	}
 
-	// Convert to slice and sort by commit index
-	obs := make([]CommitObservation, 0, len(bySHA))
-	for sha, c := range bySHA {
-		obs = append(obs, CommitObservation{
-			CommitSHA: sha,
-			CommitIdx: commitIdx[sha],
-			Prior:     1.0, // uniform prior; adjusted by heuristics if enabled
-			Passes:    c.passes,
-			Fails:     c.fails,
+	commitIndexes := make([]int, 0, len(testRuns.byCommit))
+	for commitIndex := range testRuns.byCommit {
+		commitIndexes = append(commitIndexes, commitIndex)
+	}
+	sort.Ints(commitIndexes)
+
+	observations := make([]CommitObservation, 0, len(commitIndexes))
+	for _, commitIndex := range commitIndexes {
+		counts := testRuns.byCommit[commitIndex]
+		observations = append(observations, CommitObservation{
+			CommitSHA: index.commitOrder[commitIndex],
+			CommitIdx: commitIndex,
+			Prior:     1.0,
+			Passes:    counts.passes,
+			Fails:     counts.fails,
 		})
 	}
-	sort.Slice(obs, func(i, j int) bool {
-		return obs[i].CommitIdx < obs[j].CommitIdx
-	})
-	return obs
+	return observations
 }
 
 // runBisect computes posterior probability for each candidate culprit commit.
@@ -243,8 +276,8 @@ func allFilesMatchSuffixes(files, suffixes []string) bool {
 // commitMetas is a pre-populated, read-only cache of commit metadata (SHA → github.Commit).
 //
 //nolint:revive // Keep the bisect pipeline linear so the filtering steps remain reviewable.
-func runBisectForTest(cfg BisectConfig, testName string, allRuns []TestRun, commitOrderSlice []string, runToSHA map[int64]string, commitMetas map[string]github.Commit) TestBisectReport {
-	obs := buildObservations(testName, allRuns, commitOrderSlice, runToSHA)
+func runBisectForTest(cfg BisectConfig, testName string, index *testRunIndex, commitMetas map[string]github.Commit) TestBisectReport {
+	obs := buildObservations(testName, index)
 
 	totalPasses, totalFails := 0, 0
 	for _, o := range obs {
@@ -349,42 +382,22 @@ func runBisectForTest(cfg BisectConfig, testName string, allRuns []TestRun, comm
 	}
 }
 
-// selectTopFlakyTests selects the top-N flakiest tests that meet minimum signal thresholds.
-// allRuns is the full set of test runs. Returns normalized test names sorted by failure rate desc.
-func selectTopFlakyTests(allRuns []TestRun, cfg BisectConfig) []string {
-	type testStats struct {
-		fails int
-		total int
-	}
-	stats := make(map[string]*testStats)
-	for _, run := range allRuns {
-		if run.Skipped {
-			continue
-		}
-		name := normalizeTestName(run.Name)
-		if stats[name] == nil {
-			stats[name] = &testStats{}
-		}
-		stats[name].total++
-		if run.Failed {
-			stats[name].fails++
-		}
-	}
-
+// selectTopFlakyTests selects the top-N flakiest indexed tests that meet minimum signal thresholds.
+func selectTopFlakyTests(index *testRunIndex, cfg BisectConfig) []string {
 	type ranked struct {
 		name  string
 		rate  float64
 		fails int
 	}
 	var candidates []ranked
-	for name, s := range stats {
-		if s.fails < cfg.MinFailures || s.total < cfg.MinRuns {
+	for name, testRuns := range index.tests {
+		if testRuns.failures < cfg.MinFailures || testRuns.totalRuns < cfg.MinRuns {
 			continue
 		}
 		candidates = append(candidates, ranked{
 			name:  name,
-			rate:  float64(s.fails) / float64(s.total),
-			fails: s.fails,
+			rate:  float64(testRuns.failures) / float64(testRuns.totalRuns),
+			fails: testRuns.failures,
 		})
 	}
 
@@ -409,39 +422,39 @@ func selectTopFlakyTests(allRuns []TestRun, cfg BisectConfig) []string {
 
 // runBisectAnalysis is the top-level bisect orchestrator called from the generate command.
 // It runs bisect for the top-N flakiest tests and returns their reports.
-func runBisectAnalysis(ctx context.Context, cfg BisectConfig, allRuns []TestRun, workflowRuns []github.Run) ([]TestBisectReport, error) {
-	// Build runID → SHA map from workflow runs
-	runToSHA := make(map[int64]string, len(workflowRuns))
-	var oldestSHA string
+func runBisectAnalysis(ctx context.Context, cfg BisectConfig, allTestRuns []TestRun, githubActionsRuns []github.Run) ([]TestBisectReport, error) {
+	githubActionsRunIDToCommitSHA := make(map[int64]string, len(githubActionsRuns))
+	var oldestGitHubActionsCommitSHA string
 	var oldestTime time.Time
-	for _, wr := range workflowRuns {
-		if wr.HeadSHA == "" {
+	for _, githubActionsRun := range githubActionsRuns {
+		if githubActionsRun.HeadSHA == "" {
 			continue
 		}
-		runToSHA[wr.DatabaseID] = wr.HeadSHA
-		if oldestTime.IsZero() || wr.CreatedAt.Before(oldestTime) {
-			oldestTime = wr.CreatedAt
-			oldestSHA = wr.HeadSHA
+		githubActionsRunIDToCommitSHA[githubActionsRun.DatabaseID] = githubActionsRun.HeadSHA
+		if oldestTime.IsZero() || githubActionsRun.CreatedAt.Before(oldestTime) {
+			oldestTime = githubActionsRun.CreatedAt
+			oldestGitHubActionsCommitSHA = githubActionsRun.HeadSHA
 		}
 	}
 
-	if oldestSHA == "" {
-		return nil, errors.New("no workflow runs with commit SHAs found")
+	if oldestGitHubActionsCommitSHA == "" {
+		return nil, errors.New("no GitHub Actions runs with commit SHAs found")
 	}
 
 	// Get commit ordering from git log
-	fmt.Printf("Building commit order from %s..HEAD\n", oldestSHA[:7])
-	commitOrderSlice, err := commitOrder(ctx, oldestSHA)
+	fmt.Printf("Building commit order from %s..HEAD\n", oldestGitHubActionsCommitSHA[:7])
+	commitOrderSlice, err := commitOrder(ctx, oldestGitHubActionsCommitSHA)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get commit order: %w", err)
 	}
 	if len(commitOrderSlice) == 0 {
-		return nil, fmt.Errorf("commit order is empty for anchor %s: SHA may not be an ancestor of HEAD (force-push or unrelated branch?)", oldestSHA[:7])
+		return nil, fmt.Errorf("commit order is empty for anchor %s: SHA may not be an ancestor of HEAD (force-push or unrelated branch?)", oldestGitHubActionsCommitSHA[:7])
 	}
 	fmt.Printf("Commit range: %d commits\n", len(commitOrderSlice))
+	testRuns := buildTestRunIndex(allTestRuns, commitOrderSlice, githubActionsRunIDToCommitSHA)
 
 	// Select qualifying flaky tests
-	targetTests := selectTopFlakyTests(allRuns, cfg)
+	targetTests := selectTopFlakyTests(testRuns, cfg)
 	if cfg.TopN > 0 {
 		fmt.Printf("Selected %d tests for bisect analysis (top %d, min %d failures, min %d runs)\n",
 			len(targetTests), cfg.TopN, cfg.MinFailures, cfg.MinRuns)
@@ -450,12 +463,10 @@ func runBisectAnalysis(ctx context.Context, cfg BisectConfig, allRuns []TestRun,
 			len(targetTests), cfg.MinFailures, cfg.MinRuns)
 	}
 
-	// Pre-fetch commit metadata for all unique SHAs that appear in the run set.
-	// Fetching once here (deduplicated, in parallel) avoids O(tests × commits) serial
-	// subprocess calls — the dominant cost of the bisect pipeline.
-	uniqueSHAs := make([]string, 0, len(runToSHA))
-	seenSHA := make(map[string]struct{}, len(runToSHA))
-	for _, sha := range runToSHA {
+	// Pre-fetch commit metadata for all unique GitHub Actions commit SHAs.
+	uniqueSHAs := make([]string, 0, len(githubActionsRunIDToCommitSHA))
+	seenSHA := make(map[string]struct{}, len(githubActionsRunIDToCommitSHA))
+	for _, sha := range githubActionsRunIDToCommitSHA {
 		if _, ok := seenSHA[sha]; !ok {
 			seenSHA[sha] = struct{}{}
 			uniqueSHAs = append(uniqueSHAs, sha)
@@ -468,7 +479,7 @@ func runBisectAnalysis(ctx context.Context, cfg BisectConfig, allRuns []TestRun,
 	reports := make([]TestBisectReport, 0, len(targetTests))
 	for _, testName := range targetTests {
 		start := time.Now()
-		report := runBisectForTest(cfg, testName, allRuns, commitOrderSlice, runToSHA, commitMetas)
+		report := runBisectForTest(cfg, testName, testRuns, commitMetas)
 		fmt.Printf("  Bisected %s in %s (skipped=%v)\n", testName, time.Since(start).Round(time.Millisecond), report.Skipped)
 		reports = append(reports, report)
 	}

--- a/tools/flakereport/bisect.go
+++ b/tools/flakereport/bisect.go
@@ -495,7 +495,10 @@ func runBisectAnalysis(ctx context.Context, cfg BisectConfig, allRuns []TestRun,
 			uniqueSHAs = append(uniqueSHAs, sha)
 		}
 	}
-	commitMetas := fetchCommitMetasParallel(ctx, cfg.Repo, uniqueSHAs, defaultConcurrency)
+	commitMetas, err := fetchCommitMetasParallel(ctx, cfg.Repo, uniqueSHAs, defaultConcurrency)
+	if err != nil {
+		return nil, err
+	}
 	fmt.Printf("Fetched metadata for %d/%d unique commits\n", len(commitMetas), len(uniqueSHAs))
 
 	// Run bisect for each test
@@ -511,9 +514,9 @@ func runBisectAnalysis(ctx context.Context, cfg BisectConfig, allRuns []TestRun,
 }
 
 // fetchCommitMetasParallel fetches commit metadata for a list of SHAs concurrently,
-// bounded by maxConcurrency. Returns an immutable map of SHA → github.Commit; failed
-// fetches are logged and omitted (heuristic priors fall back to 1.0).
-func fetchCommitMetasParallel(ctx context.Context, repo string, shas []string, maxConcurrency int) map[string]github.Commit {
+// bounded by maxConcurrency. Returns an immutable map of SHA → github.Commit; non-rate-limit
+// fetch failures are logged and omitted because heuristic priors fall back to 1.0.
+func fetchCommitMetasParallel(ctx context.Context, repo string, shas []string, maxConcurrency int) (map[string]github.Commit, error) {
 	metas := make([]github.Commit, len(shas))
 	ok := make([]bool, len(shas))
 
@@ -523,6 +526,9 @@ func fetchCommitMetasParallel(ctx context.Context, repo string, shas []string, m
 		g.Go(func() error {
 			meta, err := github.GetCommit(ctx, repo, sha)
 			if err != nil {
+				if isGitHubRateLimitError(err) {
+					return fmt.Errorf("GitHub API rate limit while fetching metadata for commit %s: %w", sha[:7], err)
+				}
 				fmt.Printf("Warning: failed to fetch metadata for commit %s: %v\n", sha[:7], err)
 				return nil
 			}
@@ -531,7 +537,9 @@ func fetchCommitMetasParallel(ctx context.Context, repo string, shas []string, m
 			return nil
 		})
 	}
-	_ = g.Wait()
+	if err := g.Wait(); err != nil {
+		return nil, fmt.Errorf("cannot generate complete report: %w", err)
+	}
 
 	commitMetas := make(map[string]github.Commit, len(shas))
 	for i, sha := range shas {
@@ -539,5 +547,5 @@ func fetchCommitMetasParallel(ctx context.Context, repo string, shas []string, m
 			commitMetas[sha] = metas[i]
 		}
 	}
-	return commitMetas
+	return commitMetas, nil
 }

--- a/tools/flakereport/bisect.go
+++ b/tools/flakereport/bisect.go
@@ -77,9 +77,9 @@ type commitRunCounts struct {
 }
 
 func buildTestRunIndex(
-	allTestRuns []TestRun,
+	allRuns []TestRun,
 	commitOrder []string,
-	githubActionsRunIDToCommitSHA map[int64]string,
+	runToSHA map[int64]string,
 ) *testRunIndex {
 	commitIndexes := make(map[string]int, len(commitOrder))
 	for i, sha := range commitOrder {
@@ -90,7 +90,7 @@ func buildTestRunIndex(
 		commitOrder: commitOrder,
 		tests:       make(map[string]*indexedTestRuns),
 	}
-	for _, run := range allTestRuns {
+	for _, run := range allRuns {
 		if run.Skipped {
 			continue
 		}
@@ -105,7 +105,7 @@ func buildTestRunIndex(
 			testRuns.failures++
 		}
 
-		commitSHA, ok := githubActionsRunIDToCommitSHA[run.RunID]
+		commitSHA, ok := runToSHA[run.RunID]
 		if !ok || commitSHA == "" {
 			continue
 		}
@@ -422,36 +422,36 @@ func selectTopFlakyTests(index *testRunIndex, cfg BisectConfig) []string {
 
 // runBisectAnalysis is the top-level bisect orchestrator called from the generate command.
 // It runs bisect for the top-N flakiest tests and returns their reports.
-func runBisectAnalysis(ctx context.Context, cfg BisectConfig, allTestRuns []TestRun, githubActionsRuns []github.Run) ([]TestBisectReport, error) {
-	githubActionsRunIDToCommitSHA := make(map[int64]string, len(githubActionsRuns))
-	var oldestGitHubActionsCommitSHA string
+func runBisectAnalysis(ctx context.Context, cfg BisectConfig, allRuns []TestRun, githubActionsRuns []github.Run) ([]TestBisectReport, error) {
+	runToSHA := make(map[int64]string, len(githubActionsRuns))
+	var oldestSHA string
 	var oldestTime time.Time
 	for _, githubActionsRun := range githubActionsRuns {
 		if githubActionsRun.HeadSHA == "" {
 			continue
 		}
-		githubActionsRunIDToCommitSHA[githubActionsRun.DatabaseID] = githubActionsRun.HeadSHA
+		runToSHA[githubActionsRun.DatabaseID] = githubActionsRun.HeadSHA
 		if oldestTime.IsZero() || githubActionsRun.CreatedAt.Before(oldestTime) {
 			oldestTime = githubActionsRun.CreatedAt
-			oldestGitHubActionsCommitSHA = githubActionsRun.HeadSHA
+			oldestSHA = githubActionsRun.HeadSHA
 		}
 	}
 
-	if oldestGitHubActionsCommitSHA == "" {
+	if oldestSHA == "" {
 		return nil, errors.New("no GitHub Actions runs with commit SHAs found")
 	}
 
 	// Get commit ordering from git log
-	fmt.Printf("Building commit order from %s..HEAD\n", oldestGitHubActionsCommitSHA[:7])
-	commitOrderSlice, err := commitOrder(ctx, oldestGitHubActionsCommitSHA)
+	fmt.Printf("Building commit order from %s..HEAD\n", oldestSHA[:7])
+	commitOrderSlice, err := commitOrder(ctx, oldestSHA)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get commit order: %w", err)
 	}
 	if len(commitOrderSlice) == 0 {
-		return nil, fmt.Errorf("commit order is empty for anchor %s: SHA may not be an ancestor of HEAD (force-push or unrelated branch?)", oldestGitHubActionsCommitSHA[:7])
+		return nil, fmt.Errorf("commit order is empty for anchor %s: SHA may not be an ancestor of HEAD (force-push or unrelated branch?)", oldestSHA[:7])
 	}
 	fmt.Printf("Commit range: %d commits\n", len(commitOrderSlice))
-	testRuns := buildTestRunIndex(allTestRuns, commitOrderSlice, githubActionsRunIDToCommitSHA)
+	testRuns := buildTestRunIndex(allRuns, commitOrderSlice, runToSHA)
 
 	// Select qualifying flaky tests
 	targetTests := selectTopFlakyTests(testRuns, cfg)
@@ -464,9 +464,9 @@ func runBisectAnalysis(ctx context.Context, cfg BisectConfig, allTestRuns []Test
 	}
 
 	// Pre-fetch commit metadata for all unique GitHub Actions commit SHAs.
-	uniqueSHAs := make([]string, 0, len(githubActionsRunIDToCommitSHA))
-	seenSHA := make(map[string]struct{}, len(githubActionsRunIDToCommitSHA))
-	for _, sha := range githubActionsRunIDToCommitSHA {
+	uniqueSHAs := make([]string, 0, len(runToSHA))
+	seenSHA := make(map[string]struct{}, len(runToSHA))
+	for _, sha := range runToSHA {
 		if _, ok := seenSHA[sha]; !ok {
 			seenSHA[sha] = struct{}{}
 			uniqueSHAs = append(uniqueSHAs, sha)

--- a/tools/flakereport/bisect_test.go
+++ b/tools/flakereport/bisect_test.go
@@ -262,7 +262,7 @@ func TestRunBisectInformationlessData(t *testing.T) {
 
 func TestBuildObservations(t *testing.T) {
 	commitOrderSlice := []string{"sha-a", "sha-b", "sha-c", "sha-d"}
-	githubActionsRunIDToCommitSHA := map[int64]string{
+	runToSHA := map[int64]string{
 		100: "sha-a",
 		200: "sha-b",
 		300: "sha-c",
@@ -295,7 +295,7 @@ func TestBuildObservations(t *testing.T) {
 		{Name: "TestFoo", Failed: false, RunID: 999},
 	}
 
-	index := buildTestRunIndex(runs, commitOrderSlice, githubActionsRunIDToCommitSHA)
+	index := buildTestRunIndex(runs, commitOrderSlice, runToSHA)
 	obs := buildObservations("TestFoo", index)
 	require.Equal(t, 12, index.tests["TestFoo"].totalRuns)
 	require.Equal(t, 4, index.tests["TestFoo"].failures)
@@ -487,7 +487,7 @@ func TestRunBisectForTestDirectionFilter(t *testing.T) {
 	// not introduced). The direction filter must suppress this suspect so it does not appear
 	// as a culprit in the report.
 	commitOrderSlice := []string{"sha0", "sha1", "sha2", "sha3", "sha4", "sha5"}
-	githubActionsRunIDToCommitSHA := map[int64]string{0: "sha0", 1: "sha1", 2: "sha2", 3: "sha3", 4: "sha4", 5: "sha5"}
+	runToSHA := map[int64]string{0: "sha0", 1: "sha1", 2: "sha2", 3: "sha3", 4: "sha4", 5: "sha5"}
 
 	var allRuns []TestRun
 	// sha0-sha4: 8 failures + 2 passes each (80% failure rate)
@@ -511,7 +511,7 @@ func TestRunBisectForTestDirectionFilter(t *testing.T) {
 		MinProbability: 0.5,
 	}
 
-	report := runBisectForTest(cfg, "TestFoo", buildTestRunIndex(allRuns, commitOrderSlice, githubActionsRunIDToCommitSHA), nil)
+	report := runBisectForTest(cfg, "TestFoo", buildTestRunIndex(allRuns, commitOrderSlice, runToSHA), nil)
 
 	// The only high-probability transition point (sha5, where rate dropped 80%→0%) should be
 	// filtered out by the direction filter, leaving no actionable suspects.
@@ -523,7 +523,7 @@ func TestRunBisectForTestDirectionFilterKeepsIntroduction(t *testing.T) {
 	// Complementary: failure rate INCREASES at sha3 (flake introduced). The direction filter
 	// must retain this suspect.
 	commitOrderSlice := []string{"sha0", "sha1", "sha2", "sha3", "sha4", "sha5"}
-	githubActionsRunIDToCommitSHA := map[int64]string{0: "sha0", 1: "sha1", 2: "sha2", 3: "sha3", 4: "sha4", 5: "sha5"}
+	runToSHA := map[int64]string{0: "sha0", 1: "sha1", 2: "sha2", 3: "sha3", 4: "sha4", 5: "sha5"}
 
 	var allRuns []TestRun
 	// sha0-sha2: clean (0% failure rate)
@@ -550,7 +550,7 @@ func TestRunBisectForTestDirectionFilterKeepsIntroduction(t *testing.T) {
 		MinProbability: 0.5,
 	}
 
-	report := runBisectForTest(cfg, "TestFoo", buildTestRunIndex(allRuns, commitOrderSlice, githubActionsRunIDToCommitSHA), nil)
+	report := runBisectForTest(cfg, "TestFoo", buildTestRunIndex(allRuns, commitOrderSlice, runToSHA), nil)
 
 	require.False(t, report.Skipped, "report should not be skipped: a real introduction exists")
 	require.NotEmpty(t, report.TopSuspects)

--- a/tools/flakereport/bisect_test.go
+++ b/tools/flakereport/bisect_test.go
@@ -295,8 +295,8 @@ func TestBuildObservations(t *testing.T) {
 		{Name: "TestFoo", Failed: false, RunID: 999},
 	}
 
-	index := buildTestRunIndex(runs, commitOrderSlice, runToSHA)
-	obs := buildObservations("TestFoo", index)
+	index := buildTestRunIndex(runs)
+	obs := buildObservationsByTest(runs, []string{"TestFoo"}, commitOrderSlice, runToSHA)["TestFoo"]
 	require.Equal(t, 12, index.tests["TestFoo"].totalRuns)
 	require.Equal(t, 4, index.tests["TestFoo"].failures)
 
@@ -351,14 +351,14 @@ func TestSelectTopFlakyTests(t *testing.T) {
 	t.Run("excludes tests below MinFailures threshold", func(t *testing.T) {
 		runs := makeRunsForTest("TestLowFails", 100, 2) // 2 failures: below minBisectFailures=5
 		cfg := BisectConfig{TopN: 10, MinFailures: 5, MinRuns: 10}
-		result := selectTopFlakyTests(buildTestRunIndex(runs, nil, nil), cfg)
+		result := selectTopFlakyTests(buildTestRunIndex(runs), cfg)
 		assert.NotContains(t, result, "TestLowFails")
 	})
 
 	t.Run("excludes tests below MinRuns threshold", func(t *testing.T) {
 		runs := makeRunsForTest("TestFewRuns", 10, 6) // only 10 total runs: below minBisectRuns=30
 		cfg := BisectConfig{TopN: 10, MinFailures: 5, MinRuns: 30}
-		result := selectTopFlakyTests(buildTestRunIndex(runs, nil, nil), cfg)
+		result := selectTopFlakyTests(buildTestRunIndex(runs), cfg)
 		assert.NotContains(t, result, "TestFewRuns")
 	})
 
@@ -369,7 +369,7 @@ func TestSelectTopFlakyTests(t *testing.T) {
 		runs = append(runs, makeRunsForTest("TestHighRate", 40, 20)...)
 		runs = append(runs, makeRunsForTest("TestLowRate", 40, 10)...)
 		cfg := BisectConfig{TopN: 10, MinFailures: 5, MinRuns: 30}
-		result := selectTopFlakyTests(buildTestRunIndex(runs, nil, nil), cfg)
+		result := selectTopFlakyTests(buildTestRunIndex(runs), cfg)
 		require.GreaterOrEqual(t, len(result), 2)
 		assert.Equal(t, "TestHighRate", result[0])
 		assert.Equal(t, "TestLowRate", result[1])
@@ -381,7 +381,7 @@ func TestSelectTopFlakyTests(t *testing.T) {
 			runs = append(runs, makeRunsForTest("TestFlaky"+string(rune('A'+i)), 40, 10)...)
 		}
 		cfg := BisectConfig{TopN: 3, MinFailures: 5, MinRuns: 30}
-		result := selectTopFlakyTests(buildTestRunIndex(runs, nil, nil), cfg)
+		result := selectTopFlakyTests(buildTestRunIndex(runs), cfg)
 		assert.Len(t, result, 3)
 	})
 
@@ -391,7 +391,7 @@ func TestSelectTopFlakyTests(t *testing.T) {
 			{Name: "TestSkipped", Skipped: true, Failed: true},
 		}
 		cfg := BisectConfig{TopN: 10, MinFailures: 1, MinRuns: 1}
-		result := selectTopFlakyTests(buildTestRunIndex(runs, nil, nil), cfg)
+		result := selectTopFlakyTests(buildTestRunIndex(runs), cfg)
 		assert.NotContains(t, result, "TestSkipped")
 	})
 
@@ -405,7 +405,7 @@ func TestSelectTopFlakyTests(t *testing.T) {
 			runs = append(runs, TestRun{Name: "TestFlaky (retry 1)", Failed: true})
 		}
 		cfg := BisectConfig{TopN: 10, MinFailures: 5, MinRuns: 30}
-		result := selectTopFlakyTests(buildTestRunIndex(runs, nil, nil), cfg)
+		result := selectTopFlakyTests(buildTestRunIndex(runs), cfg)
 		require.Len(t, result, 1)
 		assert.Equal(t, "TestFlaky", result[0])
 	})
@@ -511,7 +511,8 @@ func TestRunBisectForTestDirectionFilter(t *testing.T) {
 		MinProbability: 0.5,
 	}
 
-	report := runBisectForTest(cfg, "TestFoo", buildTestRunIndex(allRuns, commitOrderSlice, runToSHA), nil)
+	obs := buildObservationsByTest(allRuns, []string{"TestFoo"}, commitOrderSlice, runToSHA)["TestFoo"]
+	report := runBisectForTest(cfg, "TestFoo", obs, nil)
 
 	// The only high-probability transition point (sha5, where rate dropped 80%→0%) should be
 	// filtered out by the direction filter, leaving no actionable suspects.
@@ -550,7 +551,8 @@ func TestRunBisectForTestDirectionFilterKeepsIntroduction(t *testing.T) {
 		MinProbability: 0.5,
 	}
 
-	report := runBisectForTest(cfg, "TestFoo", buildTestRunIndex(allRuns, commitOrderSlice, runToSHA), nil)
+	obs := buildObservationsByTest(allRuns, []string{"TestFoo"}, commitOrderSlice, runToSHA)["TestFoo"]
+	report := runBisectForTest(cfg, "TestFoo", obs, nil)
 
 	require.False(t, report.Skipped, "report should not be skipped: a real introduction exists")
 	require.NotEmpty(t, report.TopSuspects)

--- a/tools/flakereport/bisect_test.go
+++ b/tools/flakereport/bisect_test.go
@@ -262,7 +262,7 @@ func TestRunBisectInformationlessData(t *testing.T) {
 
 func TestBuildObservations(t *testing.T) {
 	commitOrderSlice := []string{"sha-a", "sha-b", "sha-c", "sha-d"}
-	runToSHA := map[int64]string{
+	githubActionsRunIDToCommitSHA := map[int64]string{
 		100: "sha-a",
 		200: "sha-b",
 		300: "sha-c",
@@ -295,7 +295,10 @@ func TestBuildObservations(t *testing.T) {
 		{Name: "TestFoo", Failed: false, RunID: 999},
 	}
 
-	obs := buildObservations("TestFoo", runs, commitOrderSlice, runToSHA)
+	index := buildTestRunIndex(runs, commitOrderSlice, githubActionsRunIDToCommitSHA)
+	obs := buildObservations("TestFoo", index)
+	require.Equal(t, 12, index.tests["TestFoo"].totalRuns)
+	require.Equal(t, 4, index.tests["TestFoo"].failures)
 
 	require.Len(t, obs, 4, "should have one observation per commit with data")
 
@@ -348,14 +351,14 @@ func TestSelectTopFlakyTests(t *testing.T) {
 	t.Run("excludes tests below MinFailures threshold", func(t *testing.T) {
 		runs := makeRunsForTest("TestLowFails", 100, 2) // 2 failures: below minBisectFailures=5
 		cfg := BisectConfig{TopN: 10, MinFailures: 5, MinRuns: 10}
-		result := selectTopFlakyTests(runs, cfg)
+		result := selectTopFlakyTests(buildTestRunIndex(runs, nil, nil), cfg)
 		assert.NotContains(t, result, "TestLowFails")
 	})
 
 	t.Run("excludes tests below MinRuns threshold", func(t *testing.T) {
 		runs := makeRunsForTest("TestFewRuns", 10, 6) // only 10 total runs: below minBisectRuns=30
 		cfg := BisectConfig{TopN: 10, MinFailures: 5, MinRuns: 30}
-		result := selectTopFlakyTests(runs, cfg)
+		result := selectTopFlakyTests(buildTestRunIndex(runs, nil, nil), cfg)
 		assert.NotContains(t, result, "TestFewRuns")
 	})
 
@@ -366,7 +369,7 @@ func TestSelectTopFlakyTests(t *testing.T) {
 		runs = append(runs, makeRunsForTest("TestHighRate", 40, 20)...)
 		runs = append(runs, makeRunsForTest("TestLowRate", 40, 10)...)
 		cfg := BisectConfig{TopN: 10, MinFailures: 5, MinRuns: 30}
-		result := selectTopFlakyTests(runs, cfg)
+		result := selectTopFlakyTests(buildTestRunIndex(runs, nil, nil), cfg)
 		require.GreaterOrEqual(t, len(result), 2)
 		assert.Equal(t, "TestHighRate", result[0])
 		assert.Equal(t, "TestLowRate", result[1])
@@ -378,7 +381,7 @@ func TestSelectTopFlakyTests(t *testing.T) {
 			runs = append(runs, makeRunsForTest("TestFlaky"+string(rune('A'+i)), 40, 10)...)
 		}
 		cfg := BisectConfig{TopN: 3, MinFailures: 5, MinRuns: 30}
-		result := selectTopFlakyTests(runs, cfg)
+		result := selectTopFlakyTests(buildTestRunIndex(runs, nil, nil), cfg)
 		assert.Len(t, result, 3)
 	})
 
@@ -388,7 +391,7 @@ func TestSelectTopFlakyTests(t *testing.T) {
 			{Name: "TestSkipped", Skipped: true, Failed: true},
 		}
 		cfg := BisectConfig{TopN: 10, MinFailures: 1, MinRuns: 1}
-		result := selectTopFlakyTests(runs, cfg)
+		result := selectTopFlakyTests(buildTestRunIndex(runs, nil, nil), cfg)
 		assert.NotContains(t, result, "TestSkipped")
 	})
 
@@ -402,7 +405,7 @@ func TestSelectTopFlakyTests(t *testing.T) {
 			runs = append(runs, TestRun{Name: "TestFlaky (retry 1)", Failed: true})
 		}
 		cfg := BisectConfig{TopN: 10, MinFailures: 5, MinRuns: 30}
-		result := selectTopFlakyTests(runs, cfg)
+		result := selectTopFlakyTests(buildTestRunIndex(runs, nil, nil), cfg)
 		require.Len(t, result, 1)
 		assert.Equal(t, "TestFlaky", result[0])
 	})
@@ -484,7 +487,7 @@ func TestRunBisectForTestDirectionFilter(t *testing.T) {
 	// not introduced). The direction filter must suppress this suspect so it does not appear
 	// as a culprit in the report.
 	commitOrderSlice := []string{"sha0", "sha1", "sha2", "sha3", "sha4", "sha5"}
-	runToSHA := map[int64]string{0: "sha0", 1: "sha1", 2: "sha2", 3: "sha3", 4: "sha4", 5: "sha5"}
+	githubActionsRunIDToCommitSHA := map[int64]string{0: "sha0", 1: "sha1", 2: "sha2", 3: "sha3", 4: "sha4", 5: "sha5"}
 
 	var allRuns []TestRun
 	// sha0-sha4: 8 failures + 2 passes each (80% failure rate)
@@ -508,7 +511,7 @@ func TestRunBisectForTestDirectionFilter(t *testing.T) {
 		MinProbability: 0.5,
 	}
 
-	report := runBisectForTest(cfg, "TestFoo", allRuns, commitOrderSlice, runToSHA, nil)
+	report := runBisectForTest(cfg, "TestFoo", buildTestRunIndex(allRuns, commitOrderSlice, githubActionsRunIDToCommitSHA), nil)
 
 	// The only high-probability transition point (sha5, where rate dropped 80%→0%) should be
 	// filtered out by the direction filter, leaving no actionable suspects.
@@ -520,7 +523,7 @@ func TestRunBisectForTestDirectionFilterKeepsIntroduction(t *testing.T) {
 	// Complementary: failure rate INCREASES at sha3 (flake introduced). The direction filter
 	// must retain this suspect.
 	commitOrderSlice := []string{"sha0", "sha1", "sha2", "sha3", "sha4", "sha5"}
-	runToSHA := map[int64]string{0: "sha0", 1: "sha1", 2: "sha2", 3: "sha3", 4: "sha4", 5: "sha5"}
+	githubActionsRunIDToCommitSHA := map[int64]string{0: "sha0", 1: "sha1", 2: "sha2", 3: "sha3", 4: "sha4", 5: "sha5"}
 
 	var allRuns []TestRun
 	// sha0-sha2: clean (0% failure rate)
@@ -547,7 +550,7 @@ func TestRunBisectForTestDirectionFilterKeepsIntroduction(t *testing.T) {
 		MinProbability: 0.5,
 	}
 
-	report := runBisectForTest(cfg, "TestFoo", allRuns, commitOrderSlice, runToSHA, nil)
+	report := runBisectForTest(cfg, "TestFoo", buildTestRunIndex(allRuns, commitOrderSlice, githubActionsRunIDToCommitSHA), nil)
 
 	require.False(t, report.Skipped, "report should not be skipped: a real introduction exists")
 	require.NotEmpty(t, report.TopSuspects)


### PR DESCRIPTION
## What changed?
- Build one index from parsed test attempts keyed by normalized test name and GitHub Actions run commit.
- Reuse that index when selecting and bisecting tests instead of rescanning every parsed attempt for each candidate.
- Use `githubActions...` names in the bisect path to distinguish GitHub Actions runs from Temporal workflows.

## Why?
A report can contain millions of parsed attempts. The previous bisect loop rescanned all of them for every candidate test.

## How did you test it?
- [x] covered by existing tests
- [x] checked the diff for whitespace errors
- [ ] built
- [ ] run locally and tested manually
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
This is stacked on #11523. The index preserves full test counts for qualification while excluding attempts without an in-range GitHub Actions commit from commit observations, matching the previous behavior.