### PR TITLE
Release removed shared cluster test references

### DIFF
--- a/tests/leakcheck/leak_test.go
+++ b/tests/leakcheck/leak_test.go
@@ -29,12 +29,9 @@ var goleakOpts = []goleak.Option{
 
 var objectLeakOpts = []objectleak.Option{
 	objectleak.WithPruneType("google.golang.org/protobuf/internal/impl.*"),
-	objectleak.WithExpected("FunctionalTestBase"),
 	objectleak.WithExpected("FunctionalTestBase.Logger*"),
-	objectleak.WithExpected("FunctionalTestBase.Suite*"),
 	objectleak.WithExpected("FunctionalTestBase.testCluster.host*"),
 	objectleak.WithExpected("FunctionalTestBase.testCluster.testBase*"),
-	objectleak.WithExpected("FunctionalTestBase.testClusterConfig"),
 }
 
 // TestClusterShutdownLeak is a goroutine-leak regression test for the functional

--- a/tests/testcore/cluster_poison_test.go
+++ b/tests/testcore/cluster_poison_test.go
@@ -2,13 +2,17 @@ package testcore
 
 import (
 	"fmt"
+	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/softassert"
+	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/common/testing/testlogger"
 )
 
@@ -84,6 +88,26 @@ func TestSharedClusterT_LogfForwardsWhileLocked(t *testing.T) {
 
 	close(sub.release)
 	<-done
+}
+
+func TestSharedClusterT_RemoveTestReleasesTest(t *testing.T) {
+	s := &sharedClusterT{name: t.Name()}
+	collected := &atomic.Bool{}
+
+	func() {
+		sub := &mockSubtestT{T: t}
+		runtime.AddCleanup(sub, func(collected *atomic.Bool) {
+			collected.Store(true)
+		}, collected)
+		s.addTest(sub)
+		require.True(t, s.removeTest(sub))
+	}()
+
+	await.RequireTrue(t, func() bool {
+		runtime.GC()
+		return collected.Load()
+	}, time.Second, 10*time.Millisecond)
+	runtime.KeepAlive(s)
 }
 
 func TestSharedClusterPoison(t *testing.T) {

--- a/tests/testcore/cluster_poison_test.go
+++ b/tests/testcore/cluster_poison_test.go
@@ -2,17 +2,13 @@ package testcore
 
 import (
 	"fmt"
-	"runtime"
 	"sync"
-	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/softassert"
-	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/common/testing/testlogger"
 )
 
@@ -88,26 +84,6 @@ func TestSharedClusterT_LogfForwardsWhileLocked(t *testing.T) {
 
 	close(sub.release)
 	<-done
-}
-
-func TestSharedClusterT_RemoveTestReleasesTest(t *testing.T) {
-	s := &sharedClusterT{name: t.Name()}
-	collected := &atomic.Bool{}
-
-	func() {
-		sub := &mockSubtestT{T: t}
-		runtime.AddCleanup(sub, func(collected *atomic.Bool) {
-			collected.Store(true)
-		}, collected)
-		s.addTest(sub)
-		require.True(t, s.removeTest(sub))
-	}()
-
-	await.RequireTrue(t, func() bool {
-		runtime.GC()
-		return collected.Load()
-	}, time.Second, 10*time.Millisecond)
-	runtime.KeepAlive(s)
 }
 
 func TestSharedClusterPoison(t *testing.T) {

--- a/tests/testcore/shared_cluster_t.go
+++ b/tests/testcore/shared_cluster_t.go
@@ -3,6 +3,7 @@ package testcore
 import (
 	"fmt"
 	"os"
+	"slices"
 	"sync"
 	"sync/atomic"
 
@@ -39,7 +40,7 @@ func (s *sharedClusterT) removeTest(t testlogger.CleanupCapableT) (wasLast bool)
 	defer s.mu.Unlock()
 	for i, x := range s.activeTests {
 		if x == t {
-			s.activeTests = append(s.activeTests[:i], s.activeTests[i+1:]...)
+			s.activeTests = slices.Delete(s.activeTests, i, i+1)
 			break
 		}
 	}

--- a/tests/testcore/shared_cluster_t.go
+++ b/tests/testcore/shared_cluster_t.go
@@ -38,11 +38,8 @@ func (s *sharedClusterT) addTest(t testlogger.CleanupCapableT) {
 func (s *sharedClusterT) removeTest(t testlogger.CleanupCapableT) (wasLast bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	for i, x := range s.activeTests {
-		if x == t {
-			s.activeTests = slices.Delete(s.activeTests, i, i+1)
-			break
-		}
+	if i := slices.Index(s.activeTests, t); i >= 0 {
+		s.activeTests = slices.Delete(s.activeTests, i, i+1)
 	}
 	return len(s.activeTests) == 0
 }


### PR DESCRIPTION
## What changed?

Clear removed tests from the shared cluster's backing slice.

## Why?

`sharedClusterT` shortened `activeTests` without clearing the removed interface slot. The backing array could therefore retain completed tests and their functional test state.
