### PR TITLE
Add completion callbacks to SANOs

### DIFF
--- a/chasm/lib/nexusoperation/callbacks_test.go
+++ b/chasm/lib/nexusoperation/callbacks_test.go
@@ -1,0 +1,522 @@
+package nexusoperation
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	failurepb "go.temporal.io/api/failure/v1"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/api/workflowservice/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/lib/callback"
+	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
+	nexusoperationpb "go.temporal.io/server/chasm/lib/nexusoperation/gen/nexusoperationpb/v1"
+	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func newCallbackTestContext() *chasm.MockMutableContext {
+	return &chasm.MockMutableContext{
+		MockContext: chasm.MockContext{
+			HandleNow: func(chasm.Component) time.Time { return defaultTime },
+			HandleExecutionKey: func() chasm.ExecutionKey {
+				return chasm.ExecutionKey{NamespaceID: "ns-id", BusinessID: "op-id", RunID: "run-id"}
+			},
+			HandleNamespaceEntry: func() *namespace.Namespace {
+				return namespace.NewNamespaceForTest(&persistencespb.NamespaceInfo{Name: "ns-name"}, nil, false, nil, 0)
+			},
+			HandleExecutionInfo: func() chasm.ExecutionInfo {
+				return chasm.ExecutionInfo{CloseTime: defaultTime}
+			},
+			GoCtx: context.WithValue(context.Background(), OperationContextKey, &OperationContext{
+				MetricTagConfig: dynamicconfig.GetTypedPropertyFn(NexusMetricTagConfig{}),
+			}),
+		},
+	}
+}
+
+func TestNewStandaloneOperationAttachesCompletionCallbacks(t *testing.T) {
+	t.Parallel()
+
+	newStartReq := func(cbs ...*commonpb.Callback) *nexusoperationpb.StartNexusOperationRequest {
+		return &nexusoperationpb.StartNexusOperationRequest{
+			EndpointId: "endpoint-id",
+			FrontendRequest: &workflowservice.StartNexusOperationExecutionRequest{
+				Namespace:           "ns-name",
+				OperationId:         "op-id",
+				RequestId:           "req-id",
+				Endpoint:            "test-endpoint",
+				Service:             "test-service",
+				Operation:           "test-operation",
+				CompletionCallbacks: cbs,
+			},
+		}
+	}
+
+	t.Run("WithCallbacks", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+
+		req := newStartReq(newNexusCallback())
+		op, err := newStandaloneOperation(ctx, req, 10, newTestLinkValidator(10, 10))
+		require.NoError(t, err)
+		require.Equal(t, nexusoperationpb.OPERATION_STATUS_SCHEDULED, op.Status)
+
+		// Callbacks start in STANDBY, only transitioning to SCHEDULED when the SANO completes.
+		require.Len(t, op.Callbacks, 1)
+		attachedCB := op.Callbacks["req-id-0"].Get(ctx)
+		require.Equal(t, callbackspb.CALLBACK_STATUS_STANDBY, attachedCB.Status)
+	})
+
+	t.Run("WithoutCallbacks", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+
+		op, err := newStandaloneOperation(ctx, newStartReq(), 10, newTestLinkValidator(10, 10))
+		require.NoError(t, err)
+		require.Nil(t, op.Callbacks)
+	})
+
+	t.Run("EnforcesTheCallersLimit", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+
+		_, err := newStandaloneOperation(ctx, newStartReq(
+			newNexusCallback(),
+			newNexusCallback(),
+		), 1, newTestLinkValidator(10, 10))
+		var failedPreconditionErr *serviceerror.FailedPrecondition
+		require.ErrorAs(t, err, &failedPreconditionErr)
+		require.ErrorContains(t, err, "cannot attach more than 1 callbacks")
+	})
+}
+
+func TestAddCompletionCallbacks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("AttachesCallbacksInStandby", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+		op := newScheduledTestOperation(t, ctx)
+
+		cb1 := newNexusCallback()
+		cb1.GetNexus().Url = "https://example.com/callback-1"
+
+		// Set data on the second CB, we confirm is added to the Operation.
+		cb2 := newNexusCallback()
+		cb2.GetNexus().Url = "https://example.com/callback-2"
+		cb2.GetNexus().Header = map[string]string{
+			"key": "xxx",
+		}
+		cb2.Links = []*commonpb.Link{{Variant: &commonpb.Link_WorkflowEvent_{
+			WorkflowEvent: &commonpb.Link_WorkflowEvent{Namespace: "ns-name", WorkflowId: "wf-id"},
+		}}}
+
+		cbs := []*commonpb.Callback{
+			cb1,
+			cb2,
+		}
+
+		err := op.addCompletionCallbacks(ctx, "req-id", cbs, 10)
+		require.NoError(t, err)
+		require.Len(t, op.Callbacks, 2)
+
+		first, ok := op.Callbacks["req-id-0"]
+		require.True(t, ok)
+		firstCb := first.Get(ctx)
+		require.Equal(t, "https://example.com/callback-1", firstCb.GetCallback().GetNexus().GetUrl())
+
+		second, ok := op.Callbacks["req-id-1"]
+		require.True(t, ok)
+		secondCb := second.Get(ctx)
+		require.Equal(t, callbackspb.CALLBACK_STATUS_STANDBY, secondCb.Status)
+		require.Equal(t, defaultTime, secondCb.RegistrationTime.AsTime())
+		require.Equal(t, "https://example.com/callback-2", secondCb.GetCallback().GetNexus().GetUrl())
+		require.Equal(t, map[string]string{"key": "xxx"}, secondCb.GetCallback().GetNexus().GetHeader())
+		require.Len(t, secondCb.GetCallback().GetLinks(), 1)
+
+		// Each callback gets its own, unique request ID.
+		require.NotEqual(t, "req-id", firstCb.RequestId)
+		require.NotEqual(t, "req-id", secondCb.RequestId)
+		require.NotEqual(t, firstCb.RequestId, secondCb.RequestId)
+
+		// STANDBY means no invocation task yet; only the scheduled transition's tasks are present.
+		for _, task := range ctx.Tasks {
+			_, isInvocation := task.Payload.(*callbackspb.InvocationTask)
+			require.False(t, isInvocation, "callbacks must not be invoked while in STANDBY")
+		}
+	})
+
+	t.Run("EmptyListIsNoOp", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+		op := newScheduledTestOperation(t, ctx)
+
+		require.NoError(t, op.addCompletionCallbacks(ctx, "req-id", nil, 10))
+		require.Nil(t, op.Callbacks)
+	})
+
+	t.Run("ReAttachingTheSameRequestIsIdempotent", func(t *testing.T) {
+		// A retried start (or a retried on_conflict_options attach) must not duplicate callbacks.
+		ctx := newCallbackTestContext()
+		op := newScheduledTestOperation(t, ctx)
+		cbs := []*commonpb.Callback{newNexusCallback()}
+
+		require.NoError(t, op.addCompletionCallbacks(ctx, "req-id", cbs, 10))
+		require.NoError(t, op.addCompletionCallbacks(ctx, "req-id", cbs, 10))
+		require.Len(t, op.Callbacks, 1)
+	})
+
+	t.Run("ReAttachingTheSameRequestIsIdempotentAfterClose", func(t *testing.T) {
+		// A start request can reach addCompletionCallbacks twice: once creating the operation, then
+		// again if the client retries and the engine dedups on request ID. The operation may have closed
+		// in between, and the retry must still report success for callbacks that are already persisted
+		// rather than FailedPrecondition.
+		ctx := newCallbackTestContext()
+		op := newScheduledTestOperation(t, ctx)
+		cbs := []*commonpb.Callback{newNexusCallback()}
+
+		require.NoError(t, op.addCompletionCallbacks(ctx, "req-id", cbs, 10))
+		require.NoError(t, TransitionSucceeded.Apply(op, ctx, EventSucceeded{}))
+		require.Equal(t, callbackspb.CALLBACK_STATUS_SCHEDULED, op.Callbacks["req-id-0"].Get(ctx).Status)
+
+		tasksBefore := len(ctx.Tasks)
+		require.NoError(t, op.addCompletionCallbacks(ctx, "req-id", cbs, 10))
+
+		// The retry must leave the already-scheduled callback alone: re-attaching would reset it to
+		// STANDBY, stranding a callback the terminal transition had already released for delivery.
+		require.Len(t, op.Callbacks, 1)
+		require.Equal(t, callbackspb.CALLBACK_STATUS_SCHEDULED, op.Callbacks["req-id-0"].Get(ctx).Status)
+		require.Len(t, ctx.Tasks, tasksBefore)
+	})
+
+	t.Run("DistinctRequestsAccumulate", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+		op := newScheduledTestOperation(t, ctx)
+		cbs := []*commonpb.Callback{newNexusCallback()}
+
+		require.NoError(t, op.addCompletionCallbacks(ctx, "req-1", cbs, 10))
+		require.NoError(t, op.addCompletionCallbacks(ctx, "req-2", cbs, 10))
+		require.Len(t, op.Callbacks, 2)
+	})
+
+	t.Run("RejectsExceedingTheLimit", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+		op := newScheduledTestOperation(t, ctx)
+		cbs := []*commonpb.Callback{newNexusCallback(), newNexusCallback()}
+
+		err := op.addCompletionCallbacks(ctx, "req-id", cbs, 1)
+		var failedPreconditionErr *serviceerror.FailedPrecondition
+		require.ErrorAs(t, err, &failedPreconditionErr)
+		require.Contains(t, err.Error(), "cannot attach more than 1 callbacks")
+		require.Empty(t, op.Callbacks)
+	})
+
+	t.Run("RejectsExceedingTheLimitWithAlreadyAttachedCallbacks", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+		op := newScheduledTestOperation(t, ctx)
+
+		require.NoError(t, op.addCompletionCallbacks(ctx, "req-1", []*commonpb.Callback{
+			newNexusCallback(),
+		}, 2))
+
+		err := op.addCompletionCallbacks(ctx, "req-2", []*commonpb.Callback{
+			newNexusCallback(),
+			newNexusCallback(),
+		}, 2)
+		var failedPreconditionErr *serviceerror.FailedPrecondition
+		require.ErrorAs(t, err, &failedPreconditionErr)
+		require.Contains(t, err.Error(), "1 callbacks already attached")
+		require.Len(t, op.Callbacks, 1)
+	})
+
+	t.Run("RejectsAClosedOperation", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+		op := newScheduledTestOperation(t, ctx)
+		require.NoError(t, TransitionSucceeded.Apply(op, ctx, EventSucceeded{}))
+
+		err := op.addCompletionCallbacks(ctx, "req-id", []*commonpb.Callback{
+			newNexusCallback(),
+		}, 10)
+		var failedPreconditionErr *serviceerror.FailedPrecondition
+		require.ErrorAs(t, err, &failedPreconditionErr)
+		require.Contains(t, err.Error(), "cannot attach callbacks to a closed nexus operation")
+		require.Empty(t, op.Callbacks)
+	})
+
+	t.Run("RejectsAnEmptyRequestID", func(t *testing.T) {
+		// Callback IDs are derived from the request ID, so without one two distinct requests would
+		// produce colliding keys and silently overwrite each other. The frontend always supplies one
+		// (validator.normalizeRequestID); this guards a history-side caller that did not.
+		ctx := newCallbackTestContext()
+		op := newScheduledTestOperation(t, ctx)
+
+		err := op.addCompletionCallbacks(ctx, "", []*commonpb.Callback{
+			newNexusCallback(),
+		}, 10)
+		var invalidArgErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgErr)
+		require.Contains(t, err.Error(), "without a request ID")
+		require.Empty(t, op.Callbacks)
+	})
+}
+
+func TestScheduleCompletionCallbacksOnTerminalTransition(t *testing.T) {
+	t.Parallel()
+
+	timeoutFailure := &failurepb.Failure{
+		Message: "timed out",
+		FailureInfo: &failurepb.Failure_TimeoutFailureInfo{
+			TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
+				TimeoutType: enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
+			},
+		},
+	}
+
+	// In all scenarios, we expect the CHASM callbacks to be scheduled once the
+	// SANO transitions to a terminal state.
+	for _, tc := range []struct {
+		name           string
+		fromStatus     nexusoperationpb.OperationStatus
+		apply          func(*Operation, *chasm.MockMutableContext) error
+		expectedStatus nexusoperationpb.OperationStatus
+	}{
+		{
+			name: "Succeeded",
+			apply: func(o *Operation, ctx *chasm.MockMutableContext) error {
+				return TransitionSucceeded.Apply(o, ctx, EventSucceeded{})
+			},
+			expectedStatus: nexusoperationpb.OPERATION_STATUS_SUCCEEDED,
+		},
+		{
+			name: "Failed",
+			apply: func(o *Operation, ctx *chasm.MockMutableContext) error {
+				return TransitionFailed.Apply(o, ctx, EventFailed{
+					Failure: &failurepb.Failure{Message: "boom"},
+				})
+			},
+			expectedStatus: nexusoperationpb.OPERATION_STATUS_FAILED,
+		},
+		{
+			name: "Canceled",
+			apply: func(o *Operation, ctx *chasm.MockMutableContext) error {
+				return TransitionCanceled.Apply(o, ctx, EventCanceled{
+					Failure: &failurepb.Failure{Message: "canceled"},
+				})
+			},
+			expectedStatus: nexusoperationpb.OPERATION_STATUS_CANCELED,
+		},
+		{
+			name: "TimedOut",
+			apply: func(o *Operation, ctx *chasm.MockMutableContext) error {
+				return TransitionTimedOut.Apply(o, ctx, EventTimedOut{Failure: timeoutFailure})
+			},
+			expectedStatus: nexusoperationpb.OPERATION_STATUS_TIMED_OUT,
+		},
+		{
+			name: "Terminated",
+			apply: func(o *Operation, ctx *chasm.MockMutableContext) error {
+				_, err := o.Terminate(ctx, chasm.TerminateComponentRequest{
+					RequestID: "terminate-req-id",
+					Reason:    "because",
+				})
+				return err
+			},
+			expectedStatus: nexusoperationpb.OPERATION_STATUS_TERMINATED,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := newCallbackTestContext()
+			op := newScheduledTestOperation(t, ctx)
+			require.NoError(t, op.addCompletionCallbacks(ctx, "req-id", []*commonpb.Callback{
+				newNexusCallback(),
+			}, 10))
+
+			tasksBefore := len(ctx.Tasks)
+			require.NoError(t, tc.apply(op, ctx))
+			require.Equal(t, tc.expectedStatus, op.Status)
+
+			cb := op.Callbacks["req-id-0"].Get(ctx)
+			require.Equal(t, callbackspb.CALLBACK_STATUS_SCHEDULED, cb.Status)
+
+			// Closing must emit exactly one callback invocation task, routed to the callback's host.
+			newTasks := ctx.Tasks[tasksBefore:]
+			require.Len(t, newTasks, 1)
+			require.IsType(t, &callbackspb.InvocationTask{}, newTasks[0].Payload)
+
+			// The task's Destination attribute for Nexus callbacks is the hostname, which
+			// is fixed in newNexusCallback.
+			const wantHost = "https://nexus.ex.xxxxx.cluster.tmprl.cloud:7243"
+			require.Equal(t, wantHost, newTasks[0].Attributes.Destination)
+		})
+	}
+
+	t.Run("NoCallbacksIsANoOp", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+		op := newScheduledTestOperation(t, ctx)
+
+		tasksBefore := len(ctx.Tasks)
+		require.NoError(t, TransitionSucceeded.Apply(op, ctx, EventSucceeded{}))
+		require.Len(t, ctx.Tasks, tasksBefore)
+	})
+}
+
+func TestBuildCompletionCallbackInfos(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NoCallbacks", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+		op := newTestOperation()
+
+		infos, err := op.buildCompletionCallbackInfos(ctx)
+		require.NoError(t, err)
+		require.Nil(t, infos)
+	})
+
+	t.Run("ReportsStateAndOutcomePerCallback", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+		op := newTestOperation()
+
+		newCB := func(url string, status callbackspb.CallbackStatus) *callback.Callback {
+			cb := callback.NewCallback(
+				"req-id",
+				timestamppb.New(defaultTime),
+				&callbackspb.Callback{
+					Variant: &callbackspb.Callback_Nexus_{
+						Nexus: &callbackspb.Callback_Nexus{Url: url},
+					},
+				},
+			)
+			cb.SetStateMachineState(status)
+			return cb
+		}
+
+		failed := newCB("http://localhost:8080/failed", callbackspb.CALLBACK_STATUS_FAILED)
+		failed.Attempt = 3
+		failed.LastAttemptFailure = &failurepb.Failure{Message: "boom"}
+
+		op.Callbacks = chasm.Map[string, *callback.Callback]{
+			"req-id-0": chasm.NewComponentField(ctx, newCB("http://localhost:8080/standby", callbackspb.CALLBACK_STATUS_STANDBY)),
+			"req-id-1": chasm.NewComponentField(ctx, newCB("http://localhost:8080/succeeded", callbackspb.CALLBACK_STATUS_SUCCEEDED)),
+			"req-id-2": chasm.NewComponentField(ctx, failed),
+		}
+
+		infos, err := op.buildCompletionCallbackInfos(ctx)
+		require.NoError(t, err)
+		require.Len(t, infos, 3)
+
+		// Ordering follows the sorted callback IDs, not the (randomized) map iteration order.
+		require.Equal(t, "http://localhost:8080/standby", infos[0].GetInfo().GetCallback().GetNexus().GetUrl())
+		require.Equal(t, enumspb.CALLBACK_STATE_STANDBY, infos[0].GetInfo().GetState())
+		require.Equal(t, defaultTime, infos[0].GetInfo().GetRegistrationTime().AsTime())
+		// Every callback on a standalone operation is triggered by the operation completing.
+		require.NotNil(t, infos[0].GetTrigger().GetOperationCompleted())
+
+		require.Equal(t, enumspb.CALLBACK_STATE_SUCCEEDED, infos[1].GetInfo().GetState())
+
+		require.Equal(t, enumspb.CALLBACK_STATE_FAILED, infos[2].GetInfo().GetState())
+		require.Equal(t, int32(3), infos[2].GetInfo().GetAttempt())
+	})
+}
+
+// TestCompletionCallbacksRoundTripThroughTheTree exercises the Callbacks map against a real CHASM tree
+// rather than a mock context, so that a missing component registration or an unserializable field shows
+// up here instead of at runtime.
+func TestCompletionCallbacksRoundTripThroughTheTree(t *testing.T) {
+	logger := log.NewNoopLogger()
+	registry := chasm.NewRegistry(logger)
+	require.NoError(t, registry.Register(&chasm.CoreLibrary{}))
+	require.NoError(t, registry.Register(&Library{
+		componentOnlyLibrary: componentOnlyLibrary{
+			metricTagConfig: dynamicconfig.GetTypedPropertyFn(NexusMetricTagConfig{}),
+		},
+	}))
+	require.NoError(t, registry.Register(callback.NewNilLibrary()))
+
+	timeSource := clock.NewEventTimeSource()
+	timeSource.Update(defaultTime)
+	nodeBackend := &chasm.MockNodeBackend{
+		HandleNextTransitionCount: func() int64 { return 2 },
+		HandleGetCurrentVersion:   func() int64 { return 1 },
+		HandleCurrentVersionedTransition: func() *persistencespb.VersionedTransition {
+			return &persistencespb.VersionedTransition{NamespaceFailoverVersion: 1, TransitionCount: 1}
+		},
+		HandleGetNamespaceEntry: func() *namespace.Namespace {
+			return namespace.NewNamespaceForTest(&persistencespb.NamespaceInfo{Name: "ns-name"}, nil, false, nil, 0)
+		},
+	}
+	root := chasm.NewEmptyTree(registry, timeSource, nodeBackend, chasm.DefaultPathEncoder, logger, metrics.NoopMetricsHandler)
+	ctx := chasm.NewMutableContext(context.Background(), root)
+
+	op := NewOperation(&nexusoperationpb.OperationState{
+		Status:        nexusoperationpb.OPERATION_STATUS_STARTED,
+		Endpoint:      "test-endpoint",
+		ScheduledTime: timestamppb.New(defaultTime),
+	})
+	op.RequestData = chasm.NewDataField(ctx, &nexusoperationpb.OperationRequestData{})
+	op.Visibility = chasm.NewComponentField(ctx, chasm.NewVisibilityWithData(ctx, nil, nil))
+	require.NoError(t, op.addCompletionCallbacks(ctx, "req-id", []*commonpb.Callback{
+		newNexusCallback(),
+	}, 10))
+	require.NoError(t, root.SetRootComponent(op))
+	_, err := root.CloseTransaction()
+	require.NoError(t, err)
+
+	ctx = chasm.NewMutableContext(context.Background(), root)
+	require.Len(t, op.Callbacks, 1)
+	cb := op.Callbacks["req-id-0"].Get(ctx)
+	require.Equal(t, callbackspb.CALLBACK_STATUS_STANDBY, cb.Status)
+
+	// The callback resolves its parent via a ParentPtr, so the Operation must satisfy
+	// callback.CompletionSource from inside the tree, not just as a compile-time assertion.
+	require.NoError(t, TransitionSucceeded.Apply(op, ctx, EventSucceeded{Result: mustToPayload(t, "result")}))
+	require.Equal(t, callbackspb.CALLBACK_STATUS_SCHEDULED, cb.Status)
+
+	completion, err := cb.CompletionSource.Get(ctx).GetNexusCompletion(ctx, cb.RequestId)
+	require.NoError(t, err)
+	require.Nil(t, completion.Error)
+}
+
+// TestDescribeResponseIncludesCompletionCallbacks covers the plumbing from the component into the
+// DescribeNexusOperationExecution response.
+func TestDescribeResponseIncludesCompletionCallbacks(t *testing.T) {
+	t.Parallel()
+
+	newOp := func(ctx chasm.MutableContext) *Operation {
+		op := newTestOperation()
+		op.RequestData = chasm.NewDataField(ctx, &nexusoperationpb.OperationRequestData{})
+		op.Visibility = chasm.NewComponentField(ctx, chasm.NewVisibilityWithData(ctx, nil, nil))
+		return op
+	}
+	req := &nexusoperationpb.DescribeNexusOperationRequest{
+		FrontendRequest: &workflowservice.DescribeNexusOperationExecutionRequest{},
+	}
+
+	t.Run("WithCallbacks", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+		op := newOp(ctx)
+		require.NoError(t, op.addCompletionCallbacks(ctx, "req-id", []*commonpb.Callback{
+			newNexusCallback(),
+		}, 10))
+
+		resp, err := op.buildDescribeResponse(ctx, req)
+		require.NoError(t, err)
+
+		cbs := resp.GetFrontendResponse().GetCompletionCallbacks()
+		require.Len(t, cbs, 1)
+		require.Equal(t, enumspb.CALLBACK_STATE_STANDBY, cbs[0].GetInfo().GetState())
+	})
+
+	t.Run("WithoutCallbacks", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+		op := newOp(ctx)
+
+		resp, err := op.buildDescribeResponse(ctx, req)
+		require.NoError(t, err)
+		require.Empty(t, resp.GetFrontendResponse().GetCompletionCallbacks())
+	})
+}

