### PR TITLE
Make supported callback kinds configurable

### DIFF
--- a/chasm/lib/activity/config.go
+++ b/chasm/lib/activity/config.go
@@ -3,6 +3,7 @@ package activity
 import (
 	"go.temporal.io/server/chasm/lib/callback"
 	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/callbacks"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/retrypolicy"
 )
@@ -40,6 +41,14 @@ var (
 		`Allows attaching completion callbacks to standalone activity executions.`,
 	)
 
+	EnabledCallbackKinds = dynamicconfig.NewNamespaceTypedSettingWithConverter(
+		"activity.enabledCallbackKinds",
+		callbacks.ConvertEnabledKinds,
+		[]callbacks.Kind{callbacks.KindNexus},
+		`The list of completion callback kinds that may be attached to a standalone activity execution.
+Only consulted when activity.enableCallbacks is set.`,
+	)
+
 	EnableStandaloneActivityOperatorCommands = dynamicconfig.NewNamespaceBoolSetting(
 		"history.enableStandaloneActivityOperatorCommands",
 		false,
@@ -52,6 +61,7 @@ type Config struct {
 	BlobSizeLimitWarn                         dynamicconfig.IntPropertyFnWithNamespaceFilter
 	BreakdownMetricsByTaskQueue               dynamicconfig.TypedPropertyFnWithTaskQueueFilter[bool]
 	EnableCallbacks                           dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	EnabledCallbackKinds                      dynamicconfig.TypedPropertyFnWithNamespaceFilter[[]callbacks.Kind]
 	Enabled                                   dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	EnableStandaloneActivityOperatorCommands  dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	LongPollBuffer                            dynamicconfig.DurationPropertyFnWithNamespaceFilter
@@ -73,6 +83,7 @@ func ConfigProvider(dc *dynamicconfig.Collection) *Config {
 		BreakdownMetricsByTaskQueue:               dynamicconfig.MetricsBreakdownByTaskQueue.Get(dc),
 		DefaultActivityRetryPolicy:                dynamicconfig.DefaultActivityRetryPolicy.Get(dc),
 		EnableCallbacks:                           EnableCallbacks.Get(dc),
+		EnabledCallbackKinds:                      EnabledCallbackKinds.Get(dc),
 		Enabled:                                   Enabled.Get(dc),
 		EnableStandaloneActivityOperatorCommands:  EnableStandaloneActivityOperatorCommands.Get(dc),
 		LongPollBuffer:                            LongPollBuffer.Get(dc),

--- a/chasm/lib/activity/frontend.go
+++ b/chasm/lib/activity/frontend.go
@@ -418,7 +418,10 @@ func (h *frontendHandler) validateAndPopulateStartRequest(
 		if !h.config.EnableCallbacks(req.GetNamespace()) {
 			return nil, serviceerror.NewInvalidArgument("completion callbacks are not enabled for this namespace")
 		}
-		if err := h.callbackValidator.Validate(ctx, req.GetNamespace(), cbs); err != nil {
+		opts := callbacks.ValidatorOptions{
+			EnabledKinds: h.config.EnabledCallbackKinds(req.GetNamespace()),
+		}
+		if err := h.callbackValidator.Validate(ctx, req.GetNamespace(), cbs, opts); err != nil {
 			return nil, err
 		}
 	}

--- a/chasm/lib/activity/validator_test.go
+++ b/chasm/lib/activity/validator_test.go
@@ -2,7 +2,6 @@ package activity
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 	"time"
 
@@ -22,6 +21,7 @@ import (
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/retrypolicy"
+	test "go.temporal.io/server/common/testing"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
@@ -534,18 +534,7 @@ func TestRequestIDGeneratedWhenMissing(t *testing.T) {
 // the request's own links and those embedded in its completion callbacks reach the link
 // validator. Link shape and limit semantics are covered in common/links.
 func TestValidateAndPopulateStartRequest_CombinesRequestAndCallbackLinks(t *testing.T) {
-	callbackValidator, err := callbacks.NewValidator(callbacks.ValidatorConfig{
-		MaxCallbacksPerExecution: func(string) int { return 2000 },
-		URLMaxLength:             func(string) int { return 1000 },
-		HeaderMaxSize:            func(string) int { return 2000 },
-		EndpointRules: func(string) callbacks.AddressMatchRules {
-			return callbacks.AddressMatchRules{
-				Rules: []callbacks.AddressMatchRule{
-					{Regexp: regexp.MustCompile(`.*`), AllowInsecure: true},
-				},
-			}
-		},
-	})
+	callbackValidator, err := callbacks.NewValidator(test.NewCallbacksValidatorConfig())
 	require.NoError(t, err)
 
 	h := &frontendHandler{
@@ -554,6 +543,9 @@ func TestValidateAndPopulateStartRequest_CombinesRequestAndCallbackLinks(t *test
 			BlobSizeLimitWarn:          defaultBlobSizeLimitWarn,
 			DefaultActivityRetryPolicy: getDefaultRetrySettings,
 			EnableCallbacks:            func(string) bool { return true },
+			EnabledCallbackKinds: func(string) []callbacks.Kind {
+				return []callbacks.Kind{callbacks.KindNexus}
+			},
 			MaxIDLengthLimit:           func() int { return defaultMaxIDLengthLimit },
 			MaxUserMetadataDetailsSize: defaultMaxUserMetadataDetailsSize,
 			MaxUserMetadataSummarySize: defaultMaxUserMetadataSummarySize,
@@ -580,8 +572,10 @@ func TestValidateAndPopulateStartRequest_CombinesRequestAndCallbackLinks(t *test
 			},
 		}},
 		CompletionCallbacks: []*commonpb.Callback{{
-			Variant: &commonpb.Callback_Internal_{
-				Internal: &commonpb.Callback_Internal{},
+			Variant: &commonpb.Callback_Nexus_{
+				Nexus: &commonpb.Callback_Nexus{
+					Url: "http://localhost/cb",
+				},
 			},
 			Links: []*commonpb.Link{{
 				Variant: &commonpb.Link_BatchJob_{

--- a/chasm/lib/callback/config.go
+++ b/chasm/lib/callback/config.go
@@ -14,6 +14,18 @@ var MaxPerExecution = dynamicconfig.NewNamespaceIntSetting(
 	`MaxPerExecution is the maximum number of callbacks that can be attached to an execution (workflow or standalone activity).`,
 )
 
+// TODO(chrsmith): This just caps the size of an individual source context payload.
+// We also need to wire through an aggregate max size, for all callbacks in an execution.
+// (We expect that users will want fewer NexusHandler callbacks with larger payloads than the
+// full 2k execution callbacks, with a much smaller per-callback payload size.)
+
+var NexusHandlerSourceContextMaxSize = dynamicconfig.NewNamespaceIntSetting(
+	"callback.nexusHandler.sourceContext.maxSize",
+	1024*1024,
+	`The maximum allowed size, in bytes, of the opaque source context attached to a single NexusHandler
+completion callback. The server carries this payload to the callback's handler untouched.`,
+)
+
 var RequestTimeout = dynamicconfig.NewDestinationDurationSetting(
 	"callback.request.timeout",
 	time.Second*10,

--- a/chasm/lib/workflow/config.go
+++ b/chasm/lib/workflow/config.go
@@ -1,8 +1,16 @@
 package workflow
 
 import (
+	commoncallbacks "go.temporal.io/server/common/callbacks"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/retrypolicy"
+)
+
+var EnabledCallbackKinds = dynamicconfig.NewNamespaceTypedSettingWithConverter(
+	"workflow.enabledCallbackKinds",
+	commoncallbacks.ConvertEnabledKinds,
+	[]commoncallbacks.Kind{commoncallbacks.KindNexus},
+	`The list of completion callback kinds that may be attached to a workflow execution.`,
 )
 
 type Config struct {

--- a/common/callbacks/kind.go
+++ b/common/callbacks/kind.go
@@ -1,0 +1,77 @@
+package callbacks
+
+import (
+	"fmt"
+	"slices"
+
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/server/common/dynamicconfig"
+)
+
+// Kind identifies a callback variant.
+type Kind string
+
+const (
+	// KindUnknown is the kind of a callback with an unset or unrecognized variant.
+	KindUnknown      Kind = "unknown"
+	KindNexus        Kind = "nexus"
+	KindNexusHandler Kind = "nexusHandler"
+)
+
+func (k Kind) String() string {
+	switch k {
+	case KindUnknown, KindNexus, KindNexusHandler:
+		return string(k)
+	default:
+		return string(KindUnknown)
+	}
+}
+
+// KindOf reports which [Kind] the given callback is.
+func KindOf(cb *commonpb.Callback) Kind {
+	switch cb.GetVariant().(type) {
+	case *commonpb.Callback_Nexus_:
+		return KindNexus
+	case *commonpb.Callback_NexusHandler_:
+		return KindNexusHandler
+	case *commonpb.Callback_Internal_:
+		// Internal-variant callbacks are not used and should be removed entirely.
+		return KindUnknown
+	default:
+		return KindUnknown
+	}
+}
+
+// ConvertEnabledKinds converts a dynamic config value, a list of kind names into a []Kind.
+//
+// Returns an error and use the default config value if any callback kinds are unrecognized.
+// An empty list not specifying any callback kinds is allowed.
+func ConvertEnabledKinds(val any) ([]Kind, error) {
+	names, err := dynamicconfig.ConvertStructure[[]string](nil)(val)
+	if err != nil {
+		return nil, err
+	}
+
+	enabledKinds := make([]Kind, 0, 2)
+	configurableKinds := map[string]Kind{
+		KindNexus.String():        KindNexus,
+		KindNexusHandler.String(): KindNexusHandler,
+	}
+	var unknownNames []string
+	for _, name := range names {
+		kind, ok := configurableKinds[name]
+		if !ok {
+			unknownNames = append(unknownNames, name)
+			continue
+		}
+		if !slices.Contains(enabledKinds, kind) {
+			enabledKinds = append(enabledKinds, kind)
+		}
+	}
+	if len(unknownNames) > 0 {
+		return nil, fmt.Errorf(
+			"%v does not match a known callback kind [nexus, nexusHandler]",
+			unknownNames)
+	}
+	return enabledKinds, nil
+}

--- a/common/callbacks/kind_test.go
+++ b/common/callbacks/kind_test.go
@@ -1,0 +1,130 @@
+package callbacks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+)
+
+func TestKindOf(t *testing.T) {
+	for _, tc := range []struct {
+		callback *commonpb.Callback
+		want     Kind
+		wantName string
+	}{
+		{
+			callback: newNexusCallback(),
+			want:     KindNexus,
+			wantName: "nexus",
+		},
+		{
+			callback: newNexusHandlerCallback(),
+			want:     KindNexusHandler,
+			wantName: "nexusHandler",
+		},
+		{
+			// Internal-variant callbacks should be removed; treated as Unknown.
+			callback: &commonpb.Callback{
+				Variant: &commonpb.Callback_Internal_{
+					Internal: &commonpb.Callback_Internal{},
+				},
+			},
+			want:     KindUnknown,
+			wantName: "unknown",
+		},
+		{
+			callback: &commonpb.Callback{},
+			want:     KindUnknown,
+			wantName: "unknown",
+		},
+		{
+			callback: nil,
+			want:     KindUnknown,
+			wantName: "unknown",
+		},
+	} {
+		t.Run(tc.wantName, func(t *testing.T) {
+			require.Equal(t, tc.want, KindOf(tc.callback))
+			require.Equal(t, tc.wantName, tc.want.String())
+		})
+	}
+}
+
+func TestConvertEnabledKinds(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		val  any
+		want []Kind
+	}{
+		// Empty lists are supported. It means no callbacks are allowed on the execution.
+		{name: "Empty", val: []string{}, want: []Kind{}},
+		{name: "Nil", val: nil, want: []Kind{}},
+
+		{name: "NexusOnly", val: []string{"nexus"}, want: []Kind{KindNexus}},
+		{name: "NexusHandlerOnly", val: []string{"nexusHandler"}, want: []Kind{KindNexusHandler}},
+		{
+			name: "Both",
+			val:  []string{"nexus", "nexusHandler"},
+			want: []Kind{KindNexus, KindNexusHandler},
+		},
+		{
+			name: "OrderPreserved",
+			val:  []string{"nexusHandler", "nexus"},
+			want: []Kind{KindNexusHandler, KindNexus},
+		},
+		{
+			name: "DuplicatesDropped",
+			val:  []string{"nexus", "nexus"},
+			want: []Kind{KindNexus},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ConvertEnabledKinds(tc.val)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+
+	// Return an error for any unrecognized name, rejecting the whole value. So dynamic config
+	// parsing will log and fall back to the setting's default value.
+	for _, tc := range []struct {
+		name   string
+		val    any
+		errMsg string
+	}{
+		{name: "NotAList", val: 42, errMsg: "source data must be an array or slice"},
+		{
+			name:   "OnlyUnknownNames",
+			val:    []string{"carrier-pigeon"},
+			errMsg: `[carrier-pigeon] does not match a known callback kind`,
+		},
+		{
+			name:   "UnknownNameBesideKnownName",
+			val:    []string{"nexsus", "nexusHandler"},
+			errMsg: `[nexsus] does not match a known callback kind`,
+		},
+		{
+			// Internal callbacks are server-generated and cannot be enabled by an operator.
+			name:   "Internal",
+			val:    []string{"nexus", "internal"},
+			errMsg: `[internal] does not match a known callback kind`,
+		},
+		{
+			name:   "NotNormalizedOrTrimmed",
+			val:    []any{" Nexus", "NEXUSHANDLER", "   nexus", "nexusHandler "},
+			errMsg: "[ Nexus NEXUSHANDLER    nexus nexusHandler ] does not match a known callback kind",
+		},
+		{
+			name:   "AllUnknownNamesReported",
+			val:    []string{"nexsus", "wroker"},
+			errMsg: `[nexsus wroker] does not match a known callback kind`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ConvertEnabledKinds(tc.val)
+			require.ErrorContains(t, err, tc.errMsg)
+			require.Nil(t, got)
+		})
+	}
+}

--- a/common/callbacks/validator.go
+++ b/common/callbacks/validator.go
@@ -3,43 +3,67 @@ package callbacks
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/tqid"
 	"google.golang.org/grpc/status"
 )
 
+type ValidatorOptions struct {
+	// EnabledKinds are the callback kinds that may be attached to the execution being validated.
+	// A client-supplied callback of any other kind is rejected with an InvalidArgument error.
+	EnabledKinds []Kind
+}
+
 // Validator validates completion callbacks attached to executions (e.g. workflows and standalone activities).
 type Validator interface {
-	Validate(ctx context.Context, namespaceName string, cbs []*commonpb.Callback) error
+	// Validate rejects callbacks that are not enabled for the execution, or are malformed.
+	// Will mutate the supplied Callbacks to normalize. e.g. converting Nexus headers to lower-case.
+	Validate(ctx context.Context, namespaceName string, cbs []*commonpb.Callback, opts ValidatorOptions) error
 }
 
 // ValidatorConfig holds the limits a [Validator] enforces.
 type ValidatorConfig struct {
 	MaxCallbacksPerExecution dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxIDLengthLimit         dynamicconfig.IntPropertyFn // All ID types use the same global setting.
 
 	// Nexus-variant limits.
 	URLMaxLength  dynamicconfig.IntPropertyFnWithNamespaceFilter
 	HeaderMaxSize dynamicconfig.IntPropertyFnWithNamespaceFilter
 	EndpointRules dynamicconfig.TypedPropertyFnWithNamespaceFilter[AddressMatchRules]
+
+	// NexusHandler-variant limits.
+	MaxServiceNameLength             dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxOperationNameLength           dynamicconfig.IntPropertyFnWithNamespaceFilter
+	NexusHandlerSourceContextMaxSize dynamicconfig.IntPropertyFnWithNamespaceFilter
 }
 
 func (vc *ValidatorConfig) Validate() error {
 	var missingFields []string
-	if vc.MaxCallbacksPerExecution == nil {
-		missingFields = append(missingFields, "MaxCallbacksPerExecution")
+	assertGetterIsSet := func(name string, getter dynamicconfig.IntPropertyFnWithNamespaceFilter) {
+		if getter == nil {
+			missingFields = append(missingFields, name)
+		}
 	}
-	if vc.URLMaxLength == nil {
-		missingFields = append(missingFields, "URLMaxLength")
+
+	assertGetterIsSet("MaxCallbacksPerExecution", vc.MaxCallbacksPerExecution)
+	if vc.MaxIDLengthLimit == nil {
+		missingFields = append(missingFields, "MaxIDLengthLimit")
 	}
-	if vc.HeaderMaxSize == nil {
-		missingFields = append(missingFields, "HeaderMaxSize")
-	}
+
+	assertGetterIsSet("URLMaxLength", vc.URLMaxLength)
+	assertGetterIsSet("HeaderMaxSize", vc.HeaderMaxSize)
 	if vc.EndpointRules == nil {
 		missingFields = append(missingFields, "EndpointRules")
 	}
+
+	assertGetterIsSet("MaxServiceNameLength", vc.MaxServiceNameLength)
+	assertGetterIsSet("MaxOperationNameLength", vc.MaxOperationNameLength)
+	assertGetterIsSet("NexusHandlerSourceContextMaxSize", vc.NexusHandlerSourceContextMaxSize)
 
 	if len(missingFields) != 0 {
 		return fmt.Errorf("missing required fields: %v", missingFields)
@@ -59,9 +83,14 @@ func NewValidator(config ValidatorConfig) (Validator, error) {
 	return &validator{config: config}, nil
 }
 
-// Validate validates completion callbacks: count, URL length, endpoint allowlist, header size, and normalizes header
-// keys to lowercase.
-func (v *validator) Validate(_ context.Context, namespaceName string, cbs []*commonpb.Callback) error {
+// Validate validates completion callbacks: their kind, their count, and the fields of each variant.
+// Nexus header keys are normalized to lowercase in place.
+func (v *validator) Validate(
+	_ context.Context,
+	namespaceName string,
+	cbs []*commonpb.Callback,
+	opts ValidatorOptions,
+) error {
 	if len(cbs) > v.config.MaxCallbacksPerExecution(namespaceName) {
 		return serviceerror.NewInvalidArgumentf(
 			"cannot attach more than %d callbacks to an execution", v.config.MaxCallbacksPerExecution(namespaceName),
@@ -69,45 +98,98 @@ func (v *validator) Validate(_ context.Context, namespaceName string, cbs []*com
 	}
 
 	for _, cb := range cbs {
-		switch variant := cb.GetVariant().(type) {
-		case *commonpb.Callback_Nexus_:
-			rawURL := variant.Nexus.GetUrl()
-			if len(rawURL) > v.config.URLMaxLength(namespaceName) {
-				return serviceerror.NewInvalidArgumentf(
-					"invalid url: url length longer than max length allowed of %d", v.config.URLMaxLength(namespaceName),
-				)
-			}
-			if err := v.config.EndpointRules(namespaceName).Validate(rawURL); err != nil {
-				if s, ok := status.FromError(err); ok {
-					return serviceerror.NewInvalidArgument(s.Message())
-				}
-				return serviceerror.NewInvalidArgument(err.Error())
-			}
-
-			headerSize := 0
-			lowerCaseHeaders := make(map[string]string, len(variant.Nexus.GetHeader()))
-			for k, val := range variant.Nexus.GetHeader() {
-				headerSize += len(k) + len(val)
-				lowerCaseHeaders[strings.ToLower(k)] = val
-			}
-			if headerSize > v.config.HeaderMaxSize(namespaceName) {
-				return serviceerror.NewInvalidArgumentf(
-					"invalid header: header size longer than max allowed size of %d", v.config.HeaderMaxSize(namespaceName),
-				)
-			}
-			variant.Nexus.Header = lowerCaseHeaders
-		case *commonpb.Callback_NexusHandler_:
-			// NexusHandler callbacks aren't supported anywhere. Later, we will refactor this validator
-			// to make which callback kinds are supported configurable.
-			return serviceerror.NewInvalidArgument("nexusHandler callbacks are not enabled for this execution type")
-		case *commonpb.Callback_Internal_:
-			// Internal callbacks are server-generated, so there is nothing to validate.
-			// CHASM has no Internal variant, so FromAPICallback rejects them with
-			// InvalidArgument when the execution is backed by CHASM.
-			continue
-		default:
-			return serviceerror.NewUnimplemented(fmt.Sprintf("unknown callback variant: %T", variant))
+		if err := v.validateCallback(cb, namespaceName, opts); err != nil {
+			return err
 		}
 	}
+	return nil
+}
+
+func (v *validator) validateCallback(cb *commonpb.Callback, namespaceName string, opts ValidatorOptions) error {
+	kind := KindOf(cb)
+
+	// For unknown callbacks, prefer the "unknown callback variant" error below.
+	if kind != KindUnknown && !slices.Contains(opts.EnabledKinds, kind) {
+		return serviceerror.NewInvalidArgumentf("%s callbacks are not enabled for this execution type", kind)
+	}
+
+	switch kind {
+	case KindNexus:
+		return v.validateNexus(namespaceName, cb.GetNexus())
+	case KindNexusHandler:
+		return v.validateNexusHandler(namespaceName, cb.GetNexusHandler())
+	case KindUnknown:
+		fallthrough
+	default:
+		return serviceerror.NewUnimplementedf("unknown callback variant: %T", cb.GetVariant())
+	}
+}
+
+func (v *validator) validateNexus(namespaceName string, cb *commonpb.Callback_Nexus) error {
+	rawURL := cb.GetUrl()
+	if len(rawURL) > v.config.URLMaxLength(namespaceName) {
+		return serviceerror.NewInvalidArgumentf(
+			"invalid url: url length longer than max length allowed of %d",
+			v.config.URLMaxLength(namespaceName),
+		)
+	}
+	if err := v.config.EndpointRules(namespaceName).Validate(rawURL); err != nil {
+		msg := err.Error()
+		if s, ok := status.FromError(err); ok {
+			msg = s.Message()
+		}
+		return serviceerror.NewInvalidArgument(msg)
+	}
+
+	// Validate total size of all headers, as well as normalize to lowercase.
+	headerSize := 0
+	lowerCaseHeaders := make(map[string]string, len(cb.GetHeader()))
+	for k, val := range cb.GetHeader() {
+		headerSize += len(k) + len(val)
+		lowerCaseHeaders[strings.ToLower(k)] = val
+	}
+	if headerSize > v.config.HeaderMaxSize(namespaceName) {
+		return serviceerror.NewInvalidArgumentf(
+			"invalid header: header size longer than max allowed size of %d",
+			v.config.HeaderMaxSize(namespaceName),
+		)
+	}
+	cb.Header = lowerCaseHeaders
+	return nil
+}
+
+func (v *validator) validateNexusHandler(namespaceName string, cb *commonpb.Callback_NexusHandler) error {
+	// Task Queue
+	if err := tqid.Validate(cb.GetTaskQueueName(), v.config.MaxIDLengthLimit()); err != nil {
+		return err
+	}
+
+	// Nexus handler
+	for _, field := range []struct {
+		name      string
+		value     string
+		maxLength int
+	}{
+		{"service", cb.GetService(), v.config.MaxServiceNameLength(namespaceName)},
+		{"operation", cb.GetOperation(), v.config.MaxOperationNameLength(namespaceName)},
+	} {
+		if field.value == "" {
+			return serviceerror.NewInvalidArgumentf("%s is required", field.name)
+		}
+		if len(field.value) > field.maxLength {
+			return serviceerror.NewInvalidArgumentf(
+				"%s exceeds length limit. Length=%d Limit=%d",
+				field.name, len(field.value), field.maxLength)
+		}
+	}
+
+	// Source Context blob
+	maxSize := v.config.NexusHandlerSourceContextMaxSize(namespaceName)
+	if size := cb.GetSourceContext().Size(); size > maxSize {
+		return serviceerror.NewInvalidArgumentf(
+			"source_context exceeds size limit. Length=%d Limit=%d",
+			size, v.config.NexusHandlerSourceContextMaxSize(namespaceName))
+	}
+
 	return nil
 }

--- a/common/callbacks/validator_test.go
+++ b/common/callbacks/validator_test.go
@@ -5,12 +5,58 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
 )
+
+func newNexusCallback() *commonpb.Callback {
+	return &commonpb.Callback{
+		Variant: &commonpb.Callback_Nexus_{
+			Nexus: &commonpb.Callback_Nexus{
+				Url: "https://nexus.ex.xxxxx.cluster.tmprl.cloud:7243/Namespaces/ex.xxxxx/nexus/callback",
+				Header: map[string]string{
+					"Nexus-Operation-State": "succeeded",
+					"Content-Type":          "application/json",
+				},
+			},
+		},
+	}
+}
+
+func newNexusHandlerCallback() *commonpb.Callback {
+	return &commonpb.Callback{
+		Variant: &commonpb.Callback_NexusHandler_{
+			NexusHandler: &commonpb.Callback_NexusHandler{
+				TaskQueueName: "wc-queue",
+				Service:       "CompletionService",
+				Operation:     "DeliverAsWebhook",
+				SourceContext: &commonpb.Payload{Data: []byte("data")},
+			},
+		},
+	}
+}
+
+func newValidatorConfig() ValidatorConfig {
+	allowAllAddresses := AddressMatchRules{
+		Rules: []AddressMatchRule{
+			{Regexp: regexp.MustCompile(`.*`), AllowInsecure: true},
+		},
+	}
+	return ValidatorConfig{
+		MaxCallbacksPerExecution:         func(string) int { return 10 },
+		MaxIDLengthLimit:                 func() int { return 10 },
+		URLMaxLength:                     func(string) int { return 1000 },
+		HeaderMaxSize:                    func(string) int { return 4096 },
+		EndpointRules:                    func(string) AddressMatchRules { return allowAllAddresses },
+		MaxServiceNameLength:             func(string) int { return 40 },
+		MaxOperationNameLength:           func(string) int { return 40 },
+		NexusHandlerSourceContextMaxSize: func(string) int { return 1000 },
+	}
+}
 
 func mustNewValidator(t *testing.T, cfg ValidatorConfig) Validator {
 	t.Helper()
@@ -20,10 +66,9 @@ func mustNewValidator(t *testing.T, cfg ValidatorConfig) Validator {
 }
 
 func TestValidatorConfigValidate(t *testing.T) {
-	cfg := ValidatorConfig{
-		MaxCallbacksPerExecution: func(string) int { return 10 },
-		HeaderMaxSize:            func(string) int { return 4096 },
-	}
+	cfg := newValidatorConfig()
+	cfg.URLMaxLength = nil
+	cfg.EndpointRules = nil
 
 	_, err := NewValidator(cfg)
 	require.EqualError(t, err, "missing required fields: [URLMaxLength EndpointRules]")
@@ -45,99 +90,108 @@ func TestValidatorConfigValidateNamesEveryField(t *testing.T) {
 func TestValidateCallbacks(t *testing.T) {
 	ctx := context.Background()
 
-	allowAllAddresses := AddressMatchRules{
-		Rules: []AddressMatchRule{
-			{Regexp: regexp.MustCompile(`.*`), AllowInsecure: true},
-		},
+	opts := ValidatorOptions{
+		EnabledKinds: []Kind{KindNexus, KindNexusHandler},
 	}
-	getStandardConfig := func() ValidatorConfig {
-		return ValidatorConfig{
-			MaxCallbacksPerExecution: func(string) int { return 10 },
-			URLMaxLength:             func(string) int { return 1000 },
-			HeaderMaxSize:            func(string) int { return 4096 },
-			EndpointRules:            func(string) AddressMatchRules { return allowAllAddresses },
-		}
-	}
-	v := mustNewValidator(t, getStandardConfig())
+	v := mustNewValidator(t, newValidatorConfig())
+
+	t.Run("EmptyCallbacksNoError", func(t *testing.T) {
+		err := v.Validate(ctx, "ns", nil, opts)
+		require.NoError(t, err)
+	})
 
 	t.Run("ValidNexusCallback", func(t *testing.T) {
 		cbs := []*commonpb.Callback{
-			{Variant: &commonpb.Callback_Nexus_{
-				Nexus: &commonpb.Callback_Nexus{
-					Url:    "http://localhost:8080/callback",
-					Header: map[string]string{"Content-Type": "application/json"},
-				},
-			}},
+			newNexusCallback(),
 		}
 
-		err := v.Validate(ctx, "ns", cbs)
+		err := v.Validate(ctx, "ns", cbs, opts)
 		require.NoError(t, err)
+	})
+
+	t.Run("ValidNexusHandlerCallback", func(t *testing.T) {
+		cbs := []*commonpb.Callback{
+			newNexusHandlerCallback(),
+		}
+		require.NoError(t, v.Validate(ctx, "ns", cbs, opts))
+	})
+
+	t.Run("InternalCallbacksFail", func(t *testing.T) {
+		cbs := []*commonpb.Callback{
+			{
+				Variant: &commonpb.Callback_Internal_{
+					Internal: &commonpb.Callback_Internal{},
+				},
+			},
+		}
+
+		err := v.Validate(ctx, "ns", cbs, opts)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "unknown callback variant")
 	})
 
 	t.Run("TooManyCallbacks", func(t *testing.T) {
 		cbs := []*commonpb.Callback{
-			{Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: "http://localhost/cb1"}}},
-			{Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: "http://localhost/cb2"}}},
+			newNexusCallback(),
+			newNexusCallback(),
 		}
 
-		cfg := getStandardConfig()
+		cfg := newValidatorConfig()
 		cfg.MaxCallbacksPerExecution = func(string) int { return 1 }
 		v := mustNewValidator(t, cfg)
 
-		err := v.Validate(ctx, "ns", cbs)
+		err := v.Validate(ctx, "ns", cbs, opts)
 		var invalidArgErr *serviceerror.InvalidArgument
 		require.ErrorAs(t, err, &invalidArgErr)
-		require.Contains(t, err.Error(), "cannot attach more than 1 callbacks")
+		require.ErrorContains(t, err, "cannot attach more than 1 callbacks")
 	})
 
 	t.Run("URLTooLong", func(t *testing.T) {
+		nexusCb := newNexusCallback()
+		nexusCb.GetNexus().Url = "http://localhost/" + string(make([]byte, 51))
 		cbs := []*commonpb.Callback{
-			{Variant: &commonpb.Callback_Nexus_{
-				Nexus: &commonpb.Callback_Nexus{
-					Url: "http://localhost/" + string(make([]byte, 51)),
-				},
-			}},
+			newNexusCallback(),
+			nexusCb,
 		}
 
-		cfg := getStandardConfig()
+		cfg := newValidatorConfig()
 		cfg.URLMaxLength = func(string) int { return 50 }
 		v := mustNewValidator(t, cfg)
 
-		err := v.Validate(ctx, "ns", cbs)
+		err := v.Validate(ctx, "ns", cbs, opts)
 		var invalidArgErr *serviceerror.InvalidArgument
 		require.ErrorAs(t, err, &invalidArgErr)
-		require.Contains(t, err.Error(), "url length longer than max length allowed")
+		require.ErrorContains(t, err, "invalid url: url length longer than max length allowed of 50")
 	})
 
 	t.Run("HeaderTooLarge", func(t *testing.T) {
+		nexusCb := newNexusCallback()
+		nexusCb.GetNexus().Header = map[string]string{"X-Large": string(make([]byte, 5000))}
 		cbs := []*commonpb.Callback{
-			{Variant: &commonpb.Callback_Nexus_{
-				Nexus: &commonpb.Callback_Nexus{
-					Url:    "http://localhost:8080/callback",
-					Header: map[string]string{"X-Large": string(make([]byte, 5000))},
-				},
-			}},
+			nexusCb,
 		}
 
-		err := v.Validate(ctx, "ns", cbs)
+		err := v.Validate(ctx, "ns", cbs, opts)
 		var invalidArgErr *serviceerror.InvalidArgument
 		require.ErrorAs(t, err, &invalidArgErr)
-		require.Contains(t, err.Error(), "header size longer than max allowed size")
+		require.ErrorContains(t, err, "invalid header: header size longer than max allowed size of 4096")
 	})
 
 	t.Run("HeaderKeysNormalizedToLowercase", func(t *testing.T) {
+		nexusCb := newNexusCallback()
+		nexusCb.GetNexus().Header = map[string]string{
+			"Content-Type": "application/json",
+			"X-Custom":     "value",
+		}
 		cbs := []*commonpb.Callback{
-			{Variant: &commonpb.Callback_Nexus_{
-				Nexus: &commonpb.Callback_Nexus{
-					Url:    "http://localhost:8080/callback",
-					Header: map[string]string{"Content-Type": "application/json", "X-Custom": "value"},
-				},
-			}},
+			nexusCb,
 		}
 
-		err := v.Validate(ctx, "ns", cbs)
+		err := v.Validate(ctx, "ns", cbs, opts)
 		require.NoError(t, err)
-		nexus := cbs[0].GetNexus()
+
+		// Mutation is in-place.
+		nexus := nexusCb.GetNexus()
 		require.Equal(t, "application/json", nexus.Header["content-type"])
 		require.Equal(t, "value", nexus.Header["x-custom"])
 		_, hasMixed := nexus.Header["Content-Type"]
@@ -146,65 +200,158 @@ func TestValidateCallbacks(t *testing.T) {
 
 	t.Run("URLNotInAllowlist", func(t *testing.T) {
 		cbs := []*commonpb.Callback{
-			{Variant: &commonpb.Callback_Nexus_{
-				Nexus: &commonpb.Callback_Nexus{
-					Url: "http://localhost:8080/callback",
-				},
-			}},
+			newNexusCallback(),
 		}
 
-		cfg := getStandardConfig()
-		cfg.EndpointRules = func(string) AddressMatchRules { return AddressMatchRules{} }
+		cfg := newValidatorConfig()
+		cfg.EndpointRules = func(string) AddressMatchRules {
+			// No rules in the allow list.
+			return AddressMatchRules{}
+		}
 		v := mustNewValidator(t, cfg)
 
-		err := v.Validate(ctx, "ns", cbs)
+		err := v.Validate(ctx, "ns", cbs, opts)
 		var invalidArgErr *serviceerror.InvalidArgument
 		require.ErrorAs(t, err, &invalidArgErr)
-		require.Contains(t, err.Error(), "does not match any configured callback address")
+		require.ErrorContains(t, err, "does not match any configured callback address")
 	})
 
 	t.Run("UnsupportedVariant", func(t *testing.T) {
 		cbs := []*commonpb.Callback{
-			{Variant: nil},
+			{
+				Variant: nil,
+			},
 		}
 
-		err := v.Validate(ctx, "ns", cbs)
+		err := v.Validate(ctx, "ns", cbs, opts)
 		var unimplementedErr *serviceerror.Unimplemented
 		require.ErrorAs(t, err, &unimplementedErr)
 		require.Contains(t, err.Error(), "unknown callback variant")
 	})
+}
 
-	// Confirm that NexusHandler-variant callbacks are rejected by the callback.Validator,
-	// preventing them from being accepted.
-	t.Run("NexusHandlerVariantNotSupported", func(t *testing.T) {
-		cbs := []*commonpb.Callback{
-			{Variant: &commonpb.Callback_NexusHandler_{
-				NexusHandler: &commonpb.Callback_NexusHandler{
-					TaskQueueName: "completions-task-queue",
-					Service:       "HTTPAdapter",
-					Operation:     "DeliverAsWebhook",
-				},
-			}},
-		}
-		err := v.Validate(context.Background(), "ns", cbs)
-		var argError *serviceerror.InvalidArgument
-		require.ErrorAs(t, err, &argError)
+func TestValidateNexusHandlerCallback(t *testing.T) {
+	ctx := context.Background()
+
+	cfg := newValidatorConfig()
+	v := mustNewValidator(t, cfg)
+	opts := ValidatorOptions{
+		EnabledKinds: []Kind{KindNexus, KindNexusHandler},
+	}
+
+	for _, tc := range []struct {
+		name   string
+		mutate func(*commonpb.Callback_NexusHandler)
+		errMsg string
+	}{
+		{
+			name:   "task_queue is not set",
+			mutate: func(nh *commonpb.Callback_NexusHandler) { nh.TaskQueueName = "" },
+			errMsg: "taskQueue is not set",
+		},
+		{
+			name:   "task_queue length exceeds limit",
+			mutate: func(nh *commonpb.Callback_NexusHandler) { nh.TaskQueueName = strings.Repeat("x", 11) },
+			errMsg: "taskQueue length exceeds limit",
+		},
+		{
+			name:   "task_queue uses reserved prefix",
+			mutate: func(nh *commonpb.Callback_NexusHandler) { nh.TaskQueueName = "/_sys/tq" },
+			errMsg: "task queue name cannot start with reserved prefix /_sys/",
+		},
+		{
+			name:   "service is required",
+			mutate: func(nh *commonpb.Callback_NexusHandler) { nh.Service = "" },
+			errMsg: "service is required",
+		},
+		{
+			name:   "service length",
+			mutate: func(nh *commonpb.Callback_NexusHandler) { nh.Service = strings.Repeat("x", 41) },
+			errMsg: "service exceeds length limit",
+		},
+		{
+			name:   "operation is required",
+			mutate: func(nh *commonpb.Callback_NexusHandler) { nh.Operation = "" },
+			errMsg: "operation is required",
+		},
+		{
+			name:   "operation length",
+			mutate: func(nh *commonpb.Callback_NexusHandler) { nh.Operation = strings.Repeat("x", 41) },
+			errMsg: "operation exceeds length limit",
+		},
+		{
+			name: "source_context size",
+			mutate: func(nh *commonpb.Callback_NexusHandler) {
+				nh.SourceContext = &commonpb.Payload{Data: []byte(strings.Repeat("x", 1001))}
+			},
+			errMsg: "source_context exceeds size limit",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cb := newNexusHandlerCallback()
+			tc.mutate(cb.GetNexusHandler())
+
+			cbs := []*commonpb.Callback{
+				cb,
+			}
+
+			err := v.Validate(ctx, "ns", cbs, opts)
+			var invalidArgErr *serviceerror.InvalidArgument
+			require.ErrorAs(t, err, &invalidArgErr)
+			require.ErrorContains(t, err, tc.errMsg)
+		})
+	}
+}
+
+func TestValidateEnabledKinds(t *testing.T) {
+	ctx := context.Background()
+	v := mustNewValidator(t, newValidatorConfig())
+	nexusCb := newNexusCallback()
+	nexusHandlerCb := newNexusHandlerCallback()
+
+	allowAllKindsOpts := ValidatorOptions{
+		EnabledKinds: []Kind{KindNexus, KindNexusHandler},
+	}
+	nexusOnlyOpts := ValidatorOptions{
+		EnabledKinds: []Kind{KindNexus},
+	}
+
+	t.Run("NoCallbacks", func(t *testing.T) {
+		require.NoError(t, v.Validate(ctx, "ns", nil, nexusOnlyOpts))
+	})
+
+	t.Run("AllSupported", func(t *testing.T) {
+		require.NoError(t, v.Validate(ctx, "ns",
+			[]*commonpb.Callback{nexusCb, nexusHandlerCb},
+			allowAllKindsOpts,
+		))
+	})
+
+	t.Run("NoKindsEnabled", func(t *testing.T) {
+		// The zero value supports no client-supplied kinds at all.
+		err := v.Validate(ctx, "ns", []*commonpb.Callback{nexusCb}, ValidatorOptions{})
+		var invalidArgErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgErr)
+		require.ErrorContains(t, err, "nexus callbacks are not enabled for this execution type")
+	})
+
+	t.Run("DisabledKind", func(t *testing.T) {
+		err := v.Validate(ctx, "ns",
+			[]*commonpb.Callback{nexusCb, nexusHandlerCb},
+			ValidatorOptions{EnabledKinds: []Kind{KindNexus}},
+		)
+		var invalidArgErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgErr)
 		require.ErrorContains(t, err, "nexusHandler callbacks are not enabled for this execution type")
 	})
 
-	t.Run("EmptyCallbacksNoError", func(t *testing.T) {
-		err := v.Validate(ctx, "ns", nil)
-		require.NoError(t, err)
-	})
+	t.Run("CheckEnabledBeforeValidation", func(t *testing.T) {
+		invalidNexusHandlerCb := newNexusHandlerCallback()
+		invalidNexusHandlerCb.GetNexusHandler().TaskQueueName = ""
+		err := v.Validate(ctx, "ns", []*commonpb.Callback{invalidNexusHandlerCb}, nexusOnlyOpts)
 
-	t.Run("InternalCallbackSkipped", func(t *testing.T) {
-		cbs := []*commonpb.Callback{
-			{Variant: &commonpb.Callback_Internal_{
-				Internal: &commonpb.Callback_Internal{},
-			}},
-		}
-
-		err := v.Validate(ctx, "ns", cbs)
-		require.NoError(t, err)
+		var invalidArgErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgErr)
+		require.ErrorContains(t, err, "nexusHandler callbacks are not enabled for this execution type")
 	})
 }

--- a/common/links/validator.go
+++ b/common/links/validator.go
@@ -62,6 +62,29 @@ func validateFields(l *commonpb.Link) error {
 		if t.BatchJob.GetJobId() == "" {
 			return serviceerror.NewInvalidArgument("batch job link must not have an empty job ID")
 		}
+	case *commonpb.Link_Callback_:
+		if t.Callback.GetNamespace() == "" {
+			return serviceerror.NewInvalidArgument("callback link must have a namespace")
+		}
+		if t.Callback.GetExecution() == nil {
+			return serviceerror.NewInvalidArgument("callback link must have an execution")
+		}
+		exType := t.Callback.GetExecution().GetType()
+		if exType == enumspb.EXECUTION_TYPE_UNSPECIFIED {
+			return serviceerror.NewInvalidArgument("callback link execution must have a type")
+		}
+		if _, ok := enumspb.ExecutionType_name[int32(exType)]; !ok {
+			return serviceerror.NewInvalidArgument("callback link execution type is unknown")
+		}
+		if t.Callback.GetExecution().GetBusinessId() == "" {
+			return serviceerror.NewInvalidArgument("callback link execution must have a business ID")
+		}
+		if t.Callback.GetExecution().GetRunId() == "" {
+			return serviceerror.NewInvalidArgument("callback link execution must have a run ID")
+		}
+		if t.Callback.GetRequestId() == "" {
+			return serviceerror.NewInvalidArgument("callback link must have a request ID")
+		}
 	case *commonpb.Link_NexusOperation_:
 		if t.NexusOperation.GetNamespace() == "" {
 			return serviceerror.NewInvalidArgument("nexus operation link must not have an empty namespace field")

--- a/common/links/validator_test.go
+++ b/common/links/validator_test.go
@@ -35,6 +35,20 @@ func TestValidate(t *testing.T) {
 			BatchJob: &commonpb.Link_BatchJob{JobId: "job"},
 		},
 	}
+	validCallback := &commonpb.Link{
+		Variant: &commonpb.Link_Callback_{
+			Callback: &commonpb.Link_Callback{
+				Namespace: "ns",
+				Execution: &commonpb.Execution{
+					Type:       enumspb.EXECUTION_TYPE_NEXUS_OPERATION,
+					BusinessId: "op",
+					RunId:      "run",
+				},
+				ComponentPath: []string{"Update", "wf-update-id"},
+				RequestId:     "req",
+			},
+		},
+	}
 	validNexusOperation := &commonpb.Link{
 		Variant: &commonpb.Link_NexusOperation_{
 			NexusOperation: &commonpb.Link_NexusOperation{
@@ -67,10 +81,11 @@ func TestValidate(t *testing.T) {
 		err := links.Validate([]*commonpb.Link{
 			validWorkflowEvent,
 			validBatchJob,
+			validCallback,
 			validNexusOperation,
 			validActivity,
 			validWorkflow,
-		}, maxLinks+2, maxSize)
+		}, maxLinks+3, maxSize)
 		require.NoError(t, err)
 	})
 
@@ -118,6 +133,20 @@ func TestValidate(t *testing.T) {
 		l.GetBatchJob().JobId = ""
 		err := links.Validate([]*commonpb.Link{l}, maxLinks, maxSize)
 		require.ErrorContains(t, err, "batch job link must not have an empty job ID")
+	})
+
+	t.Run("Callback/EmptyExecution", func(t *testing.T) {
+		l := proto.Clone(validCallback).(*commonpb.Link)
+		l.GetCallback().Execution = nil
+		err := links.Validate([]*commonpb.Link{l}, maxLinks, maxSize)
+		require.ErrorContains(t, err, "callback link must have an execution")
+	})
+
+	t.Run("Callback/RequestID", func(t *testing.T) {
+		l := proto.Clone(validCallback).(*commonpb.Link)
+		l.GetCallback().RequestId = ""
+		err := links.Validate([]*commonpb.Link{l}, maxLinks, maxSize)
+		require.ErrorContains(t, err, "callback link must have a request ID")
 	})
 
 	t.Run("NexusOperation/EmptyNamespace", func(t *testing.T) {

--- a/common/testing/callbacks.go
+++ b/common/testing/callbacks.go
@@ -1,0 +1,28 @@
+package testing
+
+import (
+	"regexp"
+
+	"go.temporal.io/server/common/callbacks"
+)
+
+// NewCallbacksValidatorConfig returns a valid callbacks.ValidatorConfig that can be
+// used to create a new callbacks.Validator. Tests can override fields to set arbitrary
+// limits for aspects of the Validator to be tested.
+func NewCallbacksValidatorConfig() callbacks.ValidatorConfig {
+	allowAllAddresses := callbacks.AddressMatchRules{
+		Rules: []callbacks.AddressMatchRule{
+			{Regexp: regexp.MustCompile(`.*`), AllowInsecure: true},
+		},
+	}
+	return callbacks.ValidatorConfig{
+		MaxCallbacksPerExecution:         func(string) int { return 10 },
+		MaxIDLengthLimit:                 func() int { return 100 },
+		URLMaxLength:                     func(string) int { return 1000 },
+		HeaderMaxSize:                    func(string) int { return 4096 },
+		EndpointRules:                    func(string) callbacks.AddressMatchRules { return allowAllAddresses },
+		MaxServiceNameLength:             func(string) int { return 100 },
+		MaxOperationNameLength:           func(string) int { return 100 },
+		NexusHandlerSourceContextMaxSize: func(string) int { return 1000 },
+	}
+}

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -916,12 +916,17 @@ func OperatorHandlerProvider(
 // callbackValidatorProvider creates a callback Validator using the production dynamic config keys
 // so that existing operator configurations (callback.allowedAddresses) are honored.
 func callbackValidatorProvider(dc *dynamicconfig.Collection) (callbacks.Validator, error) {
-	return callbacks.NewValidator(callbacks.ValidatorConfig{
-		MaxCallbacksPerExecution: chasmcallback.MaxPerExecution.Get(dc),
-		URLMaxLength:             dynamicconfig.FrontendCallbackURLMaxLength.Get(dc),
-		HeaderMaxSize:            dynamicconfig.FrontendCallbackHeaderMaxSize.Get(dc),
-		EndpointRules:            chasmcallback.AllowedAddresses.Get(dc),
-	})
+	cfg := callbacks.ValidatorConfig{
+		MaxCallbacksPerExecution:         chasmcallback.MaxPerExecution.Get(dc),
+		MaxIDLengthLimit:                 dynamicconfig.MaxIDLengthLimit.Get(dc),
+		URLMaxLength:                     dynamicconfig.FrontendCallbackURLMaxLength.Get(dc),
+		HeaderMaxSize:                    dynamicconfig.FrontendCallbackHeaderMaxSize.Get(dc),
+		EndpointRules:                    chasmcallback.AllowedAddresses.Get(dc),
+		MaxServiceNameLength:             chasmnexus.MaxServiceNameLength.Get(dc),
+		MaxOperationNameLength:           chasmnexus.MaxOperationNameLength.Get(dc),
+		NexusHandlerSourceContextMaxSize: chasmcallback.NexusHandlerSourceContextMaxSize.Get(dc),
+	}
+	return callbacks.NewValidator(cfg)
 }
 
 func HandlerProvider(

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -13,6 +13,7 @@ import (
 	"go.temporal.io/server/chasm/lib/activity"
 	chasmcallback "go.temporal.io/server/chasm/lib/callback"
 	chasmnexus "go.temporal.io/server/chasm/lib/nexusoperation"
+	chasmworkflow "go.temporal.io/server/chasm/lib/workflow"
 	"go.temporal.io/server/common/callbacks"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
@@ -224,6 +225,9 @@ type Config struct {
 	MaxCallbacksPerWorkflow dynamicconfig.IntPropertyFnWithNamespaceFilter
 	CallbackEndpointConfigs dynamicconfig.TypedPropertyFnWithNamespaceFilter[callbacks.AddressMatchRules]
 
+	// The callback kinds a client may attach to a workflow execution.
+	WorkflowEnabledCallbackKinds dynamicconfig.TypedPropertyFnWithNamespaceFilter[[]callbacks.Kind]
+
 	MaxNexusOperationTokenLength   dynamicconfig.IntPropertyFnWithNamespaceFilter
 	NexusRequestHeadersBlacklist   dynamicconfig.TypedPropertyFn[*regexp.Regexp]
 	NexusForwardRequestUseEndpoint dynamicconfig.BoolPropertyFn
@@ -428,7 +432,9 @@ func NewConfig(
 		LinkMaxSize:        dynamicconfig.FrontendLinkMaxSize.Get(dc),
 		MaxLinksPerRequest: dynamicconfig.FrontendMaxLinksPerRequest.Get(dc),
 
-		CallbackEndpointConfigs:     chasmcallback.AllowedAddresses.Get(dc),
+		CallbackEndpointConfigs:      chasmcallback.AllowedAddresses.Get(dc),
+		WorkflowEnabledCallbackKinds: chasmworkflow.EnabledCallbackKinds.Get(dc),
+
 		AdminEnableListHistoryTasks: dynamicconfig.AdminEnableListHistoryTasks.Get(dc),
 
 		MaskInternalErrorDetails: dynamicconfig.FrontendMaskInternalErrorDetails.Get(dc),

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -690,7 +690,10 @@ func (wh *WorkflowHandler) prepareStartWorkflowRequest(
 	}
 
 	if cbs := request.GetCompletionCallbacks(); len(cbs) > 0 {
-		if err := wh.callbackValidator.Validate(ctx, namespaceName.String(), cbs); err != nil {
+		opts := callbacks.ValidatorOptions{
+			EnabledKinds: wh.config.WorkflowEnabledCallbackKinds(namespaceName.String()),
+		}
+		if err := wh.callbackValidator.Validate(ctx, namespaceName.String(), cbs, opts); err != nil {
 			return nil, err
 		}
 	}
@@ -5562,7 +5565,10 @@ func (wh *WorkflowHandler) prepareUpdateWorkflowRequest(
 	}
 
 	if cbs := request.GetRequest().GetCompletionCallbacks(); len(cbs) > 0 {
-		if err := wh.callbackValidator.Validate(ctx, namespaceName.String(), cbs); err != nil {
+		opts := callbacks.ValidatorOptions{
+			EnabledKinds: wh.config.WorkflowEnabledCallbackKinds(namespaceName.String()),
+		}
+		if err := wh.callbackValidator.Validate(ctx, namespaceName.String(), cbs, opts); err != nil {
 			return err
 		}
 	}

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -66,6 +66,7 @@ import (
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.temporal.io/server/common/tasktoken"
+	test "go.temporal.io/server/common/testing"
 	"go.temporal.io/server/common/testing/protorequire"
 	"go.temporal.io/server/common/tqid"
 	"go.temporal.io/server/common/wideevents"
@@ -177,18 +178,7 @@ func (s *WorkflowHandlerSuite) getWorkflowHandler(config *Config) *WorkflowHandl
 	healthInterceptor := interceptor.NewHealthInterceptor()
 	healthInterceptor.SetHealthy(true)
 
-	cbValidator, err := callbacks.NewValidator(callbacks.ValidatorConfig{
-		MaxCallbacksPerExecution: func(string) int { return 2000 },
-		URLMaxLength:             config.CallbackURLMaxLength,
-		HeaderMaxSize:            config.CallbackHeaderMaxSize,
-		EndpointRules: func(string) callbacks.AddressMatchRules {
-			return callbacks.AddressMatchRules{
-				Rules: []callbacks.AddressMatchRule{
-					{Regexp: regexp.MustCompile(`.*`), AllowInsecure: true},
-				},
-			}
-		},
-	})
+	cbValidator, err := callbacks.NewValidator(test.NewCallbacksValidatorConfig())
 	s.NoError(err)
 
 	saValidator := searchattribute.NewValidator(

--- a/service/history/api/describeworkflow/api.go
+++ b/service/history/api/describeworkflow/api.go
@@ -573,12 +573,6 @@ func buildChasmCallbackInfo(
 	cb *chasmcallback.Callback,
 	trigger *workflowpb.CallbackInfo_Trigger,
 ) (*workflowpb.CallbackInfo, error) {
-	nexusVariant := cb.GetCallback().GetNexus()
-	if nexusVariant == nil {
-		// Only Nexus callbacks are supported
-		return nil, nil
-	}
-
 	apiCb, err := cb.ToAPICallback()
 	if err != nil {
 		return nil, err

--- a/tests/callbacks_test.go
+++ b/tests/callbacks_test.go
@@ -315,7 +315,7 @@ func (s *CallbacksSuite) TestWorkflowCallbacks_InvalidArgument(opts []testcore.T
 			_, err := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 			var invalidArgument *serviceerror.InvalidArgument
 			s.ErrorAs(err, &invalidArgument)
-			s.Equal(tc.message, err.Error())
+			s.ErrorContains(err, tc.message)
 		})
 	}
 }

--- a/tests/comp_callbacks_test.go
+++ b/tests/comp_callbacks_test.go
@@ -10,6 +10,8 @@ import (
 	"go.temporal.io/server/chasm/lib/activity"
 	"go.temporal.io/server/chasm/lib/callback"
 	"go.temporal.io/server/chasm/lib/nexusoperation"
+	"go.temporal.io/server/chasm/lib/workflow"
+	"go.temporal.io/server/common/callbacks"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/tests/testcore"
@@ -39,9 +41,11 @@ func (s *CompletionCallbacksSuite) newTestEnv() *testcore.TestEnv {
 		testcore.WithDedicatedCluster(),
 		// Workflows
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
+		testcore.WithDynamicConfig(workflow.EnabledCallbackKinds, []callbacks.Kind{callbacks.KindNexus}),
 		// Standalone Activities
 		testcore.WithDynamicConfig(activity.Enabled, true),
 		testcore.WithDynamicConfig(activity.EnableCallbacks, true),
+		testcore.WithDynamicConfig(activity.EnabledCallbackKinds, []callbacks.Kind{callbacks.KindNexus}),
 		// Standalone Nexus operations
 		testcore.WithDynamicConfig(nexusoperation.Enabled, true),
 		// All Callbacks and Retry policy


### PR DESCRIPTION
⚠️ This is part of a stacked PR set, to be merged into `feature/worker-callbacks`. This will not go directly into `main`, until the overall feature is code complete.

---

## What changed?

> ℹ️ This description has been updated to reflect changes since the PR was created.
> This no longer adds the configuration to enable worker callbacks for standalone activities, workflows, or workflow updates. And instead leaves those as-is and only wires through the new configuration check.


Updates the `callback.Validator` to only allow enabled `commonpb.Callback` variants. Currently, every place in the system only accepts Nexus-variant callbacks. (It won't be until the next PR in this stack, that we add completion callbacks for SANO which will support the ability to enable Worker-variant callbacks.)

This generally meant wiring through a `callback.ValidationOptions` parameter to any place where we validated `commonpb.Callbacks`. And initializing it with the relevant configuration settings. To make this slightly easier, there is a `callback.NexusOnly()` function.

## Why?

As part of implementing worker callbacks, we need to ensure that are only supported in specific scenarios. (Initially SANO, and as we do more testing, potentially other types of executions.)

This PR expands the `callback.Validator` component so that certain callbacks can be rejected if they are an unsupported kind.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

The new verification check will reject any Internal-variant callbacks. That shouldn't be an issue, as there isn't any reason why you would send an Internal-variant callback to the service. But its a situation where we will reject requests that previously worked.
