### PR TITLE
JWT audience env config

### DIFF
--- a/common/config/config_template_embedded.yaml
+++ b/common/config/config_template_embedded.yaml
@@ -299,6 +299,7 @@ global:
         permissionsRegex: {{ default "" (env "TEMPORAL_JWT_PERMISSIONS_REGEX") }}
         authorizer: {{ default "" (env "TEMPORAL_AUTH_AUTHORIZER") }}
         claimMapper: {{ default "" (env "TEMPORAL_AUTH_CLAIM_MAPPER") }}
+        audience: {{ default "" (env "TEMPORAL_JWT_AUDIENCE") }}
 
 {{- $temporalGrpcPort := default "7233" (env "FRONTEND_GRPC_PORT") }}
 {{- $temporalHTTPPort := default "7243" (env "FRONTEND_HTTP_PORT") }}

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -268,6 +268,7 @@ global:
         permissionsRegex: {{ default .Env.TEMPORAL_JWT_PERMISSIONS_REGEX "" }}
         authorizer: {{ default .Env.TEMPORAL_AUTH_AUTHORIZER "" }}
         claimMapper: {{ default .Env.TEMPORAL_AUTH_CLAIM_MAPPER "" }}
+        audience: {{ default .Env.TEMPORAL_JWT_AUDIENCE "" }}
 
 {{- $temporalGrpcPort := default .Env.FRONTEND_GRPC_PORT "7233" }}
 {{- $temporalHTTPPort := default .Env.FRONTEND_HTTP_PORT "7243" }}


### PR DESCRIPTION
## What changed?
Added TEMPORAL_JWT_AUDIENCE to the embedded and Docker configuration templates, mapping the environment variable to global.authorization.audience.


## Why?
JWT audience validation needs to be configurable in environment-based deployments, consistent with the existing JWT authorization settings.


## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
An incorrect TEMPORAL_JWT_AUDIENCE value can cause JWT-authenticated requests with a different audience to be rejected. When unset, it defaults to an empty value, preserving existing configuration behavior.