### PR TITLE
Validate fairsim inputs and preserve counter defaults

### DIFF
--- a/tools/fairsim/sim.go
+++ b/tools/fairsim/sim.go
@@ -106,18 +106,15 @@ func RunTool(args []string) error {
 	if err != nil {
 		return err
 	}
+	if *partitions <= 0 {
+		return fmt.Errorf("partitions must be positive, got %d", *partitions)
+	}
 
-	// Load counter params
-	var params counter.CounterParams
-	if *counterFile == "" {
-		params = counter.DefaultCounterParams
-	} else {
-		data, err := os.ReadFile(*counterFile)
-		if err != nil {
-			return fmt.Errorf("failed to load counter params: %w", err)
-		} else if err = json.Unmarshal(data, &params); err != nil {
-			return fmt.Errorf("failed to load counter params: %w", err)
-		}
+	params, err := loadCounterParams(*counterFile)
+	if err != nil {
+		return err
+	}
+	if *counterFile != "" {
 		fmt.Printf("Using counter params: %#v\n\n", params)
 	}
 
@@ -147,6 +144,22 @@ func RunTool(args []string) error {
 
 	sim.finish()
 	return nil
+}
+
+func loadCounterParams(path string) (counter.CounterParams, error) {
+	params := counter.DefaultCounterParams
+	if path == "" {
+		return params, nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return counter.CounterParams{}, fmt.Errorf("failed to load counter params: %w", err)
+	}
+	if err := json.Unmarshal(data, &params); err != nil {
+		return counter.CounterParams{}, fmt.Errorf("failed to load counter params: %w", err)
+	}
+	return params, nil
 }
 
 func newLatencyStats() *latencyStats {

--- a/tools/fairsim/sim_test.go
+++ b/tools/fairsim/sim_test.go
@@ -3,12 +3,39 @@ package fairsim
 import (
 	"io"
 	"math/rand/v2"
+	"os"
+	"path/filepath"
 	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.temporal.io/server/service/matching/counter"
 )
+
+func TestRunTool_InvalidPartitions(t *testing.T) {
+	t.Parallel()
+
+	for _, partitions := range []string{"0", "-1"} {
+		t.Run(partitions, func(t *testing.T) {
+			err := RunTool([]string{"-partitions=" + partitions})
+			require.EqualError(t, err, "partitions must be positive, got "+partitions)
+		})
+	}
+}
+
+func TestLoadCounterParams_PartialConfigPreservesDefaults(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "counter.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"CMS":{"W":10}}`), 0o600))
+
+	params, err := loadCounterParams(path)
+	require.NoError(t, err)
+	expected := counter.DefaultCounterParams
+	expected.CMS.W = 10
+	require.Equal(t, expected, params)
+}
 
 func newTestSimulator() *simulator {
 	src := rand.NewPCG(rand.Uint64(), rand.Uint64())


### PR DESCRIPTION
## What changed?

- Decode partial counter parameter JSON over `counter.DefaultCounterParams`.
- Return a validation error when `-partitions` is zero or negative.
- Add regression tests for partial counter overrides and invalid partition counts.

## Why?

The README documents partial overrides such as `{"CMS":{"W":100}}`, but the simulator decoded them into a zero-valued struct. Omitted fields including `MapLimit` were reset to zero, and the documented command could panic when adding its first task. Non-positive partition counts similarly reached `rand.IntN` and panicked.

Loading partial overrides over the production defaults makes the documented parameter-sweep workflow behave as intended. Validating the partition count keeps invalid CLI input on the normal error path.

Fixes #11534

## How did you test it?

- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

Ran:

```bash
go test -tags test_dep ./tools/fairsim ./service/matching/counter
make lint-code
```

Also ran the README-style partial override against the rebuilt binary and confirmed that unspecified fields retain their defaults.

## Potential risks

This changes only the simulator CLI. Explicit values in the JSON, including zero values, still override defaults.