--- a/chasm/lib/nexusoperation/config.go
+++ b/chasm/lib/nexusoperation/config.go
@@ -6,8 +6,10 @@ import (
 	"text/template"
 	"time"
 
+	"go.temporal.io/server/chasm/lib/callback"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
+	"go.temporal.io/server/common/callbacks"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/headers"
@@ -33,6 +35,13 @@ var Enabled = dynamicconfig.NewNamespaceBoolSetting(
 	"nexusoperation.enableStandalone",
 	false,
 	`Toggles standalone Nexus operation functionality on the server.`,
+)
+
+var EnabledCallbackKinds = dynamicconfig.NewNamespaceTypedSettingWithConverter(
+	"nexusoperation.enabledCallbackKinds",
+	callbacks.ConvertEnabledKinds,
+	[]callbacks.Kind{}, // i.e. callbacks not enabled at all.
+	`The list of completion callback kinds that may be attached to a standalone Nexus operation execution.`,
 )
 
 var EnableChasmWorkflowOperations = dynamicconfig.NewNamespaceBoolSetting(
@@ -236,6 +245,8 @@ Added for safety. Defaults to true. Likely to be removed in future server versio
 type Config struct {
 	Enabled                                    dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	EnableChasm                                dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	EnabledCallbackKinds                       dynamicconfig.TypedPropertyFnWithNamespaceFilter[[]callbacks.Kind]
+	MaxCallbacksPerExecution                   dynamicconfig.IntPropertyFnWithNamespaceFilter
 	EnableChasmNexusWorkflowOperations         dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	ChasmNexusWorkflowOperationsRolloutPercent dynamicconfig.IntPropertyFnWithNamespaceFilter
 	NumHistoryShards                           int32
@@ -267,6 +278,8 @@ func configProvider(dc *dynamicconfig.Collection, cfg *config.Persistence) *Conf
 	return &Config{
 		Enabled:                            Enabled.Get(dc),
 		EnableChasm:                        dynamicconfig.EnableChasm.Get(dc),
+		EnabledCallbackKinds:               EnabledCallbackKinds.Get(dc),
+		MaxCallbacksPerExecution:           callback.MaxPerExecution.Get(dc),
 		EnableChasmNexusWorkflowOperations: EnableChasmWorkflowOperations.Get(dc),
 		ChasmNexusWorkflowOperationsRolloutPercent: ChasmWorkflowOperationsRolloutPercent.Get(dc),
 		NumHistoryShards:                   cfg.NumHistoryShards,

--- a/chasm/lib/nexusoperation/frontend.go
+++ b/chasm/lib/nexusoperation/frontend.go
@@ -10,6 +10,7 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/chasm"
 	nexusoperationpb "go.temporal.io/server/chasm/lib/nexusoperation/gen/nexusoperationpb/v1"
+	"go.temporal.io/server/common/callbacks"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/namespace"
 	commonnexus "go.temporal.io/server/common/nexus"
@@ -49,13 +50,15 @@ func NewFrontendHandler(
 	endpointRegistry commonnexus.EndpointRegistry,
 	saMapperProvider searchattribute.MapperProvider,
 	saValidator *searchattribute.Validator,
+	callbackValidator callbacks.Validator,
+	linkValidator *linkValidator,
 ) FrontendHandler {
 	return &frontendHandler{
 		client:            client,
 		config:            config,
 		namespaceRegistry: namespaceRegistry,
 		endpointRegistry:  endpointRegistry,
-		validator:         newValidator(config, logger, saMapperProvider, saValidator),
+		validator:         newValidator(config, logger, saMapperProvider, saValidator, callbackValidator, linkValidator),
 	}
 }
 
@@ -72,7 +75,7 @@ func (h *frontendHandler) StartNexusOperationExecution(
 		return nil, err
 	}
 
-	if err := h.validator.validateAndNormalizeStartRequest(req); err != nil {
+	if err := h.validator.validateAndNormalizeStartRequest(ctx, req); err != nil {
 		return nil, err
 	}
 

--- a/chasm/lib/nexusoperation/fx.go
+++ b/chasm/lib/nexusoperation/fx.go
@@ -31,6 +31,7 @@ import (
 var Module = fx.Module(
 	"chasm.lib.nexusoperation",
 	fx.Provide(configProvider),
+	fx.Provide(linkValidatorProvider),
 	fx.Provide(commonnexus.NewCallbackTokenGenerator),
 	fx.Provide(endpointRegistryProvider),
 	fx.Invoke(endpointRegistryLifetimeHooks),
@@ -51,6 +52,7 @@ var Module = fx.Module(
 var FrontendModule = fx.Module(
 	"chasm.lib.nexusoperation.frontend",
 	fx.Provide(configProvider),
+	fx.Provide(linkValidatorProvider),
 	fx.Provide(nexusoperationpb.NewNexusOperationServiceLayeredClient),
 	fx.Provide(NewFrontendHandler),
 	fx.Provide(newComponentOnlyLibrary),

--- a/chasm/lib/nexusoperation/handler.go
+++ b/chasm/lib/nexusoperation/handler.go
@@ -17,14 +17,16 @@ import (
 type handler struct {
 	nexusoperationpb.UnimplementedNexusOperationServiceServer
 
-	config *Config
-	logger log.Logger
+	config        *Config
+	linkValidator *linkValidator
+	logger        log.Logger
 }
 
-func newHandler(config *Config, logger log.Logger) *handler {
+func newHandler(config *Config, linkValidator *linkValidator, logger log.Logger) *handler {
 	return &handler{
-		config: config,
-		logger: logger,
+		config:        config,
+		linkValidator: linkValidator,
+		logger:        logger,
 	}
 }
 
@@ -36,14 +38,19 @@ func (h *handler) StartNexusOperation(
 	defer log.CapturePanic(h.logger, &err)
 
 	frontendReq := req.GetFrontendRequest()
+	// Read once, so it's consistent for both the creation and on-conflict paths,
+	// despite being in two transactions.
+	maxCallbacks := h.config.MaxCallbacksPerExecution(frontendReq.GetNamespace())
 
-	result, err := chasm.StartExecution[*Operation](
+	result, err := chasm.StartExecution(
 		ctx,
 		chasm.ExecutionKey{
 			NamespaceID: req.GetNamespaceId(),
 			BusinessID:  frontendReq.GetOperationId(),
 		},
-		newStandaloneOperation,
+		func(mutableCtx chasm.MutableContext, req *nexusoperationpb.StartNexusOperationRequest) (*Operation, error) {
+			return newStandaloneOperation(mutableCtx, req, maxCallbacks, h.linkValidator)
+		},
 		req,
 		chasm.WithRequestID(frontendReq.GetRequestId()),
 		chasm.WithBusinessIDPolicy(
@@ -52,6 +59,8 @@ func (h *handler) StartNexusOperation(
 		),
 	)
 	if err != nil {
+		// ExecutionAlreadyStarted would only be returned if the IDConflictPolicy were FAIL.
+		// Otherwise, we'd return the existing SANO. (And apply the OnConflictOptions next.)
 		if alreadyStartedErr, ok := errors.AsType[*chasm.ExecutionAlreadyStartedError](err); ok {
 			return nil, serviceerror.NewNexusOperationExecutionAlreadyStartedf(
 				alreadyStartedErr.CurrentRequestID,
@@ -64,12 +73,59 @@ func (h *handler) StartNexusOperation(
 		return nil, err
 	}
 
+	if !result.Created {
+		if err := h.applyOnConflictOptions(ctx, result.ExecutionKey, frontendReq, maxCallbacks); err != nil {
+			return nil, err
+		}
+	}
+
 	return &nexusoperationpb.StartNexusOperationResponse{
 		FrontendResponse: &workflowservice.StartNexusOperationExecutionResponse{
 			RunId:   result.ExecutionKey.RunID,
 			Started: result.Created,
 		},
 	}, nil
+}
+
+// applyOnConflictOptions applies the request's on_conflict_options to a SANO.
+func (h *handler) applyOnConflictOptions(
+	ctx context.Context,
+	key chasm.ExecutionKey,
+	req *workflowservice.StartNexusOperationExecutionRequest,
+	maxCallbacks int,
+) error {
+	cbs := req.GetCompletionCallbacks()
+	links := req.GetLinks()
+	onConflict := req.GetOnConflictOptions()
+	attachCallbacks := onConflict.GetAttachCompletionCallbacks() && len(cbs) > 0
+	attachLinks := onConflict.GetAttachLinks() && len(links) > 0
+	if !attachCallbacks && !attachLinks {
+		return nil
+	}
+
+	requestID := req.GetRequestId()
+	namespaceName := req.GetNamespace()
+	// TODO: Use chasm.UpdateWithStartExecution to avoid a second transaction once the engine supports
+	// BusinessIDConflictPolicyFail in the updateFn path. (Same for standalone Activities.)
+	_, _, err := chasm.UpdateComponent(
+		ctx,
+		chasm.NewComponentRef[*Operation](key),
+		func(o *Operation, ctx chasm.MutableContext, _ any) (any, error) {
+			if attachCallbacks {
+				if err := o.addCompletionCallbacks(ctx, requestID, cbs, maxCallbacks); err != nil {
+					return nil, err
+				}
+			}
+			if attachLinks {
+				if err := o.attachLinks(ctx, links, requestID, h.linkValidator, namespaceName); err != nil {
+					return nil, err
+				}
+			}
+			return nil, nil
+		},
+		nil,
+	)
+	return err
 }
 
 // DescribeNexusOperation queries current operation state, optionally as a long-poll that waits

--- a/chasm/lib/nexusoperation/link_validator.go
+++ b/chasm/lib/nexusoperation/link_validator.go
@@ -1,0 +1,37 @@
+package nexusoperation
+
+import (
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/links"
+)
+
+// linkValidator validates links attached to standalone Nexus operation executions.
+type linkValidator struct {
+	// Distinct per-component type: all CHASM lib fx modules provide into the same
+	// container, so *commonlinks.Validator cannot be injected directly.
+	*links.Validator
+}
+
+func newLinkValidator(
+	maxLinksPerRequest dynamicconfig.IntPropertyFnWithNamespaceFilter,
+	maxLinksPerComponent dynamicconfig.IntPropertyFnWithNamespaceFilter,
+	linkMaxSize dynamicconfig.IntPropertyFnWithNamespaceFilter,
+) *linkValidator {
+	return &linkValidator{
+		links.NewValidator(
+			"a nexus operation",
+			maxLinksPerRequest,
+			maxLinksPerComponent,
+			linkMaxSize,
+		),
+	}
+}
+
+// linkValidatorProvider builds the linkValidator from dynamic config.
+func linkValidatorProvider(dc *dynamicconfig.Collection) *linkValidator {
+	return newLinkValidator(
+		dynamicconfig.FrontendMaxLinksPerRequest.Get(dc),
+		dynamicconfig.MaxLinksPerComponent.Get(dc),
+		dynamicconfig.FrontendLinkMaxSize.Get(dc),
+	)
+}

--- a/chasm/lib/nexusoperation/links_test.go
+++ b/chasm/lib/nexusoperation/links_test.go
@@ -1,0 +1,259 @@
+package nexusoperation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/chasm"
+	nexusoperationpb "go.temporal.io/server/chasm/lib/nexusoperation/gen/nexusoperationpb/v1"
+	"go.temporal.io/server/common/testing/protorequire"
+)
+
+// newTestLinkValidator returns a linkValidator with the given caps and a permissive per-link size limit.
+func newTestLinkValidator(maxPerRequest, maxPerComponent int) *linkValidator {
+	return newLinkValidator(
+		func(string) int { return maxPerRequest },
+		func(string) int { return maxPerComponent },
+		func(string) int { return 4000 },
+	)
+}
+
+// newLinkTestContext returns a mock context backed by stored, standing in for the framework's
+// per-request link storage: writes land in ctx.LinksByRequest, while reads (Links/RequestLinks) are
+// served from stored. Tests copy a write into stored to simulate it having been persisted.
+func newLinkTestContext(stored map[string][]*commonpb.Link) *chasm.MockMutableContext {
+	ctx := newCallbackTestContext()
+	ctx.HandleLinks = func(chasm.Component) []*commonpb.Link {
+		var all []*commonpb.Link
+		for _, links := range stored {
+			all = append(all, links...)
+		}
+		return all
+	}
+	ctx.HandleRequestLinks = func(_ chasm.Component, requestID string) ([]*commonpb.Link, error) {
+		return stored[requestID], nil
+	}
+	return ctx
+}
+
+func testLink(workflowID string) *commonpb.Link {
+	return &commonpb.Link{Variant: &commonpb.Link_WorkflowEvent_{
+		WorkflowEvent: &commonpb.Link_WorkflowEvent{
+			Namespace:  "ns-name",
+			WorkflowId: workflowID,
+			RunId:      "wf-run-id",
+		},
+	}}
+}
+
+func TestNewStandaloneOperationAttachesLinks(t *testing.T) {
+	t.Parallel()
+
+	newStartReq := func(links ...*commonpb.Link) *nexusoperationpb.StartNexusOperationRequest {
+		return &nexusoperationpb.StartNexusOperationRequest{
+			EndpointId: "endpoint-id",
+			FrontendRequest: &workflowservice.StartNexusOperationExecutionRequest{
+				Namespace:   "ns-name",
+				OperationId: "op-id",
+				RequestId:   "req-id",
+				Endpoint:    "test-endpoint",
+				Service:     "test-service",
+				Operation:   "test-operation",
+				Links:       links,
+			},
+		}
+	}
+
+	t.Run("WithLinks", func(t *testing.T) {
+		ctx := newLinkTestContext(map[string][]*commonpb.Link{})
+		link := testLink("wf-id")
+
+		op, err := newStandaloneOperation(ctx, newStartReq(link), 10, newTestLinkValidator(10, 10))
+		require.NoError(t, err)
+		require.Equal(t, nexusoperationpb.OPERATION_STATUS_SCHEDULED, op.Status)
+
+		// Links are keyed by the request that contributed them.
+		protorequire.ProtoSliceEqual(t, []*commonpb.Link{link}, ctx.LinksByRequest[op]["req-id"])
+	})
+
+	t.Run("WithoutLinks", func(t *testing.T) {
+		ctx := newLinkTestContext(map[string][]*commonpb.Link{})
+
+		op, err := newStandaloneOperation(ctx, newStartReq(), 10, newTestLinkValidator(10, 10))
+		require.NoError(t, err)
+		require.Empty(t, ctx.LinksByRequest[op])
+	})
+
+	t.Run("RejectsAnInvalidLink", func(t *testing.T) {
+		ctx := newLinkTestContext(map[string][]*commonpb.Link{})
+		invalid := &commonpb.Link{Variant: &commonpb.Link_WorkflowEvent_{
+			WorkflowEvent: &commonpb.Link_WorkflowEvent{WorkflowId: "wf-id", RunId: "wf-run-id"},
+		}}
+
+		_, err := newStandaloneOperation(ctx, newStartReq(invalid), 10, newTestLinkValidator(10, 10))
+		require.ErrorAs(t, err, new(*serviceerror.InvalidArgument))
+		require.ErrorContains(t, err, "must not have an empty namespace")
+	})
+
+	t.Run("EnforcesThePerComponentCap", func(t *testing.T) {
+		ctx := newLinkTestContext(map[string][]*commonpb.Link{})
+
+		_, err := newStandaloneOperation(
+			ctx,
+			newStartReq(testLink("wf-1"), testLink("wf-2")),
+			10,
+			newTestLinkValidator(10, 1),
+		)
+		require.ErrorAs(t, err, new(*serviceerror.FailedPrecondition))
+		require.ErrorContains(t, err, "cannot attach more than 1 links to a nexus operation")
+	})
+}
+
+func TestOperationAttachLinks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("EmptyListIsANoOp", func(t *testing.T) {
+		stored := map[string][]*commonpb.Link{}
+		ctx := newLinkTestContext(stored)
+		op := newScheduledTestOperation(t, ctx)
+
+		require.NoError(t, op.attachLinks(ctx, nil, "req-id", newTestLinkValidator(10, 10), "ns-name"))
+		require.Empty(t, ctx.LinksByRequest[op])
+	})
+
+	t.Run("SameRequestIDIsNoOp", func(t *testing.T) {
+		// A retried start (or a retried on_conflict_options attach) must not duplicate links.
+		stored := map[string][]*commonpb.Link{}
+		ctx := newLinkTestContext(stored)
+		op := newScheduledTestOperation(t, ctx)
+		validator := newTestLinkValidator(10, 10)
+		linkA, linkB := testLink("wf-a"), testLink("wf-b")
+
+		// The first call records the request's links verbatim, without intra-batch dedup, matching
+		// the workflow and standalone activity start paths.
+		require.NoError(t, op.attachLinks(ctx, []*commonpb.Link{linkA, linkA}, "req-1", validator, "ns-name"))
+		stored["req-1"] = ctx.LinksByRequest[op]["req-1"]
+		protorequire.ProtoSliceEqual(t, []*commonpb.Link{linkA, linkA}, stored["req-1"])
+
+		// A retry under the same requestID is a no-op, even with different links.
+		require.NoError(t, op.attachLinks(ctx, []*commonpb.Link{linkB}, "req-1", validator, "ns-name"))
+		protorequire.ProtoSliceEqual(t, []*commonpb.Link{linkA, linkA}, ctx.LinksByRequest[op]["req-1"])
+	})
+
+	t.Run("DistinctRequestsAccumulate", func(t *testing.T) {
+		stored := map[string][]*commonpb.Link{}
+		ctx := newLinkTestContext(stored)
+		op := newScheduledTestOperation(t, ctx)
+		validator := newTestLinkValidator(10, 10)
+
+		require.NoError(t, op.attachLinks(ctx, []*commonpb.Link{testLink("wf-1")}, "req-1", validator, "ns-name"))
+		stored["req-1"] = ctx.LinksByRequest[op]["req-1"]
+		require.NoError(t, op.attachLinks(ctx, []*commonpb.Link{testLink("wf-2")}, "req-2", validator, "ns-name"))
+
+		require.Len(t, ctx.LinksByRequest[op], 2)
+	})
+
+	t.Run("RejectsAClosedOperation", func(t *testing.T) {
+		ctx := newLinkTestContext(map[string][]*commonpb.Link{})
+		op := newScheduledTestOperation(t, ctx)
+		require.NoError(t, TransitionSucceeded.Apply(op, ctx, EventSucceeded{}))
+
+		err := op.attachLinks(ctx, []*commonpb.Link{testLink("wf-id")}, "req-new", newTestLinkValidator(10, 10), "ns-name")
+		require.ErrorAs(t, err, new(*serviceerror.FailedPrecondition))
+		require.ErrorContains(t, err, "cannot attach links to a closed nexus operation")
+	})
+
+	t.Run("IsIdempotentAfterClose", func(t *testing.T) {
+		// The original attach succeeded but the response was lost; by the time the client retries the
+		// operation has closed. The retry must still report success for links already persisted.
+		link := testLink("wf-id")
+		ctx := newLinkTestContext(map[string][]*commonpb.Link{"req-1": {link}})
+		op := newScheduledTestOperation(t, ctx)
+		require.NoError(t, TransitionSucceeded.Apply(op, ctx, EventSucceeded{}))
+
+		require.NoError(t, op.attachLinks(ctx, []*commonpb.Link{link}, "req-1", newTestLinkValidator(10, 10), "ns-name"))
+	})
+
+	t.Run("RejectsExceedingThePerRequestCap", func(t *testing.T) {
+		ctx := newLinkTestContext(map[string][]*commonpb.Link{})
+		op := newScheduledTestOperation(t, ctx)
+
+		err := op.attachLinks(
+			ctx,
+			[]*commonpb.Link{testLink("wf-1"), testLink("wf-2")},
+			"req-id",
+			newTestLinkValidator(1, 10),
+			"ns-name",
+		)
+		require.ErrorAs(t, err, new(*serviceerror.InvalidArgument))
+		require.ErrorContains(t, err, "cannot attach more than 1 links per request")
+		require.Empty(t, ctx.LinksByRequest[op])
+	})
+
+	t.Run("RejectsExceedingThePerComponentCapWithAlreadyAttachedLinks", func(t *testing.T) {
+		ctx := newLinkTestContext(map[string][]*commonpb.Link{"req-1": {testLink("wf-existing")}})
+		op := newScheduledTestOperation(t, ctx)
+
+		err := op.attachLinks(
+			ctx,
+			[]*commonpb.Link{testLink("wf-new")},
+			"req-2",
+			newTestLinkValidator(10, 1),
+			"ns-name",
+		)
+		require.ErrorAs(t, err, new(*serviceerror.FailedPrecondition))
+		require.ErrorContains(t, err, "1 links already attached")
+	})
+}
+
+// TestDescribeResponseIncludesLinks covers the plumbing from both link sources into the
+// DescribeNexusOperationExecution response.
+func TestDescribeResponseIncludesLinks(t *testing.T) {
+	t.Parallel()
+
+	req := &nexusoperationpb.DescribeNexusOperationRequest{
+		FrontendRequest: &workflowservice.DescribeNexusOperationExecutionRequest{},
+	}
+	newOp := func(ctx chasm.MutableContext) *Operation {
+		op := newTestOperation()
+		op.RequestData = chasm.NewDataField(ctx, &nexusoperationpb.OperationRequestData{})
+		op.Visibility = chasm.NewComponentField(ctx, chasm.NewVisibilityWithData(ctx, nil, nil))
+		return op
+	}
+
+	t.Run("UnionsCallerAndHandlerLinks", func(t *testing.T) {
+		callerLink, handlerLink := testLink("caller-wf"), testLink("handler-wf")
+		ctx := newLinkTestContext(map[string][]*commonpb.Link{"req-id": {callerLink}})
+		op := newOp(ctx)
+		// Links returned by the Nexus handler on its start/completion response.
+		op.Links = []*commonpb.Link{handlerLink}
+
+		resp, err := op.buildDescribeResponse(ctx, req)
+		require.NoError(t, err)
+		protorequire.ProtoElementsMatch(t,
+			[]*commonpb.Link{callerLink, handlerLink},
+			resp.GetFrontendResponse().GetInfo().GetLinks())
+	})
+
+	t.Run("CallerLinksOnly", func(t *testing.T) {
+		callerLink := testLink("caller-wf")
+		ctx := newLinkTestContext(map[string][]*commonpb.Link{"req-id": {callerLink}})
+
+		resp, err := newOp(ctx).buildDescribeResponse(ctx, req)
+		require.NoError(t, err)
+		protorequire.ProtoSliceEqual(t,
+			[]*commonpb.Link{callerLink},
+			resp.GetFrontendResponse().GetInfo().GetLinks())
+	})
+
+	t.Run("WithoutLinks", func(t *testing.T) {
+		ctx := newLinkTestContext(map[string][]*commonpb.Link{})
+
+		resp, err := newOp(ctx).buildDescribeResponse(ctx, req)
+		require.NoError(t, err)
+		require.Empty(t, resp.GetFrontendResponse().GetInfo().GetLinks())
+	})
+}

--- a/chasm/lib/nexusoperation/operation.go
+++ b/chasm/lib/nexusoperation/operation.go
@@ -3,6 +3,7 @@ package nexusoperation
 import (
 	"fmt"
 	"maps"
+	"slices"
 	"strings"
 	"time"
 
@@ -12,14 +13,17 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
 	nexuspb "go.temporal.io/api/nexus/v1"
+	apinexusoperationpb "go.temporal.io/api/nexusoperation/v1" //nolint:importas
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/lib/callback"
 	nexusoperationpb "go.temporal.io/server/chasm/lib/nexusoperation/gen/nexusoperationpb/v1"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/metrics"
 	commonnexus "go.temporal.io/server/common/nexus"
+	"go.temporal.io/server/common/nexus/nexusrpc"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/softassert"
 	queueserrors "go.temporal.io/server/service/history/queues/errors"
@@ -40,6 +44,7 @@ var _ chasm.RootComponent = (*Operation)(nil)
 var _ chasm.StateMachine[nexusoperationpb.OperationStatus] = (*Operation)(nil)
 var _ chasm.VisibilitySearchAttributesProvider = (*Operation)(nil)
 var _ chasm.NexusCompletionHandler = (*Operation)(nil)
+var _ callback.CompletionSource = (*Operation)(nil)
 
 // ErrCancellationAlreadyRequested is returned when a cancellation has already been requested for an operation.
 var ErrCancellationAlreadyRequested = serviceerror.NewFailedPrecondition("cancellation already requested")
@@ -99,6 +104,10 @@ type Operation struct {
 	Cancellation chasm.Field[*Cancellation]
 	Outcome      chasm.Field[*nexusoperationpb.OperationOutcome]
 	Visibility   chasm.Field[*chasm.Visibility]
+
+	// Callbacks holds completion callbacks to be invoked when this reaches a terminal state.
+	// Keyed by completionCallbackID(requestID, index).
+	Callbacks chasm.Map[string, *callback.Callback]
 }
 
 // NewOperation creates a new Operation component with the given persisted state.
@@ -109,6 +118,8 @@ func NewOperation(state *nexusoperationpb.OperationState) *Operation {
 func newStandaloneOperation(
 	ctx chasm.MutableContext,
 	req *nexusoperationpb.StartNexusOperationRequest,
+	maxCallbacks int,
+	linkValidator *linkValidator,
 ) (*Operation, error) {
 	frontendReq := req.GetFrontendRequest()
 	op := NewOperation(&nexusoperationpb.OperationState{
@@ -133,6 +144,23 @@ func newStandaloneOperation(
 		frontendReq.GetSearchAttributes().GetIndexedFields(),
 		nil,
 	))
+	if err := op.addCompletionCallbacks(
+		ctx,
+		frontendReq.GetRequestId(),
+		frontendReq.GetCompletionCallbacks(),
+		maxCallbacks,
+	); err != nil {
+		return nil, err
+	}
+	if err := op.attachLinks(
+		ctx,
+		frontendReq.GetLinks(),
+		frontendReq.GetRequestId(),
+		linkValidator,
+		frontendReq.GetNamespace(),
+	); err != nil {
+		return nil, err
+	}
 	if err := TransitionScheduled.Apply(op, ctx, EventScheduled{}); err != nil {
 		return nil, err
 	}
@@ -304,6 +332,12 @@ func (o *Operation) loadStartArgs(
 	} else {
 		// Standalone operation: there is no workflow caller, so add a nexus_operation self-link
 		// as the caller link for the completion callback.
+		//
+		// Only the caller link goes to the handler. Links the client attached to the start request
+		// (and any it attached later via on_conflict_options) are recorded on the operation and
+		// surfaced through Describe, but are not forwarded: this matches the workflow-backed case,
+		// where the handler likewise receives only the workflow_event caller link and not the links
+		// carried on the StartWorkflowExecution request.
 		requestData := o.RequestData.Get(ctx)
 		invocationData = InvocationData{
 			Input:  requestData.GetInput(),
@@ -393,7 +427,7 @@ func (o *Operation) resolveUnsuccessfully(ctx chasm.MutableContext, failure *fai
 
 	// NextAttemptScheduleTime is only valid in BACKING_OFF; clear on close
 	o.NextAttemptScheduleTime = nil
-	return nil
+	return o.scheduleCompletionCallbacks(ctx)
 }
 
 func (o *Operation) getOrCreateOutcome(ctx chasm.MutableContext) *nexusoperationpb.OperationOutcome {
@@ -403,6 +437,211 @@ func (o *Operation) getOrCreateOutcome(ctx chasm.MutableContext) *nexusoperation
 	outcome := &nexusoperationpb.OperationOutcome{}
 	o.Outcome = chasm.NewDataField(ctx, outcome)
 	return outcome
+}
+
+// addCompletionCallbacks creates the child CHASM callback components. They stay in STANDBY until this
+// Operation reaches a terminal state.
+//
+// Callbacks are keyed by request ID plus their position within the request, so re-attaching the same
+// request is a no-op rather than a duplicate. The idempotency probe runs before the closed check, so a
+// retry still succeeds if the operation closed after the first attach.
+//
+// maxCallbacks is re-checked here because callback.Validator only bounds the callbacks on the start
+// request; callbacks added later via on_conflict_options bypass it.
+func (o *Operation) addCompletionCallbacks(
+	ctx chasm.MutableContext,
+	requestID string,
+	completionCallbacks []*commonpb.Callback,
+	maxCallbacks int,
+) error {
+	if len(completionCallbacks) == 0 {
+		return nil
+	}
+	if requestID == "" {
+		return serviceerror.NewInvalidArgument("cannot attach completion callbacks without a request ID")
+	}
+	// Attaching is atomic, so the presence of the first key means this request already attached all of
+	// its callbacks. See the note above on why this precedes the closed check.
+	if _, ok := o.Callbacks[completionCallbackID(requestID, 0)]; ok {
+		return nil
+	}
+	if o.isClosed() {
+		return serviceerror.NewFailedPrecondition("cannot attach callbacks to a closed nexus operation")
+	}
+
+	currentCount := len(o.Callbacks)
+	if len(completionCallbacks)+currentCount > maxCallbacks {
+		return serviceerror.NewFailedPreconditionf(
+			"cannot attach more than %d callbacks to a nexus operation (%d callbacks already attached)",
+			maxCallbacks,
+			currentCount,
+		)
+	}
+
+	if o.Callbacks == nil {
+		o.Callbacks = make(chasm.Map[string, *callback.Callback], len(completionCallbacks))
+	}
+
+	registrationTime := timestamppb.New(ctx.Now(o))
+	for idx, cb := range completionCallbacks {
+		chasmCB, err := callback.FromAPICallback(cb)
+		if err != nil {
+			return err
+		}
+
+		// Give each callback its own, unique request ID. Since using the same request ID as the
+		// operation which added the callbacks would be ambiguous if it added more than one callback.
+		cbRequestID := uuid.NewString()
+		callbackObj := callback.NewCallback(cbRequestID, registrationTime, chasmCB)
+		o.Callbacks[completionCallbackID(requestID, idx)] = chasm.NewComponentField(ctx, callbackObj)
+	}
+	return nil
+}
+
+// attachLinks records the given links on the operation keyed by requestID. Duplicates within the same
+// batch are kept as-is, matching the workflow and standalone activity start paths. If the requestID has
+// already been used to attach links the call is a no-op, making retries idempotent even after the
+// operation has closed. Returns an error if the operation is closed (and the requestID is new), if the
+// per-component cap would be exceeded, or if the request's per-link size, per-request count, or variant
+// shape is invalid.
+func (o *Operation) attachLinks(
+	ctx chasm.MutableContext,
+	links []*commonpb.Link,
+	requestID string,
+	validator *linkValidator,
+	namespaceName string,
+) error {
+	if len(links) == 0 {
+		return nil
+	}
+	// Idempotency check must run before isClosed: if a prior attach succeeded but the response was
+	// lost and the operation closed before the client retried, we must still return success rather
+	// than FailedPrecondition for work already persisted.
+	priorForRequest, err := ctx.RequestLinks(o, requestID)
+	if err != nil {
+		return err
+	}
+	if len(priorForRequest) > 0 {
+		return nil
+	}
+	if o.isClosed() {
+		return serviceerror.NewFailedPrecondition("cannot attach links to a closed nexus operation")
+	}
+	if err := validator.ValidateRequest(namespaceName, links); err != nil {
+		return err
+	}
+	// The cap bounds caller-attached links only; links returned by the Nexus handler
+	// (OperationState.links) arrive on a separate path and are not counted here.
+	if err := validator.ValidateTotal(namespaceName, len(ctx.Links(o)), len(links)); err != nil {
+		return err
+	}
+	return ctx.SetRequestLinks(o, requestID, links)
+}
+
+// allLinks returns every link associated with the operation: those attached by callers on their start
+// and on-conflict attach requests, plus any the Nexus handler returned on its start or completion
+// response (standalone operations only; workflow-backed ones carry theirs on history events).
+func (o *Operation) allLinks(ctx chasm.Context) []*commonpb.Link {
+	requestLinks := ctx.Links(o)
+	all := make([]*commonpb.Link, 0, len(requestLinks)+len(o.Links))
+	all = append(all, requestLinks...)
+	all = append(all, o.Links...)
+	return all
+}
+
+// completionCallbackID defines the stable key used for keeping track of attached completion callbacks.
+func completionCallbackID(requestID string, idx int) string {
+	return fmt.Sprintf("%s-%d", requestID, idx)
+}
+
+// scheduleCompletionCallbacks releases every STANDBY completion callback for delivery. Called from each
+// terminal transition.
+func (o *Operation) scheduleCompletionCallbacks(ctx chasm.MutableContext) error {
+	return callback.ScheduleStandbyCallbacks(ctx, o.Callbacks)
+}
+
+// GetNexusCompletion implements callback.CompletionSource, providing the result of the Nexus operation.
+func (o *Operation) GetNexusCompletion(ctx chasm.Context, _ string) (nexusrpc.CompleteOperationOptions, error) {
+	if !o.isClosed() {
+		return nexusrpc.CompleteOperationOptions{}, serviceerror.NewInternal("nexus operation has not completed yet")
+	}
+
+	key := ctx.ExecutionKey()
+	backLink := commonnexus.ConvertLinkNexusOperationToNexusLink(&commonpb.Link_NexusOperation{
+		Namespace:   ctx.NamespaceEntry().Name().String(),
+		OperationId: key.BusinessID,
+		RunId:       key.RunID,
+	})
+
+	opts := nexusrpc.CompleteOperationOptions{
+		StartTime: o.GetScheduledTime().AsTime(),
+		CloseTime: ctx.ExecutionInfo().CloseTime,
+		Links:     []nexus.Link{backLink},
+	}
+
+	result, failure := o.outcome(ctx)
+	if o.Status == nexusoperationpb.OPERATION_STATUS_SUCCEEDED {
+		opts.Result = result
+		return opts, nil
+	}
+	if failure == nil {
+		return nexusrpc.CompleteOperationOptions{},
+			serviceerror.NewInternalf("nexus operation in status %v has no outcome", o.Status)
+	}
+
+	state := nexus.OperationStateFailed
+	message := "operation failed"
+	if o.Status == nexusoperationpb.OPERATION_STATUS_CANCELED {
+		state = nexus.OperationStateCanceled
+		message = "operation canceled"
+	}
+
+	nf, err := commonnexus.TemporalFailureToNexusFailure(failure)
+	if err != nil {
+		return nexusrpc.CompleteOperationOptions{}, serviceerror.NewInternalf("failed to convert failure: %v", err)
+	}
+	opErr := &nexus.OperationError{
+		State:   state,
+		Message: message,
+		Cause:   &nexus.FailureError{Failure: nf},
+	}
+	if err := nexusrpc.MarkAsWrapperError(nexusrpc.DefaultFailureConverter(), opErr); err != nil {
+		return nexusrpc.CompleteOperationOptions{}, err
+	}
+	opts.Error = opErr
+	return opts, nil
+}
+
+// buildCompletionCallbackInfos projects the attached completion callbacks onto the API surface for the
+// describe response.
+func (o *Operation) buildCompletionCallbackInfos(ctx chasm.Context) ([]*apinexusoperationpb.CallbackInfo, error) {
+	if len(o.Callbacks) == 0 {
+		return nil, nil
+	}
+
+	// All standalone Nexus operation callbacks have the same trigger.
+	trigger := &apinexusoperationpb.CallbackInfo_Trigger{
+		Variant: &apinexusoperationpb.CallbackInfo_Trigger_OperationCompleted{
+			OperationCompleted: &apinexusoperationpb.CallbackInfo_OperationCompleted{},
+		},
+	}
+
+	// We make no attempt to return Callbacks in the specific order they were
+	// added, we just sort the Callbacks so that the returned CallbackInfo is
+	// stable.
+	sortedCallbackKeys := slices.Sorted(maps.Keys(o.Callbacks))
+	infos := make([]*apinexusoperationpb.CallbackInfo, 0, len(o.Callbacks))
+	for _, id := range sortedCallbackKeys {
+		info, err := o.Callbacks[id].Get(ctx).ToAPICallbackInfo(ctx)
+		if err != nil {
+			return nil, err
+		}
+		infos = append(infos, &apinexusoperationpb.CallbackInfo{
+			Trigger: trigger,
+			Info:    info,
+		})
+	}
+	return infos, nil
 }
 
 func (o *Operation) Terminate(
@@ -445,10 +684,16 @@ func (o *Operation) buildDescribeResponse(
 		return nil, err
 	}
 
+	callbackInfos, err := o.buildCompletionCallbackInfos(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	resp := &workflowservice.DescribeNexusOperationExecutionResponse{
-		RunId:         ctx.ExecutionKey().RunID,
-		Info:          o.buildExecutionInfo(ctx),
-		LongPollToken: token,
+		RunId:               ctx.ExecutionKey().RunID,
+		Info:                o.buildExecutionInfo(ctx),
+		LongPollToken:       token,
+		CompletionCallbacks: callbackInfos,
 	}
 	if req.GetFrontendRequest().GetIncludeInput() {
 		resp.Input = o.RequestData.Get(ctx).GetInput()
@@ -558,7 +803,7 @@ func (o *Operation) buildExecutionInfo(ctx chasm.Context) *nexuspb.NexusOperatio
 		},
 		NexusHeader:  requestData.GetNexusHeader(),
 		UserMetadata: requestData.GetUserMetadata(),
-		Links:        o.Links,
+		Links:        o.allLinks(ctx),
 		Identity:     requestData.GetIdentity(),
 	}
 

--- a/chasm/lib/nexusoperation/operation_statemachine.go
+++ b/chasm/lib/nexusoperation/operation_statemachine.go
@@ -190,8 +190,8 @@ var TransitionSucceeded = chasm.NewTransition(
 		}
 
 		o.emitOnSucceededMetrics(ctx, closeTime)
-		// Terminal state - no tasks to emit.
-		return nil
+		// Schedule the SANO's completion callbacks.
+		return o.scheduleCompletionCallbacks(ctx)
 	},
 )
 

--- a/chasm/lib/nexusoperation/validator.go
+++ b/chasm/lib/nexusoperation/validator.go
@@ -1,6 +1,7 @@
 package nexusoperation
 
 import (
+	"context"
 	"slices"
 	"strings"
 
@@ -10,6 +11,7 @@ import (
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/common/callbacks"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/primitives/timestamp"
@@ -33,10 +35,12 @@ type cancelOrTerminateRequest interface {
 // Requests are mutated in place: defaults are applied, values are capped to their configured
 // limits, and headers are lower-cased.
 type validator struct {
-	config           *Config
-	logger           log.Logger
-	saMapperProvider searchattribute.MapperProvider
-	saValidator      *searchattribute.Validator
+	config            *Config
+	logger            log.Logger
+	saMapperProvider  searchattribute.MapperProvider
+	saValidator       *searchattribute.Validator
+	callbackValidator callbacks.Validator
+	linkValidator     *linkValidator
 }
 
 func newValidator(
@@ -44,16 +48,23 @@ func newValidator(
 	logger log.Logger,
 	saMapperProvider searchattribute.MapperProvider,
 	saValidator *searchattribute.Validator,
+	callbackValidator callbacks.Validator,
+	linkValidator *linkValidator,
 ) *validator {
 	return &validator{
-		config:           config,
-		logger:           logger,
-		saMapperProvider: saMapperProvider,
-		saValidator:      saValidator,
+		config:            config,
+		logger:            logger,
+		saMapperProvider:  saMapperProvider,
+		saValidator:       saValidator,
+		callbackValidator: callbackValidator,
+		linkValidator:     linkValidator,
 	}
 }
 
-func (v *validator) validateAndNormalizeStartRequest(req *workflowservice.StartNexusOperationExecutionRequest) error {
+func (v *validator) validateAndNormalizeStartRequest(
+	ctx context.Context,
+	req *workflowservice.StartNexusOperationExecutionRequest,
+) error {
 	ns := req.GetNamespace()
 
 	if err := v.normalizeRequestID(&req.RequestId); err != nil {
@@ -85,6 +96,25 @@ func (v *validator) validateAndNormalizeStartRequest(req *workflowservice.StartN
 	req.NexusHeader = loweredHeaders
 
 	if err := v.validateAndNormalizeSearchAttributes(req); err != nil {
+		return err
+	}
+	// Callbacks
+	cbs := req.GetCompletionCallbacks()
+	if len(cbs) > 0 {
+		opts := callbacks.ValidatorOptions{
+			EnabledKinds: v.config.EnabledCallbackKinds(ns),
+		}
+		if err := v.callbackValidator.Validate(ctx, ns, cbs, opts); err != nil {
+			return err
+		}
+	}
+	// Links
+	links := req.GetLinks()
+	if err := v.linkValidator.ValidateRequestWithCallbacks(ns, links, cbs); err != nil {
+		return err
+	}
+
+	if err := v.validateOnConflictOptions(req); err != nil {
 		return err
 	}
 
@@ -311,6 +341,31 @@ func (v *validator) normalizeIDPolicies(req *workflowservice.StartNexusOperation
 	if req.GetIdConflictPolicy() == enumspb.NEXUS_OPERATION_ID_CONFLICT_POLICY_UNSPECIFIED {
 		req.IdConflictPolicy = enumspb.NEXUS_OPERATION_ID_CONFLICT_POLICY_FAIL
 	}
+}
+
+// validateOnConflictOptions validates the on_conflict_options of a start request:
+//   - attach_completion_callbacks requires attach_request_id, since it is embedded into the keys we use
+//     to persist them on the Operation's Callbacks map.
+//   - attach_request_id requires at least one completion callback or link, since attaching a request ID
+//     is only meaningful alongside something to attach.
+//
+// attach_links is independent and may be set on its own.
+func (v *validator) validateOnConflictOptions(req *workflowservice.StartNexusOperationExecutionRequest) error {
+	onConflictOptions := req.GetOnConflictOptions()
+	if onConflictOptions == nil {
+		return nil
+	}
+	if onConflictOptions.GetAttachCompletionCallbacks() && !onConflictOptions.GetAttachRequestId() {
+		return serviceerror.NewInvalidArgument(
+			"on_conflict_options: attach_completion_callbacks requires attach_request_id to be set")
+	}
+	if onConflictOptions.GetAttachRequestId() &&
+		len(req.GetCompletionCallbacks()) == 0 &&
+		len(req.GetLinks()) == 0 {
+		return serviceerror.NewInvalidArgument(
+			"on_conflict_options: attach_request_id requires at least one completion callback or link")
+	}
+	return nil
 }
 
 // normalizeRequestID validates the request ID, or sets it to a UUID if empty.

--- a/chasm/lib/nexusoperation/validator_test.go
+++ b/chasm/lib/nexusoperation/validator_test.go
@@ -1,6 +1,9 @@
 package nexusoperation
 
 import (
+	"context"
+	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -8,10 +11,12 @@ import (
 	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	nexusoperationpb "go.temporal.io/api/nexusoperation/v1"
 	sdkpb "go.temporal.io/api/sdk/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/callbacks"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
@@ -23,7 +28,52 @@ import (
 )
 
 func newTestValidator(config *Config) *validator {
-	return newValidator(config, log.NewNoopLogger(), nil, nil)
+	return newValidator(
+		config,
+		log.NewNoopLogger(),
+		nil,
+		nil,
+		mustNewCallbackValidator(),
+		newTestLinkValidator(10, 10),
+	)
+}
+
+func mustNewCallbackValidator() callbacks.Validator {
+	allowAllAddresses := callbacks.AddressMatchRules{
+		Rules: []callbacks.AddressMatchRule{
+			{Regexp: regexp.MustCompile(`.*`), AllowInsecure: true},
+		},
+	}
+	cfg := callbacks.ValidatorConfig{
+		MaxCallbacksPerExecution:         func(string) int { return 10 },
+		MaxIDLengthLimit:                 func() int { return 10 },
+		URLMaxLength:                     func(string) int { return 1000 },
+		HeaderMaxSize:                    func(string) int { return 4096 },
+		EndpointRules:                    func(string) callbacks.AddressMatchRules { return allowAllAddresses },
+		MaxServiceNameLength:             func(string) int { return 10 },
+		MaxOperationNameLength:           func(string) int { return 10 },
+		NexusHandlerSourceContextMaxSize: func(string) int { return 1000 },
+	}
+
+	v, err := callbacks.NewValidator(cfg)
+	if err != nil {
+		panic("creating callback validator: " + err.Error())
+	}
+	return v
+}
+
+func newNexusCallback() *commonpb.Callback {
+	return &commonpb.Callback{
+		Variant: &commonpb.Callback_Nexus_{
+			Nexus: &commonpb.Callback_Nexus{
+				Url: "https://nexus.ex.xxxxx.cluster.tmprl.cloud:7243/Namespaces/ex.xxxxx/nexus/callback",
+				Header: map[string]string{
+					"Nexus-Operation-State": "succeeded",
+					"Content-Type":          "application/json",
+				},
+			},
+		},
+	}
 }
 
 func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
@@ -56,13 +106,18 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 		MaxOperationHeaderSize:             func(string) int { return 10 },
 		DisallowedOperationHeaders:         func() []string { return []string{"disallowed-header"} },
 		MaxOperationScheduleToCloseTimeout: func(string) time.Duration { return time.Hour },
+		EnabledCallbackKinds: func(string) []callbacks.Kind {
+			return []callbacks.Kind{callbacks.KindNexus}
+		},
 	}
 
 	for _, tc := range []struct {
-		name   string
-		mutate func(*workflowservice.StartNexusOperationExecutionRequest)
-		errMsg string
-		check  func(*testing.T, *workflowservice.StartNexusOperationExecutionRequest)
+		name         string
+		mutate       func(*workflowservice.StartNexusOperationExecutionRequest)
+		mutateConfig func(*Config)
+		wantErr      string
+		// Check the request after validation, to verify situations where it normalizes values.
+		postValidateCheck func(*testing.T, *workflowservice.StartNexusOperationExecutionRequest)
 	}{
 		{
 			name: "valid request",
@@ -72,21 +127,21 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.OperationId = ""
 			},
-			errMsg: "operation_id is required",
+			wantErr: "operation_id is required",
 		},
 		{
 			name: "operation_id - exceeds length limit",
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.OperationId = strings.Repeat("x", 51)
 			},
-			errMsg: "operation_id exceeds length limit",
+			wantErr: "operation_id exceeds length limit",
 		},
 		{
 			name: "request_id - defaults empty to UUID",
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.RequestId = ""
 			},
-			check: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
+			postValidateCheck: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
 				require.Len(t, r.RequestId, 36) // UUID length
 			},
 		},
@@ -95,63 +150,63 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.RequestId = strings.Repeat("x", 51)
 			},
-			errMsg: "request_id exceeds length limit",
+			wantErr: "request_id exceeds length limit",
 		},
 		{
 			name: "identity - exceeds length limit",
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.Identity = strings.Repeat("x", 51)
 			},
-			errMsg: "identity exceeds length limit",
+			wantErr: "identity exceeds length limit",
 		},
 		{
-			name:   "endpoint - required",
-			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) { r.Endpoint = "" },
-			errMsg: "endpoint is required",
+			name:    "endpoint - required",
+			mutate:  func(r *workflowservice.StartNexusOperationExecutionRequest) { r.Endpoint = "" },
+			wantErr: "endpoint is required",
 		},
 		{
-			name:   "service - required",
-			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) { r.Service = "" },
-			errMsg: "service is required",
+			name:    "service - required",
+			mutate:  func(r *workflowservice.StartNexusOperationExecutionRequest) { r.Service = "" },
+			wantErr: "service is required",
 		},
 		{
 			name: "service - exceeds length limit",
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.Service = "too-long-svc"
 			},
-			errMsg: "service exceeds length limit",
+			wantErr: "service exceeds length limit",
 		},
 		{
-			name:   "operation - required",
-			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) { r.Operation = "" },
-			errMsg: "operation is required",
+			name:    "operation - required",
+			mutate:  func(r *workflowservice.StartNexusOperationExecutionRequest) { r.Operation = "" },
+			wantErr: "operation is required",
 		},
 		{
 			name: "operation - exceeds length limit",
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.Operation = "too-long-op!"
 			},
-			errMsg: "operation exceeds length limit",
+			wantErr: "operation exceeds length limit",
 		},
 		{
 			name: "schedule_to_close_timeout - invalid",
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.ScheduleToCloseTimeout = &durationpb.Duration{Seconds: -1}
 			},
-			errMsg: "schedule_to_close_timeout is invalid",
+			wantErr: "schedule_to_close_timeout is invalid",
 		},
 		{
 			name: "schedule_to_close_timeout - caps exceeding max",
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.ScheduleToCloseTimeout = durationpb.New(2 * time.Hour)
 			},
-			check: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
+			postValidateCheck: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
 				require.Equal(t, time.Hour, r.ScheduleToCloseTimeout.AsDuration())
 			},
 		},
 		{
 			name: "schedule_to_close_timeout - caps unset to max",
-			check: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
+			postValidateCheck: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
 				require.Equal(t, time.Hour, r.ScheduleToCloseTimeout.AsDuration())
 			},
 		},
@@ -160,7 +215,7 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.ScheduleToCloseTimeout = durationpb.New(30 * time.Minute)
 			},
-			check: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
+			postValidateCheck: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
 				require.Equal(t, 30*time.Minute, r.ScheduleToCloseTimeout.AsDuration())
 			},
 		},
@@ -169,14 +224,14 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.ScheduleToStartTimeout = &durationpb.Duration{Seconds: -1}
 			},
-			errMsg: "schedule_to_start_timeout is invalid",
+			wantErr: "schedule_to_start_timeout is invalid",
 		},
 		{
 			name: "schedule_to_start_timeout - caps to defaulted schedule_to_close_timeout",
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.ScheduleToStartTimeout = durationpb.New(2 * time.Hour)
 			},
-			check: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
+			postValidateCheck: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
 				require.Equal(t, time.Hour, r.ScheduleToCloseTimeout.AsDuration())
 				require.Equal(t, time.Hour, r.ScheduleToStartTimeout.AsDuration())
 			},
@@ -187,7 +242,7 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 				r.ScheduleToCloseTimeout = durationpb.New(30 * time.Minute)
 				r.ScheduleToStartTimeout = durationpb.New(time.Hour)
 			},
-			check: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
+			postValidateCheck: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
 				require.Equal(t, 30*time.Minute, r.ScheduleToStartTimeout.AsDuration())
 			},
 		},
@@ -197,7 +252,7 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 				r.ScheduleToCloseTimeout = durationpb.New(30 * time.Minute)
 				r.ScheduleToStartTimeout = durationpb.New(20 * time.Minute)
 			},
-			check: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
+			postValidateCheck: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
 				require.Equal(t, 20*time.Minute, r.ScheduleToStartTimeout.AsDuration())
 			},
 		},
@@ -206,14 +261,14 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.StartToCloseTimeout = &durationpb.Duration{Seconds: -1}
 			},
