### PR TITLE
Improve flaky report presentation

### DIFF
--- a/tools/flakereport/flakereport.go
+++ b/tools/flakereport/flakereport.go
@@ -197,7 +197,7 @@ func collectArtifactJobs(ctx context.Context, repo string, runs []github.Run, te
 }
 
 // buildReportSummary builds the complete report summary from processed data
-func buildReportSummary(flakyReports, timeoutReports, crashReports, ciBreakerReports []TestReport,
+func buildReportSummary(flakyReports, timeoutReports, testRunnerTimeoutReports, crashReports, ciBreakerReports []TestReport,
 	suiteReports []SuiteReport,
 	allFailures []TestFailure, allTestRuns []TestRun, runs []github.Run, successfulRuns int) *ReportSummary {
 	filteredFlakyReports := make([]TestReport, 0, len(flakyReports))
@@ -221,6 +221,7 @@ func buildReportSummary(flakyReports, timeoutReports, crashReports, ciBreakerRep
 	return &ReportSummary{
 		FlakyTests:         flakyReports,
 		Timeouts:           timeoutReports,
+		TestRunnerTimeouts: testRunnerTimeoutReports,
 		Crashes:            crashReports,
 		CIBreakers:         ciBreakerReports,
 		Suites:             suiteReports,
@@ -307,17 +308,21 @@ func runGenerateCommand(c *cli.Context) (err error) {
 	if err != nil {
 		return err
 	}
+	testFailures, testRunnerTimeouts := splitTestRunnerTimeoutFailures(allFailures)
+	allTestRuns = filterTestRunnerTimeoutRuns(allTestRuns)
 
 	fmt.Println("\n=== Processing Results ===")
 	fmt.Printf("Total test runs: %d\n", len(allTestRuns))
-	fmt.Printf("Total test failures found: %d\n", len(allFailures))
+	fmt.Printf("Total test failures found: %d\n", len(testFailures))
+	fmt.Printf("Test-runner timeouts: %d\n", len(testRunnerTimeouts))
 	fmt.Printf("Processed artifacts: %d\n", processedArtifacts)
 
 	// Count test runs by name for failure rate calculation
 	testRunCounts := countTestRuns(allTestRuns)
 
 	// Group failures by test name, then remove parent entries whose subtests were observed.
-	grouped := groupFailuresByTest(allFailures)
+	grouped := groupFailuresByTest(testFailures)
+	testRunnerTimeoutMap := groupFailuresByTest(testRunnerTimeouts)
 	filterParentTests(grouped, testRunCounts)
 	fmt.Printf("Unique tests with failures: %d\n", len(grouped))
 
@@ -328,7 +333,7 @@ func runGenerateCommand(c *cli.Context) (err error) {
 	fmt.Printf("Crash tests: %d\n", len(crashMap))
 
 	// Identify CI breakers (tests that failed all retries in a single job)
-	ciBreakerMap, ciBreakCounts := identifyCIBreakers(allFailures)
+	ciBreakerMap, ciBreakCounts := identifyCIBreakers(testFailures)
 	filterParentTests(ciBreakerMap, testRunCounts)
 	fmt.Printf("CI breaker tests (failed all retries): %d\n", len(ciBreakerMap))
 
@@ -336,18 +341,19 @@ func runGenerateCommand(c *cli.Context) (err error) {
 	reportWindow := newReportWindow(reportSince, now)
 	flakyReports := convertToReports(flakyMap, testRunCounts, repo, maxLinks, reportWindow)
 	timeoutReports := convertToReports(timeoutMap, testRunCounts, repo, maxLinks, reportWindow)
+	testRunnerTimeoutReports := convertEventReports(testRunnerTimeoutMap, repo, maxLinks, reportWindow)
 	crashReports := convertCrashesToReports(crashMap, jobs, repo, maxLinks, reportWindow)
-	ciBreakerReports := convertCIBreakersToReports(ciBreakerMap, ciBreakCounts, len(runs), repo, maxLinks, reportWindow)
+	ciBreakerReports := convertCIBreakersToReports(ciBreakerMap, ciBreakCounts, repo, maxLinks, reportWindow)
 
 	// Compute suite-level breakdown
-	suiteReports := generateSuiteReports(allFailures, allTestRuns)
+	suiteReports := generateSuiteReports(testFailures, allTestRuns)
 	fmt.Printf("Suites: %d\n", len(suiteReports))
 
 	// Build summary
 	summary := buildReportSummary(
-		flakyReports, timeoutReports, crashReports, ciBreakerReports,
+		flakyReports, timeoutReports, testRunnerTimeoutReports, crashReports, ciBreakerReports,
 		suiteReports,
-		allFailures, allTestRuns, runs, successfulRuns,
+		testFailures, allTestRuns, runs, successfulRuns,
 	)
 
 	// Optionally run Bayesian bisect analysis
@@ -392,10 +398,7 @@ func runGenerateCommand(c *cli.Context) (err error) {
 
 	// Write GitHub summary (to GITHUB_STEP_SUMMARY if set, otherwise to output dir)
 	fmt.Println("\n=== Writing GitHub summary ===")
-	summaryContent := generateGitHubSummary(summary, runID, maxLinks)
-	if len(bisectReports) > 0 {
-		summaryContent += generateBisectSummary(bisectReports, repo, bisectMinProbability)
-	}
+	summaryContent := generateGitHubSummary(summary, bisectReports, repo, runID, maxLinks, bisectMinProbability)
 	if err := writeGitHubSummary(summaryContent, outputDir); err != nil {
 		fmt.Printf("Warning: Failed to write GitHub summary: %v\n", err)
 	}

--- a/tools/flakereport/parser.go
+++ b/tools/flakereport/parser.go
@@ -14,6 +14,8 @@ import (
 var finalRegex = regexp.MustCompile(`\s*\(final\)$`)
 var trailingSuffixRegex = regexp.MustCompile(`\s*\([^)]+\)$`)
 
+const testRunnerTotalTimeout = "testrunner.TotalTimeout"
+
 // topLevelTestName extracts the suite/top-level test name from a test name.
 // For "TestSuiteV0/TestMethod" returns "TestSuiteV0".
 // For "TestFoo" (no slash) returns "TestFoo".
@@ -96,6 +98,31 @@ func normalizeTestName(name string) string {
 	}
 }
 
+func isTestRunnerTimeout(name string) bool {
+	return strings.EqualFold(normalizeTestName(name), testRunnerTotalTimeout)
+}
+
+func splitTestRunnerTimeoutFailures(failures []TestFailure) (testFailures, testRunnerTimeouts []TestFailure) {
+	for _, failure := range failures {
+		if isTestRunnerTimeout(failure.Name) {
+			testRunnerTimeouts = append(testRunnerTimeouts, failure)
+			continue
+		}
+		testFailures = append(testFailures, failure)
+	}
+	return testFailures, testRunnerTimeouts
+}
+
+func filterTestRunnerTimeoutRuns(runs []TestRun) []TestRun {
+	filtered := runs[:0]
+	for _, run := range runs {
+		if !isTestRunnerTimeout(run.Name) {
+			filtered = append(filtered, run)
+		}
+	}
+	return filtered
+}
+
 // groupFailuresByTest groups failures by normalized test name
 func groupFailuresByTest(failures []TestFailure) map[string][]TestFailure {
 	grouped := make(map[string][]TestFailure)
@@ -127,6 +154,9 @@ func countTestRuns(allRuns []TestRun) map[string]int {
 // Uses Contains (not HasSuffix) so it works on both raw and normalized names.
 func classifyFailure(name string) string {
 	lower := strings.ToLower(name)
+	if isTestRunnerTimeout(name) {
+		return "timeout"
+	}
 	if strings.Contains(lower, "(timeout)") {
 		return "timeout"
 	}
@@ -261,6 +291,13 @@ func convertToReports(grouped map[string][]TestFailure, testRunCounts map[string
 		repo, maxLinks, window)
 }
 
+func convertEventReports(grouped map[string][]TestFailure, repo string, maxLinks int, window reportWindow) []TestReport {
+	return buildReports(grouped,
+		func(_ string, failures []TestFailure) int { return len(failures) },
+		func(string, []TestFailure) int { return 0 },
+		repo, maxLinks, window)
+}
+
 // filterParentTests removes top-level test names from grouped when subtests of
 // that parent were observed in testRunCounts. A top-level failure whose subtests
 // ran in other CI jobs is already captured (with a correct denominator) in the
@@ -338,12 +375,11 @@ func convertCrashesToReports(grouped map[string][]TestFailure, jobs []ArtifactJo
 		repo, maxLinks, window)
 }
 
-// convertCIBreakersToReports converts CI breaker failures to TestReport slice.
-// totalWorkflowRuns is the total number of CI runs analyzed (denominator for break rate).
-func convertCIBreakersToReports(grouped map[string][]TestFailure, ciBreakCounts map[string]int, totalWorkflowRuns int, repo string, maxLinks int, window reportWindow) []TestReport {
+// convertCIBreakersToReports converts final-retry failures to TestReport slice.
+func convertCIBreakersToReports(grouped map[string][]TestFailure, ciBreakCounts map[string]int, repo string, maxLinks int, window reportWindow) []TestReport {
 	return buildReports(grouped,
 		func(name string, _ []TestFailure) int { return ciBreakCounts[name] },
-		func(_ string, _ []TestFailure) int { return totalWorkflowRuns },
+		func(string, []TestFailure) int { return 0 },
 		repo, maxLinks, window)
 }
 

--- a/tools/flakereport/parser.go
+++ b/tools/flakereport/parser.go
@@ -293,9 +293,17 @@ func convertToReports(grouped map[string][]TestFailure, testRunCounts map[string
 
 func convertEventReports(grouped map[string][]TestFailure, repo string, maxLinks int, window reportWindow) []TestReport {
 	return buildReports(grouped,
-		func(_ string, failures []TestFailure) int { return len(failures) },
+		func(_ string, failures []TestFailure) int { return countArtifacts(failures) },
 		func(string, []TestFailure) int { return 0 },
 		repo, maxLinks, window)
+}
+
+func countArtifacts(failures []TestFailure) int {
+	artifacts := make(map[string]struct{}, len(failures))
+	for _, failure := range failures {
+		artifacts[failure.ArtifactID] = struct{}{}
+	}
+	return len(artifacts)
 }
 
 // filterParentTests removes top-level test names from grouped when subtests of

--- a/tools/flakereport/parser_test.go
+++ b/tools/flakereport/parser_test.go
@@ -44,6 +44,24 @@ func TestNormalizeTestName(t *testing.T) {
 	}
 }
 
+func TestSplitTestRunnerTimeoutFailures(t *testing.T) {
+	failures := []TestFailure{
+		{Name: "TestFoo"},
+		{Name: "testrunner.TotalTimeout (retry 2) (final)"},
+	}
+	testFailures, timeouts := splitTestRunnerTimeoutFailures(failures)
+
+	require.Equal(t, []TestFailure{{Name: "TestFoo"}}, testFailures)
+	require.Equal(t, []TestFailure{{Name: "testrunner.TotalTimeout (retry 2) (final)"}}, timeouts)
+	require.Equal(t, "timeout", classifyFailure(timeouts[0].Name))
+
+	runs := filterTestRunnerTimeoutRuns([]TestRun{
+		{Name: "TestFoo"},
+		{Name: "testrunner.TotalTimeout (retry 2) (final)"},
+	})
+	require.Equal(t, []TestRun{{Name: "TestFoo"}}, runs)
+}
+
 func TestParseArtifactName(t *testing.T) {
 	tests := []struct {
 		name               string

--- a/tools/flakereport/parser_test.go
+++ b/tools/flakereport/parser_test.go
@@ -62,6 +62,21 @@ func TestSplitTestRunnerTimeoutFailures(t *testing.T) {
 	require.Equal(t, []TestRun{{Name: "TestFoo"}}, runs)
 }
 
+func TestConvertEventReportsCountsArtifacts(t *testing.T) {
+	until := time.Now()
+	window := newReportWindow(until.AddDate(0, 0, -7), until)
+	reports := convertEventReports(map[string][]TestFailure{
+		testRunnerTotalTimeout: {
+			{ArtifactID: "artifact-1"},
+			{ArtifactID: "artifact-1"},
+			{ArtifactID: "artifact-2"},
+		},
+	}, "temporalio/temporal", 3, window)
+
+	require.Len(t, reports, 1)
+	require.Equal(t, 2, reports[0].FailureCount)
+}
+
 func TestParseArtifactName(t *testing.T) {
 	tests := []struct {
 		name               string

--- a/tools/flakereport/report.go
+++ b/tools/flakereport/report.go
@@ -145,6 +145,7 @@ func generateOccurrenceReportTable(reports []TestReport, nameHeader, countHeader
 	if len(reports) == 0 {
 		return ""
 	}
+	reports = limitReportRows(reports)
 
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("| %s | %s | Last Occurrence | Trend | Links |\n", nameHeader, countHeader))

--- a/tools/flakereport/report.go
+++ b/tools/flakereport/report.go
@@ -37,6 +37,14 @@ func formatReportLines(reports []TestReport) []string {
 	return lines
 }
 
+func formatOccurrenceLines(reports []TestReport, countLabel string) []string {
+	lines := make([]string, 0, len(reports))
+	for _, r := range reports {
+		lines = append(lines, fmt.Sprintf("• %d %s: `%s`", r.FailureCount, countLabel, r.TestName))
+	}
+	return lines
+}
+
 // formatLinks formats GitHub URLs as numbered markdown links
 func formatLinks(urls []string, maxLinks int) string {
 	linkCount := min(len(urls), maxLinks)
@@ -128,6 +136,27 @@ func generateTestReportTable(reports []TestReport, rateHeader string, maxLinks i
 		}
 		sb.WriteString(fmt.Sprintf("| `%s` | %s | %s | `%s` | %s |\n",
 			report.TestName, rate, lastFailure, formatSparkline(report.TrendPoints), links))
+	}
+
+	return sb.String()
+}
+
+func generateOccurrenceReportTable(reports []TestReport, nameHeader, countHeader string, maxLinks int) string {
+	if len(reports) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("| %s | %s | Last Occurrence | Trend | Links |\n", nameHeader, countHeader))
+	sb.WriteString("|------|--------------------|-----------------|-------|-------|\n")
+	for _, report := range reports {
+		links := formatLinks(report.GitHubURLs, maxLinks)
+		lastOccurrence := "N/A"
+		if !report.LastFailure.IsZero() {
+			lastOccurrence = hoursAgo(report.LastFailure)
+		}
+		sb.WriteString(fmt.Sprintf("| `%s` | %d | %s | `%s` | %s |\n",
+			report.TestName, report.FailureCount, lastOccurrence, formatSparkline(report.TrendPoints), links))
 	}
 
 	return sb.String()

--- a/tools/flakereport/report_test.go
+++ b/tools/flakereport/report_test.go
@@ -63,7 +63,12 @@ func TestGenerateGitHubSummaryPutsBayesianSuspectsBeforeFailureCategories(t *tes
 
 	content := generateGitHubSummary(summary, bisectReports, "temporalio/temporal", "123", 1, 0.5)
 
-	require.Less(t, strings.Index(content, "### Bayesian Commit Suspects"), strings.Index(content, "### Failure Categories Summary"))
+	bayesianIndex := strings.Index(content, "### Bayesian Commit Suspects")
+	failureCategoriesIndex := strings.Index(content, "### Failure Categories Summary")
+	require.NotEqual(t, -1, bayesianIndex)
+	require.NotEqual(t, -1, failureCategoriesIndex)
+	require.Less(t, bayesianIndex, failureCategoriesIndex)
+	require.Contains(t, content, "| CI Execution Interruptions |")
 	require.Contains(t, content, "### CI Execution Interruptions")
 	require.Contains(t, content, "### Final-Retry Test Failures")
 }

--- a/tools/flakereport/report_test.go
+++ b/tools/flakereport/report_test.go
@@ -63,7 +63,7 @@ func TestGenerateGitHubSummaryPutsBayesianSuspectsBeforeFailureCategories(t *tes
 
 	content := generateGitHubSummary(summary, bisectReports, "temporalio/temporal", "123", 1, 0.5)
 
-	require.Less(t, strings.Index(content, "## Bayesian Commit Suspects"), strings.Index(content, "### Failure Categories Summary"))
+	require.Less(t, strings.Index(content, "### Bayesian Commit Suspects"), strings.Index(content, "### Failure Categories Summary"))
 	require.Contains(t, content, "### CI Execution Interruptions")
 	require.Contains(t, content, "### Final-Retry Test Failures")
 }

--- a/tools/flakereport/report_test.go
+++ b/tools/flakereport/report_test.go
@@ -33,6 +33,41 @@ func TestGenerateTestReportTable(t *testing.T) {
 		"| `TestFlake` | **30.0% (3/10)** | 2h ago | `▁▅█▁` | [1](https://github.com/temporalio/temporal/actions/runs/1) |\n", table)
 }
 
+func TestGenerateOccurrenceReportTable(t *testing.T) {
+	report := TestReport{
+		TestName:     testRunnerTotalTimeout,
+		FailureCount: 3,
+		GitHubURLs:   []string{"https://github.com/temporalio/temporal/actions/runs/1"},
+		TrendPoints:  []int{0, 1, 2, 0},
+	}
+
+	table := generateOccurrenceReportTable([]TestReport{report}, "Event", "Affected Artifacts", 1)
+
+	require.Equal(t, "| Event | Affected Artifacts | Last Occurrence | Trend | Links |\n"+
+		"|------|--------------------|-----------------|-------|-------|\n"+
+		"| `testrunner.TotalTimeout` | 3 | N/A | `▁▅█▁` | [1](https://github.com/temporalio/temporal/actions/runs/1) |\n", table)
+}
+
+func TestGenerateGitHubSummaryPutsBayesianSuspectsBeforeFailureCategories(t *testing.T) {
+	summary := &ReportSummary{
+		TestRunnerTimeouts: []TestReport{{TestName: testRunnerTotalTimeout, FailureCount: 1}},
+		CIBreakers:         []TestReport{{TestName: "TestFinalRetry", FailureCount: 1}},
+	}
+	bisectReports := []TestBisectReport{{
+		TestName: "TestFoo",
+		TopSuspects: []BisectResult{{
+			CommitSHA:   "0123456789abcdef",
+			Probability: 0.6,
+		}},
+	}}
+
+	content := generateGitHubSummary(summary, bisectReports, "temporalio/temporal", "123", 1, 0.5)
+
+	require.Less(t, strings.Index(content, "## Bayesian Commit Suspects"), strings.Index(content, "### Failure Categories Summary"))
+	require.Contains(t, content, "### CI Execution Interruptions")
+	require.Contains(t, content, "### Final-Retry Test Failures")
+}
+
 func TestGenerateSuiteBreakdownTable(t *testing.T) {
 	report := SuiteReport{
 		SuiteName:   "TestFunctionalSuite",

--- a/tools/flakereport/report_test.go
+++ b/tools/flakereport/report_test.go
@@ -99,6 +99,7 @@ func TestBuildReportSummaryExcludesHundredPercentFlakyTests(t *testing.T) {
 	summary := buildReportSummary(
 		[]TestReport{fullyFailing, flaky},
 		[]TestReport{timeout},
+		nil,
 		[]TestReport{crash},
 		[]TestReport{ciBreaker},
 		nil, nil, nil, nil, 0,
@@ -156,7 +157,7 @@ func TestGenerateReportLimitsNonSuiteTableRows(t *testing.T) {
 		TotalFlakyCount: total,
 	}
 
-	summaryContent := generateGitHubSummary(summary, "", 0)
+	summaryContent := generateGitHubSummary(summary, nil, "", "", 0, 0)
 	summaryContent += generateBisectSummary(bisectReports, "temporalio/temporal", 0.5)
 
 	require.Contains(t, summaryContent, "| Flaky Tests | 101 |")

--- a/tools/flakereport/slack.go
+++ b/tools/flakereport/slack.go
@@ -18,13 +18,14 @@ func buildSuccessMessage(summary *ReportSummary, runID, repo string, days int) *
 	}
 
 	// Summary stats
-	summaryText := fmt.Sprintf("*CI Success Rate:* %d/%d (%.2f%%)\n*Total Test Runs:* %d\n*Total Failures:* %d\n*Failure Rate:* %.2f per 1000 tests\n\n*CI Breakers:* %d\n*Crashes:* %d\n*Flaky Tests:* %d\n*Timeouts:* %d",
+	summaryText := fmt.Sprintf("*CI Success Rate:* %d/%d (%.2f%%)\n*Total Test Runs:* %d\n*Total Failures:* %d\n*Failure Rate:* %.2f per 1000 tests\n\n*Test Runner Timeouts:* %d\n*Final-Retry Test Failures:* %d\n*Crashes:* %d\n*Flaky Tests:* %d\n*Timeouts:* %d",
 		summary.SuccessfulRuns,
 		summary.TotalWorkflowRuns,
 		ciSuccessRate,
 		summary.TotalTestRuns,
 		summary.TotalFailures,
 		summary.OverallFailureRate,
+		len(summary.TestRunnerTimeouts),
 		len(summary.CIBreakers),
 		len(summary.Crashes),
 		summary.TotalFlakyCount,
@@ -34,12 +35,12 @@ func buildSuccessMessage(summary *ReportSummary, runID, repo string, days int) *
 	msg.AddHeader(fmt.Sprintf("Flaky Tests Report - Last %d Days", days))
 	msg.AddSection(summaryText)
 
-	// Add CI breakers details
-	if lines := formatReportLines(summary.CIBreakers); len(lines) > 0 {
+	// Add final-retry test failure details.
+	if lines := formatOccurrenceLines(summary.CIBreakers, "affected artifacts"); len(lines) > 0 {
 		if len(lines) > slackMaxListItems {
 			lines = lines[:slackMaxListItems]
 		}
-		text := fmt.Sprintf("*CI Breakers (top %d):*\n%s", slackMaxListItems, strings.Join(lines, "\n"))
+		text := fmt.Sprintf("*Final-Retry Test Failures (top %d):*\n%s", slackMaxListItems, strings.Join(lines, "\n"))
 		msg.AddSection(text)
 	}
 

--- a/tools/flakereport/slack.go
+++ b/tools/flakereport/slack.go
@@ -22,7 +22,7 @@ func buildSuccessMessage(summary *ReportSummary, runID, repo string, days int) *
 	}
 
 	// Summary stats
-	summaryText := fmt.Sprintf("*CI Success Rate:* %d/%d (%.2f%%)\n*Total Test Runs:* %d\n*Total Failures:* %d\n*Failure Rate:* %.2f per 1000 tests\n\n*Test Runner Timeouts:* %d\n*Final-Retry Test Failures:* %d\n*Crashes:* %d\n*Flaky Tests:* %d\n*Timeouts:* %d",
+	summaryText := fmt.Sprintf("*CI Success Rate:* %d/%d (%.2f%%)\n*Total Test Runs:* %d\n*Total Failures:* %d\n*Failure Rate:* %.2f per 1000 tests\n\n*CI Execution Interruptions:* %d\n*Final-Retry Test Failures:* %d\n*Crashes:* %d\n*Flaky Tests:* %d\n*Timeouts:* %d",
 		summary.SuccessfulRuns,
 		summary.TotalWorkflowRuns,
 		ciSuccessRate,

--- a/tools/flakereport/slack.go
+++ b/tools/flakereport/slack.go
@@ -16,6 +16,10 @@ func buildSuccessMessage(summary *ReportSummary, runID, repo string, days int) *
 	if summary.TotalWorkflowRuns > 0 {
 		ciSuccessRate = (float64(summary.SuccessfulRuns) / float64(summary.TotalWorkflowRuns)) * 100.0
 	}
+	testRunnerTimeouts := 0
+	for _, report := range summary.TestRunnerTimeouts {
+		testRunnerTimeouts += report.FailureCount
+	}
 
 	// Summary stats
 	summaryText := fmt.Sprintf("*CI Success Rate:* %d/%d (%.2f%%)\n*Total Test Runs:* %d\n*Total Failures:* %d\n*Failure Rate:* %.2f per 1000 tests\n\n*Test Runner Timeouts:* %d\n*Final-Retry Test Failures:* %d\n*Crashes:* %d\n*Flaky Tests:* %d\n*Timeouts:* %d",
@@ -25,7 +29,7 @@ func buildSuccessMessage(summary *ReportSummary, runID, repo string, days int) *
 		summary.TotalTestRuns,
 		summary.TotalFailures,
 		summary.OverallFailureRate,
-		len(summary.TestRunnerTimeouts),
+		testRunnerTimeouts,
 		len(summary.CIBreakers),
 		len(summary.Crashes),
 		summary.TotalFlakyCount,

--- a/tools/flakereport/types.go
+++ b/tools/flakereport/types.go
@@ -48,8 +48,9 @@ type SuiteReport struct {
 type ReportSummary struct {
 	FlakyTests         []TestReport
 	Timeouts           []TestReport  // Tests ending with "(timeout)"
+	TestRunnerTimeouts []TestReport  // Synthetic test-runner timeout events
 	Crashes            []TestReport  // Tests containing "crash"
-	CIBreakers         []TestReport  // Tests that failed all retries (3x) in a single job
+	CIBreakers         []TestReport  // Tests that failed their final retry in an artifact
 	Suites             []SuiteReport // Per-suite flake breakdown
 	TotalFailures      int           // Total raw failure count
 	TotalTestRuns      int           // Total test executions (all tests, all runs)

--- a/tools/flakereport/writer.go
+++ b/tools/flakereport/writer.go
@@ -194,7 +194,7 @@ func generateBisectSummary(reports []TestBisectReport, repo string, minProb floa
 	threshold := fmt.Sprintf("%.0f%%", minProb*100)
 
 	var sb strings.Builder
-	sb.WriteString("\n## Bayesian Commit Suspects\n\n")
+	sb.WriteString("\n### Bayesian Commit Suspects\n\n")
 
 	if qualifying == 0 {
 		sb.WriteString("No actionable commit suspects found")

--- a/tools/flakereport/writer.go
+++ b/tools/flakereport/writer.go
@@ -38,7 +38,7 @@ func writeFailuresJSON(outputDir string, failures []TestFailure, repo string) er
 }
 
 // generateGitHubSummary creates markdown summary for GitHub Actions
-func generateGitHubSummary(summary *ReportSummary, runID string, maxLinks int) string {
+func generateGitHubSummary(summary *ReportSummary, bisectReports []TestBisectReport, repo, runID string, maxLinks int, minProbability float64) string {
 	timestamp := time.Now().Format("2006-01-02 15:04:05")
 
 	var content string
@@ -57,19 +57,29 @@ func generateGitHubSummary(summary *ReportSummary, runID string, maxLinks int) s
 	content += fmt.Sprintf("* **Total Failures**: %d\n", summary.TotalFailures)
 	content += fmt.Sprintf("* **Overall Failure Rate**: %.1f per 1000 tests\n\n", summary.OverallFailureRate)
 
+	if len(bisectReports) > 0 {
+		content += generateBisectSummary(bisectReports, repo, minProbability)
+	}
+
 	// Summary table
 	content += "### Failure Categories Summary\n\n"
-	content += "| Category | Unique Tests |\n"
-	content += "|----------|--------------|\n"
-	content += fmt.Sprintf("| CI Breakers | %d |\n", len(summary.CIBreakers))
+	content += "| Category | Unique Entries |\n"
+	content += "|----------|----------------|\n"
+	content += fmt.Sprintf("| Test Runner Timeouts | %d |\n", len(summary.TestRunnerTimeouts))
+	content += fmt.Sprintf("| Final-Retry Test Failures | %d |\n", len(summary.CIBreakers))
 	content += fmt.Sprintf("| Crashes | %d |\n", len(summary.Crashes))
 	content += fmt.Sprintf("| Timeouts | %d |\n", len(summary.Timeouts))
 	content += fmt.Sprintf("| Flaky Tests | %d |\n\n", summary.TotalFlakyCount)
 
-	// CI Breakers section (tests that failed all retries)
+	if len(summary.TestRunnerTimeouts) > 0 {
+		content += "### CI Execution Interruptions\n\n"
+		content += generateOccurrenceReportTable(summary.TestRunnerTimeouts, "Event", "Affected Artifacts", maxLinks) + "\n"
+	}
+
+	// Final-retry failures are tracked per artifact, not per GitHub Actions workflow run.
 	if len(summary.CIBreakers) > 0 {
-		content += "### CI Breakers (Failed All Retries)\n\n"
-		content += generateTestReportTable(summary.CIBreakers, "CI Break Rate", maxLinks) + "\n"
+		content += "### Final-Retry Test Failures\n\n"
+		content += generateOccurrenceReportTable(summary.CIBreakers, "Test", "Affected Artifacts", maxLinks) + "\n"
 	}
 
 	// Crashes section
@@ -176,7 +186,7 @@ func writeBisectTable(sb *strings.Builder, rows []bisectTableRow, repo string) {
 	sb.WriteString("\n")
 }
 
-// generateBisectSummary creates the markdown section for bisect results to append to the GitHub summary.
+// generateBisectSummary creates the markdown section for Bayesian bisect results.
 func generateBisectSummary(reports []TestBisectReport, repo string, minProb float64) string {
 	qualifying := countQualifyingBisectReports(reports)
 

--- a/tools/flakereport/writer.go
+++ b/tools/flakereport/writer.go
@@ -65,7 +65,7 @@ func generateGitHubSummary(summary *ReportSummary, bisectReports []TestBisectRep
 	content += "### Failure Categories Summary\n\n"
 	content += "| Category | Unique Entries |\n"
 	content += "|----------|----------------|\n"
-	content += fmt.Sprintf("| Test Runner Timeouts | %d |\n", len(summary.TestRunnerTimeouts))
+	content += fmt.Sprintf("| CI Execution Interruptions | %d |\n", len(summary.TestRunnerTimeouts))
 	content += fmt.Sprintf("| Final-Retry Test Failures | %d |\n", len(summary.CIBreakers))
 	content += fmt.Sprintf("| Crashes | %d |\n", len(summary.Crashes))
 	content += fmt.Sprintf("| Timeouts | %d |\n", len(summary.Timeouts))


### PR DESCRIPTION
## What changed?

- Shows Bayesian commit suspects directly below the overall stats.
- Separates synthetic test-runner timeouts from test failures and reports affected artifacts.
- Shows final-retry test failures as affected-artifact counts rather than workflow-run rates.

## Why?

The synthetic `testrunner.TotalTimeout` event was reported both as a flaky test and as a CI breaker, while the former CI-breaker percentage mixed artifact and workflow-run units.

## How did you test it?

- `go test -tags test_dep ./tools/flakereport ./tools/common/github`
- `make lint-code`

## Potential risks

This changes report categorization and presentation only; raw `failures.json` retains synthetic timeout records as timeout events.