### PR TITLE
Suppress the "fair reader stuck" assertion during task queue unload in fair_task_reader

### DIFF
--- a/service/matching/fair_task_reader.go
+++ b/service/matching/fair_task_reader.go
@@ -414,7 +414,14 @@ func (tr *fairTaskReader) mergeTasks(tasks []*persistencespb.AllocatedTaskInfo, 
 	//
 	// The bug that led to this is fixed, but we'll leave this check defensively in case other
 	// bugs produce the same state.
-	if mode == mergeWrite && !tr.atEnd && tr.loadedTasks == 0 && !tr.readPending && tr.backoffTimer == nil {
+	//
+	// We exclude the case where the task queue is shutting down: unpinAckLevel resets atEnd on a
+	// write error, but its maybeReadTasksLocked repair is a no-op once tqCtx is cancelled (as it
+	// is when a fatal error such as a lost rangeID lease unloads the queue). That legitimately
+	// leaves us in this state, but the reader is being torn down and a fresh one will start
+	// clean, so it isn't actually stuck. Firing the assertion there is a false positive.
+	if mode == mergeWrite && !tr.atEnd && tr.loadedTasks == 0 && !tr.readPending &&
+		tr.backoffTimer == nil && tr.backlogMgr.tqCtx.Err() == nil {
 		softassert.Fail(tr.logger, "fair reader stuck")
 		metrics.FairReaderStuckDetected.With(tr.backlogMgr.metricsHandler).Record(1)
 		tr.maybeReadTasksLocked()


### PR DESCRIPTION
## What changed?
Guard the stuck reader softassert behind a check on tqCtx.Err()

## Why?
The fair backlog manager's task reader carries a defensive assertion, softassert.Fail("fair reader stuck") in mergeTasks (service/matching/ fair_task_reader.go), that fires when a write merges into a state the reader should never occupy: not at the end of the backlog, yet holding no loaded tasks, with neither a read in progress nor a retry backoff armed. In that state nothing would trigger a further read, so the reader would be unable to make progress.

That state is, however, reached legitimately while the task queue is unloading, and there the assertion is a false positive. unpinAckLevel, invoked when a write returns an error, sets atEnd to false and calls maybeReadTasksLocked to re-establish the end of the backlog; but maybeReadTasksLocked is a no-op once the queue's context has been cancelled, as it is when a fatal error such as a lost rangeID lease (a ConditionFailedError) unloads the partition. The reader is thereby left in the asserted state, and a subsequent successful write on the way down trips the assertion. The condition is benign -- the reader is being discarded and a freshly loaded one starts clean -- yet it logs an error and records the FairReaderStuckDetected metric on an event that happens in normal operation whenever a lease is lost concurrently with a write.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