-			errMsg: "start_to_close_timeout is invalid",
+			wantErr: "start_to_close_timeout is invalid",
 		},
 		{
 			name: "start_to_close_timeout - caps to defaulted schedule_to_close_timeout",
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.StartToCloseTimeout = durationpb.New(2 * time.Hour)
 			},
-			check: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
+			postValidateCheck: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
 				require.Equal(t, time.Hour, r.ScheduleToCloseTimeout.AsDuration())
 				require.Equal(t, time.Hour, r.StartToCloseTimeout.AsDuration())
 			},
@@ -224,7 +279,7 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 				r.ScheduleToCloseTimeout = durationpb.New(30 * time.Minute)
 				r.StartToCloseTimeout = durationpb.New(time.Hour)
 			},
-			check: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
+			postValidateCheck: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
 				require.Equal(t, 30*time.Minute, r.StartToCloseTimeout.AsDuration())
 			},
 		},
@@ -234,7 +289,7 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 				r.ScheduleToCloseTimeout = durationpb.New(30 * time.Minute)
 				r.StartToCloseTimeout = durationpb.New(10 * time.Minute)
 			},
-			check: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
+			postValidateCheck: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
 				require.Equal(t, 10*time.Minute, r.StartToCloseTimeout.AsDuration())
 			},
 		},
