### PR TITLE
Enforce zero expected object leaks

### DIFF
--- a/tests/leakcheck/leak_test.go
+++ b/tests/leakcheck/leak_test.go
@@ -29,7 +29,6 @@ var goleakOpts = []goleak.Option{
 
 var objectLeakOpts = []objectleak.Option{
 	objectleak.WithPruneType("google.golang.org/protobuf/internal/impl.*"),
-	objectleak.WithExpected("FunctionalTestBase.testCluster.testBase*"),
 }
 
 // TestClusterShutdownLeak is a goroutine-leak regression test for the functional


### PR DESCRIPTION
## What changed?

Remove the final `FunctionalTestBase.testCluster.testBase*` expectation. `objectLeakOpts` now contains only the protobuf traversal prune and no expected leaks.

## Why?

The preceding stack releases shared-test and process-global references. Together with the persistence ownership fixes in #11506 and #11507, functional test clusters become fully collectible.

## Testing

- `go test -count=1 ./tests/leakcheck -run '^$'`
- With #11506 and #11507 applied: `make LEAK_ITERS=5 LEAK_ITERS_WARMUP=2 LEAK_GC_SETTLE_TIMEOUT=10s LEAK_TIMEOUT=3m leak-test`

Stacked on #11543. Also depends on #11506 and #11507.
