### PR TITLE
Release removed shared cluster test references

### DIFF
--- a/tests/leakcheck/leak_test.go
+++ b/tests/leakcheck/leak_test.go
@@ -29,12 +29,9 @@ var goleakOpts = []goleak.Option{
 
 var objectLeakOpts = []objectleak.Option{
 	objectleak.WithPruneType("google.golang.org/protobuf/internal/impl.*"),
-	objectleak.WithExpected("FunctionalTestBase"),
 	objectleak.WithExpected("FunctionalTestBase.Logger*"),
-	objectleak.WithExpected("FunctionalTestBase.Suite*"),
 	objectleak.WithExpected("FunctionalTestBase.testCluster.host*"),
 	objectleak.WithExpected("FunctionalTestBase.testCluster.testBase*"),
-	objectleak.WithExpected("FunctionalTestBase.testClusterConfig"),
 }
 
 // TestClusterShutdownLeak is a goroutine-leak regression test for the functional

--- a/tests/testcore/shared_cluster_t.go
+++ b/tests/testcore/shared_cluster_t.go
@@ -3,6 +3,7 @@ package testcore
 import (
 	"fmt"
 	"os"
+	"slices"
 	"sync"
 	"sync/atomic"
 
@@ -37,11 +38,8 @@ func (s *sharedClusterT) addTest(t testlogger.CleanupCapableT) {
 func (s *sharedClusterT) removeTest(t testlogger.CleanupCapableT) (wasLast bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	for i, x := range s.activeTests {
-		if x == t {
-			s.activeTests = append(s.activeTests[:i], s.activeTests[i+1:]...)
-			break
-		}
+	if i := slices.Index(s.activeTests, t); i >= 0 {
+		s.activeTests = slices.Delete(s.activeTests, i, i+1)
 	}
 	return len(s.activeTests) == 0
 }


### PR DESCRIPTION
## What changed?

Clear removed tests from the shared cluster's backing slice.

## Why?

`sharedClusterT` shortened `activeTests` without clearing the removed interface slot. The backing array could therefore retain completed tests and their functional test state.