@@ -249,7 +304,7 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.Input = &commonpb.Payload{Data: []byte("this-input-is-longer-than-twenty-characters")}
 			},
-			errMsg: "input exceeds size limit",
+			wantErr: "input exceeds size limit",
 		},
 		{
 			name: "user_metadata.summary - exceeds size limit",
@@ -258,7 +313,7 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 					Summary: &commonpb.Payload{Data: []byte("too-long-summary")},
 				}
 			},
-			errMsg: "user_metadata.summary exceeds size limit",
+			wantErr: "user_metadata.summary exceeds size limit",
 		},
 		{
 			name: "user_metadata.details - exceeds size limit",
@@ -267,25 +322,25 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 					Details: &commonpb.Payload{Data: []byte("this-details-payload-is-too-long")},
 				}
 			},
-			errMsg: "user_metadata.details exceeds size limit",
+			wantErr: "user_metadata.details exceeds size limit",
 		},
 		{
 			name: "nexus_header - disallowed key",
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.NexusHeader = map[string]string{"Disallowed-Header": "value"}
 			},
-			errMsg: "nexus_header contains a disallowed key",
+			wantErr: "nexus_header contains a disallowed key",
 		},
 		{
 			name: "nexus_header - exceeds size limit",
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.NexusHeader = map[string]string{"key": "too-long-val"}
 			},
