### PR TITLE
Clamp matching read partition count

### DIFF
--- a/client/matching/loadbalancer.go
+++ b/client/matching/loadbalancer.go
@@ -160,7 +160,7 @@ func (lb *defaultLoadBalancer) PickReadPartition(
 	if pc.Read > 0 {
 		partitionCount = int(pc.Read)
 	} else if namespaceErr == nil {
-		partitionCount = lb.nReadPartitions(string(namespaceName), taskQueue.Name(), taskQueue.TaskType())
+		partitionCount = max(1, lb.nReadPartitions(string(namespaceName), taskQueue.Name(), taskQueue.TaskType()))
 	}
 
 	if n, ok := testhooks.Get(lb.testHooks, testhooks.MatchingLBForceReadPartition, namespace.ID(taskQueue.NamespaceId())); ok {

--- a/client/matching/loadbalancer_test.go
+++ b/client/matching/loadbalancer_test.go
@@ -320,6 +320,30 @@ func TestPickReadPartition_NoBacklogFallsBack(t *testing.T) {
 	}
 }
 
+func TestPickReadPartition_NonPositiveConfiguredCount(t *testing.T) {
+	f := newTestTaskQueueFamily(t)
+	tq := f.TaskQueue(enumspb.TASK_QUEUE_TYPE_ACTIVITY)
+
+	for name, partitionCount := range map[string]int{
+		"zero":     0,
+		"negative": -1,
+	} {
+		t.Run(name, func(t *testing.T) {
+			lb := &defaultLoadBalancer{
+				namespaceIDToName: func(namespace.ID) (namespace.Name, error) { return "fake-namespace", nil },
+				nReadPartitions: func(string, string, enumspb.TaskQueueType) int {
+					return partitionCount
+				},
+				taskQueueLBs: make(map[tqid.TaskQueue]*tqLoadBalancer),
+			}
+
+			token := lb.PickReadPartition(tq, PartitionCounts{})
+			require.Zero(t, token.TQPartition.PartitionId())
+			token.Release()
+		})
+	}
+}
+
 func TestPickReadPartition_IncompleteBacklogFallsBack(t *testing.T) {
 	f, err := tqid.NewTaskQueueFamily("fake-namespace-id", "fake-taskqueue")
 	require.NoError(t, err)


### PR DESCRIPTION
## What changed?

Clamp the dynamic-config fallback for matching read partition count to at least one, and cover zero and negative configured values with unit tests.

## Why?

Before a matching client has cached server-provided partition counts, `PickReadPartition` falls back to `matching.numTaskqueueReadPartitions`. A non-positive configured value reaches `math/rand.Intn(0)` and panics while routing a worker poll. Request handlers recover the panic as an internal error, so affected workers cannot receive tasks and each poll logs a panic until the configuration or cache state changes.

The write path already clamps the same dynamic configuration fallback to one. The matching task-queue configuration also exposes read and write counts with this lower bound. Applying the same guard in the client read path makes the behavior consistent.

## How did you test it?

- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

Ran:

```bash
go test -tags test_dep ./client/matching -count=1
go test -race -tags test_dep ./client/matching -run "^TestPickReadPartition_NonPositiveConfiguredCount$" -count=1
make lint-code
```

The regression test reproduced the pre-fix panic for both zero and negative configured counts.

## Potential risks

For invalid non-positive configuration, polls now route to the root partition instead of returning an internal error from a recovered panic. Positive configuration and server-provided partition counts are unchanged.