### PR TITLE
Fix Schedule V2 BUFFER_ONE with a deferred start

### DIFF
--- a/chasm/lib/scheduler/invoker_process_buffer_task_test.go
+++ b/chasm/lib/scheduler/invoker_process_buffer_task_test.go
@@ -317,6 +317,40 @@ func TestProcessBufferTask_BufferOne(t *testing.T) {
 	})
 }
 
+func TestProcessBufferTask_BufferOneKeepsExistingDeferredStart(t *testing.T) {
+	env := newTestEnv(t)
+	startTime := timestamppb.New(env.TimeSource.Now())
+	runProcessBufferTestCase(t, env, &processBufferTestCase{
+		InitialBufferedStarts: []*schedulespb.BufferedStart{
+			{
+				NominalTime:   startTime,
+				ActualTime:    startTime,
+				DesiredTime:   startTime,
+				RequestId:     "deferred-first",
+				WorkflowId:    "deferred-first",
+				OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE,
+				Attempt:       -1,
+			},
+			{
+				NominalTime:   startTime,
+				ActualTime:    startTime,
+				DesiredTime:   startTime,
+				RequestId:     "new-later",
+				WorkflowId:    "new-later",
+				OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE,
+			},
+		},
+		InitialRunningWorkflows:  []*commonpb.WorkflowExecution{{WorkflowId: "running", RunId: "running-run"}},
+		ExpectedBufferedStarts:   1,
+		ExpectedRunningWorkflows: 1,
+		ExpectedOverlapSkipped:   1,
+		ValidateInvoker: func(t *testing.T, invoker *scheduler.Invoker) {
+			require.Equal(t, "deferred-first", invoker.GetBufferedStarts()[0].GetRequestId())
+			require.Equal(t, int64(-1), invoker.GetBufferedStarts()[0].GetAttempt())
+		},
+	})
+}
+
 // ProcessBuffer is scheduled with an empty buffer.
 func TestProcessBufferTask_Empty(t *testing.T) {
 	env := newTestEnv(t)

--- a/chasm/lib/scheduler/invoker_tasks.go
+++ b/chasm/lib/scheduler/invoker_tasks.go
@@ -501,9 +501,11 @@ func (h *InvokerProcessBufferTaskHandler) processBuffer(
 	isRunning := len(runningWorkflows) > 0
 	result.missedCatchupByActionRunning = make(map[bool]int64)
 
-	// Processing completely ignores any BufferedStart that's already executing/backing off.
+	// Processing ignores starts that are already executing or backing off. An existing
+	// deferred BUFFER_ONE start still participates so it can reject later starts.
 	pendingBufferedStarts := util.FilterSlice(invoker.GetBufferedStarts(), func(start *schedulespb.BufferedStart) bool {
-		return start.Attempt == 0
+		return start.Attempt == 0 ||
+			(start.Attempt == -1 && scheduler.resolveOverlapPolicy(start.GetOverlapPolicy()) == enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE)
 	})
 
 	// Resolve overlap policies and trim BufferedStarts that are skipped by policy.


### PR DESCRIPTION
## Summary

- include an existing deferred BUFFER_ONE start in overlap resolution
- prevent a later occurrence from becoming a second buffered start
- add a focused regression test with one running, one deferred, and one new occurrence

## Production replay evidence

The representative V1 history changed from 5,355 V1 actions versus 4,961 CHASM actions to 5,355 versus 5,355. Extra and missing workflow identities disappeared; only observation-time differences remain.

## Test plan

- `go test -tags test_dep ./chasm/lib/scheduler -run "^TestProcessBufferTask_BufferOne(KeepsExistingDeferredStart)?$" -count=1`
- representative three-history production replay