-			errMsg: "nexus_header exceeds size limit",
+			wantErr: "nexus_header exceeds size limit",
 		},
 		{
 			name: "id_policies - defaults unspecified",
-			check: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
+			postValidateCheck: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
 				require.Equal(t, enumspb.NEXUS_OPERATION_ID_REUSE_POLICY_ALLOW_DUPLICATE, r.IdReusePolicy)
 				require.Equal(t, enumspb.NEXUS_OPERATION_ID_CONFLICT_POLICY_FAIL, r.IdConflictPolicy)
 			},
@@ -296,7 +351,7 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 				r.IdReusePolicy = enumspb.NEXUS_OPERATION_ID_REUSE_POLICY_REJECT_DUPLICATE
 				r.IdConflictPolicy = enumspb.NEXUS_OPERATION_ID_CONFLICT_POLICY_USE_EXISTING
 			},
-			check: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
+			postValidateCheck: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
 				require.Equal(t, enumspb.NEXUS_OPERATION_ID_REUSE_POLICY_REJECT_DUPLICATE, r.IdReusePolicy)
 				require.Equal(t, enumspb.NEXUS_OPERATION_ID_CONFLICT_POLICY_USE_EXISTING, r.IdConflictPolicy)
 			},
@@ -312,7 +367,7 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 					},
 				}
 			},
-			errMsg: "number of search attributes",
+			wantErr: "number of search attributes",
 		},
 		{
 			name: "search_attributes - value exceeds size limit",
@@ -326,7 +381,76 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 					},
 				}
 			},
