### PR TITLE
Attribute queue reader stuck attempts to a slice

### DIFF
--- a/service/history/queues/action_reader_stuck.go
+++ b/service/history/queues/action_reader_stuck.go
@@ -66,6 +66,7 @@ func (a *actionReaderStuck) Run(readerGroup *ReaderGroup) bool {
 			left, right := s.SplitByRange(stuckRange.InclusiveMin)
 			remaining = append(remaining, left)
 			s = right
+			r = s.Scope().Range
 		}
 
 		if r.CanSplitStrictly(stuckRange.ExclusiveMax) {
@@ -75,8 +76,7 @@ func (a *actionReaderStuck) Run(readerGroup *ReaderGroup) bool {
 		}
 
 		if len(remaining) == 0 {
-			// s lies outside the stuck range or only abuts it, so any split here
-			// would produce an empty slice.
+			// s does not overlap the stuck range.
 			return nil, false
 		}
 

--- a/service/history/queues/action_reader_stuck.go
+++ b/service/history/queues/action_reader_stuck.go
@@ -10,18 +10,21 @@ var _ Action = (*actionReaderStuck)(nil)
 
 type (
 	actionReaderStuck struct {
-		attributes *AlertAttributesReaderStuck
-		logger     log.Logger
+		attributes     *AlertAttributesReaderStuck
+		maxReaderCount int64
+		logger         log.Logger
 	}
 )
 
 func newReaderStuckAction(
 	attributes *AlertAttributesReaderStuck,
+	maxReaderCount int,
 	logger log.Logger,
 ) *actionReaderStuck {
 	return &actionReaderStuck{
-		attributes: attributes,
-		logger:     logger,
+		attributes:     attributes,
+		maxReaderCount: int64(maxReaderCount),
+		logger:         logger,
 	}
 }
 
@@ -30,6 +33,12 @@ func (a *actionReaderStuck) Name() string {
 }
 
 func (a *actionReaderStuck) Run(readerGroup *ReaderGroup) bool {
+	nextReaderID := a.attributes.ReaderID + 1
+	if nextReaderID >= a.maxReaderCount {
+		a.logger.Info("Skipped reader stuck action, no lower priority reader available", tag.QueueReaderID(a.attributes.ReaderID))
+		return false
+	}
+
 	reader, ok := readerGroup.ReaderByID(a.attributes.ReaderID)
 	if !ok {
 		a.logger.Info("Failed to get queue with readerID for reader stuck action", tag.QueueReaderID(a.attributes.ReaderID))
@@ -47,29 +56,29 @@ func (a *actionReaderStuck) Run(readerGroup *ReaderGroup) bool {
 	var splitSlices []Slice
 	reader.SplitSlices(func(s Slice) ([]Slice, bool) {
 		r := s.Scope().Range
+		if r.InclusiveMin.CompareTo(stuckRange.ExclusiveMax) >= 0 ||
+			stuckRange.InclusiveMin.CompareTo(r.ExclusiveMax) >= 0 {
+			return nil, false
+		}
+
 		if stuckRange.ContainsRange(r) {
 			splitSlices = append(splitSlices, s)
 			return nil, true
 		}
 
+		// s only partially overlaps the stuck range, so at least one of the bounds
+		// below falls strictly inside s and splitting can not produce an empty slice.
 		remaining := make([]Slice, 0, 2)
-		if s.CanSplitByRange(stuckRange.InclusiveMin) {
+		if r.InclusiveMin.CompareTo(stuckRange.InclusiveMin) < 0 {
 			left, right := s.SplitByRange(stuckRange.InclusiveMin)
 			remaining = append(remaining, left)
 			s = right
 		}
 
-		if s.CanSplitByRange(stuckRange.ExclusiveMax) {
+		if s.Scope().Range.ExclusiveMax.CompareTo(stuckRange.ExclusiveMax) > 0 {
 			left, right := s.SplitByRange(stuckRange.ExclusiveMax)
 			remaining = append(remaining, right)
 			s = left
-		}
-
-		if len(remaining) == 0 {
-			// s can't split by both min and max of stuck range,
-			// and stuck range does not contain the range of s,
-			// the only possible case is s is not overlapping with stuck range at all.
-			return nil, false
 		}
 
 		splitSlices = append(splitSlices, s)
@@ -80,7 +89,7 @@ func (a *actionReaderStuck) Run(readerGroup *ReaderGroup) bool {
 		return false
 	}
 
-	nextReader := readerGroup.GetOrCreateReader(a.attributes.ReaderID + 1)
+	nextReader := readerGroup.GetOrCreateReader(nextReaderID)
 	nextReader.MergeSlices(splitSlices...)
 	return true
 }

--- a/service/history/queues/action_reader_stuck.go
+++ b/service/history/queues/action_reader_stuck.go
@@ -11,7 +11,6 @@ var _ Action = (*actionReaderStuck)(nil)
 type (
 	actionReaderStuck struct {
 		attributes     *AlertAttributesReaderStuck
-		monitor        Monitor
 		maxReaderCount int
 		logger         log.Logger
 	}
@@ -19,13 +18,11 @@ type (
 
 func newReaderStuckAction(
 	attributes *AlertAttributesReaderStuck,
-	monitor Monitor,
 	maxReaderCount int,
 	logger log.Logger,
 ) *actionReaderStuck {
 	return &actionReaderStuck{
 		attributes:     attributes,
-		monitor:        monitor,
 		maxReaderCount: maxReaderCount,
 		logger:         logger,
 	}
@@ -38,13 +35,14 @@ func (a *actionReaderStuck) Name() string {
 func (a *actionReaderStuck) Run(readerGroup *ReaderGroup) bool {
 	nextReaderID := a.attributes.ReaderID + 1
 	if nextReaderID >= int64(a.maxReaderCount) {
-		return a.decline()
+		a.logger.Info("Skipped reader stuck action, no lower priority reader available", tag.QueueReaderID(a.attributes.ReaderID))
+		return false
 	}
 
 	reader, ok := readerGroup.ReaderByID(a.attributes.ReaderID)
 	if !ok {
 		a.logger.Info("Failed to get queue with readerID for reader stuck action", tag.QueueReaderID(a.attributes.ReaderID))
-		return a.decline()
+		return false
 	}
 
 	stuckRange := NewRange(
@@ -87,18 +85,10 @@ func (a *actionReaderStuck) Run(readerGroup *ReaderGroup) bool {
 	})
 
 	if len(splitSlices) == 0 {
-		return a.decline()
+		return false
 	}
 
 	nextReader := readerGroup.GetOrCreateReader(nextReaderID)
 	nextReader.MergeSlices(splitSlices...)
 	return true
-}
-
-// decline silences the alert before reporting that nothing was mitigated.
-// Nothing about the reader changed, so the next read at the same watermark would
-// otherwise re-alert immediately and checkpoint the queue on every read.
-func (a *actionReaderStuck) decline() bool {
-	a.monitor.SilenceAlert(AlertTypeReaderStuck)
-	return false
 }

--- a/service/history/queues/action_reader_stuck.go
+++ b/service/history/queues/action_reader_stuck.go
@@ -11,19 +11,22 @@ var _ Action = (*actionReaderStuck)(nil)
 type (
 	actionReaderStuck struct {
 		attributes     *AlertAttributesReaderStuck
-		maxReaderCount int64
+		monitor        Monitor
+		maxReaderCount int
 		logger         log.Logger
 	}
 )
 
 func newReaderStuckAction(
 	attributes *AlertAttributesReaderStuck,
+	monitor Monitor,
 	maxReaderCount int,
 	logger log.Logger,
 ) *actionReaderStuck {
 	return &actionReaderStuck{
 		attributes:     attributes,
-		maxReaderCount: int64(maxReaderCount),
+		monitor:        monitor,
+		maxReaderCount: maxReaderCount,
 		logger:         logger,
 	}
 }
@@ -34,15 +37,14 @@ func (a *actionReaderStuck) Name() string {
 
 func (a *actionReaderStuck) Run(readerGroup *ReaderGroup) bool {
 	nextReaderID := a.attributes.ReaderID + 1
-	if nextReaderID >= a.maxReaderCount {
-		a.logger.Info("Skipped reader stuck action, no lower priority reader available", tag.QueueReaderID(a.attributes.ReaderID))
-		return false
+	if nextReaderID >= int64(a.maxReaderCount) {
+		return a.decline()
 	}
 
 	reader, ok := readerGroup.ReaderByID(a.attributes.ReaderID)
 	if !ok {
 		a.logger.Info("Failed to get queue with readerID for reader stuck action", tag.QueueReaderID(a.attributes.ReaderID))
-		return false
+		return a.decline()
 	}
 
 	stuckRange := NewRange(
@@ -56,29 +58,28 @@ func (a *actionReaderStuck) Run(readerGroup *ReaderGroup) bool {
 	var splitSlices []Slice
 	reader.SplitSlices(func(s Slice) ([]Slice, bool) {
 		r := s.Scope().Range
-		if r.InclusiveMin.CompareTo(stuckRange.ExclusiveMax) >= 0 ||
-			stuckRange.InclusiveMin.CompareTo(r.ExclusiveMax) >= 0 {
-			return nil, false
-		}
-
 		if stuckRange.ContainsRange(r) {
 			splitSlices = append(splitSlices, s)
 			return nil, true
 		}
 
-		// s only partially overlaps the stuck range, so at least one of the bounds
-		// below falls strictly inside s and splitting can not produce an empty slice.
 		remaining := make([]Slice, 0, 2)
-		if r.InclusiveMin.CompareTo(stuckRange.InclusiveMin) < 0 {
+		if r.CanSplitStrictly(stuckRange.InclusiveMin) {
 			left, right := s.SplitByRange(stuckRange.InclusiveMin)
 			remaining = append(remaining, left)
 			s = right
 		}
 
-		if s.Scope().Range.ExclusiveMax.CompareTo(stuckRange.ExclusiveMax) > 0 {
+		if r.CanSplitStrictly(stuckRange.ExclusiveMax) {
 			left, right := s.SplitByRange(stuckRange.ExclusiveMax)
 			remaining = append(remaining, right)
 			s = left
+		}
+
+		if len(remaining) == 0 {
+			// s lies outside the stuck range or only abuts it, so any split here
+			// would produce an empty slice.
+			return nil, false
 		}
 
 		splitSlices = append(splitSlices, s)
@@ -86,10 +87,18 @@ func (a *actionReaderStuck) Run(readerGroup *ReaderGroup) bool {
 	})
 
 	if len(splitSlices) == 0 {
-		return false
+		return a.decline()
 	}
 
 	nextReader := readerGroup.GetOrCreateReader(nextReaderID)
 	nextReader.MergeSlices(splitSlices...)
 	return true
+}
+
+// decline silences the alert before reporting that nothing was mitigated.
+// Nothing about the reader changed, so the next read at the same watermark would
+// otherwise re-alert immediately and checkpoint the queue on every read.
+func (a *actionReaderStuck) decline() bool {
+	a.monitor.SilenceAlert(AlertTypeReaderStuck)
+	return false
 }

--- a/service/history/queues/action_reader_stuck_test.go
+++ b/service/history/queues/action_reader_stuck_test.go
@@ -13,19 +13,23 @@ import (
 	"go.temporal.io/server/service/history/tasks"
 )
 
-// readerStuckTestTime is the fire time the reader is assumed to be stuck on. The
-// stuck range the action builds from it is [readerStuckTestTime, +1s).
-var readerStuckTestTime = time.Unix(1000, 0).UTC()
+// The action derives the stuck range [readerStuckFireTime, +monitorWatermarkPrecision)
+// from the alert watermark, and every expectation below is expressed against it.
+var readerStuckFireTime = time.Unix(1000, 0).UTC()
+
+func stuckKey(offset time.Duration, taskID int64) tasks.Key {
+	return tasks.NewKey(readerStuckFireTime.Add(offset), taskID)
+}
 
 func newReaderStuckTestMonitor() *monitorImpl {
-	return newMonitor(tasks.CategoryTypeScheduled, clock.NewRealTimeSource(), &MonitorOptions{
+	return newMonitor(tasks.CategoryTypeScheduled, clock.NewEventTimeSource(), &MonitorOptions{
 		PendingTasksCriticalCount:   dynamicconfig.GetIntPropertyFn(1000),
 		ReaderStuckCriticalAttempts: dynamicconfig.GetIntPropertyFn(5),
 		SliceCountCriticalThreshold: dynamicconfig.GetIntPropertyFn(50),
 	})
 }
 
-func newReaderStuckTestSlice(monitor Monitor, r Range) *SliceImpl {
+func newReaderStuckTestSlice(monitor Monitor, r Range) Slice {
 	slice := NewSlice(
 		nil,
 		nil,
@@ -36,7 +40,8 @@ func newReaderStuckTestSlice(monitor Monitor, r Range) *SliceImpl {
 		defaultMaxPendingKeys,
 		metrics.NoopMetricsHandler,
 	)
-	// Drop the iterators so the slices never attempt to load from persistence.
+	// paginationFnProvider is nil, so these slices must never be read. Clearing the
+	// iterators keeps MoreTasks false so no reader ever selects them.
 	slice.iterators = nil
 	return slice
 }
@@ -54,7 +59,7 @@ func newReaderStuckTestReaderGroup(monitor Monitor) *ReaderGroup {
 			},
 			nil,
 			nil,
-			clock.NewRealTimeSource(),
+			clock.NewEventTimeSource(),
 			NewReaderPriorityRateLimiter(func() float64 { return 20 }, 2),
 			monitor,
 			NoopReaderCompletionFn,
@@ -64,18 +69,19 @@ func newReaderStuckTestReaderGroup(monitor Monitor) *ReaderGroup {
 	})
 }
 
-func newReaderStuckTestAction(readerID int64, maxReaderCount int) *actionReaderStuck {
+func newReaderStuckTestAction(monitor Monitor, readerID int64, maxReaderCount int) *actionReaderStuck {
 	return newReaderStuckAction(
 		&AlertAttributesReaderStuck{
 			ReaderID:         readerID,
-			CurrentWatermark: tasks.NewKey(readerStuckTestTime, 0),
+			CurrentWatermark: stuckKey(0, 0),
 		},
+		monitor,
 		maxReaderCount,
 		log.NewTestLogger(),
 	)
 }
 
-func sliceRanges(reader Reader) []Range {
+func readerSliceRanges(reader Reader) []Range {
 	var ranges []Range
 	reader.WalkSlices(func(slice Slice) {
 		ranges = append(ranges, slice.Scope().Range)
@@ -83,139 +89,257 @@ func sliceRanges(reader Reader) []Range {
 	return ranges
 }
 
-func TestReaderStuckActionMovesStuckWindowToNextReader(t *testing.T) {
-	monitor := newReaderStuckTestMonitor()
-	defer monitor.Close()
-
-	// The slice extends on both sides of the stuck window, so it has to be split
-	// into three and only the middle piece handed to the next reader.
-	slice := newReaderStuckTestSlice(monitor, NewRange(
-		tasks.NewKey(readerStuckTestTime.Add(-10*time.Second), 0),
-		tasks.NewKey(readerStuckTestTime.Add(10*time.Second), 0),
-	))
-
-	readerGroup := newReaderStuckTestReaderGroup(monitor)
-	readerGroup.NewReader(DefaultReaderId, slice)
-
-	require.True(t, newReaderStuckTestAction(DefaultReaderId, 2).Run(readerGroup))
-
-	reader, ok := readerGroup.ReaderByID(DefaultReaderId)
-	require.True(t, ok)
-	require.Equal(t, []Range{
-		NewRange(
-			tasks.NewKey(readerStuckTestTime.Add(-10*time.Second), 0),
-			tasks.NewKey(readerStuckTestTime, 0),
-		),
-		NewRange(
-			tasks.NewKey(readerStuckTestTime.Add(time.Second), 0),
-			tasks.NewKey(readerStuckTestTime.Add(10*time.Second), 0),
-		),
-	}, sliceRanges(reader))
-
-	nextReader, ok := readerGroup.ReaderByID(DefaultReaderId + 1)
-	require.True(t, ok)
-	require.Equal(t, []Range{
-		NewRange(
-			tasks.NewKey(readerStuckTestTime, 0),
-			tasks.NewKey(readerStuckTestTime.Add(time.Second), 0),
-		),
-	}, sliceRanges(nextReader))
-}
-
-func TestReaderStuckActionMovesWholeSliceInsideStuckWindow(t *testing.T) {
-	monitor := newReaderStuckTestMonitor()
-	defer monitor.Close()
-
-	sliceRange := NewRange(
-		tasks.NewKey(readerStuckTestTime, 5),
-		tasks.NewKey(readerStuckTestTime.Add(500*time.Millisecond), 0),
-	)
-	readerGroup := newReaderStuckTestReaderGroup(monitor)
-	readerGroup.NewReader(DefaultReaderId, newReaderStuckTestSlice(monitor, sliceRange))
-
-	require.True(t, newReaderStuckTestAction(DefaultReaderId, 2).Run(readerGroup))
-
-	reader, ok := readerGroup.ReaderByID(DefaultReaderId)
-	require.True(t, ok)
-	require.Empty(t, sliceRanges(reader))
-
-	nextReader, ok := readerGroup.ReaderByID(DefaultReaderId + 1)
-	require.True(t, ok)
-	require.Equal(t, []Range{sliceRange}, sliceRanges(nextReader))
-}
-
-func TestReaderStuckActionLeavesNonOverlappingSlicesAlone(t *testing.T) {
-	monitor := newReaderStuckTestMonitor()
-	defer monitor.Close()
-
-	// These two slices only touch the stuck range at its bounds. Splitting either of
-	// them can only produce empty slices, so both must be left where they are.
-	before := NewRange(
-		tasks.NewKey(readerStuckTestTime.Add(-5*time.Second), 0),
-		tasks.NewKey(readerStuckTestTime, 0),
-	)
-	after := NewRange(
-		tasks.NewKey(readerStuckTestTime.Add(time.Second), 0),
-		tasks.NewKey(readerStuckTestTime.Add(5*time.Second), 0),
-	)
-
-	readerGroup := newReaderStuckTestReaderGroup(monitor)
-	readerGroup.NewReader(
-		DefaultReaderId,
-		newReaderStuckTestSlice(monitor, before),
-		newReaderStuckTestSlice(monitor, after),
-	)
-
-	require.False(t, newReaderStuckTestAction(DefaultReaderId, 2).Run(readerGroup))
-
-	reader, ok := readerGroup.ReaderByID(DefaultReaderId)
-	require.True(t, ok)
-	require.Equal(t, []Range{before, after}, sliceRanges(reader))
-
-	_, ok = readerGroup.ReaderByID(DefaultReaderId + 1)
-	require.False(t, ok, "next reader should not be created when nothing was moved")
-}
-
-func TestReaderStuckActionStopsAtMaxReaderCount(t *testing.T) {
+func TestReaderStuckActionRun(t *testing.T) {
 	testCases := []struct {
 		name           string
 		readerID       int64
 		maxReaderCount int
+		sliceRanges    []Range
+		wantMitigated  bool
+		wantKept       []Range
+		wantMoved      []Range
 	}{
-		{name: "only default reader allowed", readerID: DefaultReaderId, maxReaderCount: 1},
-		{name: "already on the last reader", readerID: DefaultReaderId + 1, maxReaderCount: 2},
+		{
+			name:           "slice spans both sides of the stuck range",
+			readerID:       DefaultReaderId,
+			maxReaderCount: 2,
+			sliceRanges:    []Range{NewRange(stuckKey(-10*time.Second, 0), stuckKey(10*time.Second, 0))},
+			wantMitigated:  true,
+			wantKept: []Range{
+				NewRange(stuckKey(-10*time.Second, 0), stuckKey(0, 0)),
+				NewRange(stuckKey(time.Second, 0), stuckKey(10*time.Second, 0)),
+			},
+			wantMoved: []Range{NewRange(stuckKey(0, 0), stuckKey(time.Second, 0))},
+		},
+		{
+			name:           "slice contained in the stuck range",
+			readerID:       DefaultReaderId,
+			maxReaderCount: 2,
+			sliceRanges:    []Range{NewRange(stuckKey(0, 5), stuckKey(500*time.Millisecond, 0))},
+			wantMitigated:  true,
+			wantKept:       nil,
+			wantMoved:      []Range{NewRange(stuckKey(0, 5), stuckKey(500*time.Millisecond, 0))},
+		},
+		{
+			name:           "slice starts before the stuck range and ends inside it",
+			readerID:       DefaultReaderId,
+			maxReaderCount: 2,
+			sliceRanges:    []Range{NewRange(stuckKey(-time.Second, 0), stuckKey(500*time.Millisecond, 0))},
+			wantMitigated:  true,
+			wantKept:       []Range{NewRange(stuckKey(-time.Second, 0), stuckKey(0, 0))},
+			wantMoved:      []Range{NewRange(stuckKey(0, 0), stuckKey(500*time.Millisecond, 0))},
+		},
+		{
+			name:           "slice starts inside the stuck range and ends after it",
+			readerID:       DefaultReaderId,
+			maxReaderCount: 2,
+			sliceRanges:    []Range{NewRange(stuckKey(500*time.Millisecond, 0), stuckKey(2*time.Second, 0))},
+			wantMitigated:  true,
+			wantKept:       []Range{NewRange(stuckKey(time.Second, 0), stuckKey(2*time.Second, 0))},
+			wantMoved:      []Range{NewRange(stuckKey(500*time.Millisecond, 0), stuckKey(time.Second, 0))},
+		},
+		{
+			// The two moved pieces are contiguous, so MergeSlices combines them.
+			name:           "several slices overlap the stuck range",
+			readerID:       DefaultReaderId,
+			maxReaderCount: 2,
+			sliceRanges: []Range{
+				NewRange(stuckKey(0, 0), stuckKey(300*time.Millisecond, 0)),
+				NewRange(stuckKey(300*time.Millisecond, 0), stuckKey(2*time.Second, 0)),
+			},
+			wantMitigated: true,
+			wantKept:      []Range{NewRange(stuckKey(time.Second, 0), stuckKey(2*time.Second, 0))},
+			wantMoved:     []Range{NewRange(stuckKey(0, 0), stuckKey(time.Second, 0))},
+		},
+		{
+			name:           "slices only abut the stuck range",
+			readerID:       DefaultReaderId,
+			maxReaderCount: 2,
+			sliceRanges: []Range{
+				NewRange(stuckKey(-5*time.Second, 0), stuckKey(0, 0)),
+				NewRange(stuckKey(time.Second, 0), stuckKey(5*time.Second, 0)),
+			},
+			wantMitigated: false,
+			wantKept: []Range{
+				NewRange(stuckKey(-5*time.Second, 0), stuckKey(0, 0)),
+				NewRange(stuckKey(time.Second, 0), stuckKey(5*time.Second, 0)),
+			},
+			wantMoved: nil,
+		},
+		{
+			name:           "no reader below the default one is allowed",
+			readerID:       DefaultReaderId,
+			maxReaderCount: 1,
+			sliceRanges:    []Range{NewRange(stuckKey(0, 0), stuckKey(500*time.Millisecond, 0))},
+			wantMitigated:  false,
+			wantKept:       []Range{NewRange(stuckKey(0, 0), stuckKey(500*time.Millisecond, 0))},
+			wantMoved:      nil,
+		},
+		{
+			name:           "already on the last reader",
+			readerID:       DefaultReaderId + 1,
+			maxReaderCount: 2,
+			sliceRanges:    []Range{NewRange(stuckKey(0, 0), stuckKey(500*time.Millisecond, 0))},
+			wantMitigated:  false,
+			wantKept:       []Range{NewRange(stuckKey(0, 0), stuckKey(500*time.Millisecond, 0))},
+			wantMoved:      nil,
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			monitor := newReaderStuckTestMonitor()
-			defer monitor.Close()
+			t.Cleanup(monitor.Close)
 
-			sliceRange := NewRange(
-				tasks.NewKey(readerStuckTestTime, 0),
-				tasks.NewKey(readerStuckTestTime.Add(500*time.Millisecond), 0),
-			)
+			slices := make([]Slice, 0, len(tc.sliceRanges))
+			for _, r := range tc.sliceRanges {
+				slices = append(slices, newReaderStuckTestSlice(monitor, r))
+			}
 			readerGroup := newReaderStuckTestReaderGroup(monitor)
-			readerGroup.NewReader(tc.readerID, newReaderStuckTestSlice(monitor, sliceRange))
+			readerGroup.NewReader(tc.readerID, slices...)
 
-			require.False(t, newReaderStuckTestAction(tc.readerID, tc.maxReaderCount).Run(readerGroup))
+			action := newReaderStuckTestAction(monitor, tc.readerID, tc.maxReaderCount)
+			require.Equal(t, tc.wantMitigated, action.Run(readerGroup))
 
 			reader, ok := readerGroup.ReaderByID(tc.readerID)
 			require.True(t, ok)
-			require.Equal(t, []Range{sliceRange}, sliceRanges(reader))
+			require.Equal(t, tc.wantKept, readerSliceRanges(reader))
 
-			_, ok = readerGroup.ReaderByID(tc.readerID + 1)
-			require.False(t, ok)
+			nextReader, ok := readerGroup.ReaderByID(tc.readerID + 1)
+			if tc.wantMoved == nil {
+				// Also guards against the next reader being created for an empty slice;
+				// SplitSlices drops those, so the kept ranges alone would not notice.
+				require.False(t, ok, "next reader should not be created when nothing moved")
+				return
+			}
+			require.True(t, ok)
+			require.Equal(t, tc.wantMoved, readerSliceRanges(nextReader))
 		})
 	}
 }
 
-func TestReaderStuckActionMissingReader(t *testing.T) {
+func TestReaderStuckActionMergesIntoExistingNextReader(t *testing.T) {
 	monitor := newReaderStuckTestMonitor()
-	defer monitor.Close()
+	t.Cleanup(monitor.Close)
+
+	readerGroup := newReaderStuckTestReaderGroup(monitor)
+	readerGroup.NewReader(
+		DefaultReaderId,
+		newReaderStuckTestSlice(monitor, NewRange(stuckKey(0, 0), stuckKey(2*time.Second, 0))),
+	)
+	existing := NewRange(stuckKey(10*time.Second, 0), stuckKey(20*time.Second, 0))
+	readerGroup.NewReader(DefaultReaderId+1, newReaderStuckTestSlice(monitor, existing))
+
+	require.True(t, newReaderStuckTestAction(monitor, DefaultReaderId, 2).Run(readerGroup))
+
+	nextReader, ok := readerGroup.ReaderByID(DefaultReaderId + 1)
+	require.True(t, ok)
+	require.Equal(t, []Range{
+		NewRange(stuckKey(0, 0), stuckKey(time.Second, 0)),
+		existing,
+	}, readerSliceRanges(nextReader))
+}
+
+func TestReaderStuckActionSkipsWhenReaderMissing(t *testing.T) {
+	monitor := newReaderStuckTestMonitor()
+	t.Cleanup(monitor.Close)
 
 	readerGroup := newReaderStuckTestReaderGroup(monitor)
 
-	require.False(t, newReaderStuckTestAction(DefaultReaderId, 2).Run(readerGroup))
+	require.False(t, newReaderStuckTestAction(monitor, DefaultReaderId, 2).Run(readerGroup))
 	require.Empty(t, readerGroup.Readers())
+}
+
+func TestReaderStuckActionSilencesAlertWhenDeclining(t *testing.T) {
+	// Declining without silencing would re-alert on the reader's next read, and every
+	// alert checkpoints the queue.
+	testCases := []struct {
+		name           string
+		maxReaderCount int
+		sliceRanges    []Range
+	}{
+		{
+			name:           "no reader available",
+			maxReaderCount: 1,
+			sliceRanges:    []Range{NewRange(stuckKey(0, 0), stuckKey(500*time.Millisecond, 0))},
+		},
+		{
+			name:           "nothing overlaps the stuck range",
+			maxReaderCount: 2,
+			sliceRanges:    []Range{NewRange(stuckKey(time.Second, 0), stuckKey(5*time.Second, 0))},
+		},
+		{
+			name:           "reader missing",
+			maxReaderCount: 2,
+			sliceRanges:    nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			monitor := newReaderStuckTestMonitor()
+			t.Cleanup(monitor.Close)
+
+			readerGroup := newReaderStuckTestReaderGroup(monitor)
+			if tc.sliceRanges != nil {
+				slices := make([]Slice, 0, len(tc.sliceRanges))
+				for _, r := range tc.sliceRanges {
+					slices = append(slices, newReaderStuckTestSlice(monitor, r))
+				}
+				readerGroup.NewReader(DefaultReaderId, slices...)
+			}
+
+			require.False(t, newReaderStuckTestAction(monitor, DefaultReaderId, tc.maxReaderCount).Run(readerGroup))
+
+			slice := newReaderStuckTestSlice(monitor, NewRange(stuckKey(0, 0), stuckKey(time.Second, 0)))
+			for i := 0; i != monitor.options.ReaderStuckCriticalAttempts()+1; i++ {
+				monitor.SetSliceReadWatermark(slice, DefaultReaderId, stuckKey(0, int64(i)))
+			}
+			select {
+			case <-monitor.AlertCh():
+				require.FailNow(t, "alert should be silenced after the action declined")
+			default:
+			}
+		})
+	}
+}
+
+func TestReaderStuckActionDoesNotCascadeAfterMovingSlice(t *testing.T) {
+	// The moved slice keeps its monitor entry, so the receiving reader has to build up
+	// its own attempts before the slice is demoted again.
+	monitor := newReaderStuckTestMonitor()
+	t.Cleanup(monitor.Close)
+
+	sliceRange := NewRange(stuckKey(0, 0), stuckKey(500*time.Millisecond, 0))
+	slice := newReaderStuckTestSlice(monitor, sliceRange)
+	readerGroup := newReaderStuckTestReaderGroup(monitor)
+	readerGroup.NewReader(DefaultReaderId, slice)
+
+	criticalAttempts := monitor.options.ReaderStuckCriticalAttempts()
+	for i := 0; i != criticalAttempts; i++ {
+		monitor.SetSliceReadWatermark(slice, DefaultReaderId, stuckKey(0, int64(i)))
+	}
+	alert := <-monitor.AlertCh()
+	require.Equal(t, DefaultReaderId, alert.AlertAttributesReaderStuck.ReaderID)
+	monitor.ResolveAlert(alert.AlertType)
+
+	require.True(t, newReaderStuckTestAction(monitor, DefaultReaderId, 3).Run(readerGroup))
+
+	// The first read by the new owner must not re-trigger the alert.
+	monitor.SetSliceReadWatermark(slice, DefaultReaderId+1, stuckKey(0, 0))
+	select {
+	case <-monitor.AlertCh():
+		require.FailNow(t, "a slice must not be demoted again on the new reader's first read")
+	default:
+	}
+
+	for i := 1; i != criticalAttempts; i++ {
+		monitor.SetSliceReadWatermark(slice, DefaultReaderId+1, stuckKey(0, int64(i)))
+	}
+	select {
+	case alert := <-monitor.AlertCh():
+		require.Equal(t, DefaultReaderId+1, alert.AlertAttributesReaderStuck.ReaderID)
+	default:
+		require.FailNow(t, "expected the new reader to alert after its own attempts")
+	}
 }

--- a/service/history/queues/action_reader_stuck_test.go
+++ b/service/history/queues/action_reader_stuck_test.go
@@ -13,11 +13,9 @@ import (
 	"go.temporal.io/server/service/history/tasks"
 )
 
-// The action derives the stuck range [readerStuckFireTime, +monitorWatermarkPrecision)
-// from the alert watermark, and every expectation below is expressed against it.
 var readerStuckFireTime = time.Unix(1000, 0).UTC()
 
-func stuckKey(offset time.Duration, taskID int64) tasks.Key {
+func readerStuckKey(offset time.Duration, taskID int64) tasks.Key {
 	return tasks.NewKey(readerStuckFireTime.Add(offset), taskID)
 }
 
@@ -69,13 +67,12 @@ func newReaderStuckTestReaderGroup(monitor Monitor) *ReaderGroup {
 	})
 }
 
-func newReaderStuckTestAction(monitor Monitor, readerID int64, maxReaderCount int) *actionReaderStuck {
+func newReaderStuckTestAction(readerID int64, maxReaderCount int) *actionReaderStuck {
 	return newReaderStuckAction(
 		&AlertAttributesReaderStuck{
 			ReaderID:         readerID,
-			CurrentWatermark: stuckKey(0, 0),
+			CurrentWatermark: readerStuckKey(0, 0),
 		},
-		monitor,
 		maxReaderCount,
 		log.NewTestLogger(),
 	)
@@ -103,85 +100,84 @@ func TestReaderStuckActionRun(t *testing.T) {
 			name:           "slice spans both sides of the stuck range",
 			readerID:       DefaultReaderId,
 			maxReaderCount: 2,
-			sliceRanges:    []Range{NewRange(stuckKey(-10*time.Second, 0), stuckKey(10*time.Second, 0))},
+			sliceRanges:    []Range{NewRange(readerStuckKey(-10*time.Second, 0), readerStuckKey(10*time.Second, 0))},
 			wantMitigated:  true,
 			wantKept: []Range{
-				NewRange(stuckKey(-10*time.Second, 0), stuckKey(0, 0)),
-				NewRange(stuckKey(time.Second, 0), stuckKey(10*time.Second, 0)),
+				NewRange(readerStuckKey(-10*time.Second, 0), readerStuckKey(0, 0)),
+				NewRange(readerStuckKey(time.Second, 0), readerStuckKey(10*time.Second, 0)),
 			},
-			wantMoved: []Range{NewRange(stuckKey(0, 0), stuckKey(time.Second, 0))},
+			wantMoved: []Range{NewRange(readerStuckKey(0, 0), readerStuckKey(time.Second, 0))},
 		},
 		{
 			name:           "slice contained in the stuck range",
 			readerID:       DefaultReaderId,
 			maxReaderCount: 2,
-			sliceRanges:    []Range{NewRange(stuckKey(0, 5), stuckKey(500*time.Millisecond, 0))},
+			sliceRanges:    []Range{NewRange(readerStuckKey(0, 5), readerStuckKey(500*time.Millisecond, 0))},
 			wantMitigated:  true,
 			wantKept:       nil,
-			wantMoved:      []Range{NewRange(stuckKey(0, 5), stuckKey(500*time.Millisecond, 0))},
+			wantMoved:      []Range{NewRange(readerStuckKey(0, 5), readerStuckKey(500*time.Millisecond, 0))},
 		},
 		{
 			name:           "slice starts before the stuck range and ends inside it",
 			readerID:       DefaultReaderId,
 			maxReaderCount: 2,
-			sliceRanges:    []Range{NewRange(stuckKey(-time.Second, 0), stuckKey(500*time.Millisecond, 0))},
+			sliceRanges:    []Range{NewRange(readerStuckKey(-time.Second, 0), readerStuckKey(500*time.Millisecond, 0))},
 			wantMitigated:  true,
-			wantKept:       []Range{NewRange(stuckKey(-time.Second, 0), stuckKey(0, 0))},
-			wantMoved:      []Range{NewRange(stuckKey(0, 0), stuckKey(500*time.Millisecond, 0))},
+			wantKept:       []Range{NewRange(readerStuckKey(-time.Second, 0), readerStuckKey(0, 0))},
+			wantMoved:      []Range{NewRange(readerStuckKey(0, 0), readerStuckKey(500*time.Millisecond, 0))},
 		},
 		{
 			name:           "slice starts inside the stuck range and ends after it",
 			readerID:       DefaultReaderId,
 			maxReaderCount: 2,
-			sliceRanges:    []Range{NewRange(stuckKey(500*time.Millisecond, 0), stuckKey(2*time.Second, 0))},
+			sliceRanges:    []Range{NewRange(readerStuckKey(500*time.Millisecond, 0), readerStuckKey(2*time.Second, 0))},
 			wantMitigated:  true,
-			wantKept:       []Range{NewRange(stuckKey(time.Second, 0), stuckKey(2*time.Second, 0))},
-			wantMoved:      []Range{NewRange(stuckKey(500*time.Millisecond, 0), stuckKey(time.Second, 0))},
+			wantKept:       []Range{NewRange(readerStuckKey(time.Second, 0), readerStuckKey(2*time.Second, 0))},
+			wantMoved:      []Range{NewRange(readerStuckKey(500*time.Millisecond, 0), readerStuckKey(time.Second, 0))},
 		},
 		{
-			// The two moved pieces are contiguous, so MergeSlices combines them.
 			name:           "several slices overlap the stuck range",
 			readerID:       DefaultReaderId,
 			maxReaderCount: 2,
 			sliceRanges: []Range{
-				NewRange(stuckKey(0, 0), stuckKey(300*time.Millisecond, 0)),
-				NewRange(stuckKey(300*time.Millisecond, 0), stuckKey(2*time.Second, 0)),
+				NewRange(readerStuckKey(0, 0), readerStuckKey(300*time.Millisecond, 0)),
+				NewRange(readerStuckKey(300*time.Millisecond, 0), readerStuckKey(2*time.Second, 0)),
 			},
 			wantMitigated: true,
-			wantKept:      []Range{NewRange(stuckKey(time.Second, 0), stuckKey(2*time.Second, 0))},
-			wantMoved:     []Range{NewRange(stuckKey(0, 0), stuckKey(time.Second, 0))},
+			wantKept:      []Range{NewRange(readerStuckKey(time.Second, 0), readerStuckKey(2*time.Second, 0))},
+			wantMoved:     []Range{NewRange(readerStuckKey(0, 0), readerStuckKey(time.Second, 0))},
 		},
 		{
 			name:           "slices only abut the stuck range",
 			readerID:       DefaultReaderId,
 			maxReaderCount: 2,
 			sliceRanges: []Range{
-				NewRange(stuckKey(-5*time.Second, 0), stuckKey(0, 0)),
-				NewRange(stuckKey(time.Second, 0), stuckKey(5*time.Second, 0)),
+				NewRange(readerStuckKey(-5*time.Second, 0), readerStuckKey(0, 0)),
+				NewRange(readerStuckKey(time.Second, 0), readerStuckKey(5*time.Second, 0)),
 			},
 			wantMitigated: false,
 			wantKept: []Range{
-				NewRange(stuckKey(-5*time.Second, 0), stuckKey(0, 0)),
-				NewRange(stuckKey(time.Second, 0), stuckKey(5*time.Second, 0)),
+				NewRange(readerStuckKey(-5*time.Second, 0), readerStuckKey(0, 0)),
+				NewRange(readerStuckKey(time.Second, 0), readerStuckKey(5*time.Second, 0)),
 			},
 			wantMoved: nil,
 		},
 		{
-			name:           "no reader below the default one is allowed",
+			name:           "max reader count reached",
 			readerID:       DefaultReaderId,
 			maxReaderCount: 1,
-			sliceRanges:    []Range{NewRange(stuckKey(0, 0), stuckKey(500*time.Millisecond, 0))},
+			sliceRanges:    []Range{NewRange(readerStuckKey(0, 0), readerStuckKey(500*time.Millisecond, 0))},
 			wantMitigated:  false,
-			wantKept:       []Range{NewRange(stuckKey(0, 0), stuckKey(500*time.Millisecond, 0))},
+			wantKept:       []Range{NewRange(readerStuckKey(0, 0), readerStuckKey(500*time.Millisecond, 0))},
 			wantMoved:      nil,
 		},
 		{
 			name:           "already on the last reader",
 			readerID:       DefaultReaderId + 1,
 			maxReaderCount: 2,
-			sliceRanges:    []Range{NewRange(stuckKey(0, 0), stuckKey(500*time.Millisecond, 0))},
+			sliceRanges:    []Range{NewRange(readerStuckKey(0, 0), readerStuckKey(500*time.Millisecond, 0))},
 			wantMitigated:  false,
-			wantKept:       []Range{NewRange(stuckKey(0, 0), stuckKey(500*time.Millisecond, 0))},
+			wantKept:       []Range{NewRange(readerStuckKey(0, 0), readerStuckKey(500*time.Millisecond, 0))},
 			wantMoved:      nil,
 		},
 	}
@@ -198,7 +194,7 @@ func TestReaderStuckActionRun(t *testing.T) {
 			readerGroup := newReaderStuckTestReaderGroup(monitor)
 			readerGroup.NewReader(tc.readerID, slices...)
 
-			action := newReaderStuckTestAction(monitor, tc.readerID, tc.maxReaderCount)
+			action := newReaderStuckTestAction(tc.readerID, tc.maxReaderCount)
 			require.Equal(t, tc.wantMitigated, action.Run(readerGroup))
 
 			reader, ok := readerGroup.ReaderByID(tc.readerID)
@@ -225,17 +221,17 @@ func TestReaderStuckActionMergesIntoExistingNextReader(t *testing.T) {
 	readerGroup := newReaderStuckTestReaderGroup(monitor)
 	readerGroup.NewReader(
 		DefaultReaderId,
-		newReaderStuckTestSlice(monitor, NewRange(stuckKey(0, 0), stuckKey(2*time.Second, 0))),
+		newReaderStuckTestSlice(monitor, NewRange(readerStuckKey(0, 0), readerStuckKey(2*time.Second, 0))),
 	)
-	existing := NewRange(stuckKey(10*time.Second, 0), stuckKey(20*time.Second, 0))
+	existing := NewRange(readerStuckKey(10*time.Second, 0), readerStuckKey(20*time.Second, 0))
 	readerGroup.NewReader(DefaultReaderId+1, newReaderStuckTestSlice(monitor, existing))
 
-	require.True(t, newReaderStuckTestAction(monitor, DefaultReaderId, 2).Run(readerGroup))
+	require.True(t, newReaderStuckTestAction(DefaultReaderId, 2).Run(readerGroup))
 
 	nextReader, ok := readerGroup.ReaderByID(DefaultReaderId + 1)
 	require.True(t, ok)
 	require.Equal(t, []Range{
-		NewRange(stuckKey(0, 0), stuckKey(time.Second, 0)),
+		NewRange(readerStuckKey(0, 0), readerStuckKey(time.Second, 0)),
 		existing,
 	}, readerSliceRanges(nextReader))
 }
@@ -246,62 +242,8 @@ func TestReaderStuckActionSkipsWhenReaderMissing(t *testing.T) {
 
 	readerGroup := newReaderStuckTestReaderGroup(monitor)
 
-	require.False(t, newReaderStuckTestAction(monitor, DefaultReaderId, 2).Run(readerGroup))
+	require.False(t, newReaderStuckTestAction(DefaultReaderId, 2).Run(readerGroup))
 	require.Empty(t, readerGroup.Readers())
-}
-
-func TestReaderStuckActionSilencesAlertWhenDeclining(t *testing.T) {
-	// Declining without silencing would re-alert on the reader's next read, and every
-	// alert checkpoints the queue.
-	testCases := []struct {
-		name           string
-		maxReaderCount int
-		sliceRanges    []Range
-	}{
-		{
-			name:           "no reader available",
-			maxReaderCount: 1,
-			sliceRanges:    []Range{NewRange(stuckKey(0, 0), stuckKey(500*time.Millisecond, 0))},
-		},
-		{
-			name:           "nothing overlaps the stuck range",
-			maxReaderCount: 2,
-			sliceRanges:    []Range{NewRange(stuckKey(time.Second, 0), stuckKey(5*time.Second, 0))},
-		},
-		{
-			name:           "reader missing",
-			maxReaderCount: 2,
-			sliceRanges:    nil,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			monitor := newReaderStuckTestMonitor()
-			t.Cleanup(monitor.Close)
-
-			readerGroup := newReaderStuckTestReaderGroup(monitor)
-			if tc.sliceRanges != nil {
-				slices := make([]Slice, 0, len(tc.sliceRanges))
-				for _, r := range tc.sliceRanges {
-					slices = append(slices, newReaderStuckTestSlice(monitor, r))
-				}
-				readerGroup.NewReader(DefaultReaderId, slices...)
-			}
-
-			require.False(t, newReaderStuckTestAction(monitor, DefaultReaderId, tc.maxReaderCount).Run(readerGroup))
-
-			slice := newReaderStuckTestSlice(monitor, NewRange(stuckKey(0, 0), stuckKey(time.Second, 0)))
-			for i := 0; i != monitor.options.ReaderStuckCriticalAttempts()+1; i++ {
-				monitor.SetSliceReadWatermark(slice, DefaultReaderId, stuckKey(0, int64(i)))
-			}
-			select {
-			case <-monitor.AlertCh():
-				require.FailNow(t, "alert should be silenced after the action declined")
-			default:
-			}
-		})
-	}
 }
 
 func TestReaderStuckActionDoesNotCascadeAfterMovingSlice(t *testing.T) {
@@ -310,23 +252,27 @@ func TestReaderStuckActionDoesNotCascadeAfterMovingSlice(t *testing.T) {
 	monitor := newReaderStuckTestMonitor()
 	t.Cleanup(monitor.Close)
 
-	sliceRange := NewRange(stuckKey(0, 0), stuckKey(500*time.Millisecond, 0))
+	sliceRange := NewRange(readerStuckKey(0, 0), readerStuckKey(500*time.Millisecond, 0))
 	slice := newReaderStuckTestSlice(monitor, sliceRange)
 	readerGroup := newReaderStuckTestReaderGroup(monitor)
 	readerGroup.NewReader(DefaultReaderId, slice)
 
 	criticalAttempts := monitor.options.ReaderStuckCriticalAttempts()
 	for i := 0; i != criticalAttempts; i++ {
-		monitor.SetSliceReadWatermark(slice, DefaultReaderId, stuckKey(0, int64(i)))
+		monitor.SetSliceReadWatermark(slice, DefaultReaderId, readerStuckKey(0, int64(i)))
 	}
-	alert := <-monitor.AlertCh()
+	var alert *Alert
+	select {
+	case alert = <-monitor.AlertCh():
+	default:
+		require.FailNow(t, "expected the original reader to alert")
+	}
 	require.Equal(t, DefaultReaderId, alert.AlertAttributesReaderStuck.ReaderID)
 	monitor.ResolveAlert(alert.AlertType)
 
-	require.True(t, newReaderStuckTestAction(monitor, DefaultReaderId, 3).Run(readerGroup))
+	require.True(t, newReaderStuckTestAction(DefaultReaderId, 3).Run(readerGroup))
 
-	// The first read by the new owner must not re-trigger the alert.
-	monitor.SetSliceReadWatermark(slice, DefaultReaderId+1, stuckKey(0, 0))
+	monitor.SetSliceReadWatermark(slice, DefaultReaderId+1, readerStuckKey(0, 0))
 	select {
 	case <-monitor.AlertCh():
 		require.FailNow(t, "a slice must not be demoted again on the new reader's first read")
@@ -334,7 +280,7 @@ func TestReaderStuckActionDoesNotCascadeAfterMovingSlice(t *testing.T) {
 	}
 
 	for i := 1; i != criticalAttempts; i++ {
-		monitor.SetSliceReadWatermark(slice, DefaultReaderId+1, stuckKey(0, int64(i)))
+		monitor.SetSliceReadWatermark(slice, DefaultReaderId+1, readerStuckKey(0, int64(i)))
 	}
 	select {
 	case alert := <-monitor.AlertCh():

--- a/service/history/queues/action_reader_stuck_test.go
+++ b/service/history/queues/action_reader_stuck_test.go
@@ -38,8 +38,7 @@ func newReaderStuckTestSlice(monitor Monitor, r Range) Slice {
 		defaultMaxPendingKeys,
 		metrics.NoopMetricsHandler,
 	)
-	// paginationFnProvider is nil, so these slices must never be read. Clearing the
-	// iterators keeps MoreTasks false so no reader ever selects them.
+	// These slices must never be read; paginationFnProvider is nil.
 	slice.iterators = nil
 	return slice
 }
@@ -203,8 +202,6 @@ func TestReaderStuckActionRun(t *testing.T) {
 
 			nextReader, ok := readerGroup.ReaderByID(tc.readerID + 1)
 			if tc.wantMoved == nil {
-				// Also guards against the next reader being created for an empty slice;
-				// SplitSlices drops those, so the kept ranges alone would not notice.
 				require.False(t, ok, "next reader should not be created when nothing moved")
 				return
 			}

--- a/service/history/queues/action_reader_stuck_test.go
+++ b/service/history/queues/action_reader_stuck_test.go
@@ -1,0 +1,221 @@
+package queues
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/predicates"
+	"go.temporal.io/server/service/history/tasks"
+)
+
+// readerStuckTestTime is the fire time the reader is assumed to be stuck on. The
+// stuck range the action builds from it is [readerStuckTestTime, +1s).
+var readerStuckTestTime = time.Unix(1000, 0).UTC()
+
+func newReaderStuckTestMonitor() *monitorImpl {
+	return newMonitor(tasks.CategoryTypeScheduled, clock.NewRealTimeSource(), &MonitorOptions{
+		PendingTasksCriticalCount:   dynamicconfig.GetIntPropertyFn(1000),
+		ReaderStuckCriticalAttempts: dynamicconfig.GetIntPropertyFn(5),
+		SliceCountCriticalThreshold: dynamicconfig.GetIntPropertyFn(50),
+	})
+}
+
+func newReaderStuckTestSlice(monitor Monitor, r Range) *SliceImpl {
+	slice := NewSlice(
+		nil,
+		nil,
+		monitor,
+		NewScope(r, predicates.Universal[tasks.Task]()),
+		GrouperNamespaceID{},
+		noPredicateSizeLimit,
+		defaultMaxPendingKeys,
+		metrics.NoopMetricsHandler,
+	)
+	// Drop the iterators so the slices never attempt to load from persistence.
+	slice.iterators = nil
+	return slice
+}
+
+func newReaderStuckTestReaderGroup(monitor Monitor) *ReaderGroup {
+	return NewReaderGroup(func(readerID int64, slices []Slice) Reader {
+		return NewReader(
+			readerID,
+			slices,
+			&ReaderOptions{
+				BatchSize:            dynamicconfig.GetIntPropertyFn(10),
+				MaxPendingTasksCount: dynamicconfig.GetIntPropertyFn(100),
+				PollBackoffInterval:  dynamicconfig.GetDurationPropertyFn(200 * time.Millisecond),
+				MaxPredicateSize:     dynamicconfig.GetIntPropertyFn(10),
+			},
+			nil,
+			nil,
+			clock.NewRealTimeSource(),
+			NewReaderPriorityRateLimiter(func() float64 { return 20 }, 2),
+			monitor,
+			NoopReaderCompletionFn,
+			log.NewTestLogger(),
+			metrics.NoopMetricsHandler,
+		)
+	})
+}
+
+func newReaderStuckTestAction(readerID int64, maxReaderCount int) *actionReaderStuck {
+	return newReaderStuckAction(
+		&AlertAttributesReaderStuck{
+			ReaderID:         readerID,
+			CurrentWatermark: tasks.NewKey(readerStuckTestTime, 0),
+		},
+		maxReaderCount,
+		log.NewTestLogger(),
+	)
+}
+
+func sliceRanges(reader Reader) []Range {
+	var ranges []Range
+	reader.WalkSlices(func(slice Slice) {
+		ranges = append(ranges, slice.Scope().Range)
+	})
+	return ranges
+}
+
+func TestReaderStuckActionMovesStuckWindowToNextReader(t *testing.T) {
+	monitor := newReaderStuckTestMonitor()
+	defer monitor.Close()
+
+	// The slice extends on both sides of the stuck window, so it has to be split
+	// into three and only the middle piece handed to the next reader.
+	slice := newReaderStuckTestSlice(monitor, NewRange(
+		tasks.NewKey(readerStuckTestTime.Add(-10*time.Second), 0),
+		tasks.NewKey(readerStuckTestTime.Add(10*time.Second), 0),
+	))
+
+	readerGroup := newReaderStuckTestReaderGroup(monitor)
+	readerGroup.NewReader(DefaultReaderId, slice)
+
+	require.True(t, newReaderStuckTestAction(DefaultReaderId, 2).Run(readerGroup))
+
+	reader, ok := readerGroup.ReaderByID(DefaultReaderId)
+	require.True(t, ok)
+	require.Equal(t, []Range{
+		NewRange(
+			tasks.NewKey(readerStuckTestTime.Add(-10*time.Second), 0),
+			tasks.NewKey(readerStuckTestTime, 0),
+		),
+		NewRange(
+			tasks.NewKey(readerStuckTestTime.Add(time.Second), 0),
+			tasks.NewKey(readerStuckTestTime.Add(10*time.Second), 0),
+		),
+	}, sliceRanges(reader))
+
+	nextReader, ok := readerGroup.ReaderByID(DefaultReaderId + 1)
+	require.True(t, ok)
+	require.Equal(t, []Range{
+		NewRange(
+			tasks.NewKey(readerStuckTestTime, 0),
+			tasks.NewKey(readerStuckTestTime.Add(time.Second), 0),
+		),
+	}, sliceRanges(nextReader))
+}
+
+func TestReaderStuckActionMovesWholeSliceInsideStuckWindow(t *testing.T) {
+	monitor := newReaderStuckTestMonitor()
+	defer monitor.Close()
+
+	sliceRange := NewRange(
+		tasks.NewKey(readerStuckTestTime, 5),
+		tasks.NewKey(readerStuckTestTime.Add(500*time.Millisecond), 0),
+	)
+	readerGroup := newReaderStuckTestReaderGroup(monitor)
+	readerGroup.NewReader(DefaultReaderId, newReaderStuckTestSlice(monitor, sliceRange))
+
+	require.True(t, newReaderStuckTestAction(DefaultReaderId, 2).Run(readerGroup))
+
+	reader, ok := readerGroup.ReaderByID(DefaultReaderId)
+	require.True(t, ok)
+	require.Empty(t, sliceRanges(reader))
+
+	nextReader, ok := readerGroup.ReaderByID(DefaultReaderId + 1)
+	require.True(t, ok)
+	require.Equal(t, []Range{sliceRange}, sliceRanges(nextReader))
+}
+
+func TestReaderStuckActionLeavesNonOverlappingSlicesAlone(t *testing.T) {
+	monitor := newReaderStuckTestMonitor()
+	defer monitor.Close()
+
+	// These two slices only touch the stuck range at its bounds. Splitting either of
+	// them can only produce empty slices, so both must be left where they are.
+	before := NewRange(
+		tasks.NewKey(readerStuckTestTime.Add(-5*time.Second), 0),
+		tasks.NewKey(readerStuckTestTime, 0),
+	)
+	after := NewRange(
+		tasks.NewKey(readerStuckTestTime.Add(time.Second), 0),
+		tasks.NewKey(readerStuckTestTime.Add(5*time.Second), 0),
+	)
+
+	readerGroup := newReaderStuckTestReaderGroup(monitor)
+	readerGroup.NewReader(
+		DefaultReaderId,
+		newReaderStuckTestSlice(monitor, before),
+		newReaderStuckTestSlice(monitor, after),
+	)
+
+	require.False(t, newReaderStuckTestAction(DefaultReaderId, 2).Run(readerGroup))
+
+	reader, ok := readerGroup.ReaderByID(DefaultReaderId)
+	require.True(t, ok)
+	require.Equal(t, []Range{before, after}, sliceRanges(reader))
+
+	_, ok = readerGroup.ReaderByID(DefaultReaderId + 1)
+	require.False(t, ok, "next reader should not be created when nothing was moved")
+}
+
+func TestReaderStuckActionStopsAtMaxReaderCount(t *testing.T) {
+	testCases := []struct {
+		name           string
+		readerID       int64
+		maxReaderCount int
+	}{
+		{name: "only default reader allowed", readerID: DefaultReaderId, maxReaderCount: 1},
+		{name: "already on the last reader", readerID: DefaultReaderId + 1, maxReaderCount: 2},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			monitor := newReaderStuckTestMonitor()
+			defer monitor.Close()
+
+			sliceRange := NewRange(
+				tasks.NewKey(readerStuckTestTime, 0),
+				tasks.NewKey(readerStuckTestTime.Add(500*time.Millisecond), 0),
+			)
+			readerGroup := newReaderStuckTestReaderGroup(monitor)
+			readerGroup.NewReader(tc.readerID, newReaderStuckTestSlice(monitor, sliceRange))
+
+			require.False(t, newReaderStuckTestAction(tc.readerID, tc.maxReaderCount).Run(readerGroup))
+
+			reader, ok := readerGroup.ReaderByID(tc.readerID)
+			require.True(t, ok)
+			require.Equal(t, []Range{sliceRange}, sliceRanges(reader))
+
+			_, ok = readerGroup.ReaderByID(tc.readerID + 1)
+			require.False(t, ok)
+		})
+	}
+}
+
+func TestReaderStuckActionMissingReader(t *testing.T) {
+	monitor := newReaderStuckTestMonitor()
+	defer monitor.Close()
+
+	readerGroup := newReaderStuckTestReaderGroup(monitor)
+
+	require.False(t, newReaderStuckTestAction(DefaultReaderId, 2).Run(readerGroup))
+	require.Empty(t, readerGroup.Readers())
+}

--- a/service/history/queues/mitigator.go
+++ b/service/history/queues/mitigator.go
@@ -71,7 +71,6 @@ func (m *mitigatorImpl) Mitigate(alert Alert) {
 	case AlertTypeReaderStuck:
 		action = newReaderStuckAction(
 			alert.AlertAttributesReaderStuck,
-			m.monitor,
 			m.maxReaderCount(),
 			m.logger,
 		)

--- a/service/history/queues/mitigator.go
+++ b/service/history/queues/mitigator.go
@@ -71,6 +71,7 @@ func (m *mitigatorImpl) Mitigate(alert Alert) {
 	case AlertTypeReaderStuck:
 		action = newReaderStuckAction(
 			alert.AlertAttributesReaderStuck,
+			m.maxReaderCount(),
 			m.logger,
 		)
 	case AlertTypeSliceCount:

--- a/service/history/queues/mitigator.go
+++ b/service/history/queues/mitigator.go
@@ -71,6 +71,7 @@ func (m *mitigatorImpl) Mitigate(alert Alert) {
 	case AlertTypeReaderStuck:
 		action = newReaderStuckAction(
 			alert.AlertAttributesReaderStuck,
+			m.monitor,
 			m.maxReaderCount(),
 			m.logger,
 		)

--- a/service/history/queues/mitigator_test.go
+++ b/service/history/queues/mitigator_test.go
@@ -127,7 +127,6 @@ func (s *mitigatorSuite) TestMitigate_ReaderStuckActionGetsMaxReaderCount() {
 	action, ok := actualAction.(*actionReaderStuck)
 	s.True(ok)
 	s.Equal(3, action.maxReaderCount)
-	s.Equal(s.monitor, action.monitor)
 }
 
 func (s *mitigatorSuite) TestMitigate_ResolveAlert() {

--- a/service/history/queues/mitigator_test.go
+++ b/service/history/queues/mitigator_test.go
@@ -104,6 +104,32 @@ func (s *mitigatorSuite) TestMitigate_ActionMatchAlert() {
 	}
 }
 
+func (s *mitigatorSuite) TestMitigate_ReaderStuckActionGetsMaxReaderCount() {
+	// Without the reader count the action can not tell whether a lower priority
+	// reader exists, and it declines every alert.
+	var actualAction Action
+	s.mitigator.actionRunner = func(
+		action Action,
+		_ *ReaderGroup,
+		_ metrics.Handler,
+	) {
+		actualAction = action
+	}
+
+	s.mitigator.Mitigate(Alert{
+		AlertType: AlertTypeReaderStuck,
+		AlertAttributesReaderStuck: &AlertAttributesReaderStuck{
+			ReaderID:         1,
+			CurrentWatermark: NewRandomKey(),
+		},
+	})
+
+	action, ok := actualAction.(*actionReaderStuck)
+	s.True(ok)
+	s.Equal(3, action.maxReaderCount)
+	s.Equal(s.monitor, action.monitor)
+}
+
 func (s *mitigatorSuite) TestMitigate_ResolveAlert() {
 	s.mitigator.actionRunner = func(
 		_ Action,

--- a/service/history/queues/monitor.go
+++ b/service/history/queues/monitor.go
@@ -183,12 +183,7 @@ func (m *monitorImpl) GetTotalSliceCount() int {
 	m.Lock()
 	defer m.Unlock()
 
-	count := 0
-	for _, sliceCount := range m.readerSliceCount {
-		count += sliceCount
-	}
-
-	return count
+	return m.totalSliceCount
 }
 
 func (m *monitorImpl) GetSliceCount(readerID int64) int {

--- a/service/history/queues/monitor.go
+++ b/service/history/queues/monitor.go
@@ -26,8 +26,8 @@ type (
 		GetSlicePendingTaskCount(slice Slice) int
 		SetSlicePendingTaskCount(slice Slice, count int)
 
-		GetReaderWatermark(readerID int64) (tasks.Key, bool)
-		SetReaderWatermark(readerID int64, watermark tasks.Key)
+		GetSliceReadWatermark(slice Slice) (tasks.Key, bool)
+		SetSliceReadWatermark(readerID int64, slice Slice, watermark tasks.Key)
 
 		GetTotalSliceCount() int
 		GetSliceCount(readerID int64) int
@@ -68,17 +68,21 @@ type (
 	}
 
 	readerStats struct {
-		progress   readerProgress
 		sliceCount int
 	}
 
-	readerProgress struct {
+	// readProgress tracks how many consecutive times a reader loaded tasks from a
+	// slice without advancing past watermark. Attributing this to a slice rather
+	// than to wall clock time keeps a burst of newly created slices covering the
+	// same fire time window from looking like a stuck reader.
+	readProgress struct {
 		watermark tasks.Key
 		attempts  int
 	}
 
 	sliceStats struct {
 		pendingTaskCount int
+		readProgress     readProgress
 	}
 )
 
@@ -139,21 +143,23 @@ func (m *monitorImpl) SetSlicePendingTaskCount(slice Slice, count int) {
 	}
 }
 
-func (m *monitorImpl) GetReaderWatermark(readerID int64) (tasks.Key, bool) {
+func (m *monitorImpl) GetSliceReadWatermark(slice Slice) (tasks.Key, bool) {
 	m.Lock()
 	defer m.Unlock()
 
-	stats, ok := m.readerStats[readerID]
-	if !ok {
+	stats, ok := m.sliceStats[slice]
+	if !ok || stats.readProgress.attempts == 0 {
 		return tasks.MinimumKey, false
 	}
 
-	return stats.progress.watermark, true
+	return stats.readProgress.watermark, true
 }
 
-func (m *monitorImpl) SetReaderWatermark(readerID int64, watermark tasks.Key) {
-	// TODO: currently only tracking default reader progress for scheduled queue
-	if readerID != DefaultReaderId || m.categoryType != tasks.CategoryTypeScheduled {
+func (m *monitorImpl) SetSliceReadWatermark(readerID int64, slice Slice, watermark tasks.Key) {
+	// Fire time is only comparable across reads for scheduled queues. Immediate
+	// task keys all carry tasks.DefaultFireTime, so a watermark window there would
+	// cover the entire queue.
+	if m.categoryType != tasks.CategoryTypeScheduled {
 		return
 	}
 
@@ -163,26 +169,26 @@ func (m *monitorImpl) SetReaderWatermark(readerID int64, watermark tasks.Key) {
 	watermark.FireTime = watermark.FireTime.Truncate(monitorWatermarkPrecision)
 	watermark.TaskID = 0
 
-	stats := m.readerStats[readerID]
-	if stats.progress.watermark.CompareTo(watermark) != 0 {
-		stats.progress = readerProgress{
+	stats := m.sliceStats[slice]
+	if stats.readProgress.watermark.CompareTo(watermark) != 0 {
+		stats.readProgress = readProgress{
 			watermark: watermark,
 			attempts:  1,
 		}
-		m.readerStats[readerID] = stats
+		m.sliceStats[slice] = stats
 		return
 	}
 
-	stats.progress.attempts++
-	m.readerStats[readerID] = stats
+	stats.readProgress.attempts++
+	m.sliceStats[slice] = stats
 
 	criticalAttempts := m.options.ReaderStuckCriticalAttempts()
-	if criticalAttempts > 0 && stats.progress.attempts >= criticalAttempts {
+	if criticalAttempts > 0 && stats.readProgress.attempts >= criticalAttempts {
 		m.sendAlertLocked(&Alert{
 			AlertType: AlertTypeReaderStuck,
 			AlertAttributesReaderStuck: &AlertAttributesReaderStuck{
 				ReaderID:         readerID,
-				CurrentWatermark: stats.progress.watermark,
+				CurrentWatermark: stats.readProgress.watermark,
 			},
 		})
 	}

--- a/service/history/queues/monitor.go
+++ b/service/history/queues/monitor.go
@@ -26,8 +26,7 @@ type (
 		GetSlicePendingTaskCount(slice Slice) int
 		SetSlicePendingTaskCount(slice Slice, count int)
 
-		GetSliceReadWatermark(slice Slice) (tasks.Key, bool)
-		SetSliceReadWatermark(readerID int64, slice Slice, watermark tasks.Key)
+		SetSliceReadWatermark(slice Slice, readerID int64, watermark tasks.Key)
 
 		GetTotalSliceCount() int
 		GetSliceCount(readerID int64) int
@@ -71,18 +70,19 @@ type (
 		sliceCount int
 	}
 
-	// readProgress tracks how many consecutive times a reader loaded tasks from a
-	// slice without advancing past watermark. Attributing this to a slice rather
-	// than to wall clock time keeps a burst of newly created slices covering the
-	// same fire time window from looking like a stuck reader.
+	// readProgress counts consecutive reads that ended on the same watermark. It is
+	// kept per slice because many slices can cover one fire time window, and a read
+	// that advances one of them says nothing about the others. It is kept per reader
+	// so that a slice handed to another reader is judged on that reader's own reads.
 	readProgress struct {
+		readerID  int64
 		watermark tasks.Key
 		attempts  int
 	}
 
 	sliceStats struct {
 		pendingTaskCount int
-		readProgress     readProgress
+		progress         readProgress
 	}
 )
 
@@ -143,22 +143,9 @@ func (m *monitorImpl) SetSlicePendingTaskCount(slice Slice, count int) {
 	}
 }
 
-func (m *monitorImpl) GetSliceReadWatermark(slice Slice) (tasks.Key, bool) {
-	m.Lock()
-	defer m.Unlock()
-
-	stats, ok := m.sliceStats[slice]
-	if !ok || stats.readProgress.attempts == 0 {
-		return tasks.MinimumKey, false
-	}
-
-	return stats.readProgress.watermark, true
-}
-
-func (m *monitorImpl) SetSliceReadWatermark(readerID int64, slice Slice, watermark tasks.Key) {
-	// Fire time is only comparable across reads for scheduled queues. Immediate
-	// task keys all carry tasks.DefaultFireTime, so a watermark window there would
-	// cover the entire queue.
+func (m *monitorImpl) SetSliceReadWatermark(slice Slice, readerID int64, watermark tasks.Key) {
+	// Immediate task keys all carry tasks.DefaultFireTime, so a window derived from
+	// a watermark would cover the whole queue.
 	if m.categoryType != tasks.CategoryTypeScheduled {
 		return
 	}
@@ -170,8 +157,9 @@ func (m *monitorImpl) SetSliceReadWatermark(readerID int64, slice Slice, waterma
 	watermark.TaskID = 0
 
 	stats := m.sliceStats[slice]
-	if stats.readProgress.watermark.CompareTo(watermark) != 0 {
-		stats.readProgress = readProgress{
+	if stats.progress.readerID != readerID || stats.progress.watermark.CompareTo(watermark) != 0 {
+		stats.progress = readProgress{
+			readerID:  readerID,
 			watermark: watermark,
 			attempts:  1,
 		}
@@ -179,16 +167,16 @@ func (m *monitorImpl) SetSliceReadWatermark(readerID int64, slice Slice, waterma
 		return
 	}
 
-	stats.readProgress.attempts++
+	stats.progress.attempts++
 	m.sliceStats[slice] = stats
 
 	criticalAttempts := m.options.ReaderStuckCriticalAttempts()
-	if criticalAttempts > 0 && stats.readProgress.attempts >= criticalAttempts {
+	if criticalAttempts > 0 && stats.progress.attempts >= criticalAttempts {
 		m.sendAlertLocked(&Alert{
 			AlertType: AlertTypeReaderStuck,
 			AlertAttributesReaderStuck: &AlertAttributesReaderStuck{
 				ReaderID:         readerID,
-				CurrentWatermark: stats.readProgress.watermark,
+				CurrentWatermark: stats.progress.watermark,
 			},
 		})
 	}

--- a/service/history/queues/monitor.go
+++ b/service/history/queues/monitor.go
@@ -66,9 +66,9 @@ type (
 		shutdownCh     chan struct{}
 	}
 
-	// Progress is tracked per slice and per reader so that neither an unrelated slice
-	// covering the same fire time window nor a previous owner of the slice contributes
-	// to stuck detection. alerted keeps one window from alerting on every later read.
+	// readProgress counts consecutive reads of one slice by one reader that ended on
+	// the same watermark. Another slice covering the same window, or a previous owner
+	// of this slice, must not count. alerted limits a window to one alert.
 	readProgress struct {
 		readerID  int64
 		watermark tasks.Key
@@ -166,18 +166,16 @@ func (m *monitorImpl) SetSliceReadWatermark(slice Slice, readerID int64, waterma
 	stats.progress.attempts++
 
 	criticalAttempts := m.options.ReaderStuckCriticalAttempts()
-	if stats.progress.alerted || criticalAttempts <= 0 || stats.progress.attempts < criticalAttempts {
-		m.sliceStats[slice] = stats
-		return
+	if !stats.progress.alerted && criticalAttempts > 0 && stats.progress.attempts >= criticalAttempts {
+		stats.progress.alerted = m.sendAlertLocked(&Alert{
+			AlertType: AlertTypeReaderStuck,
+			AlertAttributesReaderStuck: &AlertAttributesReaderStuck{
+				ReaderID:         readerID,
+				CurrentWatermark: stats.progress.watermark,
+			},
+		})
 	}
 
-	stats.progress.alerted = m.sendAlertLocked(&Alert{
-		AlertType: AlertTypeReaderStuck,
-		AlertAttributesReaderStuck: &AlertAttributesReaderStuck{
-			ReaderID:         readerID,
-			CurrentWatermark: stats.progress.watermark,
-		},
-	})
 	m.sliceStats[slice] = stats
 }
 
@@ -236,12 +234,7 @@ func (m *monitorImpl) RemoveReader(readerID int64) {
 	m.Lock()
 	defer m.Unlock()
 
-	sliceCount, ok := m.readerSliceCount[readerID]
-	if !ok {
-		return
-	}
-
-	m.totalSliceCount -= sliceCount
+	m.totalSliceCount -= m.readerSliceCount[readerID]
 	delete(m.readerSliceCount, readerID)
 }
 

--- a/service/history/queues/monitor.go
+++ b/service/history/queues/monitor.go
@@ -53,8 +53,8 @@ type (
 		totalPendingTaskCount int
 		totalSliceCount       int
 
-		readerStats map[int64]readerStats
-		sliceStats  map[Slice]sliceStats
+		readerSliceCount map[int64]int
+		sliceStats       map[Slice]sliceStats
 
 		categoryType tasks.CategoryType
 		timeSource   clock.TimeSource
@@ -66,18 +66,14 @@ type (
 		shutdownCh     chan struct{}
 	}
 
-	readerStats struct {
-		sliceCount int
-	}
-
-	// readProgress counts consecutive reads that ended on the same watermark. It is
-	// kept per slice because many slices can cover one fire time window, and a read
-	// that advances one of them says nothing about the others. It is kept per reader
-	// so that a slice handed to another reader is judged on that reader's own reads.
+	// Progress is tracked per slice and per reader so that neither an unrelated slice
+	// covering the same fire time window nor a previous owner of the slice contributes
+	// to stuck detection. alerted keeps one window from alerting on every later read.
 	readProgress struct {
 		readerID  int64
 		watermark tasks.Key
 		attempts  int
+		alerted   bool
 	}
 
 	sliceStats struct {
@@ -92,15 +88,15 @@ func newMonitor(
 	options *MonitorOptions,
 ) *monitorImpl {
 	return &monitorImpl{
-		readerStats:    make(map[int64]readerStats),
-		sliceStats:     make(map[Slice]sliceStats),
-		categoryType:   categoryType,
-		timeSource:     timeSource,
-		options:        options,
-		pendingAlerts:  make(map[AlertType]struct{}),
-		silencedAlerts: make(map[AlertType]time.Time),
-		alertCh:        make(chan *Alert, alertChSize),
-		shutdownCh:     make(chan struct{}),
+		readerSliceCount: make(map[int64]int),
+		sliceStats:       make(map[Slice]sliceStats),
+		categoryType:     categoryType,
+		timeSource:       timeSource,
+		options:          options,
+		pendingAlerts:    make(map[AlertType]struct{}),
+		silencedAlerts:   make(map[AlertType]time.Time),
+		alertCh:          make(chan *Alert, alertChSize),
+		shutdownCh:       make(chan struct{}),
 	}
 }
 
@@ -168,18 +164,21 @@ func (m *monitorImpl) SetSliceReadWatermark(slice Slice, readerID int64, waterma
 	}
 
 	stats.progress.attempts++
-	m.sliceStats[slice] = stats
 
 	criticalAttempts := m.options.ReaderStuckCriticalAttempts()
-	if criticalAttempts > 0 && stats.progress.attempts >= criticalAttempts {
-		m.sendAlertLocked(&Alert{
-			AlertType: AlertTypeReaderStuck,
-			AlertAttributesReaderStuck: &AlertAttributesReaderStuck{
-				ReaderID:         readerID,
-				CurrentWatermark: stats.progress.watermark,
-			},
-		})
+	if stats.progress.alerted || criticalAttempts <= 0 || stats.progress.attempts < criticalAttempts {
+		m.sliceStats[slice] = stats
+		return
 	}
+
+	stats.progress.alerted = m.sendAlertLocked(&Alert{
+		AlertType: AlertTypeReaderStuck,
+		AlertAttributesReaderStuck: &AlertAttributesReaderStuck{
+			ReaderID:         readerID,
+			CurrentWatermark: stats.progress.watermark,
+		},
+	})
+	m.sliceStats[slice] = stats
 }
 
 func (m *monitorImpl) GetTotalSliceCount() int {
@@ -187,8 +186,8 @@ func (m *monitorImpl) GetTotalSliceCount() int {
 	defer m.Unlock()
 
 	count := 0
-	for _, stats := range m.readerStats {
-		count += stats.sliceCount
+	for _, sliceCount := range m.readerSliceCount {
+		count += sliceCount
 	}
 
 	return count
@@ -198,21 +197,15 @@ func (m *monitorImpl) GetSliceCount(readerID int64) int {
 	m.Lock()
 	defer m.Unlock()
 
-	if stats, ok := m.readerStats[readerID]; ok {
-		return stats.sliceCount
-	}
-	return 0
+	return m.readerSliceCount[readerID]
 }
 
 func (m *monitorImpl) SetSliceCount(readerID int64, count int) {
 	m.Lock()
 	defer m.Unlock()
 
-	stats := m.readerStats[readerID]
-	m.totalSliceCount = m.totalSliceCount - stats.sliceCount + count
-
-	stats.sliceCount = count
-	m.readerStats[readerID] = stats
+	m.totalSliceCount = m.totalSliceCount - m.readerSliceCount[readerID] + count
+	m.readerSliceCount[readerID] = count
 
 	criticalSliceCount := m.options.SliceCountCriticalThreshold()
 	if criticalSliceCount > 0 && m.totalSliceCount > criticalSliceCount {
@@ -243,13 +236,13 @@ func (m *monitorImpl) RemoveReader(readerID int64) {
 	m.Lock()
 	defer m.Unlock()
 
-	stats, ok := m.readerStats[readerID]
+	sliceCount, ok := m.readerSliceCount[readerID]
 	if !ok {
 		return
 	}
 
-	m.totalSliceCount -= stats.sliceCount
-	delete(m.readerStats, readerID)
+	m.totalSliceCount -= sliceCount
+	delete(m.readerSliceCount, readerID)
 }
 
 func (m *monitorImpl) ResolveAlert(alertType AlertType) {
@@ -288,26 +281,30 @@ func (m *monitorImpl) Close() {
 	}
 }
 
-func (m *monitorImpl) sendAlertLocked(alert *Alert) {
+// sendAlertLocked reports whether the alert was queued, so callers that latch on
+// having reported a condition do not latch on an alert that was dropped.
+func (m *monitorImpl) sendAlertLocked(alert *Alert) bool {
 	if m.isClosed() {
 		// make sure alert won't be sent to a closed chan
-		return
+		return false
 	}
 
 	if m.timeSource.Now().Before(m.silencedAlerts[alert.AlertType]) {
-		return
+		return false
 	}
 
 	// dedup alerts, we only need one outstanding alert per alert type
 	if _, ok := m.pendingAlerts[alert.AlertType]; ok {
-		return
+		return false
 	}
 
 	select {
 	case m.alertCh <- alert:
 		m.pendingAlerts[alert.AlertType] = struct{}{}
+		return true
 	default:
 		// do not block if alertCh full
+		return false
 	}
 }
 

--- a/service/history/queues/monitor_test.go
+++ b/service/history/queues/monitor_test.go
@@ -120,8 +120,7 @@ func (s *monitorSuite) requireNoAlert(msg string) {
 func (s *monitorSuite) TestSliceReadWatermarkStats() {
 	slice := &SliceImpl{}
 
-	// The fire time is deliberately not aligned to monitorWatermarkPrecision so the
-	// expected watermark below also covers truncation, not just the task ID reset.
+	// 750ms is unaligned to monitorWatermarkPrecision, so the expectation covers truncation.
 	watermark := readerStuckKey(750*time.Millisecond, rand.Int63())
 	expectedAlert := Alert{
 		AlertType: AlertTypeReaderStuck,
@@ -135,9 +134,6 @@ func (s *monitorSuite) TestSliceReadWatermarkStats() {
 		s.monitor.SetSliceReadWatermark(slice, DefaultReaderId, watermark)
 	}
 	s.Equal(expectedAlert, *s.receiveAlert())
-
-	s.monitor.SetSliceReadWatermark(slice, DefaultReaderId, watermark)
-	s.requireNoAlert("should have only one outstanding reader stuck alert")
 
 	// The same window stays reported once however long the reader sits on it, so
 	// mitigating it does not cost an alert and a checkpoint per read.
@@ -191,6 +187,17 @@ func (s *monitorSuite) TestSliceReadWatermarkStats_ReadsSpreadAcrossSlices() {
 	}
 
 	s.requireNoAlert("reads spread across distinct slices should not trigger reader stuck alert")
+}
+
+func (s *monitorSuite) TestSliceReadWatermarkStats_NewOwnerResetsAttempts() {
+	slice := &SliceImpl{}
+	watermark := readerStuckKey(0, 0)
+	for i := 0; i != s.monitor.options.ReaderStuckCriticalAttempts()-1; i++ {
+		s.monitor.SetSliceReadWatermark(slice, DefaultReaderId, watermark)
+	}
+
+	s.monitor.SetSliceReadWatermark(slice, DefaultReaderId+1, watermark)
+	s.requireNoAlert("a new owning reader restarts the attempt count")
 }
 
 func (s *monitorSuite) TestSliceReadWatermarkStats_AdvancingWatermarkResetsAttempts() {

--- a/service/history/queues/monitor_test.go
+++ b/service/history/queues/monitor_test.go
@@ -164,7 +164,7 @@ func (s *monitorSuite) TestSliceReadWatermarkStats_DroppedAlertIsRetried() {
 	for i := 0; i != criticalAttempts; i++ {
 		s.monitor.SetSliceReadWatermark(first, DefaultReaderId, readerStuckKey(0, int64(i)))
 	}
-	s.NotNil(s.receiveAlert())
+	s.receiveAlert()
 
 	// The second window is dropped by the outstanding alert dedup, so it must not be
 	// treated as reported or it would never be mitigated.
@@ -175,7 +175,7 @@ func (s *monitorSuite) TestSliceReadWatermarkStats_DroppedAlertIsRetried() {
 
 	s.monitor.ResolveAlert(AlertTypeReaderStuck)
 	s.monitor.SetSliceReadWatermark(second, DefaultReaderId, readerStuckKey(0, 0))
-	s.NotNil(s.receiveAlert())
+	s.receiveAlert()
 }
 
 func (s *monitorSuite) TestSliceReadWatermarkStats_ReadsSpreadAcrossSlices() {
@@ -311,6 +311,10 @@ func (s *monitorSuite) TestSliceCount() {
 			CriticalSliceCount: threshold,
 		},
 	}, *alert)
+
+	s.monitor.RemoveReader(DefaultReaderId + 1)
+	s.Equal(threshold*2, s.monitor.GetTotalSliceCount())
+	s.Equal(0, s.monitor.GetSliceCount(DefaultReaderId+1))
 }
 
 func (s *monitorSuite) TestResolveAlert() {

--- a/service/history/queues/monitor_test.go
+++ b/service/history/queues/monitor_test.go
@@ -99,22 +99,21 @@ func (s *monitorSuite) TestPendingTasksStats() {
 	s.Equal(1, s.monitor.GetTotalPendingTaskCount())
 }
 
-func (s *monitorSuite) TestReaderWatermarkStats() {
-	_, ok := s.monitor.GetReaderWatermark(DefaultReaderId)
+func (s *monitorSuite) TestSliceReadWatermarkStats() {
+	slice := &SliceImpl{}
+
+	_, ok := s.monitor.GetSliceReadWatermark(slice)
 	s.False(ok)
 
 	now := time.Now().Truncate(monitorWatermarkPrecision)
-	s.monitor.SetReaderWatermark(DefaultReaderId, tasks.NewKey(now, rand.Int63()))
-	watermark, ok := s.monitor.GetReaderWatermark(DefaultReaderId)
+	s.monitor.SetSliceReadWatermark(DefaultReaderId, slice, tasks.NewKey(now, rand.Int63()))
+	watermark, ok := s.monitor.GetSliceReadWatermark(slice)
 	s.True(ok)
-	s.Equal(tasks.NewKey(
-		now.Truncate(monitorWatermarkPrecision),
-		0,
-	), watermark)
+	s.Equal(tasks.NewKey(now, 0), watermark)
 
 	for i := 0; i != s.monitor.options.ReaderStuckCriticalAttempts(); i++ {
 		now = now.Add(time.Millisecond * 100)
-		s.monitor.SetReaderWatermark(DefaultReaderId, tasks.NewKey(now, rand.Int63()))
+		s.monitor.SetSliceReadWatermark(DefaultReaderId, slice, tasks.NewKey(now, rand.Int63()))
 	}
 
 	alert := <-s.alertCh
@@ -130,17 +129,76 @@ func (s *monitorSuite) TestReaderWatermarkStats() {
 	}
 	s.Equal(expectedAlert, *alert)
 
-	s.monitor.SetReaderWatermark(DefaultReaderId, tasks.NewKey(now, rand.Int63()))
+	s.monitor.SetSliceReadWatermark(DefaultReaderId, slice, tasks.NewKey(now, rand.Int63()))
 	select {
 	case <-s.alertCh:
-		s.Fail("should have only one outstanding slice count alert")
+		s.Fail("should have only one outstanding reader stuck alert")
 	default:
 	}
 
 	s.monitor.ResolveAlert(alert.AlertType)
-	s.monitor.SetReaderWatermark(DefaultReaderId, tasks.NewKey(now, rand.Int63()))
+	s.monitor.SetSliceReadWatermark(DefaultReaderId, slice, tasks.NewKey(now, rand.Int63()))
 	alert = <-s.alertCh
 	s.Equal(expectedAlert, *alert)
+}
+
+func (s *monitorSuite) TestSliceReadWatermarkStats_ReadsSpreadAcrossSlices() {
+	// A shard that keeps generating tasks gets a new slice per notification, and
+	// several of them can cover the same fire time second. Every read makes progress
+	// in its own slice, so this must not be reported as a stuck reader.
+	now := time.Now().Truncate(monitorWatermarkPrecision)
+	for i := 0; i != s.monitor.options.ReaderStuckCriticalAttempts()*2; i++ {
+		s.monitor.SetSliceReadWatermark(DefaultReaderId, &SliceImpl{}, tasks.NewKey(now, rand.Int63()))
+	}
+
+	select {
+	case <-s.alertCh:
+		s.Fail("reads spread across distinct slices should not trigger reader stuck alert")
+	default:
+	}
+}
+
+func (s *monitorSuite) TestSliceReadWatermarkStats_NonDefaultReader() {
+	slice := &SliceImpl{}
+	readerID := DefaultReaderId + 1
+
+	now := time.Now().Truncate(monitorWatermarkPrecision)
+	for i := 0; i != s.monitor.options.ReaderStuckCriticalAttempts(); i++ {
+		s.monitor.SetSliceReadWatermark(readerID, slice, tasks.NewKey(now, rand.Int63()))
+	}
+
+	alert := <-s.alertCh
+	s.Equal(AlertTypeReaderStuck, alert.AlertType)
+	s.Equal(readerID, alert.AlertAttributesReaderStuck.ReaderID)
+}
+
+func (s *monitorSuite) TestSliceReadWatermarkStats_ImmediateQueueNotTracked() {
+	monitor := newMonitor(tasks.CategoryTypeImmediate, s.mockTimeSource, s.monitor.options)
+	defer monitor.Close()
+
+	slice := &SliceImpl{}
+	for i := 0; i != monitor.options.ReaderStuckCriticalAttempts()*2; i++ {
+		monitor.SetSliceReadWatermark(DefaultReaderId, slice, tasks.NewKey(tasks.DefaultFireTime, int64(i)))
+	}
+
+	select {
+	case <-monitor.AlertCh():
+		s.Fail("immediate queue should not track slice read progress")
+	default:
+	}
+}
+
+func (s *monitorSuite) TestRemoveSliceClearsReadProgress() {
+	slice := &SliceImpl{}
+
+	now := time.Now().Truncate(monitorWatermarkPrecision)
+	s.monitor.SetSliceReadWatermark(DefaultReaderId, slice, tasks.NewKey(now, rand.Int63()))
+	_, ok := s.monitor.GetSliceReadWatermark(slice)
+	s.True(ok)
+
+	s.monitor.RemoveSlice(slice)
+	_, ok = s.monitor.GetSliceReadWatermark(slice)
+	s.False(ok)
 }
 
 func (s *monitorSuite) TestSliceCount() {

--- a/service/history/queues/monitor_test.go
+++ b/service/history/queues/monitor_test.go
@@ -122,12 +122,12 @@ func (s *monitorSuite) TestSliceReadWatermarkStats() {
 
 	// The fire time is deliberately not aligned to monitorWatermarkPrecision so the
 	// expected watermark below also covers truncation, not just the task ID reset.
-	watermark := stuckKey(750*time.Millisecond, rand.Int63())
+	watermark := readerStuckKey(750*time.Millisecond, rand.Int63())
 	expectedAlert := Alert{
 		AlertType: AlertTypeReaderStuck,
 		AlertAttributesReaderStuck: &AlertAttributesReaderStuck{
 			ReaderID:         DefaultReaderId,
-			CurrentWatermark: stuckKey(0, 0),
+			CurrentWatermark: readerStuckKey(0, 0),
 		},
 	}
 
@@ -139,9 +139,47 @@ func (s *monitorSuite) TestSliceReadWatermarkStats() {
 	s.monitor.SetSliceReadWatermark(slice, DefaultReaderId, watermark)
 	s.requireNoAlert("should have only one outstanding reader stuck alert")
 
+	// The same window stays reported once however long the reader sits on it, so
+	// mitigating it does not cost an alert and a checkpoint per read.
 	s.monitor.ResolveAlert(AlertTypeReaderStuck)
-	s.monitor.SetSliceReadWatermark(slice, DefaultReaderId, watermark)
-	s.Equal(expectedAlert, *s.receiveAlert())
+	for i := 0; i != s.monitor.options.ReaderStuckCriticalAttempts()*2; i++ {
+		s.monitor.SetSliceReadWatermark(slice, DefaultReaderId, watermark)
+	}
+	s.requireNoAlert("a stuck window should only be reported once")
+
+	// Getting stuck on a later window is a new condition worth reporting.
+	later := readerStuckKey(monitorWatermarkPrecision+750*time.Millisecond, rand.Int63())
+	for i := 0; i != s.monitor.options.ReaderStuckCriticalAttempts(); i++ {
+		s.monitor.SetSliceReadWatermark(slice, DefaultReaderId, later)
+	}
+	s.Equal(Alert{
+		AlertType: AlertTypeReaderStuck,
+		AlertAttributesReaderStuck: &AlertAttributesReaderStuck{
+			ReaderID:         DefaultReaderId,
+			CurrentWatermark: readerStuckKey(monitorWatermarkPrecision, 0),
+		},
+	}, *s.receiveAlert())
+}
+
+func (s *monitorSuite) TestSliceReadWatermarkStats_DroppedAlertIsRetried() {
+	criticalAttempts := s.monitor.options.ReaderStuckCriticalAttempts()
+	first, second := &SliceImpl{}, &SliceImpl{}
+
+	for i := 0; i != criticalAttempts; i++ {
+		s.monitor.SetSliceReadWatermark(first, DefaultReaderId, readerStuckKey(0, int64(i)))
+	}
+	s.NotNil(s.receiveAlert())
+
+	// The second window is dropped by the outstanding alert dedup, so it must not be
+	// treated as reported or it would never be mitigated.
+	for i := 0; i != criticalAttempts; i++ {
+		s.monitor.SetSliceReadWatermark(second, DefaultReaderId, readerStuckKey(0, int64(i)))
+	}
+	s.requireNoAlert("only one reader stuck alert should be outstanding")
+
+	s.monitor.ResolveAlert(AlertTypeReaderStuck)
+	s.monitor.SetSliceReadWatermark(second, DefaultReaderId, readerStuckKey(0, 0))
+	s.NotNil(s.receiveAlert())
 }
 
 func (s *monitorSuite) TestSliceReadWatermarkStats_ReadsSpreadAcrossSlices() {
@@ -149,7 +187,7 @@ func (s *monitorSuite) TestSliceReadWatermarkStats_ReadsSpreadAcrossSlices() {
 	// several of them can cover one fire time window. Every read makes progress in
 	// its own slice, so this must not be reported as a stuck reader.
 	for i := 0; i != s.monitor.options.ReaderStuckCriticalAttempts()*2; i++ {
-		s.monitor.SetSliceReadWatermark(&SliceImpl{}, DefaultReaderId, stuckKey(0, int64(i)))
+		s.monitor.SetSliceReadWatermark(&SliceImpl{}, DefaultReaderId, readerStuckKey(0, int64(i)))
 	}
 
 	s.requireNoAlert("reads spread across distinct slices should not trigger reader stuck alert")
@@ -161,7 +199,7 @@ func (s *monitorSuite) TestSliceReadWatermarkStats_AdvancingWatermarkResetsAttem
 		s.monitor.SetSliceReadWatermark(
 			slice,
 			DefaultReaderId,
-			stuckKey(time.Duration(i)*monitorWatermarkPrecision, rand.Int63()),
+			readerStuckKey(time.Duration(i)*monitorWatermarkPrecision, rand.Int63()),
 		)
 	}
 
@@ -173,7 +211,7 @@ func (s *monitorSuite) TestSliceReadWatermarkStats_AlertingDisabled() {
 
 	slice := &SliceImpl{}
 	for i := 0; i != 20; i++ {
-		s.monitor.SetSliceReadWatermark(slice, DefaultReaderId, stuckKey(0, int64(i)))
+		s.monitor.SetSliceReadWatermark(slice, DefaultReaderId, readerStuckKey(0, int64(i)))
 	}
 
 	s.requireNoAlert("reader stuck detection is disabled when critical attempts is 0")
@@ -184,14 +222,14 @@ func (s *monitorSuite) TestSliceReadWatermarkStats_NonDefaultReader() {
 	readerID := DefaultReaderId + 1
 
 	for i := 0; i != s.monitor.options.ReaderStuckCriticalAttempts(); i++ {
-		s.monitor.SetSliceReadWatermark(slice, readerID, stuckKey(0, int64(i)))
+		s.monitor.SetSliceReadWatermark(slice, readerID, readerStuckKey(0, int64(i)))
 	}
 
 	s.Equal(Alert{
 		AlertType: AlertTypeReaderStuck,
 		AlertAttributesReaderStuck: &AlertAttributesReaderStuck{
 			ReaderID:         readerID,
-			CurrentWatermark: stuckKey(0, 0),
+			CurrentWatermark: readerStuckKey(0, 0),
 		},
 	}, *s.receiveAlert())
 }
@@ -215,14 +253,12 @@ func (s *monitorSuite) TestSliceReadWatermarkStats_ImmediateQueueNotTracked() {
 func (s *monitorSuite) TestRemoveSliceResetsReadProgress() {
 	slice := &SliceImpl{}
 	for i := 0; i != s.monitor.options.ReaderStuckCriticalAttempts()-1; i++ {
-		s.monitor.SetSliceReadWatermark(slice, DefaultReaderId, stuckKey(0, int64(i)))
+		s.monitor.SetSliceReadWatermark(slice, DefaultReaderId, readerStuckKey(0, int64(i)))
 	}
 
 	s.monitor.RemoveSlice(slice)
 
-	// The attempt count restarted, so the read that would have crossed the threshold
-	// no longer does.
-	s.monitor.SetSliceReadWatermark(slice, DefaultReaderId, stuckKey(0, 0))
+	s.monitor.SetSliceReadWatermark(slice, DefaultReaderId, readerStuckKey(0, 0))
 	s.requireNoAlert("RemoveSlice should reset the stuck attempt counter")
 }
 

--- a/service/history/queues/monitor_test.go
+++ b/service/history/queues/monitor_test.go
@@ -99,77 +99,101 @@ func (s *monitorSuite) TestPendingTasksStats() {
 	s.Equal(1, s.monitor.GetTotalPendingTaskCount())
 }
 
+func (s *monitorSuite) receiveAlert() *Alert {
+	select {
+	case alert := <-s.alertCh:
+		return alert
+	default:
+		s.FailNow("expected an alert")
+		return nil
+	}
+}
+
+func (s *monitorSuite) requireNoAlert(msg string) {
+	select {
+	case <-s.alertCh:
+		s.Fail(msg)
+	default:
+	}
+}
+
 func (s *monitorSuite) TestSliceReadWatermarkStats() {
 	slice := &SliceImpl{}
 
-	_, ok := s.monitor.GetSliceReadWatermark(slice)
-	s.False(ok)
-
-	now := time.Now().Truncate(monitorWatermarkPrecision)
-	s.monitor.SetSliceReadWatermark(DefaultReaderId, slice, tasks.NewKey(now, rand.Int63()))
-	watermark, ok := s.monitor.GetSliceReadWatermark(slice)
-	s.True(ok)
-	s.Equal(tasks.NewKey(now, 0), watermark)
-
-	for i := 0; i != s.monitor.options.ReaderStuckCriticalAttempts(); i++ {
-		now = now.Add(time.Millisecond * 100)
-		s.monitor.SetSliceReadWatermark(DefaultReaderId, slice, tasks.NewKey(now, rand.Int63()))
-	}
-
-	alert := <-s.alertCh
+	// The fire time is deliberately not aligned to monitorWatermarkPrecision so the
+	// expected watermark below also covers truncation, not just the task ID reset.
+	watermark := stuckKey(750*time.Millisecond, rand.Int63())
 	expectedAlert := Alert{
 		AlertType: AlertTypeReaderStuck,
 		AlertAttributesReaderStuck: &AlertAttributesReaderStuck{
-			ReaderID: DefaultReaderId,
-			CurrentWatermark: tasks.NewKey(
-				now.Truncate(monitorWatermarkPrecision),
-				0,
-			),
+			ReaderID:         DefaultReaderId,
+			CurrentWatermark: stuckKey(0, 0),
 		},
 	}
-	s.Equal(expectedAlert, *alert)
 
-	s.monitor.SetSliceReadWatermark(DefaultReaderId, slice, tasks.NewKey(now, rand.Int63()))
-	select {
-	case <-s.alertCh:
-		s.Fail("should have only one outstanding reader stuck alert")
-	default:
+	for i := 0; i != s.monitor.options.ReaderStuckCriticalAttempts(); i++ {
+		s.monitor.SetSliceReadWatermark(slice, DefaultReaderId, watermark)
 	}
+	s.Equal(expectedAlert, *s.receiveAlert())
 
-	s.monitor.ResolveAlert(alert.AlertType)
-	s.monitor.SetSliceReadWatermark(DefaultReaderId, slice, tasks.NewKey(now, rand.Int63()))
-	alert = <-s.alertCh
-	s.Equal(expectedAlert, *alert)
+	s.monitor.SetSliceReadWatermark(slice, DefaultReaderId, watermark)
+	s.requireNoAlert("should have only one outstanding reader stuck alert")
+
+	s.monitor.ResolveAlert(AlertTypeReaderStuck)
+	s.monitor.SetSliceReadWatermark(slice, DefaultReaderId, watermark)
+	s.Equal(expectedAlert, *s.receiveAlert())
 }
 
 func (s *monitorSuite) TestSliceReadWatermarkStats_ReadsSpreadAcrossSlices() {
 	// A shard that keeps generating tasks gets a new slice per notification, and
-	// several of them can cover the same fire time second. Every read makes progress
-	// in its own slice, so this must not be reported as a stuck reader.
-	now := time.Now().Truncate(monitorWatermarkPrecision)
+	// several of them can cover one fire time window. Every read makes progress in
+	// its own slice, so this must not be reported as a stuck reader.
 	for i := 0; i != s.monitor.options.ReaderStuckCriticalAttempts()*2; i++ {
-		s.monitor.SetSliceReadWatermark(DefaultReaderId, &SliceImpl{}, tasks.NewKey(now, rand.Int63()))
+		s.monitor.SetSliceReadWatermark(&SliceImpl{}, DefaultReaderId, stuckKey(0, int64(i)))
 	}
 
-	select {
-	case <-s.alertCh:
-		s.Fail("reads spread across distinct slices should not trigger reader stuck alert")
-	default:
+	s.requireNoAlert("reads spread across distinct slices should not trigger reader stuck alert")
+}
+
+func (s *monitorSuite) TestSliceReadWatermarkStats_AdvancingWatermarkResetsAttempts() {
+	slice := &SliceImpl{}
+	for i := 0; i != s.monitor.options.ReaderStuckCriticalAttempts()*2; i++ {
+		s.monitor.SetSliceReadWatermark(
+			slice,
+			DefaultReaderId,
+			stuckKey(time.Duration(i)*monitorWatermarkPrecision, rand.Int63()),
+		)
 	}
+
+	s.requireNoAlert("a reader whose watermark keeps advancing is not stuck")
+}
+
+func (s *monitorSuite) TestSliceReadWatermarkStats_AlertingDisabled() {
+	s.monitor.options.ReaderStuckCriticalAttempts = dynamicconfig.GetIntPropertyFn(0)
+
+	slice := &SliceImpl{}
+	for i := 0; i != 20; i++ {
+		s.monitor.SetSliceReadWatermark(slice, DefaultReaderId, stuckKey(0, int64(i)))
+	}
+
+	s.requireNoAlert("reader stuck detection is disabled when critical attempts is 0")
 }
 
 func (s *monitorSuite) TestSliceReadWatermarkStats_NonDefaultReader() {
 	slice := &SliceImpl{}
 	readerID := DefaultReaderId + 1
 
-	now := time.Now().Truncate(monitorWatermarkPrecision)
 	for i := 0; i != s.monitor.options.ReaderStuckCriticalAttempts(); i++ {
-		s.monitor.SetSliceReadWatermark(readerID, slice, tasks.NewKey(now, rand.Int63()))
+		s.monitor.SetSliceReadWatermark(slice, readerID, stuckKey(0, int64(i)))
 	}
 
-	alert := <-s.alertCh
-	s.Equal(AlertTypeReaderStuck, alert.AlertType)
-	s.Equal(readerID, alert.AlertAttributesReaderStuck.ReaderID)
+	s.Equal(Alert{
+		AlertType: AlertTypeReaderStuck,
+		AlertAttributesReaderStuck: &AlertAttributesReaderStuck{
+			ReaderID:         readerID,
+			CurrentWatermark: stuckKey(0, 0),
+		},
+	}, *s.receiveAlert())
 }
 
 func (s *monitorSuite) TestSliceReadWatermarkStats_ImmediateQueueNotTracked() {
@@ -178,7 +202,7 @@ func (s *monitorSuite) TestSliceReadWatermarkStats_ImmediateQueueNotTracked() {
 
 	slice := &SliceImpl{}
 	for i := 0; i != monitor.options.ReaderStuckCriticalAttempts()*2; i++ {
-		monitor.SetSliceReadWatermark(DefaultReaderId, slice, tasks.NewKey(tasks.DefaultFireTime, int64(i)))
+		monitor.SetSliceReadWatermark(slice, DefaultReaderId, tasks.NewKey(tasks.DefaultFireTime, int64(i)))
 	}
 
 	select {
@@ -188,17 +212,18 @@ func (s *monitorSuite) TestSliceReadWatermarkStats_ImmediateQueueNotTracked() {
 	}
 }
 
-func (s *monitorSuite) TestRemoveSliceClearsReadProgress() {
+func (s *monitorSuite) TestRemoveSliceResetsReadProgress() {
 	slice := &SliceImpl{}
-
-	now := time.Now().Truncate(monitorWatermarkPrecision)
-	s.monitor.SetSliceReadWatermark(DefaultReaderId, slice, tasks.NewKey(now, rand.Int63()))
-	_, ok := s.monitor.GetSliceReadWatermark(slice)
-	s.True(ok)
+	for i := 0; i != s.monitor.options.ReaderStuckCriticalAttempts()-1; i++ {
+		s.monitor.SetSliceReadWatermark(slice, DefaultReaderId, stuckKey(0, int64(i)))
+	}
 
 	s.monitor.RemoveSlice(slice)
-	_, ok = s.monitor.GetSliceReadWatermark(slice)
-	s.False(ok)
+
+	// The attempt count restarted, so the read that would have crossed the threshold
+	// no longer does.
+	s.monitor.SetSliceReadWatermark(slice, DefaultReaderId, stuckKey(0, 0))
+	s.requireNoAlert("RemoveSlice should reset the stuck attempt counter")
 }
 
 func (s *monitorSuite) TestSliceCount() {

--- a/service/history/queues/range.go
+++ b/service/history/queues/range.go
@@ -51,6 +51,14 @@ func (r *Range) CanSplit(
 	return r.ContainsKey(key) || r.ExclusiveMax.CompareTo(key) == 0
 }
 
+// CanSplitStrictly reports whether splitting at key yields two non-empty ranges.
+// CanSplit also accepts InclusiveMin and ExclusiveMax, which produce an empty side.
+func (r *Range) CanSplitStrictly(
+	key tasks.Key,
+) bool {
+	return key.CompareTo(r.InclusiveMin) > 0 && key.CompareTo(r.ExclusiveMax) < 0
+}
+
 func (r *Range) Split(
 	key tasks.Key,
 ) (left Range, right Range) {

--- a/service/history/queues/range_test.go
+++ b/service/history/queues/range_test.go
@@ -197,26 +197,19 @@ func (s *rangeSuite) TestCanSplit() {
 }
 
 func (s *rangeSuite) TestCanSplitStrictly() {
-	key := NewRandomKey()
-	ranges := []Range{
-		NewRandomRange(),
-		NewRange(key, key),
-	}
+	r := NewRange(
+		tasks.NewKey(time.Unix(0, 100), 10),
+		tasks.NewKey(time.Unix(0, 100), 20),
+	)
 
-	for _, r := range ranges {
-		s.False(r.CanSplitStrictly(r.InclusiveMin))
-		s.False(r.CanSplitStrictly(r.ExclusiveMax))
+	s.False(r.CanSplitStrictly(tasks.NewKey(time.Unix(0, 100), 9)))
+	s.False(r.CanSplitStrictly(r.InclusiveMin))
+	s.True(r.CanSplitStrictly(tasks.NewKey(time.Unix(0, 100), 15)))
+	s.False(r.CanSplitStrictly(r.ExclusiveMax))
+	s.False(r.CanSplitStrictly(tasks.NewKey(time.Unix(0, 100), 21)))
 
-		if !r.IsEmpty() {
-			for i := 0; i != 1000; i++ {
-				testKey := NewRandomKeyInRange(r)
-				if testKey.CompareTo(r.InclusiveMin) == 0 {
-					continue
-				}
-				s.True(r.CanSplitStrictly(testKey))
-			}
-		}
-	}
+	empty := NewRange(r.InclusiveMin, r.InclusiveMin)
+	s.False(empty.CanSplitStrictly(r.InclusiveMin))
 }
 
 func (s *rangeSuite) TestCanMerge() {

--- a/service/history/queues/range_test.go
+++ b/service/history/queues/range_test.go
@@ -196,6 +196,29 @@ func (s *rangeSuite) TestCanSplit() {
 	}
 }
 
+func (s *rangeSuite) TestCanSplitStrictly() {
+	key := NewRandomKey()
+	ranges := []Range{
+		NewRandomRange(),
+		NewRange(key, key),
+	}
+
+	for _, r := range ranges {
+		s.False(r.CanSplitStrictly(r.InclusiveMin))
+		s.False(r.CanSplitStrictly(r.ExclusiveMax))
+
+		if !r.IsEmpty() {
+			for i := 0; i != 1000; i++ {
+				testKey := NewRandomKeyInRange(r)
+				if testKey.CompareTo(r.InclusiveMin) == 0 {
+					continue
+				}
+				s.True(r.CanSplitStrictly(testKey))
+			}
+		}
+	}
+}
+
 func (s *rangeSuite) TestCanMerge() {
 	key := NewRandomKey()
 	ranges := []Range{

--- a/service/history/queues/reader.go
+++ b/service/history/queues/reader.go
@@ -468,7 +468,7 @@ func (r *ReaderImpl) loadAndSubmitTasks() {
 		for _, task := range tasks {
 			r.submit(task)
 		}
-		r.monitor.SetReaderWatermark(r.readerID, tasks[len(tasks)-1].GetKey())
+		r.monitor.SetSliceReadWatermark(r.readerID, loadSlice, tasks[len(tasks)-1].GetKey())
 	}
 
 	if loadSlice.MoreTasks() {

--- a/service/history/queues/reader.go
+++ b/service/history/queues/reader.go
@@ -468,7 +468,7 @@ func (r *ReaderImpl) loadAndSubmitTasks() {
 		for _, task := range tasks {
 			r.submit(task)
 		}
-		r.monitor.SetSliceReadWatermark(r.readerID, loadSlice, tasks[len(tasks)-1].GetKey())
+		r.monitor.SetSliceReadWatermark(loadSlice, r.readerID, tasks[len(tasks)-1].GetKey())
 	}
 
 	if loadSlice.MoreTasks() {

--- a/service/history/queues/reader_test.go
+++ b/service/history/queues/reader_test.go
@@ -393,7 +393,9 @@ func (s *readerSuite) TestLoadAndSubmitTasks_TooManyPendingTasks() {
 }
 
 func (s *readerSuite) TestLoadAndSubmitTasks_MoreTasks() {
-	scopes := NewRandomScopes(1)
+	// Two scopes and a non-default reader ID so the read progress assertion below can
+	// not be satisfied by attributing progress to the wrong slice or reader.
+	scopes := NewRandomScopes(2)
 
 	paginationFnProvider := func(_ Range) collection.PaginationFn[tasks.Task] {
 		return func(paginationToken []byte) ([]tasks.Task, []byte, error) {
@@ -413,6 +415,7 @@ func (s *readerSuite) TestLoadAndSubmitTasks_MoreTasks() {
 
 	completionFnCalled := false
 	reader := s.newTestReader(scopes, paginationFnProvider, func(_ int64) { completionFnCalled = true })
+	reader.readerID = DefaultReaderId + 1
 	mockTimeSource := clock.NewEventTimeSource()
 	mockTimeSource.Update(scopes[0].Range.ExclusiveMax.FireTime)
 	reader.timeSource = mockTimeSource

--- a/service/history/queues/reader_test.go
+++ b/service/history/queues/reader_test.go
@@ -424,11 +424,18 @@ func (s *readerSuite) TestLoadAndSubmitTasks_MoreTasks() {
 	}).AnyTimes()
 	s.mockRescheduler.EXPECT().Len().Return(0).AnyTimes()
 
+	loadSlice := reader.nextReadSlice.Value.(Slice)
 	reader.loadAndSubmitTasks()
 	<-reader.notifyCh // should trigger next round of load
 	s.Equal(reader.options.BatchSize(), taskSubmitted)
 	s.True(scopes[0].Equals(reader.nextReadSlice.Value.(Slice).Scope()))
 	s.False(completionFnCalled)
+
+	// Read progress has to be attributed to the slice that was read, otherwise
+	// unrelated slices covering the same fire time window share a counter.
+	progress := s.monitor.sliceStats[loadSlice].progress
+	s.Equal(reader.readerID, progress.readerID)
+	s.Equal(1, progress.attempts)
 }
 
 func (s *readerSuite) TestLoadAndSubmitTasks_NoMoreTasks_HasNextSlice() {


### PR DESCRIPTION
## What changed?

- count reader stuck attempts per slice and per owning reader instead of per wall clock second (`SetReaderWatermark` -> `SetSliceReadWatermark`)
- report each stuck window once, and only when the alert was actually queued
- track read progress for every reader rather than only the default one, and stop creating readers at `MaxReaderCount`
- only split slices that genuinely overlap the stuck range, via a new `Range.CanSplitStrictly`

## Why?

The attempt counter was keyed on the truncated fire time of the last loaded task. A shard that keeps generating tasks gets a new slice per notification and several of them can land in the same second, so every read made progress in its own slice while the shared counter still climbed — the policy fired on healthy shards. That is why `history.queueReaderStuckCriticalAttempts` is currently raised high enough to disable it in practice. Attributing attempts to a slice only counts repeated reads that fail to move past one fire time window *within a single slice*, which is the condition worth splitting out, and it needs no extra time threshold to tell the two apart.

Progress is also keyed on the owning reader, so a slice moved whole to the next reader is judged on that reader's own reads instead of being demoted again on its first one.

`Range.CanSplit` is inclusive at both bounds, so slices merely adjacent to the stuck window were split into empty pieces and merged into the next reader, creating that reader for nothing.

## How did you test it?
- [x] built
- [x] covered by existing tests
- [x] added new unit test(s)

`action_reader_stuck.go` had no test file before. The new table test covers every overlap shape, the reader count bound, and the merge into an existing next reader. Each fix was confirmed to fail against the pre-fix logic, including that the reader attributes progress to the slice and reader it actually read with.

## Potential risks

Reader stuck is effectively disabled by config today, so this only changes production behaviour once `queueReaderStuckCriticalAttempts` is lowered again.

Tracking non-default readers means the last reader can now alert for a window nothing can be done about, since there is no lower priority reader to move it to. The report-once latch bounds that to one alert per slice and window, but each one still costs a checkpoint.

Known limitation worth a decision before the config is lowered: slice identity is not stable. `processNewRange` merges each new range into the reader's slices, and `MergeWithSlice` destroys and rebuilds them, so the attempt count restarts. That can only delay detection, never cause a false positive, but on a shard that keeps generating timers the merge cadence can outrun `ReaderStuckCriticalAttempts` reads and hold detection off. Carrying progress across split/merge, or keying it on `(readerID, watermark, Range.InclusiveMin)` which survives a merge, would close the gap — both need their own eviction story, so they are left out here.