### PR TITLE
Trace inbound Nexus HTTP requests

### DIFF
--- a/common/telemetry/http.go
+++ b/common/telemetry/http.go
@@ -35,25 +35,25 @@ func (i HTTPClientTransportInstrumenter) Instrument(rt http.RoundTripper) http.R
 	return i(rt)
 }
 
-// HTTPHandlerWrapper wraps HTTP handlers with the service's tracing configuration.
-type HTTPHandlerWrapper func(http.Handler, string) http.Handler
+// HTTPServerHandlerInstrumenter instruments an HTTP server handler and uses spanName for its spans.
+type HTTPServerHandlerInstrumenter func(handler http.Handler, spanName string) http.Handler
 
-// NewHTTPHandlerWrapper binds a tracer provider and propagator to HTTP handlers.
-func NewHTTPHandlerWrapper(
+// NewHTTPServerHandlerInstrumenter binds a tracer provider and propagator for reuse across HTTP server handlers.
+func NewHTTPServerHandlerInstrumenter(
 	tracerProvider trace.TracerProvider,
 	propagator propagation.TextMapPropagator,
-) HTTPHandlerWrapper {
-	return func(handler http.Handler, operation string) http.Handler {
-		return NewHTTPHandler(handler, operation, tracerProvider, propagator)
+) HTTPServerHandlerInstrumenter {
+	return func(handler http.Handler, spanName string) http.Handler {
+		return NewHTTPHandler(handler, spanName, tracerProvider, propagator)
 	}
 }
 
-// Wrap instruments handler, or returns it unchanged when the wrapper is unset.
-func (w HTTPHandlerWrapper) Wrap(handler http.Handler, operation string) http.Handler {
-	if w == nil {
+// Instrument instruments handler, or returns it unchanged when the instrumenter is unset.
+func (i HTTPServerHandlerInstrumenter) Instrument(handler http.Handler, spanName string) http.Handler {
+	if i == nil {
 		return handler
 	}
-	return w(handler, operation)
+	return i(handler, spanName)
 }
 
 // NewHTTPClientTransport instruments outbound HTTP requests with OpenTelemetry client spans

--- a/common/telemetry/http.go
+++ b/common/telemetry/http.go
@@ -35,6 +35,27 @@ func (i HTTPClientTransportInstrumenter) Instrument(rt http.RoundTripper) http.R
 	return i(rt)
 }
 
+// HTTPHandlerWrapper wraps HTTP handlers with the service's tracing configuration.
+type HTTPHandlerWrapper func(http.Handler, string) http.Handler
+
+// NewHTTPHandlerWrapper binds a tracer provider and propagator to HTTP handlers.
+func NewHTTPHandlerWrapper(
+	tracerProvider trace.TracerProvider,
+	propagator propagation.TextMapPropagator,
+) HTTPHandlerWrapper {
+	return func(handler http.Handler, operation string) http.Handler {
+		return NewHTTPHandler(handler, operation, tracerProvider, propagator)
+	}
+}
+
+// Wrap instruments handler, or returns it unchanged when the wrapper is unset.
+func (w HTTPHandlerWrapper) Wrap(handler http.Handler, operation string) http.Handler {
+	if w == nil {
+		return handler
+	}
+	return w(handler, operation)
+}
+
 // NewHTTPClientTransport instruments outbound HTTP requests with OpenTelemetry client spans
 // and injects trace context using propagator. If propagator is nil, it defaults to W3C Trace Context.
 func NewHTTPClientTransport(

--- a/common/telemetry/http_test.go
+++ b/common/telemetry/http_test.go
@@ -419,6 +419,24 @@ func TestNewHTTPClientTransport(t *testing.T) {
 
 // Verifies server handler construction, standard tracing, and debug body handling.
 func TestNewHTTPHandler(t *testing.T) {
+	// The wrapper carries HTTP tracing configuration without exposing it to handler owners.
+	t.Run("HandlerWrapper", func(t *testing.T) {
+		t.Parallel()
+
+		handler := http.NewServeMux()
+		var disabled HTTPHandlerWrapper
+		require.Same(t, handler, disabled.Wrap(handler, "test-handler"))
+
+		recorder := tracetest.NewSpanRecorder()
+		tp := trace.NewTracerProvider(trace.WithSpanProcessor(recorder))
+		wrapper := NewHTTPHandlerWrapper(tp, nil)
+		wrapper.Wrap(handler, "test-handler").ServeHTTP(
+			httptest.NewRecorder(),
+			httptest.NewRequest(http.MethodGet, "http://example.com", nil),
+		)
+		require.Equal(t, "test-handler", recorder.Ended()[0].Name())
+	})
+
 	// Debug-only headers and payloads must remain absent unless debug mode is enabled.
 	t.Run("SkipsHeadersAndPayloadsByDefault", func(t *testing.T) {
 		t.Parallel()

--- a/common/telemetry/http_test.go
+++ b/common/telemetry/http_test.go
@@ -419,18 +419,18 @@ func TestNewHTTPClientTransport(t *testing.T) {
 
 // Verifies server handler construction, standard tracing, and debug body handling.
 func TestNewHTTPHandler(t *testing.T) {
-	// The wrapper carries HTTP tracing configuration without exposing it to handler owners.
-	t.Run("HandlerWrapper", func(t *testing.T) {
+	// The instrumenter carries HTTP tracing configuration without exposing it to handler owners.
+	t.Run("ServerHandlerInstrumenter", func(t *testing.T) {
 		t.Parallel()
 
 		handler := http.NewServeMux()
-		var disabled HTTPHandlerWrapper
-		require.Same(t, handler, disabled.Wrap(handler, "test-handler"))
+		var disabled HTTPServerHandlerInstrumenter
+		require.Same(t, handler, disabled.Instrument(handler, "test-handler"))
 
 		recorder := tracetest.NewSpanRecorder()
 		tp := trace.NewTracerProvider(trace.WithSpanProcessor(recorder))
-		wrapper := NewHTTPHandlerWrapper(tp, nil)
-		wrapper.Wrap(handler, "test-handler").ServeHTTP(
+		instrumenter := NewHTTPServerHandlerInstrumenter(tp, nil)
+		instrumenter.Instrument(handler, "test-handler").ServeHTTP(
 			httptest.NewRecorder(),
 			httptest.NewRequest(http.MethodGet, "http://example.com", nil),
 		)

--- a/service/frontend/nexus_operation_http_handler.go
+++ b/service/frontend/nexus_operation_http_handler.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/nexus-rpc/sdk-go/nexus"
-	"go.opentelemetry.io/otel/propagation"
-	"go.opentelemetry.io/otel/trace"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/api/matchingservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
@@ -47,8 +45,7 @@ type NexusOperationHTTPHandler struct {
 	namespaceRateLimitInterceptor        interceptor.NamespaceRateLimitInterceptor
 	namespaceConcurrencyLimitInterceptor *interceptor.ConcurrentRequestLimitInterceptor
 	rateLimitInterceptor                 *interceptor.RateLimitInterceptor
-	tracerProvider                       trace.TracerProvider
-	propagator                           propagation.TextMapPropagator
+	httpHandlerWrapper                   telemetry.HTTPHandlerWrapper
 }
 
 func NewNexusOperationHTTPHandler(
@@ -69,8 +66,7 @@ func NewNexusOperationHTTPHandler(
 	rateLimitInterceptor *interceptor.RateLimitInterceptor,
 	logger log.Logger,
 	httpTraceProvider commonnexus.HTTPClientTraceProvider,
-	tracerProvider trace.TracerProvider,
-	propagator propagation.TextMapPropagator,
+	httpHandlerWrapper telemetry.HTTPHandlerWrapper,
 ) *NexusOperationHTTPHandler {
 	return &NexusOperationHTTPHandler{
 		base: nexusrpc.BaseHTTPHandler{
@@ -86,8 +82,7 @@ func NewNexusOperationHTTPHandler(
 		namespaceConcurrencyLimitInterceptor: namespaceConcurrencyLimitInterceptor,
 		rateLimitInterceptor:                 rateLimitInterceptor,
 		preprocessErrorCounter:               metricsHandler.Counter(metrics.NexusRequestPreProcessErrors.Name()).Record,
-		tracerProvider:                       tracerProvider,
-		propagator:                           propagator,
+		httpHandlerWrapper:                   httpHandlerWrapper,
 		nexusHandler: nexusrpc.NewHTTPHandler(nexusrpc.HandlerOptions{
 			Handler: &nexusHandler{
 				logger:                        logger,
@@ -116,22 +111,9 @@ func NewNexusOperationHTTPHandler(
 
 func (h *NexusOperationHTTPHandler) RegisterRoutes(r *mux.Router) {
 	r.PathPrefix("/" + commonnexus.RouteDispatchNexusTaskByNamespaceAndTaskQueue.Representation() + "/").
-		Handler(h.wrapWithTracing(http.HandlerFunc(h.dispatchNexusTaskByNamespaceAndTaskQueue), "DispatchNexusTaskByNamespaceAndTaskQueue"))
+		Handler(h.httpHandlerWrapper.Wrap(http.HandlerFunc(h.dispatchNexusTaskByNamespaceAndTaskQueue), "DispatchNexusTaskByNamespaceAndTaskQueue"))
 	r.PathPrefix("/" + commonnexus.RouteDispatchNexusTaskByEndpoint.Representation() + "/").
-		Handler(h.wrapWithTracing(http.HandlerFunc(h.dispatchNexusTaskByEndpoint), "DispatchNexusTaskByEndpoint"))
-}
-
-// wrapWithTracing wraps an HTTP handler with otelhttp so that incoming Nexus requests produce a
-// server span carrying http.* semantic-convention attributes and extract any upstream W3C
-// TraceContext into the request's context. The span name matches the Nexus route's
-// representation, mirroring the gRPC stats handler that names spans after the RPC method.
-func (h *NexusOperationHTTPHandler) wrapWithTracing(handler http.Handler, route string) http.Handler {
-	return telemetry.NewHTTPHandler(
-		handler,
-		route,
-		h.tracerProvider,
-		h.propagator,
-	)
+		Handler(h.httpHandlerWrapper.Wrap(http.HandlerFunc(h.dispatchNexusTaskByEndpoint), "DispatchNexusTaskByEndpoint"))
 }
 
 func (h *NexusOperationHTTPHandler) writeFailure(writer http.ResponseWriter, r *http.Request, err error) {

--- a/service/frontend/nexus_operation_http_handler.go
+++ b/service/frontend/nexus_operation_http_handler.go
@@ -46,7 +46,7 @@ type NexusOperationHTTPHandler struct {
 	namespaceRateLimitInterceptor        interceptor.NamespaceRateLimitInterceptor
 	namespaceConcurrencyLimitInterceptor *interceptor.ConcurrentRequestLimitInterceptor
 	rateLimitInterceptor                 *interceptor.RateLimitInterceptor
-	httpHandlerWrapper                   telemetry.HTTPHandlerWrapper
+	httpServerHandlerInstrumenter        telemetry.HTTPServerHandlerInstrumenter
 }
 
 func NewNexusOperationHTTPHandler(
@@ -67,7 +67,7 @@ func NewNexusOperationHTTPHandler(
 	rateLimitInterceptor *interceptor.RateLimitInterceptor,
 	logger log.Logger,
 	httpTraceProvider commonnexus.HTTPClientTraceProvider,
-	httpHandlerWrapper telemetry.HTTPHandlerWrapper,
+	httpServerHandlerInstrumenter telemetry.HTTPServerHandlerInstrumenter,
 ) *NexusOperationHTTPHandler {
 	return &NexusOperationHTTPHandler{
 		base: nexusrpc.BaseHTTPHandler{
@@ -83,7 +83,7 @@ func NewNexusOperationHTTPHandler(
 		namespaceConcurrencyLimitInterceptor: namespaceConcurrencyLimitInterceptor,
 		rateLimitInterceptor:                 rateLimitInterceptor,
 		preprocessErrorCounter:               metricsHandler.Counter(metrics.NexusRequestPreProcessErrors.Name()).Record,
-		httpHandlerWrapper:                   httpHandlerWrapper,
+		httpServerHandlerInstrumenter:        httpServerHandlerInstrumenter,
 		nexusHandler: nexusrpc.NewHTTPHandler(nexusrpc.HandlerOptions{
 			Handler: &nexusHandler{
 				logger:                        logger,
@@ -112,9 +112,9 @@ func NewNexusOperationHTTPHandler(
 
 func (h *NexusOperationHTTPHandler) RegisterRoutes(r *mux.Router) {
 	r.PathPrefix("/" + commonnexus.RouteDispatchNexusTaskByNamespaceAndTaskQueue.Representation() + "/").
-		Handler(h.httpHandlerWrapper.Wrap(http.HandlerFunc(h.dispatchNexusTaskByNamespaceAndTaskQueue), strings.TrimPrefix(configs.DispatchNexusTaskByNamespaceAndTaskQueueAPIName, "/")))
+		Handler(h.httpServerHandlerInstrumenter.Instrument(http.HandlerFunc(h.dispatchNexusTaskByNamespaceAndTaskQueue), strings.TrimPrefix(configs.DispatchNexusTaskByNamespaceAndTaskQueueAPIName, "/")))
 	r.PathPrefix("/" + commonnexus.RouteDispatchNexusTaskByEndpoint.Representation() + "/").
-		Handler(h.httpHandlerWrapper.Wrap(http.HandlerFunc(h.dispatchNexusTaskByEndpoint), strings.TrimPrefix(configs.DispatchNexusTaskByEndpointAPIName, "/")))
+		Handler(h.httpServerHandlerInstrumenter.Instrument(http.HandlerFunc(h.dispatchNexusTaskByEndpoint), strings.TrimPrefix(configs.DispatchNexusTaskByEndpointAPIName, "/")))
 }
 
 func (h *NexusOperationHTTPHandler) writeFailure(writer http.ResponseWriter, r *http.Request, err error) {

--- a/service/frontend/nexus_operation_http_handler.go
+++ b/service/frontend/nexus_operation_http_handler.go
@@ -111,10 +111,22 @@ func NewNexusOperationHTTPHandler(
 }
 
 func (h *NexusOperationHTTPHandler) RegisterRoutes(r *mux.Router) {
-	r.PathPrefix("/" + commonnexus.RouteDispatchNexusTaskByNamespaceAndTaskQueue.Representation() + "/").
-		Handler(h.httpServerHandlerInstrumenter.Instrument(http.HandlerFunc(h.dispatchNexusTaskByNamespaceAndTaskQueue), strings.TrimPrefix(configs.DispatchNexusTaskByNamespaceAndTaskQueueAPIName, "/")))
-	r.PathPrefix("/" + commonnexus.RouteDispatchNexusTaskByEndpoint.Representation() + "/").
-		Handler(h.httpServerHandlerInstrumenter.Instrument(http.HandlerFunc(h.dispatchNexusTaskByEndpoint), strings.TrimPrefix(configs.DispatchNexusTaskByEndpointAPIName, "/")))
+	register := func(route, apiName string, handler http.HandlerFunc) {
+		spanName := strings.TrimPrefix(apiName, "/")
+		instrumentedHandler := h.httpServerHandlerInstrumenter.Instrument(handler, spanName)
+		r.PathPrefix("/" + route + "/").Handler(instrumentedHandler)
+	}
+
+	register(
+		commonnexus.RouteDispatchNexusTaskByNamespaceAndTaskQueue.Representation(),
+		configs.DispatchNexusTaskByNamespaceAndTaskQueueAPIName,
+		h.dispatchNexusTaskByNamespaceAndTaskQueue,
+	)
+	register(
+		commonnexus.RouteDispatchNexusTaskByEndpoint.Representation(),
+		configs.DispatchNexusTaskByEndpointAPIName,
+		h.dispatchNexusTaskByEndpoint,
+	)
 }
 
 func (h *NexusOperationHTTPHandler) writeFailure(writer http.ResponseWriter, r *http.Request, err error) {

--- a/service/frontend/nexus_operation_http_handler.go
+++ b/service/frontend/nexus_operation_http_handler.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/nexus-rpc/sdk-go/nexus"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/api/matchingservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
@@ -25,6 +27,7 @@ import (
 	"go.temporal.io/server/common/routing"
 	"go.temporal.io/server/common/rpc"
 	"go.temporal.io/server/common/rpc/interceptor"
+	"go.temporal.io/server/common/telemetry"
 	"go.temporal.io/server/service/frontend/configs"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -44,6 +47,8 @@ type NexusOperationHTTPHandler struct {
 	namespaceRateLimitInterceptor        interceptor.NamespaceRateLimitInterceptor
 	namespaceConcurrencyLimitInterceptor *interceptor.ConcurrentRequestLimitInterceptor
 	rateLimitInterceptor                 *interceptor.RateLimitInterceptor
+	tracerProvider                       trace.TracerProvider
+	propagator                           propagation.TextMapPropagator
 }
 
 func NewNexusOperationHTTPHandler(
@@ -64,6 +69,8 @@ func NewNexusOperationHTTPHandler(
 	rateLimitInterceptor *interceptor.RateLimitInterceptor,
 	logger log.Logger,
 	httpTraceProvider commonnexus.HTTPClientTraceProvider,
+	tracerProvider trace.TracerProvider,
+	propagator propagation.TextMapPropagator,
 ) *NexusOperationHTTPHandler {
 	return &NexusOperationHTTPHandler{
 		base: nexusrpc.BaseHTTPHandler{
@@ -79,6 +86,8 @@ func NewNexusOperationHTTPHandler(
 		namespaceConcurrencyLimitInterceptor: namespaceConcurrencyLimitInterceptor,
 		rateLimitInterceptor:                 rateLimitInterceptor,
 		preprocessErrorCounter:               metricsHandler.Counter(metrics.NexusRequestPreProcessErrors.Name()).Record,
+		tracerProvider:                       tracerProvider,
+		propagator:                           propagator,
 		nexusHandler: nexusrpc.NewHTTPHandler(nexusrpc.HandlerOptions{
 			Handler: &nexusHandler{
 				logger:                        logger,
@@ -107,9 +116,22 @@ func NewNexusOperationHTTPHandler(
 
 func (h *NexusOperationHTTPHandler) RegisterRoutes(r *mux.Router) {
 	r.PathPrefix("/" + commonnexus.RouteDispatchNexusTaskByNamespaceAndTaskQueue.Representation() + "/").
-		HandlerFunc(h.dispatchNexusTaskByNamespaceAndTaskQueue)
+		Handler(h.wrapWithTracing(http.HandlerFunc(h.dispatchNexusTaskByNamespaceAndTaskQueue), "DispatchNexusTaskByNamespaceAndTaskQueue"))
 	r.PathPrefix("/" + commonnexus.RouteDispatchNexusTaskByEndpoint.Representation() + "/").
-		HandlerFunc(h.dispatchNexusTaskByEndpoint)
+		Handler(h.wrapWithTracing(http.HandlerFunc(h.dispatchNexusTaskByEndpoint), "DispatchNexusTaskByEndpoint"))
+}
+
+// wrapWithTracing wraps an HTTP handler with otelhttp so that incoming Nexus requests produce a
+// server span carrying http.* semantic-convention attributes and extract any upstream W3C
+// TraceContext into the request's context. The span name matches the Nexus route's
+// representation, mirroring the gRPC stats handler that names spans after the RPC method.
+func (h *NexusOperationHTTPHandler) wrapWithTracing(handler http.Handler, route string) http.Handler {
+	return telemetry.NewHTTPHandler(
+		handler,
+		route,
+		h.tracerProvider,
+		h.propagator,
+	)
 }
 
 func (h *NexusOperationHTTPHandler) writeFailure(writer http.ResponseWriter, r *http.Request, err error) {

--- a/service/frontend/nexus_operation_http_handler.go
+++ b/service/frontend/nexus_operation_http_handler.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -111,9 +112,9 @@ func NewNexusOperationHTTPHandler(
 
 func (h *NexusOperationHTTPHandler) RegisterRoutes(r *mux.Router) {
 	r.PathPrefix("/" + commonnexus.RouteDispatchNexusTaskByNamespaceAndTaskQueue.Representation() + "/").
-		Handler(h.httpHandlerWrapper.Wrap(http.HandlerFunc(h.dispatchNexusTaskByNamespaceAndTaskQueue), "DispatchNexusTaskByNamespaceAndTaskQueue"))
+		Handler(h.httpHandlerWrapper.Wrap(http.HandlerFunc(h.dispatchNexusTaskByNamespaceAndTaskQueue), strings.TrimPrefix(configs.DispatchNexusTaskByNamespaceAndTaskQueueAPIName, "/")))
 	r.PathPrefix("/" + commonnexus.RouteDispatchNexusTaskByEndpoint.Representation() + "/").
-		Handler(h.httpHandlerWrapper.Wrap(http.HandlerFunc(h.dispatchNexusTaskByEndpoint), "DispatchNexusTaskByEndpoint"))
+		Handler(h.httpHandlerWrapper.Wrap(http.HandlerFunc(h.dispatchNexusTaskByEndpoint), strings.TrimPrefix(configs.DispatchNexusTaskByEndpointAPIName, "/")))
 }
 
 func (h *NexusOperationHTTPHandler) writeFailure(writer http.ResponseWriter, r *http.Request, err error) {

--- a/service/frontend/nexus_operation_http_handler_test.go
+++ b/service/frontend/nexus_operation_http_handler_test.go
@@ -10,6 +10,10 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/nexus-rpc/sdk-go/nexus"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
 	"go.temporal.io/api/serviceerror"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/log"
@@ -48,7 +52,22 @@ func newTestNexusOperationHTTPHandler(
 	endpointRegistry commonnexus.EndpointRegistry,
 	namespaceRegistry namespace.Registry,
 ) (*NexusOperationHTTPHandler, *mux.Router) {
+	return newTestNexusOperationHTTPHandlerWithTracing(endpointRegistry, namespaceRegistry, nil, nil)
+}
+
+func newTestNexusOperationHTTPHandlerWithTracing(
+	endpointRegistry commonnexus.EndpointRegistry,
+	namespaceRegistry namespace.Registry,
+	tracerProvider trace.TracerProvider,
+	propagator propagation.TextMapPropagator,
+) (*NexusOperationHTTPHandler, *mux.Router) {
 	logger := log.NewTestLogger()
+	if tracerProvider == nil {
+		tracerProvider = sdktrace.NewTracerProvider()
+	}
+	if propagator == nil {
+		propagator = propagation.TraceContext{}
+	}
 	h := &NexusOperationHTTPHandler{
 		base: nexusrpc.BaseHTTPHandler{
 			Logger:           log.NewSlogLogger(logger),
@@ -58,6 +77,8 @@ func newTestNexusOperationHTTPHandler(
 		enpointRegistry:        endpointRegistry,
 		namespaceRegistry:      namespaceRegistry,
 		preprocessErrorCounter: metrics.CounterFunc(func(int64, ...metrics.Tag) {}),
+		tracerProvider:         tracerProvider,
+		propagator:             propagator,
 	}
 	router := mux.NewRouter()
 	h.RegisterRoutes(router)
@@ -148,4 +169,88 @@ func TestDispatchNexusTaskByEndpoint_NamespaceNotFound_Retryable(t *testing.T) {
 	var failure nexus.Failure
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&failure))
 	require.Equal(t, "invalid endpoint target", failure.Message)
+}
+
+// TestDispatchNexusTaskByEndpoint_OuterSpan verifies that the otelhttp wrapper produces a
+// server span named after the Nexus route, extracts the W3C TraceContext from the incoming
+// request, and links the resulting span to the upstream trace.
+func TestDispatchNexusTaskByEndpoint_OuterSpan(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+
+	reg := nexustest.FakeEndpointRegistry{
+		OnGetByID: func(_ context.Context, _ string) (*persistencespb.NexusEndpointEntry, error) {
+			return nil, serviceerror.NewNotFound("endpoint not found")
+		},
+	}
+	_, router := newTestNexusOperationHTTPHandlerWithTracing(reg, nil, tp, propagation.TraceContext{})
+
+	// Build an upstream traceparent and inject it into the outgoing request.
+	upstreamTracer := tp.Tracer("test-upstream")
+	upstreamCtx, upstreamSpan := upstreamTracer.Start(context.Background(), "upstream")
+	upstreamTraceID := upstreamSpan.SpanContext().TraceID()
+	upstreamSpanID := upstreamSpan.SpanContext().SpanID()
+
+	path := "/" + commonnexus.RouteDispatchNexusTaskByEndpoint.Path("test-endpoint-id") + "/test-service/test-operation"
+	req := httptest.NewRequest(http.MethodPost, path, nil)
+	propagation.TraceContext{}.Inject(upstreamCtx, propagation.HeaderCarrier(req.Header))
+	upstreamSpan.End()
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+
+	// Find the server span produced by the otelhttp wrapper.
+	var serverSpan sdktrace.ReadOnlySpan
+	for _, s := range recorder.Ended() {
+		if s.SpanKind() == trace.SpanKindServer {
+			serverSpan = s
+			break
+		}
+	}
+	require.NotNil(t, serverSpan, "expected an otelhttp server span")
+	require.Equal(t, "DispatchNexusTaskByEndpoint", serverSpan.Name())
+	require.Equal(t, upstreamTraceID, serverSpan.SpanContext().TraceID(),
+		"server span should inherit trace id from upstream traceparent")
+	require.Equal(t, upstreamSpanID, serverSpan.Parent().SpanID(),
+		"server span parent should reference upstream span")
+
+	// otelhttp sets http.* semconv attributes on the server span. Spot-check one.
+	hasMethod := false
+	for _, kv := range serverSpan.Attributes() {
+		if string(kv.Key) == "http.request.method" || string(kv.Key) == "http.method" {
+			hasMethod = true
+			require.Equal(t, http.MethodPost, kv.Value.AsString())
+		}
+	}
+	require.True(t, hasMethod, "expected http method attribute on server span")
+}
+
+// TestDispatchNexusTaskByEndpoint_NoUpstreamSpan verifies the wrapper still creates a span
+// when no traceparent is present (i.e., the span has a fresh trace id with no parent).
+func TestDispatchNexusTaskByEndpoint_NoUpstreamSpan(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+
+	reg := nexustest.FakeEndpointRegistry{
+		OnGetByID: func(_ context.Context, _ string) (*persistencespb.NexusEndpointEntry, error) {
+			return nil, serviceerror.NewNotFound("endpoint not found")
+		},
+	}
+	_, router := newTestNexusOperationHTTPHandlerWithTracing(reg, nil, tp, propagation.TraceContext{})
+
+	rec := doNexusHTTPRequest(t, router, "test-endpoint-id")
+	require.Equal(t, http.StatusNotFound, rec.Code)
+
+	require.GreaterOrEqual(t, len(recorder.Ended()), 1, "expected at least one recorded span")
+	var serverSpan sdktrace.ReadOnlySpan
+	for _, s := range recorder.Ended() {
+		if s.SpanKind() == trace.SpanKindServer {
+			serverSpan = s
+			break
+		}
+	}
+	require.NotNil(t, serverSpan)
+	require.Equal(t, "DispatchNexusTaskByEndpoint", serverSpan.Name())
+	require.False(t, serverSpan.Parent().IsValid(), "expected no parent span when no traceparent header is set")
 }

--- a/service/frontend/nexus_operation_http_handler_test.go
+++ b/service/frontend/nexus_operation_http_handler_test.go
@@ -10,10 +10,6 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/nexus-rpc/sdk-go/nexus"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel/propagation"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	"go.opentelemetry.io/otel/trace"
 	"go.temporal.io/api/serviceerror"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/log"
@@ -52,22 +48,7 @@ func newTestNexusOperationHTTPHandler(
 	endpointRegistry commonnexus.EndpointRegistry,
 	namespaceRegistry namespace.Registry,
 ) (*NexusOperationHTTPHandler, *mux.Router) {
-	return newTestNexusOperationHTTPHandlerWithTracing(endpointRegistry, namespaceRegistry, nil, nil)
-}
-
-func newTestNexusOperationHTTPHandlerWithTracing(
-	endpointRegistry commonnexus.EndpointRegistry,
-	namespaceRegistry namespace.Registry,
-	tracerProvider trace.TracerProvider,
-	propagator propagation.TextMapPropagator,
-) (*NexusOperationHTTPHandler, *mux.Router) {
 	logger := log.NewTestLogger()
-	if tracerProvider == nil {
-		tracerProvider = sdktrace.NewTracerProvider()
-	}
-	if propagator == nil {
-		propagator = propagation.TraceContext{}
-	}
 	h := &NexusOperationHTTPHandler{
 		base: nexusrpc.BaseHTTPHandler{
 			Logger:           log.NewSlogLogger(logger),
@@ -77,8 +58,6 @@ func newTestNexusOperationHTTPHandlerWithTracing(
 		enpointRegistry:        endpointRegistry,
 		namespaceRegistry:      namespaceRegistry,
 		preprocessErrorCounter: metrics.CounterFunc(func(int64, ...metrics.Tag) {}),
-		tracerProvider:         tracerProvider,
-		propagator:             propagator,
 	}
 	router := mux.NewRouter()
 	h.RegisterRoutes(router)
@@ -169,88 +148,4 @@ func TestDispatchNexusTaskByEndpoint_NamespaceNotFound_Retryable(t *testing.T) {
 	var failure nexus.Failure
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&failure))
 	require.Equal(t, "invalid endpoint target", failure.Message)
-}
-
-// TestDispatchNexusTaskByEndpoint_OuterSpan verifies that the otelhttp wrapper produces a
-// server span named after the Nexus route, extracts the W3C TraceContext from the incoming
-// request, and links the resulting span to the upstream trace.
-func TestDispatchNexusTaskByEndpoint_OuterSpan(t *testing.T) {
-	recorder := tracetest.NewSpanRecorder()
-	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
-
-	reg := nexustest.FakeEndpointRegistry{
-		OnGetByID: func(_ context.Context, _ string) (*persistencespb.NexusEndpointEntry, error) {
-			return nil, serviceerror.NewNotFound("endpoint not found")
-		},
-	}
-	_, router := newTestNexusOperationHTTPHandlerWithTracing(reg, nil, tp, propagation.TraceContext{})
-
-	// Build an upstream traceparent and inject it into the outgoing request.
-	upstreamTracer := tp.Tracer("test-upstream")
-	upstreamCtx, upstreamSpan := upstreamTracer.Start(context.Background(), "upstream")
-	upstreamTraceID := upstreamSpan.SpanContext().TraceID()
-	upstreamSpanID := upstreamSpan.SpanContext().SpanID()
-
-	path := "/" + commonnexus.RouteDispatchNexusTaskByEndpoint.Path("test-endpoint-id") + "/test-service/test-operation"
-	req := httptest.NewRequest(http.MethodPost, path, nil)
-	propagation.TraceContext{}.Inject(upstreamCtx, propagation.HeaderCarrier(req.Header))
-	upstreamSpan.End()
-
-	rec := httptest.NewRecorder()
-	router.ServeHTTP(rec, req)
-	require.Equal(t, http.StatusNotFound, rec.Code)
-
-	// Find the server span produced by the otelhttp wrapper.
-	var serverSpan sdktrace.ReadOnlySpan
-	for _, s := range recorder.Ended() {
-		if s.SpanKind() == trace.SpanKindServer {
-			serverSpan = s
-			break
-		}
-	}
-	require.NotNil(t, serverSpan, "expected an otelhttp server span")
-	require.Equal(t, "DispatchNexusTaskByEndpoint", serverSpan.Name())
-	require.Equal(t, upstreamTraceID, serverSpan.SpanContext().TraceID(),
-		"server span should inherit trace id from upstream traceparent")
-	require.Equal(t, upstreamSpanID, serverSpan.Parent().SpanID(),
-		"server span parent should reference upstream span")
-
-	// otelhttp sets http.* semconv attributes on the server span. Spot-check one.
-	hasMethod := false
-	for _, kv := range serverSpan.Attributes() {
-		if string(kv.Key) == "http.request.method" || string(kv.Key) == "http.method" {
-			hasMethod = true
-			require.Equal(t, http.MethodPost, kv.Value.AsString())
-		}
-	}
-	require.True(t, hasMethod, "expected http method attribute on server span")
-}
-
-// TestDispatchNexusTaskByEndpoint_NoUpstreamSpan verifies the wrapper still creates a span
-// when no traceparent is present (i.e., the span has a fresh trace id with no parent).
-func TestDispatchNexusTaskByEndpoint_NoUpstreamSpan(t *testing.T) {
-	recorder := tracetest.NewSpanRecorder()
-	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
-
-	reg := nexustest.FakeEndpointRegistry{
-		OnGetByID: func(_ context.Context, _ string) (*persistencespb.NexusEndpointEntry, error) {
-			return nil, serviceerror.NewNotFound("endpoint not found")
-		},
-	}
-	_, router := newTestNexusOperationHTTPHandlerWithTracing(reg, nil, tp, propagation.TraceContext{})
-
-	rec := doNexusHTTPRequest(t, router, "test-endpoint-id")
-	require.Equal(t, http.StatusNotFound, rec.Code)
-
-	require.GreaterOrEqual(t, len(recorder.Ended()), 1, "expected at least one recorded span")
-	var serverSpan sdktrace.ReadOnlySpan
-	for _, s := range recorder.Ended() {
-		if s.SpanKind() == trace.SpanKindServer {
-			serverSpan = s
-			break
-		}
-	}
-	require.NotNil(t, serverSpan)
-	require.Equal(t, "DispatchNexusTaskByEndpoint", serverSpan.Name())
-	require.False(t, serverSpan.Parent().IsValid(), "expected no parent span when no traceparent header is set")
 }

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -1037,6 +1037,7 @@ var TraceExportModule = fx.Options(
 //   - telemetry.ServerStatsHandler
 //   - telemetry.ClientStatsHandler
 //   - telemetry.HTTPClientTransportInstrumenter
+//   - telemetry.HTTPHandlerWrapper
 var ServiceTracingModule = fx.Options(
 	fx.Supply([]otelsdktrace.BatchSpanProcessorOption{}),
 	fx.Provide(
@@ -1107,6 +1108,7 @@ var ServiceTracingModule = fx.Options(
 	fx.Provide(telemetry.NewServerStatsHandler),
 	fx.Provide(telemetry.NewClientStatsHandler),
 	fx.Provide(telemetry.NewHTTPClientTransportInstrumenter),
+	fx.Provide(telemetry.NewHTTPHandlerWrapper),
 	fx.Provide(metrics.NewServerStatsHandler),
 )
 

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -1037,7 +1037,7 @@ var TraceExportModule = fx.Options(
 //   - telemetry.ServerStatsHandler
 //   - telemetry.ClientStatsHandler
 //   - telemetry.HTTPClientTransportInstrumenter
-//   - telemetry.HTTPHandlerWrapper
+//   - telemetry.HTTPServerHandlerInstrumenter
 var ServiceTracingModule = fx.Options(
 	fx.Supply([]otelsdktrace.BatchSpanProcessorOption{}),
 	fx.Provide(
@@ -1108,7 +1108,7 @@ var ServiceTracingModule = fx.Options(
 	fx.Provide(telemetry.NewServerStatsHandler),
 	fx.Provide(telemetry.NewClientStatsHandler),
 	fx.Provide(telemetry.NewHTTPClientTransportInstrumenter),
-	fx.Provide(telemetry.NewHTTPHandlerWrapper),
+	fx.Provide(telemetry.NewHTTPServerHandlerInstrumenter),
 	fx.Provide(metrics.NewServerStatsHandler),
 )
 

--- a/tests/nexus_api_test.go
+++ b/tests/nexus_api_test.go
@@ -273,7 +273,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Outcomes(useTemporalFailures
 		endpoint := env.createNexusEndpoint(s.Context(), s.T(), tc.endpointName, testcore.RandomizeStr("task-queue"))
 		var dispatchURL string
 		if dispatchOnlyByEndpoint {
-			dispatchURL = getDispatchByEndpointURL(env.HttpAPIAddress(), endpoint.Id)
+			dispatchURL = env.getDispatchByEndpointURL(endpoint.Id)
 		} else {
 			dispatchURL = getDispatchByNsAndTqURL(env.HttpAPIAddress(), env.Namespace().String(), endpoint.Spec.Target.GetWorker().TaskQueue)
 		}
@@ -420,7 +420,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Claims(useTemporalFailures b
 		testEndpoint := env.createNexusEndpoint(s.Context(), s.T(), testcore.RandomizeStr("test-endpoint"), taskQueue)
 		var dispatchURL string
 		if dispatchOnlyByEndpoint {
-			dispatchURL = getDispatchByEndpointURL(env.HttpAPIAddress(), testEndpoint.Id)
+			dispatchURL = env.getDispatchByEndpointURL(testEndpoint.Id)
 		} else {
 			dispatchURL = getDispatchByNsAndTqURL(env.HttpAPIAddress(), env.Namespace().String(), taskQueue)
 		}
@@ -534,7 +534,7 @@ func (s *NexusApiTestSuite) TestNexusCancelOperation_Outcomes(useTemporalFailure
 		endpoint := env.createNexusEndpoint(s.Context(), s.T(), tc.endpointName, testcore.RandomizeStr("task-queue"))
 		var dispatchURL string
 		if dispatchOnlyByEndpoint {
-			dispatchURL = getDispatchByEndpointURL(env.HttpAPIAddress(), endpoint.Id)
+			dispatchURL = env.getDispatchByEndpointURL(endpoint.Id)
 		} else {
 			dispatchURL = getDispatchByNsAndTqURL(env.HttpAPIAddress(), env.Namespace().String(), endpoint.Spec.Target.GetWorker().TaskQueue)
 		}
@@ -687,7 +687,7 @@ func (s *NexusApiTestSuite) TestNexusClientNameMetricPropagation(useTemporalFail
 
 	// Trigger a Nexus start operation via HTTP to unblock the poller.
 	client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{
-		BaseURL: getDispatchByEndpointURL(env.HttpAPIAddress(), endpoint.Id),
+		BaseURL: env.getDispatchByEndpointURL(endpoint.Id),
 		Service: "test-service",
 	})
 	s.NoError(err)
@@ -723,8 +723,4 @@ func getDispatchByNsAndTqURL(address string, namespace string, taskQueue string)
 				TaskQueue: taskQueue,
 			}),
 	)
-}
-
-func getDispatchByEndpointURL(address string, endpoint string) string {
-	return fmt.Sprintf("http://%s/%s", address, commonnexus.RouteDispatchNexusTaskByEndpoint.Path(endpoint))
 }

--- a/tests/nexus_api_test.go
+++ b/tests/nexus_api_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -273,9 +272,9 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Outcomes(useTemporalFailures
 		endpoint := env.createNexusEndpoint(s.Context(), s.T(), tc.endpointName, testcore.RandomizeStr("task-queue"))
 		var dispatchURL string
 		if dispatchOnlyByEndpoint {
-			dispatchURL = env.getDispatchByEndpointURL(endpoint.Id)
+			dispatchURL = env.dispatchByEndpointURL(endpoint.Id)
 		} else {
-			dispatchURL = getDispatchByNsAndTqURL(env.HttpAPIAddress(), env.Namespace().String(), endpoint.Spec.Target.GetWorker().TaskQueue)
+			dispatchURL = env.dispatchByNsAndTqURL(env.Namespace().String(), endpoint.Spec.Target.GetWorker().TaskQueue)
 		}
 
 		httpCaller, headerCapture := newHeaderCaptureCaller()
@@ -420,9 +419,9 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Claims(useTemporalFailures b
 		testEndpoint := env.createNexusEndpoint(s.Context(), s.T(), testcore.RandomizeStr("test-endpoint"), taskQueue)
 		var dispatchURL string
 		if dispatchOnlyByEndpoint {
-			dispatchURL = env.getDispatchByEndpointURL(testEndpoint.Id)
+			dispatchURL = env.dispatchByEndpointURL(testEndpoint.Id)
 		} else {
-			dispatchURL = getDispatchByNsAndTqURL(env.HttpAPIAddress(), env.Namespace().String(), taskQueue)
+			dispatchURL = env.dispatchByNsAndTqURL(env.Namespace().String(), taskQueue)
 		}
 
 		client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{BaseURL: dispatchURL, Service: "test-service"})
@@ -534,9 +533,9 @@ func (s *NexusApiTestSuite) TestNexusCancelOperation_Outcomes(useTemporalFailure
 		endpoint := env.createNexusEndpoint(s.Context(), s.T(), tc.endpointName, testcore.RandomizeStr("task-queue"))
 		var dispatchURL string
 		if dispatchOnlyByEndpoint {
-			dispatchURL = env.getDispatchByEndpointURL(endpoint.Id)
+			dispatchURL = env.dispatchByEndpointURL(endpoint.Id)
 		} else {
-			dispatchURL = getDispatchByNsAndTqURL(env.HttpAPIAddress(), env.Namespace().String(), endpoint.Spec.Target.GetWorker().TaskQueue)
+			dispatchURL = env.dispatchByNsAndTqURL(env.Namespace().String(), endpoint.Spec.Target.GetWorker().TaskQueue)
 		}
 
 		httpCaller, headerCapture := newHeaderCaptureCaller()
@@ -631,7 +630,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_WithNamespaceAndTaskQueue_Su
 	})
 	s.NoError(err)
 
-	u := getDispatchByNsAndTqURL(env.HttpAPIAddress(), env.Namespace().String(), taskQueue)
+	u := env.dispatchByNsAndTqURL(env.Namespace().String(), taskQueue)
 	client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{BaseURL: u, Service: "test-service"})
 	s.NoError(err)
 	// Versioned poller gets task
@@ -687,7 +686,7 @@ func (s *NexusApiTestSuite) TestNexusClientNameMetricPropagation(useTemporalFail
 
 	// Trigger a Nexus start operation via HTTP to unblock the poller.
 	client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{
-		BaseURL: env.getDispatchByEndpointURL(endpoint.Id),
+		BaseURL: env.dispatchByEndpointURL(endpoint.Id),
 		Service: "test-service",
 	})
 	s.NoError(err)
@@ -711,16 +710,4 @@ func (s *NexusApiTestSuite) TestNexusClientNameMetricPropagation(useTemporalFail
 
 func nexusEchoHandler(_ *testing.T, res *workflowservice.PollNexusTaskQueueResponse) (*nexusTaskResponse, error) {
 	return &nexusTaskResponse{StartResult: &nexus.HandlerStartOperationResultSync[*commonpb.Payload]{Value: res.Request.GetStartOperation().GetPayload()}}, nil
-}
-
-func getDispatchByNsAndTqURL(address string, namespace string, taskQueue string) string {
-	return fmt.Sprintf(
-		"http://%s/%s",
-		address,
-		commonnexus.RouteDispatchNexusTaskByNamespaceAndTaskQueue.
-			Path(commonnexus.NamespaceAndTaskQueue{
-				Namespace: namespace,
-				TaskQueue: taskQueue,
-			}),
-	)
 }

--- a/tests/nexus_api_test.go
+++ b/tests/nexus_api_test.go
@@ -274,7 +274,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Outcomes(useTemporalFailures
 		if dispatchOnlyByEndpoint {
 			dispatchURL = env.dispatchByEndpointURL(endpoint.Id)
 		} else {
-			dispatchURL = env.dispatchByNsAndTqURL(env.Namespace().String(), endpoint.Spec.Target.GetWorker().TaskQueue)
+			dispatchURL = env.dispatchByTaskQueueURL(endpoint.Spec.Target.GetWorker().TaskQueue)
 		}
 
 		httpCaller, headerCapture := newHeaderCaptureCaller()
@@ -421,7 +421,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Claims(useTemporalFailures b
 		if dispatchOnlyByEndpoint {
 			dispatchURL = env.dispatchByEndpointURL(testEndpoint.Id)
 		} else {
-			dispatchURL = env.dispatchByNsAndTqURL(env.Namespace().String(), taskQueue)
+			dispatchURL = env.dispatchByTaskQueueURL(taskQueue)
 		}
 
 		client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{BaseURL: dispatchURL, Service: "test-service"})
@@ -535,7 +535,7 @@ func (s *NexusApiTestSuite) TestNexusCancelOperation_Outcomes(useTemporalFailure
 		if dispatchOnlyByEndpoint {
 			dispatchURL = env.dispatchByEndpointURL(endpoint.Id)
 		} else {
-			dispatchURL = env.dispatchByNsAndTqURL(env.Namespace().String(), endpoint.Spec.Target.GetWorker().TaskQueue)
+			dispatchURL = env.dispatchByTaskQueueURL(endpoint.Spec.Target.GetWorker().TaskQueue)
 		}
 
 		httpCaller, headerCapture := newHeaderCaptureCaller()
@@ -630,7 +630,7 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_WithNamespaceAndTaskQueue_Su
 	})
 	s.NoError(err)
 
-	u := env.dispatchByNsAndTqURL(env.Namespace().String(), taskQueue)
+	u := env.dispatchByTaskQueueURL(taskQueue)
 	client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{BaseURL: u, Service: "test-service"})
 	s.NoError(err)
 	// Versioned poller gets task

--- a/tests/nexus_api_validation_test.go
+++ b/tests/nexus_api_validation_test.go
@@ -34,7 +34,7 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_WithNamespaceAndTa
 	// Also use this test to verify that namespaces are unescaped in the path.
 	taskQueue := testcore.RandomizeStr("task-queue")
 	namespace := "namespace not/found"
-	u := env.dispatchByNsAndTqURL(namespace, taskQueue)
+	u := env.dispatchByNamespaceAndTaskQueueURL(namespace, taskQueue)
 	client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{BaseURL: u, Service: "test-service"})
 	s.NoError(err)
 	capture := env.StartNamespaceMetricCaptureFor(namespace)
@@ -65,7 +65,7 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_WithNamespaceAndTa
 		namespace.WriteString("namespace-is-a-very-long-string")
 	}
 
-	u := env.dispatchByNsAndTqURL(namespace.String(), taskQueue)
+	u := env.dispatchByNamespaceAndTaskQueueURL(namespace.String(), taskQueue)
 	client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{BaseURL: u, Service: "test-service"})
 	s.NoError(err)
 	capture := env.StartGlobalMetricCapture()
@@ -195,7 +195,7 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_Forbidden() {
 		if dispatchOnlyByEndpoint {
 			dispatchURL = env.dispatchByEndpointURL(testEndpoint.Id)
 		} else {
-			dispatchURL = env.dispatchByNsAndTqURL(env.Namespace().String(), taskQueue)
+			dispatchURL = env.dispatchByTaskQueueURL(taskQueue)
 		}
 
 		client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{BaseURL: dispatchURL, Service: "test-service"})
@@ -237,7 +237,7 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_PayloadSizeLimit()
 		if dispatchOnlyByEndpoint {
 			dispatchURL = env.dispatchByEndpointURL(testEndpoint.Id)
 		} else {
-			dispatchURL = env.dispatchByNsAndTqURL(env.Namespace().String(), taskQueue)
+			dispatchURL = env.dispatchByTaskQueueURL(taskQueue)
 		}
 
 		client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{BaseURL: dispatchURL, Service: "test-service"})

--- a/tests/nexus_api_validation_test.go
+++ b/tests/nexus_api_validation_test.go
@@ -193,7 +193,7 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_Forbidden() {
 
 		var dispatchURL string
 		if dispatchOnlyByEndpoint {
-			dispatchURL = getDispatchByEndpointURL(env.HttpAPIAddress(), testEndpoint.Id)
+			dispatchURL = env.getDispatchByEndpointURL(testEndpoint.Id)
 		} else {
 			dispatchURL = getDispatchByNsAndTqURL(env.HttpAPIAddress(), env.Namespace().String(), taskQueue)
 		}
@@ -235,7 +235,7 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_PayloadSizeLimit()
 
 		var dispatchURL string
 		if dispatchOnlyByEndpoint {
-			dispatchURL = getDispatchByEndpointURL(env.HttpAPIAddress(), testEndpoint.Id)
+			dispatchURL = env.getDispatchByEndpointURL(testEndpoint.Id)
 		} else {
 			dispatchURL = getDispatchByNsAndTqURL(env.HttpAPIAddress(), env.Namespace().String(), taskQueue)
 		}
@@ -368,7 +368,7 @@ func (s *NexusAPIValidationTestSuite) TestNexus_RespondNexusTaskMethods_Validate
 
 func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_ByEndpoint_EndpointNotFound() {
 	env := newNexusTestEnv(s.T(), false, testcore.WithDedicatedCluster())
-	u := getDispatchByEndpointURL(env.HttpAPIAddress(), uuid.NewString())
+	u := env.getDispatchByEndpointURL(uuid.NewString())
 	client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{BaseURL: u, Service: "test-service"})
 	s.NoError(err)
 	capture := env.StartGlobalMetricCapture()

--- a/tests/nexus_api_validation_test.go
+++ b/tests/nexus_api_validation_test.go
@@ -34,7 +34,7 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_WithNamespaceAndTa
 	// Also use this test to verify that namespaces are unescaped in the path.
 	taskQueue := testcore.RandomizeStr("task-queue")
 	namespace := "namespace not/found"
-	u := getDispatchByNsAndTqURL(env.HttpAPIAddress(), namespace, taskQueue)
+	u := env.dispatchByNsAndTqURL(namespace, taskQueue)
 	client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{BaseURL: u, Service: "test-service"})
 	s.NoError(err)
 	capture := env.StartNamespaceMetricCaptureFor(namespace)
@@ -65,7 +65,7 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_WithNamespaceAndTa
 		namespace.WriteString("namespace-is-a-very-long-string")
 	}
 
-	u := getDispatchByNsAndTqURL(env.HttpAPIAddress(), namespace.String(), taskQueue)
+	u := env.dispatchByNsAndTqURL(namespace.String(), taskQueue)
 	client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{BaseURL: u, Service: "test-service"})
 	s.NoError(err)
 	capture := env.StartGlobalMetricCapture()
@@ -193,9 +193,9 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_Forbidden() {
 
 		var dispatchURL string
 		if dispatchOnlyByEndpoint {
-			dispatchURL = env.getDispatchByEndpointURL(testEndpoint.Id)
+			dispatchURL = env.dispatchByEndpointURL(testEndpoint.Id)
 		} else {
-			dispatchURL = getDispatchByNsAndTqURL(env.HttpAPIAddress(), env.Namespace().String(), taskQueue)
+			dispatchURL = env.dispatchByNsAndTqURL(env.Namespace().String(), taskQueue)
 		}
 
 		client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{BaseURL: dispatchURL, Service: "test-service"})
@@ -235,9 +235,9 @@ func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_PayloadSizeLimit()
 
 		var dispatchURL string
 		if dispatchOnlyByEndpoint {
-			dispatchURL = env.getDispatchByEndpointURL(testEndpoint.Id)
+			dispatchURL = env.dispatchByEndpointURL(testEndpoint.Id)
 		} else {
-			dispatchURL = getDispatchByNsAndTqURL(env.HttpAPIAddress(), env.Namespace().String(), taskQueue)
+			dispatchURL = env.dispatchByNsAndTqURL(env.Namespace().String(), taskQueue)
 		}
 
 		client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{BaseURL: dispatchURL, Service: "test-service"})
@@ -368,7 +368,7 @@ func (s *NexusAPIValidationTestSuite) TestNexus_RespondNexusTaskMethods_Validate
 
 func (s *NexusAPIValidationTestSuite) TestNexusStartOperation_ByEndpoint_EndpointNotFound() {
 	env := newNexusTestEnv(s.T(), false, testcore.WithDedicatedCluster())
-	u := env.getDispatchByEndpointURL(uuid.NewString())
+	u := env.dispatchByEndpointURL(uuid.NewString())
 	client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{BaseURL: u, Service: "test-service"})
 	s.NoError(err)
 	capture := env.StartGlobalMetricCapture()

--- a/tests/nexus_otel_test.go
+++ b/tests/nexus_otel_test.go
@@ -231,8 +231,8 @@ func (s *NexusOTELSuite) TestNamespaceAndTaskQueueDispatch() {
 	})
 	s.NoError(err)
 
-	// Use a fixed traceparent to isolate server-side extraction from client instrumentation.
-	// Nexus API tests cover forwarding arbitrary headers to workers.
+	// Inject a fixed traceparent so this test exercises the server independently of client instrumentation.
+	// Nexus API tests separately verify that frontend request headers reach workers.
 	requestHeaders := nexus.Header{
 		"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
 	}

--- a/tests/nexus_otel_test.go
+++ b/tests/nexus_otel_test.go
@@ -208,57 +208,9 @@ func (s *NexusOTELSuite) TestOperation() {
 	})
 }
 
-// Verifies asynchronous operation cancellation uses the instrumented production HTTP client.
-func (s *NexusOTELSuite) TestExternalOperationCancellation() {
-	exporter := tracetest.NewInMemoryExporter()
-	env := s.newTestEnv(exporter)
-
-	cancelRequestHeaders := make(chan headerGetter, 1)
-	operationToken := env.Tv().Any().String()
-	endpointName := env.createRandomExternalNexusServer(s.Context(), s.T(), nexustest.Handler{
-		OnStartOperation: func(_ context.Context, _, _ string, _ *nexus.LazyValue, _ nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
-			return &nexus.HandlerStartOperationResultAsync{OperationToken: operationToken}, nil
-		},
-		OnCancelOperation: func(_ context.Context, _, _, _ string, options nexus.CancelOperationOptions) error {
-			cancelRequestHeaders <- options.Header
-			return nil
-		},
-	})
-
-	operationID := env.Tv().Any().String()
-	startResponse, err := env.FrontendClient().StartNexusOperationExecution(s.Context(), &workflowservice.StartNexusOperationExecutionRequest{
-		Namespace:              env.Namespace().String(),
-		OperationId:            operationID,
-		Endpoint:               endpointName,
-		Service:                env.Tv().Service(),
-		Operation:              env.Tv().Operation(),
-		RequestId:              env.Tv().RequestID(),
-		ScheduleToCloseTimeout: durationpb.New(time.Minute),
-	})
-	s.NoError(err)
-
-	_, err = env.FrontendClient().PollNexusOperationExecution(s.Context(), &workflowservice.PollNexusOperationExecutionRequest{
-		Namespace:   env.Namespace().String(),
-		OperationId: operationID,
-		RunId:       startResponse.RunId,
-		WaitStage:   enumspb.NEXUS_OPERATION_WAIT_STAGE_STARTED,
-	})
-	s.NoError(err)
-	_, err = env.FrontendClient().RequestCancelNexusOperationExecution(s.Context(), &workflowservice.RequestCancelNexusOperationExecutionRequest{
-		Namespace:   env.Namespace().String(),
-		OperationId: operationID,
-		RunId:       startResponse.RunId,
-		Reason:      env.Tv().Any().String(),
-	})
-	s.NoError(err)
-	s.requireExportedClientSpan(exporter, cancelRequestHeaders)
-}
-
-// Verifies worker-target Nexus operations connect local frontend client and server spans.
 func (s *NexusOTELSuite) TestWorkerOperation() {
 	exporter := tracetest.NewInMemoryExporter()
 	env := s.newTestEnv(exporter)
-	tv := env.Tv().WithTaskQueue(env.WorkerTaskQueue())
 
 	requestHeaders := make(chan nexus.Header, 1)
 	service := nexus.NewService("test-service")
@@ -266,22 +218,27 @@ func (s *NexusOTELSuite) TestWorkerOperation() {
 		requestHeaders <- options.Header
 		return tv.Any().String(), nil
 	})
-	service.MustRegister(operation)
 
-	nexusWorker := worker.New(env.SdkClient(), tv.TaskQueue().GetName(), worker.Options{})
-	nexusWorker.RegisterNexusService(service)
-	s.NoError(nexusWorker.Start())
-	s.T().Cleanup(nexusWorker.Stop)
+	// Verifies the namespace and task queue dispatch route is instrumented independently of forwarding.
+	s.Run("ByNamespaceAndTaskQueue", func(s *NexusOTELSuite) {
+		tv := env.Tv().Sub("ByNamespaceAndTaskQueue")
+		taskQueue := tv.RequestID()
+		pollerErrCh := env.nexusTaskPoller(s.Context(), s.T(), taskQueue, nexusEchoHandler)
+		client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{
+			BaseURL: getDispatchByNsAndTqURL(env.HttpAPIAddress(), env.Namespace().String(), taskQueue),
+			Service: "test-service",
+		})
+		s.NoError(err)
 
-	endpoint := env.createNexusEndpoint(s.Context(), s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), tv.TaskQueue().GetName())
-	_, err := env.FrontendClient().StartNexusOperationExecution(s.Context(), &workflowservice.StartNexusOperationExecutionRequest{
-		Namespace:              env.Namespace().String(),
-		OperationId:            tv.Any().String(),
-		Endpoint:               endpoint.GetSpec().GetName(),
-		Service:                service.Name,
-		Operation:              operation.Name(),
-		RequestId:              tv.RequestID(),
-		ScheduleToCloseTimeout: durationpb.New(time.Minute),
+		requestHeaders := nexus.Header{
+			"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+		}
+		_, err = nexusrpc.StartOperation(s.Context(), client, op, tv.Any().String(), nexus.StartOperationOptions{
+			Header: requestHeaders,
+		})
+		s.NoError(err)
+		s.NoError(<-pollerErrCh)
+		s.requireExportedServerSpan(exporter, requestHeaders, "DispatchNexusTaskByNamespaceAndTaskQueue", "io.temporal.frontend")
 	})
 	s.NoError(err)
 

--- a/tests/nexus_otel_test.go
+++ b/tests/nexus_otel_test.go
@@ -208,7 +208,7 @@ func (s *NexusOTELSuite) TestOperation() {
 	})
 }
 
-// Verifies worker-target Nexus operations trace requests routed through the local frontend client.
+// Verifies worker-target Nexus operations connect local frontend client and server spans.
 func (s *NexusOTELSuite) TestWorkerOperation() {
 	exporter := tracetest.NewInMemoryExporter()
 	env := s.newTestEnv(exporter)
@@ -330,4 +330,34 @@ func (s *NexusOTELSuite) nexusHTTPSpans(
 		})
 	}
 	return result, httpSpans
+}
+
+func (s *NexusOTELSuite) requireExportedServerSpan(
+	exporter *tracetest.InMemoryExporter,
+	headers headerGetter,
+	operation string,
+) {
+	traceID, clientSpanID := s.requireTraceContext(headers)
+	s.AwaitTrue(func() bool {
+		for _, span := range exporter.GetSpans() {
+			if span.Name == operation &&
+				span.SpanKind == oteltrace.SpanKindServer &&
+				span.SpanContext.TraceID() == traceID &&
+				span.Parent.SpanID() == clientSpanID {
+				return true
+			}
+		}
+		return false
+	}, 10*time.Second, 100*time.Millisecond)
+}
+
+func (s *NexusOTELSuite) requireTraceContext(headers headerGetter) (oteltrace.TraceID, oteltrace.SpanID) {
+	// Extract trace context from headers.
+	traceparent := strings.Split(headers.Get("traceparent"), "-")
+	s.Len(traceparent, 4)
+	traceID, err := oteltrace.TraceIDFromHex(traceparent[1])
+	s.NoError(err)
+	spanID, err := oteltrace.SpanIDFromHex(traceparent[2])
+	s.NoError(err)
+	return traceID, spanID
 }

--- a/tests/nexus_otel_test.go
+++ b/tests/nexus_otel_test.go
@@ -272,11 +272,8 @@ func (s *NexusOTELSuite) TestNamespaceAndTaskQueueDispatch() {
 		traceID      = "4bf92f3577b34da6a3ce929d0e0e4736"
 		parentSpanID = "00f067aa0ba902b7"
 	)
-	requestHeaders := nexus.Header{
-		"traceparent": "00-" + traceID + "-" + parentSpanID + "-01",
-	}
 	_, err = nexusrpc.StartOperation(s.Context(), nexusClient, op, env.Tv().Any().String(), nexus.StartOperationOptions{
-		Header: requestHeaders,
+		Header: nexus.Header{"traceparent": "00-" + traceID + "-" + parentSpanID + "-01"},
 	})
 	s.NoError(err)
 	s.NoError(<-pollerErrCh)

--- a/tests/nexus_otel_test.go
+++ b/tests/nexus_otel_test.go
@@ -63,8 +63,7 @@ func (s *NexusOTELSuite) newTestEnv(exporter sdktrace.SpanExporter) *NexusTestEn
 
 // Verifies production callback wiring propagates trace context and stored headers end to end.
 func (s *NexusOTELSuite) TestCallback() {
-	exporter := tracetest.NewInMemoryExporter()
-	env := s.newTestEnv(exporter)
+	env := s.newTestEnv(tracetest.NewInMemoryExporter())
 
 	requestHeaders := make(chan http.Header, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -215,7 +214,40 @@ func (s *NexusOTELSuite) TestOperation() {
 		Reason:      tv.Any().String(),
 	})
 	s.NoError(err)
-	s.requireExportedNexusHTTPSpanPair(callerExporter, handlerExporter, operationPathSuffix+"/cancel")
+	s.requireNexusHTTPSpans(exporter, oteltrace.SpanContext{}, []nexusHTTPSpan{
+		{
+			TraceID:     1,
+			SpanID:      1,
+			Name:        "HTTP POST",
+			ServiceName: "io.temporal.history",
+			Kind:        oteltrace.SpanKindClient,
+		},
+		{
+			TraceID:      1,
+			SpanID:       2,
+			ParentSpanID: 1,
+			Name:         "temporal.api.nexusservice.v1.NexusService/DispatchByEndpoint",
+			ServiceName:  "io.temporal.frontend",
+			Kind:         oteltrace.SpanKindServer,
+			URLPath:      operationURLPath,
+		},
+		{
+			TraceID:     2,
+			SpanID:      1,
+			Name:        "HTTP POST",
+			ServiceName: "io.temporal.history",
+			Kind:        oteltrace.SpanKindClient,
+		},
+		{
+			TraceID:      2,
+			SpanID:       2,
+			ParentSpanID: 1,
+			Name:         "temporal.api.nexusservice.v1.NexusService/DispatchByEndpoint",
+			ServiceName:  "io.temporal.frontend",
+			Kind:         oteltrace.SpanKindServer,
+			URLPath:      operationURLPath + "/cancel",
+		},
+	})
 }
 
 // Verifies the namespace and task queue dispatch route is instrumented independently of forwarding.
@@ -241,18 +273,27 @@ func (s *NexusOTELSuite) TestNamespaceAndTaskQueueDispatch() {
 	})
 	s.NoError(err)
 	s.NoError(<-pollerErrCh)
-	s.requireExportedServerSpan(
-		exporter,
-		requestHeaders,
-		"temporal.api.nexusservice.v1.NexusService/DispatchByNamespaceAndTaskQueue",
-		"io.temporal.frontend",
+
+	parentSpanContext := oteltrace.SpanContextFromContext(
+		propagation.TraceContext{}.Extract(s.Context(), propagation.MapCarrier(requestHeaders)),
 	)
+	s.Require().True(parentSpanContext.IsValid())
+	s.requireNexusHTTPSpans(exporter, parentSpanContext, []nexusHTTPSpan{{
+		TraceID:      1,
+		SpanID:       2,
+		ParentSpanID: 1,
+		Name:         "temporal.api.nexusservice.v1.NexusService/DispatchByNamespaceAndTaskQueue",
+		ServiceName:  "io.temporal.frontend",
+		Kind:         oteltrace.SpanKindServer,
+		URLPath:      dispatchURL.Path + "/test-service/my-operation",
+	}})
 }
 
-func (s *NexusOTELSuite) requireExportedNexusHTTPSpanPair(
-	callerExporter *tracetest.InMemoryExporter,
-	handlerExporter *tracetest.InMemoryExporter,
-	pathSuffix string,
+// requireNexusHTTPSpans compares all exported HTTP spans after assigning stable local IDs.
+func (s *NexusOTELSuite) requireNexusHTTPSpans(
+	exporter *tracetest.InMemoryExporter,
+	externalParent oteltrace.SpanContext,
+	expected []nexusHTTPSpan,
 ) {
 	s.T().Helper()
 	s.Await(func(s *NexusOTELSuite) {
@@ -376,57 +417,31 @@ func (s *NexusOTELSuite) nexusHTTPSpans(
 	return result, httpSpans
 }
 
-func (s *NexusOTELSuite) requireExportedServerSpan(
-	exporter *tracetest.InMemoryExporter,
-	headers headerGetter,
-	operation string,
-	serviceName string,
-) {
-	traceID, clientSpanID := s.requireTraceContext(headers)
-	var exportedSpan tracetest.SpanStub
-	s.Await(func(s *NexusOTELSuite) {
-		spans := exporter.GetSpans()
-		for _, span := range spans {
-			if span.Name == operation &&
-				span.SpanKind == oteltrace.SpanKindServer &&
-				span.SpanContext.TraceID() == traceID &&
-				span.Parent.SpanID() == clientSpanID {
-				exportedSpan = span
-				return
+	result := make([]nexusHTTPSpan, 0, len(httpSpans))
+	for _, span := range httpSpans {
+		traceID := span.SpanContext.TraceID()
+		var serviceName string
+		if span.Resource != nil {
+			if value, ok := span.Resource.Set().Value(semconv.ServiceNameKey); ok {
+				serviceName = value.AsString()
 			}
 		}
-		s.Require().Fail("matching server span not found", "exported spans: %v", spans)
-	}, 10*time.Second, 100*time.Millisecond)
-	s.Require().Equal(serviceName, spanServiceName(exportedSpan))
-}
-
-func spanServiceName(span tracetest.SpanStub) string {
-	if span.Resource == nil {
-		return ""
-	}
-	serviceName, ok := span.Resource.Set().Value(semconv.ServiceNameKey)
-	if !ok {
-		return ""
-	}
-	return serviceName.AsString()
-}
-
-func spanURLPath(span tracetest.SpanStub) string {
-	for _, attr := range span.Attributes {
-		if attr.Key == semconv.URLPathKey {
-			return attr.Value.AsString()
+		var urlPath string
+		for _, attr := range span.Attributes {
+			if attr.Key == semconv.URLPathKey {
+				urlPath = attr.Value.AsString()
+				break
+			}
 		}
+		result = append(result, nexusHTTPSpan{
+			TraceID:      traceIDs[traceID],
+			SpanID:       spanIDs[traceID][span.SpanContext.SpanID()],
+			ParentSpanID: spanIDs[traceID][span.Parent.SpanID()],
+			Name:         span.Name,
+			ServiceName:  serviceName,
+			Kind:         span.SpanKind,
+			URLPath:      urlPath,
+		})
 	}
-	return ""
-}
-
-func (s *NexusOTELSuite) requireTraceContext(headers headerGetter) (oteltrace.TraceID, oteltrace.SpanID) {
-	// Extract trace context from headers.
-	traceparent := strings.Split(headers.Get("traceparent"), "-")
-	s.Len(traceparent, 4)
-	traceID, err := oteltrace.TraceIDFromHex(traceparent[1])
-	s.NoError(err)
-	spanID, err := oteltrace.SpanIDFromHex(traceparent[2])
-	s.NoError(err)
-	return traceID, spanID
+	return result
 }

--- a/tests/nexus_otel_test.go
+++ b/tests/nexus_otel_test.go
@@ -208,6 +208,52 @@ func (s *NexusOTELSuite) TestOperation() {
 	})
 }
 
+// Verifies asynchronous operation cancellation uses the instrumented production HTTP client.
+func (s *NexusOTELSuite) TestExternalOperationCancellation() {
+	exporter := tracetest.NewInMemoryExporter()
+	env := s.newTestEnv(exporter)
+
+	cancelRequestHeaders := make(chan headerGetter, 1)
+	operationToken := env.Tv().Any().String()
+	endpointName := env.createRandomExternalNexusServer(s.Context(), s.T(), nexustest.Handler{
+		OnStartOperation: func(_ context.Context, _, _ string, _ *nexus.LazyValue, _ nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
+			return &nexus.HandlerStartOperationResultAsync{OperationToken: operationToken}, nil
+		},
+		OnCancelOperation: func(_ context.Context, _, _, _ string, options nexus.CancelOperationOptions) error {
+			cancelRequestHeaders <- options.Header
+			return nil
+		},
+	})
+
+	operationID := env.Tv().Any().String()
+	startResponse, err := env.FrontendClient().StartNexusOperationExecution(s.Context(), &workflowservice.StartNexusOperationExecutionRequest{
+		Namespace:              env.Namespace().String(),
+		OperationId:            operationID,
+		Endpoint:               endpointName,
+		Service:                env.Tv().Service(),
+		Operation:              env.Tv().Operation(),
+		RequestId:              env.Tv().RequestID(),
+		ScheduleToCloseTimeout: durationpb.New(time.Minute),
+	})
+	s.NoError(err)
+
+	_, err = env.FrontendClient().PollNexusOperationExecution(s.Context(), &workflowservice.PollNexusOperationExecutionRequest{
+		Namespace:   env.Namespace().String(),
+		OperationId: operationID,
+		RunId:       startResponse.RunId,
+		WaitStage:   enumspb.NEXUS_OPERATION_WAIT_STAGE_STARTED,
+	})
+	s.NoError(err)
+	_, err = env.FrontendClient().RequestCancelNexusOperationExecution(s.Context(), &workflowservice.RequestCancelNexusOperationExecutionRequest{
+		Namespace:   env.Namespace().String(),
+		OperationId: operationID,
+		RunId:       startResponse.RunId,
+		Reason:      env.Tv().Any().String(),
+	})
+	s.NoError(err)
+	s.requireExportedClientSpan(exporter, cancelRequestHeaders)
+}
+
 // Verifies worker-target Nexus operations connect local frontend client and server spans.
 func (s *NexusOTELSuite) TestWorkerOperation() {
 	exporter := tracetest.NewInMemoryExporter()
@@ -336,19 +382,30 @@ func (s *NexusOTELSuite) requireExportedServerSpan(
 	exporter *tracetest.InMemoryExporter,
 	headers headerGetter,
 	operation string,
+	serviceName string,
 ) {
 	traceID, clientSpanID := s.requireTraceContext(headers)
+	var exportedSpan tracetest.SpanStub
 	s.AwaitTrue(func() bool {
 		for _, span := range exporter.GetSpans() {
 			if span.Name == operation &&
 				span.SpanKind == oteltrace.SpanKindServer &&
 				span.SpanContext.TraceID() == traceID &&
 				span.Parent.SpanID() == clientSpanID {
+				exportedSpan = span
 				return true
 			}
 		}
 		return false
 	}, 10*time.Second, 100*time.Millisecond)
+	s.requireSpanServiceName(exportedSpan, serviceName)
+}
+
+func (s *NexusOTELSuite) requireSpanServiceName(span tracetest.SpanStub, expected string) {
+	s.Require().NotNil(span.Resource)
+	serviceName, ok := span.Resource.Set().Value(semconv.ServiceNameKey)
+	s.Require().True(ok)
+	s.Require().Equal(expected, serviceName.AsString())
 }
 
 func (s *NexusOTELSuite) requireTraceContext(headers headerGetter) (oteltrace.TraceID, oteltrace.SpanID) {

--- a/tests/nexus_otel_test.go
+++ b/tests/nexus_otel_test.go
@@ -26,18 +26,20 @@ import (
 	"go.temporal.io/server/chasm/lib/callback"
 	"go.temporal.io/server/chasm/lib/nexusoperation"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/nexus/nexusrpc"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/tests/testcore"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 type nexusHTTPSpan struct {
-	TraceID     int
-	SpanID      int
-	Name        string
-	ServiceName string
-	Kind        oteltrace.SpanKind
-	URLPath     string
+	TraceID      int
+	SpanID       int
+	ParentSpanID int
+	Name         string
+	ServiceName  string
+	Kind         oteltrace.SpanKind
+	URLPath      string
 }
 
 type NexusOTELSuite struct {
@@ -126,7 +128,7 @@ func (s *NexusOTELSuite) TestCallback() {
 	s.Require().Equal(spanContext.SpanID(), httpSpans[0].SpanContext.SpanID())
 }
 
-// Verifies asynchronous start and cancellation use the instrumented external Nexus HTTP client.
+// Verifies asynchronous start and cancellation connect real History client and Frontend server spans.
 func (s *NexusOTELSuite) TestOperation() {
 	exporter := tracetest.NewInMemoryExporter()
 	callerEnv := s.newTestEnv(exporter)
@@ -198,34 +200,6 @@ func (s *NexusOTELSuite) TestOperation() {
 			URLPath:     operationURLPath,
 		},
 		{
-			TraceID:     2,
-			SpanID:      1,
-			Name:        "HTTP POST",
-			ServiceName: "io.temporal.history",
-			Kind:        oteltrace.SpanKindClient,
-			URLPath:     operationURLPath + "/cancel",
-		},
-	})
-	s.NoError(err)
-	s.Require().Equal(enumspb.NEXUS_OPERATION_WAIT_STAGE_STARTED, pollResponse.GetWaitStage())
-	_, err = callerEnv.FrontendClient().RequestCancelNexusOperationExecution(s.Context(), &workflowservice.RequestCancelNexusOperationExecutionRequest{
-		Namespace:   callerEnv.Namespace().String(),
-		OperationId: operationID,
-		RunId:       startResponse.RunId,
-		Reason:      tv.Any().String(),
-	})
-	s.NoError(err)
-
-	operationURLPath := "/nexus/endpoints/" + handlerWorkerEndpoint.Id + "/services/" + service.Name + "/" + operation.Name()
-	s.requireNexusHTTPSpans(exporter, oteltrace.SpanContext{}, []nexusHTTPSpan{
-		{
-			TraceID:     1,
-			SpanID:      1,
-			Name:        "HTTP POST",
-			ServiceName: "io.temporal.history",
-			Kind:        oteltrace.SpanKindClient,
-		},
-		{
 			TraceID:      1,
 			SpanID:       2,
 			ParentSpanID: 1,
@@ -240,6 +214,7 @@ func (s *NexusOTELSuite) TestOperation() {
 			Name:        "HTTP POST",
 			ServiceName: "io.temporal.history",
 			Kind:        oteltrace.SpanKindClient,
+			URLPath:     operationURLPath + "/cancel",
 		},
 		{
 			TraceID:      2,
@@ -253,16 +228,82 @@ func (s *NexusOTELSuite) TestOperation() {
 	})
 }
 
-// Verifies the namespace and task queue dispatch route is instrumented independently of forwarding.
-func (s *NexusOTELSuite) TestNamespaceAndTaskQueueDispatch() {
+// Verifies worker-target Nexus operations connect local Frontend client and server spans.
+func (s *NexusOTELSuite) TestWorkerOperation() {
 	exporter := tracetest.NewInMemoryExporter()
 	env := s.newTestEnv(exporter)
+	tv := env.Tv().WithTaskQueue(env.WorkerTaskQueue())
 
 	requestHeaders := make(chan nexus.Header, 1)
 	service := nexus.NewService("test-service")
 	operation := nexus.NewSyncOperation("test-operation", func(_ context.Context, _ nexus.NoValue, options nexus.StartOperationOptions) (string, error) {
 		requestHeaders <- options.Header
 		return tv.Any().String(), nil
+	})
+	service.MustRegister(operation)
+
+	nexusWorker := worker.New(env.SdkClient(), tv.TaskQueue().GetName(), worker.Options{})
+	nexusWorker.RegisterNexusService(service)
+	s.NoError(nexusWorker.Start())
+	s.T().Cleanup(nexusWorker.Stop)
+
+	endpoint := env.createNexusEndpoint(s.Context(), s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), tv.TaskQueue().GetName())
+	_, err := env.FrontendClient().StartNexusOperationExecution(s.Context(), &workflowservice.StartNexusOperationExecutionRequest{
+		Namespace:              env.Namespace().String(),
+		OperationId:            tv.Any().String(),
+		Endpoint:               endpoint.GetSpec().GetName(),
+		Service:                service.Name,
+		Operation:              operation.Name(),
+		RequestId:              tv.RequestID(),
+		ScheduleToCloseTimeout: durationpb.New(time.Minute),
+	})
+	s.NoError(err)
+
+	var headers nexus.Header
+	select {
+	case headers = <-requestHeaders:
+	case <-s.Context().Done():
+		s.FailNow("timed out waiting for Nexus operation", s.Context().Err().Error())
+	}
+	operationURLPath := "/nexus/endpoints/" + endpoint.Id + "/services/" + service.Name + "/" + operation.Name()
+	httpSpans := s.requireNexusHTTPSpans(exporter, []nexusHTTPSpan{
+		{
+			TraceID:     1,
+			SpanID:      1,
+			Name:        "HTTP POST",
+			ServiceName: "io.temporal.history",
+			Kind:        oteltrace.SpanKindClient,
+			URLPath:     operationURLPath,
+		},
+		{
+			TraceID:      1,
+			SpanID:       2,
+			ParentSpanID: 1,
+			Name:         "temporal.api.nexusservice.v1.NexusService/DispatchByEndpoint",
+			ServiceName:  "io.temporal.frontend",
+			Kind:         oteltrace.SpanKindServer,
+			URLPath:      operationURLPath,
+		},
+	})
+	spanContext := oteltrace.SpanContextFromContext(
+		propagation.TraceContext{}.Extract(s.Context(), propagation.MapCarrier(headers)),
+	)
+	s.Require().True(spanContext.IsValid())
+	s.Require().Equal(spanContext.TraceID(), httpSpans[0].SpanContext.TraceID())
+	s.Require().Equal(spanContext.SpanID(), httpSpans[0].SpanContext.SpanID())
+}
+
+// Verifies the namespace and task queue dispatch route is instrumented independently of forwarding.
+func (s *NexusOTELSuite) TestNamespaceAndTaskQueueDispatch() {
+	exporter := tracetest.NewInMemoryExporter()
+	env := s.newTestEnv(exporter)
+	taskQueue := env.Tv().TaskQueue().GetName()
+	pollerErrCh := env.nexusTaskPoller(s.Context(), s.T(), taskQueue, nexusEchoHandler)
+	dispatchURL, err := url.Parse(env.dispatchByTaskQueueURL(taskQueue))
+	s.NoError(err)
+	nexusClient, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{
+		BaseURL: dispatchURL.String(),
+		Service: "test-service",
 	})
 	s.NoError(err)
 
@@ -288,65 +329,6 @@ func (s *NexusOTELSuite) TestNamespaceAndTaskQueueDispatch() {
 	}})
 	s.Require().Equal(traceID, httpSpans[0].SpanContext.TraceID().String())
 	s.Require().Equal(parentSpanID, httpSpans[0].Parent.SpanID().String())
-}
-
-// requireNexusHTTPSpans compares all exported HTTP spans after assigning stable local IDs
-// and returns the matching raw spans for context propagation assertions.
-func (s *NexusOTELSuite) requireNexusHTTPSpans(
-	exporter *tracetest.InMemoryExporter,
-	expected []nexusHTTPSpan,
-) tracetest.SpanStubs {
-	s.T().Helper()
-	var httpSpans tracetest.SpanStubs
-	s.Await(func(s *NexusOTELSuite) {
-		callerSpans := callerExporter.GetSpans()
-		handlerSpans := handlerExporter.GetSpans()
-		for _, serverSpan := range handlerSpans {
-			if serverSpan.Name != "temporal.api.nexusservice.v1.NexusService/DispatchByEndpoint" ||
-				serverSpan.SpanKind != oteltrace.SpanKindServer ||
-				spanServiceName(serverSpan) != "io.temporal.frontend" ||
-				!strings.HasSuffix(spanURLPath(serverSpan), pathSuffix) {
-				continue
-			}
-			for _, clientSpan := range callerSpans {
-				if clientSpan.SpanKind == oteltrace.SpanKindClient &&
-					spanServiceName(clientSpan) == "io.temporal.history" &&
-					clientSpan.SpanContext.TraceID() == serverSpan.SpanContext.TraceID() &&
-					clientSpan.SpanContext.SpanID() == serverSpan.Parent.SpanID() {
-					return
-				}
-			}
-		}
-		_, err = nexusrpc.StartOperation(s.Context(), client, op, tv.Any().String(), nexus.StartOperationOptions{
-			Header: requestHeaders,
-		})
-		s.NoError(err)
-		s.NoError(<-pollerErrCh)
-		s.requireExportedServerSpan(exporter, requestHeaders, "DispatchNexusTaskByNamespaceAndTaskQueue", "io.temporal.frontend")
-	})
-	s.NoError(err)
-
-	var headers nexus.Header
-	select {
-	case headers = <-requestHeaders:
-	case <-s.Context().Done():
-		s.FailNow("timed out waiting for Nexus operation", s.Context().Err().Error())
-	}
-	operationURLPath := "/nexus/endpoints/" + endpoint.Id + "/services/" + service.Name + "/" + operation.Name()
-	httpSpans := s.requireNexusHTTPSpans(exporter, []nexusHTTPSpan{{
-		TraceID:     1,
-		SpanID:      1,
-		Name:        "HTTP POST",
-		ServiceName: "io.temporal.history",
-		Kind:        oteltrace.SpanKindClient,
-		URLPath:     operationURLPath,
-	}})
-	spanContext := oteltrace.SpanContextFromContext(
-		propagation.TraceContext{}.Extract(s.Context(), propagation.MapCarrier(headers)),
-	)
-	s.Require().True(spanContext.IsValid())
-	s.Require().Equal(spanContext.TraceID(), httpSpans[0].SpanContext.TraceID())
-	s.Require().Equal(spanContext.SpanID(), httpSpans[0].SpanContext.SpanID())
 }
 
 // requireNexusHTTPSpans compares all exported HTTP spans after assigning stable local IDs
@@ -405,34 +387,6 @@ func (s *NexusOTELSuite) nexusHTTPSpans(
 				if parsedURL, err := url.Parse(attr.Value.AsString()); err == nil {
 					urlPath = parsedURL.Path
 				}
-			}
-		}
-		result = append(result, nexusHTTPSpan{
-			TraceID:     traceIDs[traceID],
-			SpanID:      spanIDs[traceID][span.SpanContext.SpanID()],
-			Name:        span.Name,
-			ServiceName: serviceName,
-			Kind:        span.SpanKind,
-			URLPath:     urlPath,
-		})
-	}
-	return result, httpSpans
-}
-
-	result := make([]nexusHTTPSpan, 0, len(httpSpans))
-	for _, span := range httpSpans {
-		traceID := span.SpanContext.TraceID()
-		var serviceName string
-		if span.Resource != nil {
-			if value, ok := span.Resource.Set().Value(semconv.ServiceNameKey); ok {
-				serviceName = value.AsString()
-			}
-		}
-		var urlPath string
-		for _, attr := range span.Attributes {
-			if attr.Key == semconv.URLPathKey {
-				urlPath = attr.Value.AsString()
-				break
 			}
 		}
 		result = append(result, nexusHTTPSpan{

--- a/tests/nexus_otel_test.go
+++ b/tests/nexus_otel_test.go
@@ -231,6 +231,8 @@ func (s *NexusOTELSuite) TestNamespaceAndTaskQueueDispatch() {
 	})
 	s.NoError(err)
 
+	// Use a fixed traceparent to isolate server-side extraction from client instrumentation.
+	// Nexus API tests cover forwarding arbitrary headers to workers.
 	requestHeaders := nexus.Header{
 		"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
 	}

--- a/tests/nexus_otel_test.go
+++ b/tests/nexus_otel_test.go
@@ -27,6 +27,7 @@ import (
 	"go.temporal.io/server/chasm/lib/nexusoperation"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/testing/parallelsuite"
+	"go.temporal.io/server/service/frontend/configs"
 	"go.temporal.io/server/tests/testcore"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
@@ -62,7 +63,7 @@ func (s *NexusOTELSuite) newTestEnv(exporter sdktrace.SpanExporter) *NexusTestEn
 }
 
 // Verifies production callback wiring propagates trace context and stored headers end to end.
-func (s *NexusOTELSuite) TestCallback() {
+func (s *NexusOTELSuite) TestWorkflowCompletionCallback() {
 	exporter := tracetest.NewInMemoryExporter()
 	env := s.newTestEnv(exporter)
 
@@ -239,7 +240,12 @@ func (s *NexusOTELSuite) TestNamespaceAndTaskQueueDispatch() {
 	})
 	s.NoError(err)
 	s.NoError(<-pollerErrCh)
-	s.requireExportedServerSpan(exporter, requestHeaders, "DispatchNexusTaskByNamespaceAndTaskQueue", "io.temporal.frontend")
+	s.requireExportedServerSpan(
+		exporter,
+		requestHeaders,
+		strings.TrimPrefix(configs.DispatchNexusTaskByNamespaceAndTaskQueueAPIName, "/"),
+		"io.temporal.frontend",
+	)
 }
 
 func (s *NexusOTELSuite) requireExportedNexusHTTPSpanPairs(
@@ -250,7 +256,7 @@ func (s *NexusOTELSuite) requireExportedNexusHTTPSpanPairs(
 	s.Await(func(s *NexusOTELSuite) {
 		pairs := 0
 		for _, serverSpan := range handlerExporter.GetSpans() {
-			if serverSpan.Name != "DispatchNexusTaskByEndpoint" ||
+			if serverSpan.Name != strings.TrimPrefix(configs.DispatchNexusTaskByEndpointAPIName, "/") ||
 				serverSpan.SpanKind != oteltrace.SpanKindServer ||
 				spanServiceName(serverSpan) != "io.temporal.frontend" {
 				continue
@@ -374,17 +380,18 @@ func (s *NexusOTELSuite) requireExportedServerSpan(
 ) {
 	traceID, clientSpanID := s.requireTraceContext(headers)
 	var exportedSpan tracetest.SpanStub
-	s.AwaitTrue(func() bool {
-		for _, span := range exporter.GetSpans() {
+	s.Await(func(s *NexusOTELSuite) {
+		spans := exporter.GetSpans()
+		for _, span := range spans {
 			if span.Name == operation &&
 				span.SpanKind == oteltrace.SpanKindServer &&
 				span.SpanContext.TraceID() == traceID &&
 				span.Parent.SpanID() == clientSpanID {
 				exportedSpan = span
-				return true
+				return
 			}
 		}
-		return false
+		s.Require().Fail("matching server span not found", "exported spans: %v", spans)
 	}, 10*time.Second, 100*time.Millisecond)
 	s.requireSpanServiceName(exportedSpan, serviceName)
 }

--- a/tests/nexus_otel_test.go
+++ b/tests/nexus_otel_test.go
@@ -63,7 +63,8 @@ func (s *NexusOTELSuite) newTestEnv(exporter sdktrace.SpanExporter) *NexusTestEn
 
 // Verifies production callback wiring propagates trace context and stored headers end to end.
 func (s *NexusOTELSuite) TestCallback() {
-	env := s.newTestEnv(tracetest.NewInMemoryExporter())
+	exporter := tracetest.NewInMemoryExporter()
+	env := s.newTestEnv(exporter)
 
 	requestHeaders := make(chan http.Header, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -267,8 +268,12 @@ func (s *NexusOTELSuite) TestNamespaceAndTaskQueueDispatch() {
 
 	// Inject a fixed traceparent so this test exercises the server independently of client instrumentation.
 	// Nexus API tests separately verify that frontend request headers reach workers.
+	const (
+		traceID      = "4bf92f3577b34da6a3ce929d0e0e4736"
+		parentSpanID = "00f067aa0ba902b7"
+	)
 	requestHeaders := nexus.Header{
-		"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+		"traceparent": "00-" + traceID + "-" + parentSpanID + "-01",
 	}
 	_, err = nexusrpc.StartOperation(s.Context(), nexusClient, op, env.Tv().Any().String(), nexus.StartOperationOptions{
 		Header: requestHeaders,
@@ -276,28 +281,26 @@ func (s *NexusOTELSuite) TestNamespaceAndTaskQueueDispatch() {
 	s.NoError(err)
 	s.NoError(<-pollerErrCh)
 
-	parentSpanContext := oteltrace.SpanContextFromContext(
-		propagation.TraceContext{}.Extract(s.Context(), propagation.MapCarrier(requestHeaders)),
-	)
-	s.Require().True(parentSpanContext.IsValid())
-	s.requireNexusHTTPSpans(exporter, parentSpanContext, []nexusHTTPSpan{{
-		TraceID:      1,
-		SpanID:       2,
-		ParentSpanID: 1,
-		Name:         "temporal.api.nexusservice.v1.NexusService/DispatchByNamespaceAndTaskQueue",
-		ServiceName:  "io.temporal.frontend",
-		Kind:         oteltrace.SpanKindServer,
-		URLPath:      dispatchURL.Path + "/test-service/my-operation",
+	httpSpans := s.requireNexusHTTPSpans(exporter, []nexusHTTPSpan{{
+		TraceID:     1,
+		SpanID:      1,
+		Name:        "temporal.api.nexusservice.v1.NexusService/DispatchByNamespaceAndTaskQueue",
+		ServiceName: "io.temporal.frontend",
+		Kind:        oteltrace.SpanKindServer,
+		URLPath:     dispatchURL.Path + "/test-service/my-operation",
 	}})
+	s.Require().Equal(traceID, httpSpans[0].SpanContext.TraceID().String())
+	s.Require().Equal(parentSpanID, httpSpans[0].Parent.SpanID().String())
 }
 
-// requireNexusHTTPSpans compares all exported HTTP spans after assigning stable local IDs.
+// requireNexusHTTPSpans compares all exported HTTP spans after assigning stable local IDs
+// and returns the matching raw spans for context propagation assertions.
 func (s *NexusOTELSuite) requireNexusHTTPSpans(
 	exporter *tracetest.InMemoryExporter,
-	externalParent oteltrace.SpanContext,
 	expected []nexusHTTPSpan,
-) {
+) tracetest.SpanStubs {
 	s.T().Helper()
+	var httpSpans tracetest.SpanStubs
 	s.Await(func(s *NexusOTELSuite) {
 		callerSpans := callerExporter.GetSpans()
 		handlerSpans := handlerExporter.GetSpans()
@@ -445,5 +448,5 @@ func (s *NexusOTELSuite) nexusHTTPSpans(
 			URLPath:      urlPath,
 		})
 	}
-	return result
+	return result, httpSpans
 }

--- a/tests/nexus_otel_test.go
+++ b/tests/nexus_otel_test.go
@@ -27,7 +27,6 @@ import (
 	"go.temporal.io/server/chasm/lib/nexusoperation"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/testing/parallelsuite"
-	"go.temporal.io/server/service/frontend/configs"
 	"go.temporal.io/server/tests/testcore"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
@@ -63,7 +62,7 @@ func (s *NexusOTELSuite) newTestEnv(exporter sdktrace.SpanExporter) *NexusTestEn
 }
 
 // Verifies production callback wiring propagates trace context and stored headers end to end.
-func (s *NexusOTELSuite) TestWorkflowCompletionCallback() {
+func (s *NexusOTELSuite) TestCallback() {
 	exporter := tracetest.NewInMemoryExporter()
 	env := s.newTestEnv(exporter)
 
@@ -243,7 +242,7 @@ func (s *NexusOTELSuite) TestNamespaceAndTaskQueueDispatch() {
 	s.requireExportedServerSpan(
 		exporter,
 		requestHeaders,
-		strings.TrimPrefix(configs.DispatchNexusTaskByNamespaceAndTaskQueueAPIName, "/"),
+		"temporal.api.nexusservice.v1.NexusService/DispatchByNamespaceAndTaskQueue",
 		"io.temporal.frontend",
 	)
 }
@@ -256,7 +255,7 @@ func (s *NexusOTELSuite) requireExportedNexusHTTPSpanPairs(
 	s.Await(func(s *NexusOTELSuite) {
 		pairs := 0
 		for _, serverSpan := range handlerExporter.GetSpans() {
-			if serverSpan.Name != strings.TrimPrefix(configs.DispatchNexusTaskByEndpointAPIName, "/") ||
+			if serverSpan.Name != "temporal.api.nexusservice.v1.NexusService/DispatchByEndpoint" ||
 				serverSpan.SpanKind != oteltrace.SpanKindServer ||
 				spanServiceName(serverSpan) != "io.temporal.frontend" {
 				continue

--- a/tests/nexus_otel_test.go
+++ b/tests/nexus_otel_test.go
@@ -215,7 +215,7 @@ func (s *NexusOTELSuite) TestOperation() {
 		Reason:      tv.Any().String(),
 	})
 	s.NoError(err)
-	s.requireExportedNexusHTTPSpanPairs(callerExporter, handlerExporter, 2)
+	s.requireExportedNexusHTTPSpanPair(callerExporter, handlerExporter, operationPathSuffix+"/cancel")
 }
 
 // Verifies the namespace and task queue dispatch route is instrumented independently of forwarding.
@@ -247,25 +247,27 @@ func (s *NexusOTELSuite) TestNamespaceAndTaskQueueDispatch() {
 	)
 }
 
-func (s *NexusOTELSuite) requireExportedNexusHTTPSpanPairs(
+func (s *NexusOTELSuite) requireExportedNexusHTTPSpanPair(
 	callerExporter *tracetest.InMemoryExporter,
 	handlerExporter *tracetest.InMemoryExporter,
-	expected int,
+	pathSuffix string,
 ) {
 	s.Await(func(s *NexusOTELSuite) {
-		pairs := 0
-		for _, serverSpan := range handlerExporter.GetSpans() {
+		callerSpans := callerExporter.GetSpans()
+		handlerSpans := handlerExporter.GetSpans()
+		for _, serverSpan := range handlerSpans {
 			if serverSpan.Name != "temporal.api.nexusservice.v1.NexusService/DispatchByEndpoint" ||
 				serverSpan.SpanKind != oteltrace.SpanKindServer ||
-				spanServiceName(serverSpan) != "io.temporal.frontend" {
+				spanServiceName(serverSpan) != "io.temporal.frontend" ||
+				!strings.HasSuffix(spanURLPath(serverSpan), pathSuffix) {
 				continue
 			}
-			for _, clientSpan := range callerExporter.GetSpans() {
+			for _, clientSpan := range callerSpans {
 				if clientSpan.SpanKind == oteltrace.SpanKindClient &&
 					spanServiceName(clientSpan) == "io.temporal.history" &&
 					clientSpan.SpanContext.TraceID() == serverSpan.SpanContext.TraceID() &&
 					clientSpan.SpanContext.SpanID() == serverSpan.Parent.SpanID() {
-					pairs++
+					return
 				}
 			}
 		}
@@ -392,14 +394,7 @@ func (s *NexusOTELSuite) requireExportedServerSpan(
 		}
 		s.Require().Fail("matching server span not found", "exported spans: %v", spans)
 	}, 10*time.Second, 100*time.Millisecond)
-	s.requireSpanServiceName(exportedSpan, serviceName)
-}
-
-func (s *NexusOTELSuite) requireSpanServiceName(span tracetest.SpanStub, expected string) {
-	s.Require().NotNil(span.Resource)
-	serviceName, ok := span.Resource.Set().Value(semconv.ServiceNameKey)
-	s.Require().True(ok)
-	s.Require().Equal(expected, serviceName.AsString())
+	s.Require().Equal(serviceName, spanServiceName(exportedSpan))
 }
 
 func spanServiceName(span tracetest.SpanStub) string {
@@ -411,6 +406,15 @@ func spanServiceName(span tracetest.SpanStub) string {
 		return ""
 	}
 	return serviceName.AsString()
+}
+
+func spanURLPath(span tracetest.SpanStub) string {
+	for _, attr := range span.Attributes {
+		if attr.Key == semconv.URLPathKey {
+			return attr.Value.AsString()
+		}
+	}
+	return ""
 }
 
 func (s *NexusOTELSuite) requireTraceContext(headers headerGetter) (oteltrace.TraceID, oteltrace.SpanID) {

--- a/tests/nexus_otel_test.go
+++ b/tests/nexus_otel_test.go
@@ -252,6 +252,7 @@ func (s *NexusOTELSuite) requireExportedNexusHTTPSpanPair(
 	handlerExporter *tracetest.InMemoryExporter,
 	pathSuffix string,
 ) {
+	s.T().Helper()
 	s.Await(func(s *NexusOTELSuite) {
 		callerSpans := callerExporter.GetSpans()
 		handlerSpans := handlerExporter.GetSpans()

--- a/tests/nexus_otel_test.go
+++ b/tests/nexus_otel_test.go
@@ -206,9 +206,20 @@ func (s *NexusOTELSuite) TestOperation() {
 			URLPath:     operationURLPath + "/cancel",
 		},
 	})
+	s.NoError(err)
+	s.Require().Equal(enumspb.NEXUS_OPERATION_WAIT_STAGE_STARTED, pollResponse.GetWaitStage())
+	_, err = callerEnv.FrontendClient().RequestCancelNexusOperationExecution(s.Context(), &workflowservice.RequestCancelNexusOperationExecutionRequest{
+		Namespace:   callerEnv.Namespace().String(),
+		OperationId: operationID,
+		RunId:       startResponse.RunId,
+		Reason:      tv.Any().String(),
+	})
+	s.NoError(err)
+	s.requireExportedNexusHTTPSpanPairs(callerExporter, handlerExporter, 2)
 }
 
-func (s *NexusOTELSuite) TestWorkerOperation() {
+// Verifies the namespace and task queue dispatch route is instrumented independently of forwarding.
+func (s *NexusOTELSuite) TestNamespaceAndTaskQueueDispatch() {
 	exporter := tracetest.NewInMemoryExporter()
 	env := s.newTestEnv(exporter)
 
@@ -218,20 +229,40 @@ func (s *NexusOTELSuite) TestWorkerOperation() {
 		requestHeaders <- options.Header
 		return tv.Any().String(), nil
 	})
+	s.NoError(err)
 
-	// Verifies the namespace and task queue dispatch route is instrumented independently of forwarding.
-	s.Run("ByNamespaceAndTaskQueue", func(s *NexusOTELSuite) {
-		tv := env.Tv().Sub("ByNamespaceAndTaskQueue")
-		taskQueue := tv.RequestID()
-		pollerErrCh := env.nexusTaskPoller(s.Context(), s.T(), taskQueue, nexusEchoHandler)
-		client, err := nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{
-			BaseURL: getDispatchByNsAndTqURL(env.HttpAPIAddress(), env.Namespace().String(), taskQueue),
-			Service: "test-service",
-		})
-		s.NoError(err)
+	requestHeaders := nexus.Header{
+		"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+	}
+	_, err = nexusrpc.StartOperation(s.Context(), nexusClient, op, tv.Any().String(), nexus.StartOperationOptions{
+		Header: requestHeaders,
+	})
+	s.NoError(err)
+	s.NoError(<-pollerErrCh)
+	s.requireExportedServerSpan(exporter, requestHeaders, "DispatchNexusTaskByNamespaceAndTaskQueue", "io.temporal.frontend")
+}
 
-		requestHeaders := nexus.Header{
-			"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+func (s *NexusOTELSuite) requireExportedNexusHTTPSpanPairs(
+	callerExporter *tracetest.InMemoryExporter,
+	handlerExporter *tracetest.InMemoryExporter,
+	expected int,
+) {
+	s.Await(func(s *NexusOTELSuite) {
+		pairs := 0
+		for _, serverSpan := range handlerExporter.GetSpans() {
+			if serverSpan.Name != "DispatchNexusTaskByEndpoint" ||
+				serverSpan.SpanKind != oteltrace.SpanKindServer ||
+				spanServiceName(serverSpan) != "io.temporal.frontend" {
+				continue
+			}
+			for _, clientSpan := range callerExporter.GetSpans() {
+				if clientSpan.SpanKind == oteltrace.SpanKindClient &&
+					spanServiceName(clientSpan) == "io.temporal.history" &&
+					clientSpan.SpanContext.TraceID() == serverSpan.SpanContext.TraceID() &&
+					clientSpan.SpanContext.SpanID() == serverSpan.Parent.SpanID() {
+					pairs++
+				}
+			}
 		}
 		_, err = nexusrpc.StartOperation(s.Context(), client, op, tv.Any().String(), nexus.StartOperationOptions{
 			Header: requestHeaders,
@@ -363,6 +394,17 @@ func (s *NexusOTELSuite) requireSpanServiceName(span tracetest.SpanStub, expecte
 	serviceName, ok := span.Resource.Set().Value(semconv.ServiceNameKey)
 	s.Require().True(ok)
 	s.Require().Equal(expected, serviceName.AsString())
+}
+
+func spanServiceName(span tracetest.SpanStub) string {
+	if span.Resource == nil {
+		return ""
+	}
+	serviceName, ok := span.Resource.Set().Value(semconv.ServiceNameKey)
+	if !ok {
+		return ""
+	}
+	return serviceName.AsString()
 }
 
 func (s *NexusOTELSuite) requireTraceContext(headers headerGetter) (oteltrace.TraceID, oteltrace.SpanID) {

--- a/tests/nexus_otel_test.go
+++ b/tests/nexus_otel_test.go
@@ -214,6 +214,8 @@ func (s *NexusOTELSuite) TestOperation() {
 		Reason:      tv.Any().String(),
 	})
 	s.NoError(err)
+
+	operationURLPath := "/nexus/endpoints/" + handlerWorkerEndpoint.Id + "/services/" + service.Name + "/" + operation.Name()
 	s.requireNexusHTTPSpans(exporter, oteltrace.SpanContext{}, []nexusHTTPSpan{
 		{
 			TraceID:     1,

--- a/tests/nexus_otel_test.go
+++ b/tests/nexus_otel_test.go
@@ -234,7 +234,7 @@ func (s *NexusOTELSuite) TestNamespaceAndTaskQueueDispatch() {
 	requestHeaders := nexus.Header{
 		"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
 	}
-	_, err = nexusrpc.StartOperation(s.Context(), nexusClient, op, tv.Any().String(), nexus.StartOperationOptions{
+	_, err = nexusrpc.StartOperation(s.Context(), nexusClient, op, env.Tv().Any().String(), nexus.StartOperationOptions{
 		Header: requestHeaders,
 	})
 	s.NoError(err)

--- a/tests/nexus_test_base.go
+++ b/tests/nexus_test_base.go
@@ -103,6 +103,14 @@ func (env *NexusTestEnv) dispatchByEndpointURL(endpoint string) string {
 	return "http://" + env.HttpAPIAddress() + "/" + cnexus.RouteDispatchNexusTaskByEndpoint.Path(endpoint)
 }
 
+func (env *NexusTestEnv) dispatchByNsAndTqURL(namespace string, taskQueue string) string {
+	return "http://" + env.HttpAPIAddress() + "/" + cnexus.RouteDispatchNexusTaskByNamespaceAndTaskQueue.
+		Path(cnexus.NamespaceAndTaskQueue{
+			Namespace: namespace,
+			TaskQueue: taskQueue,
+		})
+}
+
 // nexusTaskResponse represents a successful response from a nexus task handler.
 // A nil response indicates no response should be sent (e.g., handler timed out).
 type nexusTaskResponse struct {

--- a/tests/nexus_test_base.go
+++ b/tests/nexus_test_base.go
@@ -103,7 +103,11 @@ func (env *NexusTestEnv) dispatchByEndpointURL(endpoint string) string {
 	return "http://" + env.HttpAPIAddress() + "/" + cnexus.RouteDispatchNexusTaskByEndpoint.Path(endpoint)
 }
 
-func (env *NexusTestEnv) dispatchByNsAndTqURL(namespace string, taskQueue string) string {
+func (env *NexusTestEnv) dispatchByTaskQueueURL(taskQueue string) string {
+	return env.dispatchByNamespaceAndTaskQueueURL(env.Namespace().String(), taskQueue)
+}
+
+func (env *NexusTestEnv) dispatchByNamespaceAndTaskQueueURL(namespace string, taskQueue string) string {
 	return "http://" + env.HttpAPIAddress() + "/" + cnexus.RouteDispatchNexusTaskByNamespaceAndTaskQueue.
 		Path(cnexus.NamespaceAndTaskQueue{
 			Namespace: namespace,


### PR DESCRIPTION
## What changed?
Wrapped the frontend Nexus dispatch routes with the shared OpenTelemetry HTTP handler.

## Why?
Nexus HTTP requests need an inbound server span to connect the caller trace.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