-			errMsg: "exceeds size limit",
+			wantErr: "exceeds size limit",
+		},
+		{
+			name: "completion_callbacks - accepts the nexus variant",
+			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
+				r.CompletionCallbacks = []*commonpb.Callback{newNexusCallback()}
+			},
+		},
+		{
+			name: "links - accepts a valid link",
+			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
+				r.Links = []*commonpb.Link{testLink("wf-id")}
+			},
+		},
+		{
+			name: "links - rejects an incomplete variant",
+			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
+				r.Links = []*commonpb.Link{{Variant: &commonpb.Link_WorkflowEvent_{
+					WorkflowEvent: &commonpb.Link_WorkflowEvent{WorkflowId: "wf-id", RunId: "wf-run-id"},
+				}}}
+			},
+			wantErr: "must not have an empty namespace",
+		},
+		{
+			name: "links - rejects more than the per-request limit",
+			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
+				// newTestLinkValidator below allows 10 links per request.
+				for i := range 11 {
+					r.Links = append(r.Links, testLink(fmt.Sprintf("wf-%d", i)))
+				}
+			},
+			wantErr: "cannot attach more than 10 links per request",
+		},
+		{
+			name: "on_conflict_options - attach_completion_callbacks requires attach_request_id",
+			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
+				r.CompletionCallbacks = []*commonpb.Callback{newNexusCallback()}
+				r.OnConflictOptions = &nexusoperationpb.OnConflictOptions{
+					AttachCompletionCallbacks: true,
+				}
+			},
+			wantErr: "attach_completion_callbacks requires attach_request_id",
+		},
+		{
+			name: "on_conflict_options - attach_request_id requires a completion callback or a link",
+			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
+				r.OnConflictOptions = &nexusoperationpb.OnConflictOptions{
+					AttachRequestId: true,
+				}
+			},
+			wantErr: "attach_request_id requires at least one completion callback or link",
+		},
+		{
+			name: "on_conflict_options - attach_request_id is satisfied by links alone",
+			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
+				r.Links = []*commonpb.Link{testLink("wf-id")}
+				r.OnConflictOptions = &nexusoperationpb.OnConflictOptions{
+					AttachRequestId: true,
+					AttachLinks:     true,
+				}
+			},
+		},
+		{
+			name: "on_conflict_options - attach_links may be set on its own",
+			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
+				r.Links = []*commonpb.Link{testLink("wf-id")}
+				r.OnConflictOptions = &nexusoperationpb.OnConflictOptions{
+					AttachLinks: true,
+				}
+			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -346,17 +470,22 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 			if tc.mutate != nil {
 				tc.mutate(req)
 			}
-			err := newValidator(config, log.NewNoopLogger(), nil, saValidator).
-				validateAndNormalizeStartRequest(req)
-			if tc.errMsg != "" {
+			caseConfig := *config
+			if tc.mutateConfig != nil {
+				tc.mutateConfig(&caseConfig)
+			}
+			cbValidator := mustNewCallbackValidator()
+			err := newValidator(&caseConfig, log.NewNoopLogger(), nil, saValidator, cbValidator, newTestLinkValidator(10, 10)).
+				validateAndNormalizeStartRequest(context.Background(), req)
+			if tc.wantErr != "" {
 				var invalidArgErr *serviceerror.InvalidArgument
 				require.ErrorAs(t, err, &invalidArgErr)
-				require.Contains(t, err.Error(), tc.errMsg)
+				require.Contains(t, err.Error(), tc.wantErr)
 			} else {
 				require.NoError(t, err)
 			}
-			if tc.check != nil {
-				tc.check(t, req)
+			if tc.postValidateCheck != nil {
+				tc.postValidateCheck(t, req)
 			}
 		})
 	}
@@ -787,4 +916,100 @@ func TestValidatePollNexusOperationExecutionRequest(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateOnConflictOptions(t *testing.T) {
+	t.Parallel()
+
+	// on_conflict_options validation is config-independent.
+	v := newTestValidator(&Config{})
+	cb := newNexusCallback()
+
+	t.Run("Unset", func(t *testing.T) {
+		require.NoError(t, v.validateOnConflictOptions(&workflowservice.StartNexusOperationExecutionRequest{}))
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		require.NoError(t, v.validateOnConflictOptions(&workflowservice.StartNexusOperationExecutionRequest{
+			OnConflictOptions: &nexusoperationpb.OnConflictOptions{},
+		}))
+	})
+
+	t.Run("AttachRequestIdAndCallbacksWithCallback", func(t *testing.T) {
+		require.NoError(t, v.validateOnConflictOptions(&workflowservice.StartNexusOperationExecutionRequest{
+			CompletionCallbacks: []*commonpb.Callback{cb},
+			OnConflictOptions: &nexusoperationpb.OnConflictOptions{
+				AttachRequestId:           true,
+				AttachCompletionCallbacks: true,
+			},
+		}))
+	})
+
+	t.Run("AttachRequestIdOnlyWithCallback", func(t *testing.T) {
+		require.NoError(t, v.validateOnConflictOptions(&workflowservice.StartNexusOperationExecutionRequest{
+			CompletionCallbacks: []*commonpb.Callback{cb},
+			OnConflictOptions:   &nexusoperationpb.OnConflictOptions{AttachRequestId: true},
+		}))
+	})
+
+	t.Run("AttachCallbacksWithoutAttachRequestId", func(t *testing.T) {
+		err := v.validateOnConflictOptions(&workflowservice.StartNexusOperationExecutionRequest{
+			CompletionCallbacks: []*commonpb.Callback{cb},
+			OnConflictOptions: &nexusoperationpb.OnConflictOptions{
+				AttachCompletionCallbacks: true,
+			},
+		})
+		var invalidArgErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgErr)
+		require.Contains(t, err.Error(), "attach_completion_callbacks requires attach_request_id")
+	})
+
+	t.Run("AttachRequestIdOnlyWithLink", func(t *testing.T) {
+		require.NoError(t, v.validateOnConflictOptions(&workflowservice.StartNexusOperationExecutionRequest{
+			Links:             []*commonpb.Link{testLink("wf-id")},
+			OnConflictOptions: &nexusoperationpb.OnConflictOptions{AttachRequestId: true},
+		}))
+	})
+
+	t.Run("AttachLinksOnly", func(t *testing.T) {
+		// attach_links stands on its own: links are keyed by the request ID the caller always supplies.
+		require.NoError(t, v.validateOnConflictOptions(&workflowservice.StartNexusOperationExecutionRequest{
+			Links:             []*commonpb.Link{testLink("wf-id")},
+			OnConflictOptions: &nexusoperationpb.OnConflictOptions{AttachLinks: true},
+		}))
+	})
+
+	t.Run("AttachLinksAndCallbacks", func(t *testing.T) {
+		require.NoError(t, v.validateOnConflictOptions(&workflowservice.StartNexusOperationExecutionRequest{
+			CompletionCallbacks: []*commonpb.Callback{cb},
+			Links:               []*commonpb.Link{testLink("wf-id")},
+			OnConflictOptions: &nexusoperationpb.OnConflictOptions{
+				AttachRequestId:           true,
+				AttachCompletionCallbacks: true,
+				AttachLinks:               true,
+			},
+		}))
+	})
+
+	t.Run("AttachRequestIdWithoutCallbackOrLink", func(t *testing.T) {
+		err := v.validateOnConflictOptions(&workflowservice.StartNexusOperationExecutionRequest{
+			OnConflictOptions: &nexusoperationpb.OnConflictOptions{AttachRequestId: true},
+		})
+		var invalidArgErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgErr)
+		require.Contains(t, err.Error(), "attach_request_id requires at least one completion callback or link")
+	})
+
+	t.Run("AttachRequestIdAndCallbacksWithoutCallbackProvided", func(t *testing.T) {
+		err := v.validateOnConflictOptions(&workflowservice.StartNexusOperationExecutionRequest{
+			OnConflictOptions: &nexusoperationpb.OnConflictOptions{
+				AttachRequestId:           true,
+				AttachCompletionCallbacks: true,
+			},
+		})
+		var invalidArgErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgErr)
+		require.Contains(t, err.Error(), "attach_request_id requires at least one completion callback")
+	})
+
 }

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -234,6 +234,8 @@ func (s *WorkflowHandlerSuite) getWorkflowHandler(config *Config) *WorkflowHandl
 			nil,
 			s.mockResource.GetSearchAttributesMapperProvider(),
 			nil,
+			nil,
+			nil,
 		),
 		nil, // Not testing CHASM registry here
 		quotas.NoopRequestRateLimiter,

--- a/tests/comp_callbacks.go
+++ b/tests/comp_callbacks.go
@@ -370,3 +370,93 @@ func (saa *standaloneActivityExecutionType) awaitCallbackState(
 	}
 	return saa.baseAwaitCallbackState(t, describeFn, wantState, errorStates)
 }
