### PR TITLE
Reproduce migrated zero catchup compatibility gap

### DIFF
--- a/chasm/lib/scheduler/migration/migration_test.go
+++ b/chasm/lib/scheduler/migration/migration_test.go
@@ -146,6 +146,28 @@ func TestLegacyToCreateFromMigrationStateRequest(t *testing.T) {
 	require.Equal(t, memo.GetFields(), migrationState.Memo)
 }
 
+func TestLegacyToCreateFromMigrationStateRequest_PreservesZeroCatchupWindow(t *testing.T) {
+	now := time.Now().UTC()
+	schedule := newTestSchedule()
+	schedule.Policies.CatchupWindow = durationpb.New(0)
+	req := LegacyToCreateFromMigrationStateRequest(
+		schedule,
+		&schedulepb.ScheduleInfo{},
+		&schedulespb.InternalState{
+			Namespace:         "test-ns",
+			NamespaceId:       "test-ns-id",
+			ScheduleId:        "test-sched-id",
+			LastProcessedTime: timestamppb.New(now),
+		},
+		nil,
+		nil,
+		now,
+	)
+
+	require.NotNil(t, req.GetState().GetSchedulerState().GetSchedule().GetPolicies().GetCatchupWindow())
+	require.Zero(t, req.GetState().GetSchedulerState().GetSchedule().GetPolicies().GetCatchupWindow().AsDuration())
+}
+
 func TestLegacyToCreateFromMigrationStateRequest_StripsSystemSearchAttributes(t *testing.T) {
 	// V1 scheduler workflows carry TemporalNamespaceDivision ('TemporalScheduler')
 	// and TemporalSchedulePaused in their search attributes. Both are system SAs

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -454,6 +454,19 @@ func (s *workflowSuite) TestCatchupWindow() {
 	s.True(workflow.IsContinueAsNewError(s.env.GetWorkflowError()))
 }
 
+func (s *workflowSuite) TestZeroCatchupWindowUsesMinimum() {
+	legacy := &scheduler{
+		StartScheduleArgs: &schedulespb.StartScheduleArgs{Schedule: &schedulepb.Schedule{
+			Policies: &schedulepb.SchedulePolicies{CatchupWindow: durationpb.New(0)},
+		}},
+		tweakables: TweakablePolicies{
+			DefaultCatchupWindow: 365 * 24 * time.Hour,
+			MinCatchupWindow:     10 * time.Second,
+		},
+	}
+	s.Equal(10*time.Second, legacy.getCatchupWindow())
+}
+
 func (s *workflowSuite) TestCatchupWindowWhilePaused() {
 	// written using low-level mocks so we can set initial state
 


### PR DESCRIPTION
## Summary

- characterize V1 resolution of an explicit zero catchup window to the 10-second minimum
- prove migration currently preserves the explicit zero value
- pair these tests with existing CHASM coverage where zero resolves to the one-year default

## Finding

This is a genuine migration compatibility difference. In the representative history, all 15 CHASM-only actions were decided 10 to 112 seconds after nominal time. V1 dropped them under its 10-second window while CHASM retained them under its default window.

This draft intentionally does not choose a fix. A migration-only compatibility rule may be appropriate; globally changing V2 would alter its intended zero-means-unset behavior.

## Test plan

- `go test -tags test_dep ./service/worker/scheduler -run "^TestWorkflow/TestZeroCatchupWindowUsesMinimum$" -count=1`
- `go test -tags test_dep ./chasm/lib/scheduler/migration -run "^TestLegacyToCreateFromMigrationStateRequest_PreservesZeroCatchupWindow$" -count=1`
- existing CHASM non-positive catchup tests
- representative three-history production replay