### PR TITLE
Honor Schedule immediate-trigger scheduled time

### DIFF
--- a/chasm/lib/scheduler/backfiller_tasks_test.go
+++ b/chasm/lib/scheduler/backfiller_tasks_test.go
@@ -117,6 +117,39 @@ func TestBackfillTask_TriggerImmediate(t *testing.T) {
 	})
 }
 
+func TestImmediateTriggerUsesScheduledTime(t *testing.T) {
+	env := newTestEnv(t)
+	processingTime := env.TimeSource.Now().UTC()
+	requestedTime := processingTime.Add(-time.Second)
+
+	runBackfillTestCase(t, env, &backfillTestCase{
+		InitialTriggerRequest: &schedulepb.TriggerImmediatelyRequest{
+			ScheduledTime: timestamppb.New(requestedTime),
+		},
+		ExpectedBufferedStarts: 1,
+		ExpectedComplete:       true,
+		ValidateInvoker: func(t *testing.T, invoker *scheduler.Invoker) {
+			start := invoker.GetBufferedStarts()[0]
+			require.Equal(t, requestedTime, start.GetNominalTime().AsTime())
+			require.NotEqual(t, processingTime, start.GetNominalTime().AsTime())
+		},
+	})
+}
+
+func TestImmediateTriggerWithoutScheduledTimeUsesFrameworkTime(t *testing.T) {
+	env := newTestEnv(t)
+	processingTime := env.TimeSource.Now().UTC()
+
+	runBackfillTestCase(t, env, &backfillTestCase{
+		InitialTriggerRequest:  &schedulepb.TriggerImmediatelyRequest{},
+		ExpectedBufferedStarts: 1,
+		ExpectedComplete:       true,
+		ValidateInvoker: func(t *testing.T, invoker *scheduler.Invoker) {
+			require.Equal(t, processingTime, invoker.GetBufferedStarts()[0].GetNominalTime().AsTime())
+		},
+	})
+}
+
 // An immediately-triggered run will back off and retry if the buffer is full.
 func TestBackfillTask_TriggerImmediateFullBuffer(t *testing.T) {
 	env := newTestEnv(t)

--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -403,9 +403,11 @@ func (s *Scheduler) NewImmediateBackfiller(
 	backfiller.Request = &schedulerpb.BackfillerState_TriggerRequest{
 		TriggerRequest: request,
 	}
-	// Trigger backfills fire a single action at creation time; processTrigger uses
-	// LastProcessedTime as that action's deterministic time, so it must be set.
-	backfiller.LastProcessedTime = timestamppb.New(ctx.Now(s))
+	triggerTime := timestamp.TimeValue(request.GetScheduledTime())
+	if triggerTime.IsZero() {
+		triggerTime = ctx.Now(s)
+	}
+	backfiller.LastProcessedTime = timestamppb.New(triggerTime)
 	return backfiller
 }
 


### PR DESCRIPTION
## Summary
- use TriggerImmediately.ScheduledTime as the immediate action nominal time
- retain framework time as the fallback when ScheduledTime is absent
- cover both paths with focused scheduler tests

## Why
Schedule V1 honors this identity timestamp. Ignoring it can change the workflow ID when request processing crosses a whole-second boundary.

## Testing
- go test -tags test_dep ./chasm/lib/scheduler -run ^(TestBackfillTask_TriggerImmediate|TestImmediateTrigger) -count=1