+
+// standaloneNexusOperationExecutionType implements the executionWithCallbacks using standalone Nexus operations.
+type standaloneNexusOperationExecutionType struct {
+	baseExecutionWithCallbacks
+}
+
+var _ executionWithCallbacks = (*standaloneNexusOperationExecutionType)(nil)
+
+func (sno *standaloneNexusOperationExecutionType) startAndCompleteEx(
+	t *testing.T,
+	env *testcore.TestEnv,
+	callback *commonpb.Callback,
+) (string, error) {
+	t.Helper()
+	ctx := t.Context()
+
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	operationID := testcore.RandomizeStr(t.Name())
+	nexusTestEnv := NexusTestEnv{
+		TestEnv:             env,
+		useTemporalFailures: true,
+	}
+	alwaysSuccessNexusEndpoint := nexusTestEnv.createSyncSuccessEndpoint(ctx, t, "operation-result")
+
+	// Start the standalone Nexus operation.
+	startReq := &workflowservice.StartNexusOperationExecutionRequest{
+		Namespace: env.Namespace().String(),
+
+		// The always success endpoint ignores the Service/Operation fields.
+		Endpoint:  alwaysSuccessNexusEndpoint,
+		Service:   "nexus-service",
+		Operation: "nexus-operation",
+
+		OperationId:            operationID,
+		ScheduleToCloseTimeout: durationpb.New(10 * time.Second),
+		CompletionCallbacks: []*commonpb.Callback{
+			callback,
+		},
+	}
+	startResp, err := env.FrontendClient().StartNexusOperationExecution(ctx, startReq)
+	if err != nil {
+		return "", err
+	}
+
+	require.True(t, startResp.GetStarted())
+
+	// Wait for the Nexus operation to be resolved, only then are its completion callbacks triggered.
+	await.Require(ctx, t, func(c *await.T) {
+		descReq := &workflowservice.DescribeNexusOperationExecutionRequest{
+			Namespace:      env.Namespace().String(),
+			OperationId:    operationID,
+			IncludeOutcome: true,
+		}
+		descResp, err := env.FrontendClient().DescribeNexusOperationExecution(c.Context(), descReq)
+		require.NoError(t, err)
+
+		gotStatus := descResp.GetInfo().GetStatus()
+		require.Equal(c, enumspb.NEXUS_OPERATION_EXECUTION_STATUS_COMPLETED, gotStatus)
+	}, 10*time.Second, 200*time.Millisecond)
+
+	return operationID, nil
+}
+
+func (sno *standaloneNexusOperationExecutionType) awaitCallbackState(
+	t *testing.T,
+	executionID string,
+	env *testcore.TestEnv,
+	wantState enumspb.CallbackState,
+	errorStates []enumspb.CallbackState,
+) *callbackpb.CallbackInfo {
+	t.Helper()
+
+	describeFn := func(ctx context.Context) (*callbackpb.CallbackInfo, error) {
+		descResp, err := env.FrontendClient().DescribeNexusOperationExecution(ctx, &workflowservice.DescribeNexusOperationExecutionRequest{
+			Namespace:   env.Namespace().String(),
+			OperationId: executionID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		callbacks := descResp.GetCompletionCallbacks()
+		if len(callbacks) != 1 {
+			return nil, fmt.Errorf("expected 1 callback, got %d", len(callbacks))
+		}
+		return callbacks[0].GetInfo(), nil
+	}
+	return sno.baseAwaitCallbackState(t, describeFn, wantState, errorStates)
+}

--- a/tests/comp_callbacks_test.go
+++ b/tests/comp_callbacks_test.go
@@ -48,6 +48,7 @@ func (s *CompletionCallbacksSuite) newTestEnv() *testcore.TestEnv {
 		testcore.WithDynamicConfig(activity.EnabledCallbackKinds, []callbacks.Kind{callbacks.KindNexus}),
 		// Standalone Nexus operations
 		testcore.WithDynamicConfig(nexusoperation.Enabled, true),
+		testcore.WithDynamicConfig(nexusoperation.EnabledCallbackKinds, []callbacks.Kind{callbacks.KindNexus}),
 		// All Callbacks and Retry policy
 		testcore.WithDynamicConfig(callback.AllowedAddresses,
 			[]any{map[string]any{"Pattern": "*", "AllowInsecure": true}}),
@@ -74,13 +75,13 @@ type completionCallbackTestcase func(*CompletionCallbacksSuite, executionWithCal
 // forEachTestCombination runs the given testcase across all permutations of execution types and callback variants.
 func (s *CompletionCallbacksSuite) forEachTestCombination(testFn completionCallbackTestcase) {
 	// Types of Temporal executions that support completion callbacks.
-	// COMING SOON: Standalone Nexus operations (which don't support comp. callbacks yet)
 	executionTypes := []struct {
 		Name      string
 		Execution executionWithCallbacks
 	}{
-		{"Workflow", &workflowExecutionType{}},
 		{"StandaloneActivity", &standaloneActivityExecutionType{}},
+		{"StandaloneNexusOperation", &standaloneNexusOperationExecutionType{}},
+		{"Workflow", &workflowExecutionType{}},
 	}
 
 	// Types of callback targets.

--- a/tests/nexus_standalone_callbacks_test.go
+++ b/tests/nexus_standalone_callbacks_test.go
@@ -1,0 +1,453 @@
+package tests
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"github.com/stretchr/testify/require"
+	callbackpb "go.temporal.io/api/callback/v1"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	nexusoperationpb "go.temporal.io/api/nexusoperation/v1"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/chasm/lib/callback"
+	"go.temporal.io/server/chasm/lib/nexusoperation"
+	"go.temporal.io/server/common/callbacks"
+	"go.temporal.io/server/common/dynamicconfig"
+	commonnexus "go.temporal.io/server/common/nexus"
+	"go.temporal.io/server/common/nexus/nexustest"
+	"go.temporal.io/server/common/testing/await"
+	"go.temporal.io/server/common/testing/parallelsuite"
+	"go.temporal.io/server/common/testing/protorequire"
+	"go.temporal.io/server/common/testing/testvars"
+	"go.temporal.io/server/tests/testcore"
+)
+
+// NexusStandaloneCallbacksTestSuite covers standalone Nexus operation
+// behavior with regard to completion callbacks.
+type NexusStandaloneCallbacksTestSuite struct {
+	parallelsuite.Suite[*NexusStandaloneCallbacksTestSuite]
+}
+
+func TestNexusStandaloneCallbacksTestSuite(t *testing.T) {
+	parallelsuite.Run(t, &NexusStandaloneCallbacksTestSuite{})
+}
+
+func (s *NexusStandaloneCallbacksTestSuite) newTestEnv(enableCallbacks bool) *NexusTestEnv {
+	var kinds []callbacks.Kind
+	if enableCallbacks {
+		kinds = append(kinds, callbacks.KindNexus)
+	}
+
+	env := newNexusTestEnv(s.T(), true,
+		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
+		testcore.WithDynamicConfig(nexusoperation.Enabled, true),
+		testcore.WithDynamicConfig(nexusoperation.EnabledCallbackKinds, kinds),
+	)
+	if enableCallbacks {
+		env.OverrideDynamicConfig(
+			callback.AllowedAddresses,
+			[]any{map[string]any{"Pattern": "*", "AllowInsecure": true}},
+		)
+	}
+	return env
+}
+
+// awaitCallbackInfo polls DescribeNexusOperationExecution until the operation's single completion
+// callback reaches wantState, then returns it.
+func (s *NexusStandaloneCallbacksTestSuite) awaitCallbackInfo(
+	env *NexusTestEnv,
+	operationID string,
+	wantState enumspb.CallbackState,
+) *callbackpb.CallbackInfo {
+	s.T().Helper()
+
+	var cbInfo *callbackpb.CallbackInfo
+	await.Require(s.Context(), s.T(), func(c *await.T) {
+		cbs := env.describeNexusOperation(c.Context(), c, operationID).GetCompletionCallbacks()
+		require.Len(c, cbs, 1)
+		cbInfo = cbs[0].GetInfo()
+		require.NotNil(c, cbInfo)
+		require.Equal(c, wantState, cbInfo.GetState())
+	}, 10*time.Second, 100*time.Millisecond)
+	return cbInfo
+}
+
+func (s *NexusStandaloneCallbacksTestSuite) TestCompletionCallbacks() {
+	env := s.newTestEnv(true)
+	alwaysSuccessEndpointName := env.createSyncSuccessEndpoint(s.Context(), s.T(), "operation-result")
+
+	s.Run("DeliveredOnSuccess", func(s *NexusStandaloneCallbacksTestSuite) {
+		ctx := s.Context()
+		ch, callbackAddress := newNexusCompletionHandler(s.T())
+
+		operationID := testvars.New(s.T()).Any().String()
+		startResp, err := env.startNexusOperation(ctx, &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId:         operationID,
+			Endpoint:            alwaysSuccessEndpointName,
+			CompletionCallbacks: []*commonpb.Callback{nexusCompletionCallback(callbackAddress)},
+		})
+		s.NoError(err)
+		s.True(startResp.GetStarted())
+
+		// Verify the callback was actually delivered with the operation's result.
+		var completionBody []byte
+		select {
+		case completion := <-ch.requestCh:
+			s.Equal(nexus.OperationStateSucceeded, completion.State)
+			s.Nil(completion.Error)
+			s.False(completion.StartTime.IsZero())
+			s.False(completion.CloseTime.IsZero())
+			body, readErr := io.ReadAll(completion.HTTPRequest.Body)
+			_ = completion.HTTPRequest.Body.Close()
+			s.NoError(readErr)
+			s.JSONEq(`"operation-result"`, string(body))
+			completionBody = body
+			// The completion carries a back-link to the operation that produced it.
+			wantLink := commonnexus.ConvertLinkNexusOperationToNexusLink(&commonpb.Link_NexusOperation{
+				Namespace:   env.Namespace().String(),
+				OperationId: operationID,
+				RunId:       startResp.GetRunId(),
+			})
+			s.Require().Len(completion.Links, 1)
+			s.Equal(wantLink.URL.String(), completion.Links[0].URL.String())
+			s.Equal(wantLink.Type, completion.Links[0].Type)
+			// Unblock CompleteOperation so it returns 200 OK to the callback library.
+			ch.requestCompleteCh <- nil
+		case <-ctx.Done():
+			s.FailNow("timed out waiting for the completion callback")
+		}
+
+		// Verify the operation is in completed state, and that the callback delivered the
+		// same result the operation.
+		descResp := env.describeNexusOperation(ctx, s.T(), operationID)
+		s.Equal(enumspb.NEXUS_OPERATION_EXECUTION_STATUS_COMPLETED, descResp.GetInfo().GetStatus())
+		s.Equal(string(descResp.GetResult().GetData()), string(completionBody))
+
+		// Wait for the callback to complete and confirm it has a Success result.
+		cbInfo := s.awaitCallbackInfo(env, operationID, enumspb.CALLBACK_STATE_SUCCEEDED)
+		s.Equal(callbackAddress, cbInfo.GetCallback().GetNexus().GetUrl())
+	})
+
+	s.Run("DeliveredOnFailure", func(s *NexusStandaloneCallbacksTestSuite) {
+		ctx := s.Context()
+		alwaysFailingEndpointName := env.createRandomExternalNexusServer(ctx, s.T(), nexustest.Handler{
+			OnStartOperation: func(
+				ctx context.Context,
+				service, operation string,
+				input *nexus.LazyValue,
+				options nexus.StartOperationOptions,
+			) (nexus.HandlerStartOperationResult[any], error) {
+				return nil, &nexus.OperationError{
+					State: nexus.OperationStateFailed,
+					Cause: &nexus.FailureError{Failure: nexus.Failure{Message: "deliberate failure"}},
+				}
+			},
+		})
+		ch, callbackAddress := newNexusCompletionHandler(s.T())
+
+		operationID := testvars.New(s.T()).Any().String()
+		_, err := env.startNexusOperation(ctx, &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId:         operationID,
+			Endpoint:            alwaysFailingEndpointName,
+			CompletionCallbacks: []*commonpb.Callback{nexusCompletionCallback(callbackAddress)},
+		})
+		s.NoError(err)
+
+		// Verify the callback was actually delivered with failure state.
+		select {
+		case completion := <-ch.requestCh:
+			s.Equal(nexus.OperationStateFailed, completion.State)
+			s.False(completion.StartTime.IsZero())
+			s.False(completion.CloseTime.IsZero())
+			s.Require().NotNil(completion.Error)
+			var failureErr *nexus.FailureError
+			s.Require().ErrorAs(completion.Error.Cause, &failureErr)
+			// The handler's error is wrapped as an OperationError whose cause carries the original
+			// message, which is how a Nexus operation failure round-trips through a completion.
+			tFailure, convErr := commonnexus.NexusFailureToTemporalFailure(failureErr.Failure)
+			s.NoError(convErr)
+			s.Equal("OperationError", tFailure.GetApplicationFailureInfo().GetType())
+			s.Equal("deliberate failure", tFailure.GetCause().GetMessage())
+			ch.requestCompleteCh <- nil
+		case <-ctx.Done():
+			s.FailNow("timed out waiting for the completion callback")
+		}
+
+		// Verify the operation is in failed state.
+		descResp := env.describeNexusOperation(ctx, s.T(), operationID)
+		s.Equal(enumspb.NEXUS_OPERATION_EXECUTION_STATUS_FAILED, descResp.GetInfo().GetStatus())
+
+		// The operation may have failed, but the callback reporting that failure was successful.
+		s.awaitCallbackInfo(env, operationID, enumspb.CALLBACK_STATE_SUCCEEDED)
+	})
+
+	// Verify that if the callback fails to be delivered for some reason, that the failure is
+	// persisted correctly and available from the Describe operation.
+	s.Run("CallbackDeliveryFailure", func(s *NexusStandaloneCallbacksTestSuite) {
+		ctx := s.Context()
+		ch, callbackAddress := newNexusCompletionHandler(s.T())
+
+		operationID := testvars.New(s.T()).Any().String()
+		_, err := env.startNexusOperation(ctx, &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId:         operationID,
+			Endpoint:            alwaysSuccessEndpointName,
+			CompletionCallbacks: []*commonpb.Callback{nexusCompletionCallback(callbackAddress)},
+		})
+		s.NoError(err)
+
+		// Simulate the completion handler returning a retryable error followed by an unretryable
+		// error. Confirm the SANO's CallbackInfo includes the terminal failure.
+		for deliveryAttempt := 1; deliveryAttempt <= 2; deliveryAttempt++ {
+			select {
+			case completion := <-ch.requestCh:
+				s.Equal(nexus.OperationStateSucceeded, completion.State)
+				if deliveryAttempt == 1 {
+					// While the handler is blocked here the callback is in flight: Describe reports
+					// it as scheduled, with no attempts recorded yet.
+					cbInfo := s.awaitCallbackInfo(env, operationID, enumspb.CALLBACK_STATE_SCHEDULED)
+					s.EqualValues(0, cbInfo.GetAttempt())
+					s.Nil(cbInfo.GetLastAttemptFailure())
+
+					// Retryable error.
+					ch.requestCompleteCh <- nexus.NewHandlerErrorf(nexus.HandlerErrorTypeUnavailable, "delivery #1")
+				} else {
+					// The second delivery attempt: Describe now describes the previous attempt.
+					cbInfo := s.awaitCallbackInfo(env, operationID, enumspb.CALLBACK_STATE_SCHEDULED)
+					s.EqualValues(1, cbInfo.GetAttempt()) // 1 attempt so far, the 2nd is in-progress.
+					s.NotNil(cbInfo.GetLastAttemptFailure())
+					s.Contains(cbInfo.GetLastAttemptFailure().GetMessage(), "delivery #1")
+
+					// Unretryable error.
+					ch.requestCompleteCh <- nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "delivery #2")
+				}
+			case <-ctx.Done():
+				s.FailNow("timed out waiting for the completion callback")
+			}
+		}
+
+		// A failed callback delivery does not affect the operation itself.
+		gotStatus := env.describeNexusOperation(ctx, s.T(), operationID).GetInfo().GetStatus()
+		s.Equal(enumspb.NEXUS_OPERATION_EXECUTION_STATUS_COMPLETED, gotStatus)
+
+		// Verify the completion callback delivery has failed.
+		cbInfo := s.awaitCallbackInfo(env, operationID, enumspb.CALLBACK_STATE_FAILED)
+		// Both the last delivery failure and the terminal failure come from delivery #2.
+		const lastDeliveryFailureMessage = "handler error (BAD_REQUEST): delivery #2"
+		s.Equal(lastDeliveryFailureMessage, cbInfo.GetLastAttemptFailure().GetMessage())
+	})
+
+	s.Run("DescribeReportsStandbyBeforeClose", func(s *NexusStandaloneCallbacksTestSuite) {
+		ctx := s.Context()
+		endpointName := env.createAsyncEndpoint(ctx, s.T())
+
+		operationID := testvars.New(s.T()).Any().String()
+		_, err := env.startNexusOperation(ctx, &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId: operationID,
+			Endpoint:    endpointName,
+			CompletionCallbacks: []*commonpb.Callback{
+				nexusCompletionCallback("http://localhost/cb1"),
+				nexusCompletionCallback("http://localhost/cb2"),
+			},
+		})
+		s.NoError(err)
+
+		// The operation stays STARTED, so its callbacks stay in STANDBY with no result.
+		infos := env.describeNexusOperation(ctx, s.T(), operationID).GetCompletionCallbacks()
+		s.Len(infos, 2)
+		for _, info := range infos {
+			// Every callback on a standalone operation is triggered by the operation completing.
+			s.NotNil(info.GetTrigger().GetOperationCompleted())
+			s.Equal(enumspb.CALLBACK_STATE_STANDBY, info.GetInfo().GetState())
+			s.NotNil(info.GetInfo().GetRegistrationTime())
+		}
+	})
+
+	s.Run("AttachOnConflict", func(s *NexusStandaloneCallbacksTestSuite) {
+		ctx := s.Context()
+		endpointName := env.createAsyncEndpoint(ctx, s.T())
+
+		operationID := testvars.New(s.T()).Any().String()
+		startResp, err := env.startNexusOperation(ctx, &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId:         operationID,
+			Endpoint:            endpointName,
+			RequestId:           "first-request",
+			CompletionCallbacks: []*commonpb.Callback{nexusCompletionCallback("http://localhost/cb1")},
+		})
+		s.NoError(err)
+		s.True(startResp.GetStarted())
+
+		attachReq := &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId:         operationID,
+			Endpoint:            endpointName,
+			RequestId:           "second-request",
+			CompletionCallbacks: []*commonpb.Callback{nexusCompletionCallback("http://localhost/cb2")},
+			IdConflictPolicy:    enumspb.NEXUS_OPERATION_ID_CONFLICT_POLICY_USE_EXISTING,
+			OnConflictOptions: &nexusoperationpb.OnConflictOptions{
+				AttachRequestId:           true,
+				AttachCompletionCallbacks: true,
+			},
+		}
+		attachResp, err := env.startNexusOperation(ctx, attachReq)
+		s.NoError(err)
+		s.False(attachResp.GetStarted(), "the second request must not have created an operation")
+		s.Equal(startResp.GetRunId(), attachResp.GetRunId())
+
+		callbackInfos := env.describeNexusOperation(ctx, s.T(), operationID).GetCompletionCallbacks()
+		s.Require().Len(callbackInfos, 2)
+		s.Equal("http://localhost/cb1", callbackInfos[0].GetInfo().GetCallback().GetNexus().GetUrl())
+		s.Equal("http://localhost/cb2", callbackInfos[1].GetInfo().GetCallback().GetNexus().GetUrl())
+		s.Equal(enumspb.CALLBACK_STATE_STANDBY, callbackInfos[0].GetInfo().GetState())
+		s.Equal(enumspb.CALLBACK_STATE_STANDBY, callbackInfos[1].GetInfo().GetState())
+
+		// Replaying the same attach must not duplicate any of the callbacks.
+		_, err = env.startNexusOperation(ctx, attachReq)
+		s.NoError(err)
+		newDescribeResp := env.describeNexusOperation(ctx, s.T(), operationID)
+		s.Len(newDescribeResp.GetCompletionCallbacks(), 2)
+	})
+
+	// Confirm that SANO fails with callback kinds that are not enabled.
+	s.Run("RejectNonNexusCallbacks", func(s *NexusStandaloneCallbacksTestSuite) {
+		for _, tc := range []struct {
+			name     string
+			callback *commonpb.Callback
+			// errTarget is a pointer to a serviceerror pointer, as ErrorAs expects.
+			errTarget any
+			errMsg    string
+		}{
+			{
+				name: "nexus handler",
+				callback: &commonpb.Callback{Variant: &commonpb.Callback_NexusHandler_{NexusHandler: &commonpb.Callback_NexusHandler{
+					TaskQueueName: "completions-task-queue",
+					Service:       "HTTPAdapter",
+					Operation:     "DeliverAsWebhook",
+				}}},
+				// The callback is well-formed, but the NexusHandler kind is not enabled (see
+				// newTestEnv). A disabled kind is an InvalidArgument, not the Unimplemented that
+				// a variant the server does not recognize at all gets.
+				errTarget: new(*serviceerror.InvalidArgument),
+				errMsg:    "nexusHandler callbacks are not enabled for this execution type",
+			},
+			{
+				name:      "unset",
+				callback:  &commonpb.Callback{},
+				errTarget: new(*serviceerror.Unimplemented),
+				errMsg:    "unknown callback variant",
+			},
+		} {
+			s.Run(tc.name, func(s *NexusStandaloneCallbacksTestSuite) {
+				resp, err := env.startNexusOperation(s.Context(), &workflowservice.StartNexusOperationExecutionRequest{
+					OperationId:         testvars.New(s.T()).Any().String(),
+					Endpoint:            alwaysSuccessEndpointName,
+					CompletionCallbacks: []*commonpb.Callback{tc.callback},
+				})
+				s.Nil(resp)
+
+				s.ErrorAs(err, tc.errTarget)
+				s.ErrorContains(err, tc.errMsg)
+			})
+		}
+	})
+
+	// Links and callbacks are attached by independent options, so a single request may carry both.
+	s.Run("AttachLinksAndCallbacksOnConflict", func(s *NexusStandaloneCallbacksTestSuite) {
+		ctx := s.Context()
+		t := s.T()
+
+		endpointName := env.createRandomExternalNexusServer(s.Context(), t, nexustest.Handler{
+			OnStartOperation: func(
+				ctx context.Context,
+				service, operation string,
+				input *nexus.LazyValue,
+				options nexus.StartOperationOptions,
+			) (nexus.HandlerStartOperationResult[any], error) {
+				return &nexus.HandlerStartOperationResultAsync{OperationToken: "test-operation-token"}, nil
+			},
+		})
+
+		firstLink := standaloneNexusTestLink(env, "first-wf")
+		secondLink := standaloneNexusTestLink(env, "second-wf")
+
+		operationID := testvars.New(t).Any().String()
+		startResp, err := env.startNexusOperation(ctx, &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId:         operationID,
+			Endpoint:            endpointName,
+			RequestId:           "first-request",
+			CompletionCallbacks: []*commonpb.Callback{nexusCompletionCallback("http://localhost/cb1")},
+			Links:               []*commonpb.Link{firstLink},
+		})
+		s.NoError(err)
+		s.True(startResp.GetStarted())
+
+		attachResp, err := env.startNexusOperation(ctx, &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId:         operationID,
+			Endpoint:            endpointName,
+			RequestId:           "second-request",
+			CompletionCallbacks: []*commonpb.Callback{nexusCompletionCallback("http://localhost/cb2")},
+			Links:               []*commonpb.Link{secondLink},
+			IdConflictPolicy:    enumspb.NEXUS_OPERATION_ID_CONFLICT_POLICY_USE_EXISTING,
+			OnConflictOptions: &nexusoperationpb.OnConflictOptions{
+				AttachRequestId:           true,
+				AttachCompletionCallbacks: true,
+				AttachLinks:               true,
+			},
+		})
+		s.NoError(err)
+		s.False(attachResp.GetStarted(), "the second request must not have created an operation")
+
+		descResp, err := env.FrontendClient().DescribeNexusOperationExecution(s.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
+			Namespace:   env.Namespace().String(),
+			OperationId: operationID,
+		})
+		s.NoError(err)
+		// Links are stored per request ID, so their relative order is non-deterministic.
+		protorequire.ProtoElementsMatch(t,
+			[]*commonpb.Link{firstLink, secondLink},
+			descResp.GetInfo().GetLinks())
+	})
+}
+
+// TestCallbacksDisabled confirms that an empty nexusoperation.enabledCallbackKinds gates the whole
+// surface, including the on-conflict attach path.
+func (s *NexusStandaloneCallbacksTestSuite) TestCallbacksDisabled() {
+	// Test environment with SANO not supporting completion callbacks.
+	env := s.newTestEnv(false)
+	endpointName := env.createRandomExternalNexusServer(s.Context(), s.T(), nexustest.Handler{})
+	cbs := []*commonpb.Callback{nexusCompletionCallback("http://localhost/cb")}
+
+	s.Run("StartWithCallbacksFails", func(s *NexusStandaloneCallbacksTestSuite) {
+		_, err := env.startNexusOperation(s.Context(), &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId:         testvars.New(s.T()).Any().String(),
+			Endpoint:            endpointName,
+			CompletionCallbacks: cbs,
+		})
+		s.ErrorContains(err, "nexus callbacks are not enabled for this execution type")
+	})
+
+	s.Run("OnConflictAttachCallbacksFails", func(s *NexusStandaloneCallbacksTestSuite) {
+		_, err := env.startNexusOperation(s.Context(), &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId:         testvars.New(s.T()).Any().String(),
+			Endpoint:            endpointName,
+			CompletionCallbacks: cbs,
+			IdConflictPolicy:    enumspb.NEXUS_OPERATION_ID_CONFLICT_POLICY_USE_EXISTING,
+			OnConflictOptions: &nexusoperationpb.OnConflictOptions{
+				AttachRequestId:           true,
+				AttachCompletionCallbacks: true,
+			},
+		})
+		s.ErrorContains(err, "nexus callbacks are not enabled for this execution type")
+	})
+}
+
+// nexusCompletionCallback builds a Nexus-variant completion callback targeting url, typically the URL
+// returned by [newNexusCompletionHandler].
+func nexusCompletionCallback(url string) *commonpb.Callback {
+	return &commonpb.Callback{
+		Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: url}},
+	}
+}

--- a/tests/nexus_standalone_test.go
+++ b/tests/nexus_standalone_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/nexus-rpc/sdk-go/nexus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,6 +16,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
 	nexuspb "go.temporal.io/api/nexus/v1"
+	nexusoperationpb "go.temporal.io/api/nexusoperation/v1"
 	sdkpb "go.temporal.io/api/sdk/v1"
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
@@ -223,6 +225,143 @@ func (s *NexusStandaloneTestSuite) TestStartStandaloneNexusOperation() {
 		s.Equal(resp1.RunId, resp2.RunId)
 		s.False(resp2.GetStarted())
 	})
+}
+
+// standaloneNexusTestLink returns a new workflow event link.
+func standaloneNexusTestLink(env *NexusTestEnv, workflowID string) *commonpb.Link {
+	return &commonpb.Link{
+		Variant: &commonpb.Link_WorkflowEvent_{
+			WorkflowEvent: &commonpb.Link_WorkflowEvent{
+				Namespace:  env.Namespace().String(),
+				WorkflowId: workflowID,
+				RunId:      "wf-run-id",
+				Reference: &commonpb.Link_WorkflowEvent_EventRef{
+					EventRef: &commonpb.Link_WorkflowEvent_EventReference{
+						EventId:   1,
+						EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestStandaloneNexusOperationLinks covers links a caller attaches to a standalone Nexus operation,
+// on start and via on_conflict_options, along with the limits enforced on both paths.
+func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationLinks() {
+	ctx := context.Background()
+	env := s.newTestEnv()
+
+	// The async operation remains STARTED, so it remains open for on-conflict attaches.
+	endpointName := env.createAsyncEndpoint(ctx, s.T())
+
+	// Calls Describe- and returns the attached links.
+	describeLinks := func(s *NexusStandaloneTestSuite, operationID string) []*commonpb.Link {
+		t := s.T()
+		t.Helper()
+		descResp, err := env.FrontendClient().DescribeNexusOperationExecution(
+			ctx,
+			&workflowservice.DescribeNexusOperationExecutionRequest{
+				Namespace:   env.Namespace().String(),
+				OperationId: operationID,
+			})
+		require.NoError(t, err)
+		return descResp.GetInfo().GetLinks()
+	}
+
+	s.Run("AttachedOnStart", func(s *NexusStandaloneTestSuite) {
+		t := s.T()
+		operationID := uuid.NewString()
+		links := []*commonpb.Link{
+			standaloneNexusTestLink(env, "start-wf-1"),
+			standaloneNexusTestLink(env, "start-wf-2"),
+		}
+
+		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId: operationID,
+			Endpoint:    endpointName,
+			Links:       links,
+		})
+		s.NoError(err)
+		s.True(startResp.GetStarted())
+
+		gotLinks := describeLinks(s, operationID)
+		protorequire.ProtoSliceEqual(t, links, gotLinks)
+	})
+
+	s.Run("AttachLinksOnConflictMergesLinks", func(s *NexusStandaloneTestSuite) {
+		t := s.T()
+		operationID := uuid.NewString()
+		firstLink := standaloneNexusTestLink(env, "merge-wf-1")
+		secondLink := standaloneNexusTestLink(env, "merge-wf-2")
+
+		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId: operationID,
+			Endpoint:    endpointName,
+			RequestId:   "first-request",
+			Links:       []*commonpb.Link{firstLink},
+		})
+		s.NoError(err)
+		s.True(startResp.GetStarted())
+
+		// Call Start again with the same operation ID, with the conflict policy to
+		// use the existing SANO but attach links.
+		attachReq := &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId:      operationID,
+			Endpoint:         endpointName,
+			RequestId:        "second-request",
+			Links:            []*commonpb.Link{secondLink},
+			IdConflictPolicy: enumspb.NEXUS_OPERATION_ID_CONFLICT_POLICY_USE_EXISTING,
+			OnConflictOptions: &nexusoperationpb.OnConflictOptions{
+				AttachLinks: true,
+			},
+		}
+		attachResp, err := s.startNexusOperation(env, attachReq)
+		s.NoError(err)
+		s.False(attachResp.GetStarted())
+		s.Equal(startResp.GetRunId(), attachResp.GetRunId())
+
+		expected := []*commonpb.Link{firstLink, secondLink}
+		// Links are stored per request ID, so their relative order is non-deterministic.
+		gotLinks := describeLinks(s, operationID)
+		protorequire.ProtoElementsMatch(t, expected, gotLinks)
+
+		// Replaying the same request must not duplicate the links it already attached.
+		_, err = s.startNexusOperation(env, attachReq)
+		s.NoError(err)
+		gotLinks = describeLinks(s, operationID)
+		protorequire.ProtoElementsMatch(t, expected, gotLinks)
+	})
+
+	s.Run("LinksIgnoredOnConflictWithoutAttachLinks", func(s *NexusStandaloneTestSuite) {
+		t := s.T()
+		operationID := uuid.NewString()
+		firstLink := standaloneNexusTestLink(env, "ignored-wf-1")
+
+		_, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId: operationID,
+			Endpoint:    endpointName,
+			RequestId:   "first-request",
+			Links:       []*commonpb.Link{firstLink},
+		})
+		s.NoError(err)
+
+		_, err = s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId:      operationID,
+			Endpoint:         endpointName,
+			RequestId:        "second-request",
+			Links:            []*commonpb.Link{standaloneNexusTestLink(env, "ignored-wf-2")},
+			IdConflictPolicy: enumspb.NEXUS_OPERATION_ID_CONFLICT_POLICY_USE_EXISTING,
+			// attach_links intentionally omitted — the second request's links must be dropped.
+		})
+		s.NoError(err)
+
+		gotLinks := describeLinks(s, operationID)
+		protorequire.ProtoSliceEqual(t, []*commonpb.Link{firstLink}, gotLinks)
+	})
+
+	// The per-request and per-execution link caps are covered by unit tests
+	// TestNewStandaloneOperationAttachesLinks and TestOperationAttachLinks.
 }
 
 func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {

--- a/tests/nexus_test_base.go
+++ b/tests/nexus_test_base.go
@@ -1,10 +1,12 @@
 package tests
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/nexus-rpc/sdk-go/nexus"
@@ -20,6 +22,7 @@ import (
 	"go.temporal.io/server/common/nexus/nexusrpc"
 	"go.temporal.io/server/common/nexus/nexustest"
 	"go.temporal.io/server/tests/testcore"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 type NexusTestEnv struct {
@@ -32,6 +35,38 @@ func newNexusTestEnv(t *testing.T, useTemporalFailures bool, opts ...testcore.Te
 		TestEnv:             testcore.NewEnv(t, opts...),
 		useTemporalFailures: useTemporalFailures,
 	}
+}
+
+// startNexusOperation starts a standalone Nexus operation, applying defaults for
+// required fields tests usually don't care about.
+func (env *NexusTestEnv) startNexusOperation(
+	ctx context.Context,
+	req *workflowservice.StartNexusOperationExecutionRequest,
+) (*workflowservice.StartNexusOperationExecutionResponse, error) {
+	req.Namespace = cmp.Or(req.Namespace, env.Namespace().String())
+	req.Service = cmp.Or(req.Service, "test-service")
+	req.Operation = cmp.Or(req.Operation, "test-operation")
+	req.RequestId = cmp.Or(req.RequestId, env.Tv().RequestID())
+	if req.ScheduleToCloseTimeout == nil {
+		req.ScheduleToCloseTimeout = durationpb.New(10 * time.Minute)
+	}
+
+	return env.FrontendClient().StartNexusOperationExecution(ctx, req)
+}
+
+// describeNexusOperation describes a standalone Nexus operation by ID, including its outcome.
+func (env *NexusTestEnv) describeNexusOperation(
+	ctx context.Context,
+	t require.TestingT,
+	operationID string,
+) *workflowservice.DescribeNexusOperationExecutionResponse {
+	descResp, err := env.FrontendClient().DescribeNexusOperationExecution(ctx, &workflowservice.DescribeNexusOperationExecutionRequest{
+		Namespace:      env.Namespace().String(),
+		OperationId:    operationID,
+		IncludeOutcome: true,
+	})
+	require.NoError(t, err)
+	return descResp
 }
 
 func (env *NexusTestEnv) createNexusEndpoint(ctx context.Context, t *testing.T, name string, taskQueue string) *nexuspb.Endpoint {
@@ -113,6 +148,37 @@ func (env *NexusTestEnv) dispatchByNamespaceAndTaskQueueURL(namespace string, ta
 			Namespace: namespace,
 			TaskQueue: taskQueue,
 		})
+}
+
+// createSyncSuccessEndpoint registers an endpoint whose handler completes every operation
+// synchronously with the supplied result payload. Shutdown as part with the test's Cleanup.
+func (env *NexusTestEnv) createSyncSuccessEndpoint(ctx context.Context, t *testing.T, result string) string {
+	return env.createRandomExternalNexusServer(ctx, t, nexustest.Handler{
+		OnStartOperation: func(
+			ctx context.Context,
+			service, operation string,
+			input *nexus.LazyValue,
+			options nexus.StartOperationOptions,
+		) (nexus.HandlerStartOperationResult[any], error) {
+			return &nexus.HandlerStartOperationResultSync[any]{Value: result}, nil
+		},
+	})
+}
+
+// createAsyncEndpoint registers an endpoint whose handler leaves every operation running async,
+// so calls to the endpoint remain in the STARTED state until it is completed by other means.
+// (e.g. the Nexus operation gets canceled or terminated.)
+func (env *NexusTestEnv) createAsyncEndpoint(ctx context.Context, t *testing.T) string {
+	return env.createRandomExternalNexusServer(ctx, t, nexustest.Handler{
+		OnStartOperation: func(
+			ctx context.Context,
+			service, operation string,
+			input *nexus.LazyValue,
+			options nexus.StartOperationOptions,
+		) (nexus.HandlerStartOperationResult[any], error) {
+			return &nexus.HandlerStartOperationResultAsync{OperationToken: "test-operation-token"}, nil
+		},
+	})
 }
 
 // nexusTaskResponse represents a successful response from a nexus task handler.


### PR DESCRIPTION
⚠️ This is part of a stacked PR set, to be merged into `feature/worker-callbacks`. This will not go directly into `main`, until the overall feature is code complete.

This set of commits were earlier proposed as PR https://github.com/temporalio/temporal/pull/11415, but have since been rebased on top of other changes.

---


## What changed?

The API surface area for the worker callbacks feature adds a new `completion_callbacks` field to SANOs, allowing users to register callbacks to be executed when the SANO completes. (Just like standalone Activities.)

This PR implements that feature for SANO, allowing completion callbacks to be added, executed, and for their status to be reported by the `DescribeNexusOperationExecution` endpoint.

Another couple of features were added as well, to maintain parity with standalone Activities as well. SANOs now provide an `on_conflict_policy` and `links`. The behavior of the conflict policy has been patterned closely after how it is implemented for standalone activities. (To avoid duplication for "Link validation", the functionality was moved into the `chasm` package so it could be reused for both SAA and SANO.)

Completion callbacks for SANOs is governed by two configuration options (following the pattern introduced in the previous PR in the stack): `EnableCallbacks bool` which controls if callbacks can be used at all, and a separate `EnabledCallbackKinds callback.EnabledCallbackKinds` defining which forms of callbacks can be accepted. This defaults to just Nexus-callbacks, and will change when Worker-variant callbacks are actually implemented in a subsequent PR.

## Why?

This is part of the overall worker callbacks feature.

## Notes

Something that this implementation does that standalone Activities does not, is provide a stable response for the `Describe-` endpoint.

If you call `DescribeActivityExecution` multiple times when it has completion callbacks, the order of the returned `CallbackInfo`s will be non-deterministic. (Because it loops over a `map` which isn't stable.)

In the SANO case, we first sort the callbacks by their request ID. So you would get the same result for each call to `Describe-`. (But note that we don't make any attempt to preserve the _ordering_ of callbacks. Just that they are are returned in the same order.)

## How did you test it?

- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)

## Potential risks

It's essentially a new feature, and so there are lots of edge cases we need to consider. For example, that repeated calls to `Start-` are idempotent. That the `on_conflict_options` are honored, etc. Otherwise, we run the risk of SANO being slightly inconsistent with how completion callbacks work for standalone Activities.