### PR TITLE
Refactor NamespaceRateLimitInterceptor with functions to consume N tokens

### DIFF
--- a/common/rpc/interceptor/namespace_rate_limit.go
+++ b/common/rpc/interceptor/namespace_rate_limit.go
@@ -31,15 +31,55 @@ var (
 
 type (
 	NamespaceRateLimitInterceptor interface {
-		Intercept(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error)
-		Allow(namespaceName namespace.Name, methodName string, headerGetter headers.HeaderGetter) error
-		Wait(ctx context.Context, namespaceName namespace.Name, methodName string, headerGetter headers.HeaderGetter) error
+		Intercept(
+			ctx context.Context,
+			req any,
+			info *grpc.UnaryServerInfo,
+			handler grpc.UnaryHandler,
+		) (resp any, err error)
+
+		InterceptN(
+			ctx context.Context,
+			req any,
+			info *grpc.UnaryServerInfo,
+			handler grpc.UnaryHandler,
+			numToken int,
+		) (resp any, err error)
+
+		Allow(
+			ctx context.Context,
+			namespaceName namespace.Name,
+			methodName string,
+			headerGetter headers.HeaderGetter,
+		) error
+
+		Wait(
+			ctx context.Context,
+			namespaceName namespace.Name,
+			methodName string,
+			headerGetter headers.HeaderGetter,
+		) error
+
+		AllowN(
+			ctx context.Context,
+			namespaceName namespace.Name,
+			methodName string,
+			headerGetter headers.HeaderGetter,
+			numToken int,
+		) error
+
+		WaitN(
+			ctx context.Context,
+			namespaceName namespace.Name,
+			methodName string,
+			headerGetter headers.HeaderGetter,
+			numToken int,
+		) error
 	}
 
 	NamespaceRateLimitInterceptorImpl struct {
 		namespaceRegistry                 namespace.Registry
 		rateLimiter                       quotas.RequestRateLimiter
-		tokens                            map[string]int
 		reducePollWorkflowHistoryPriority dynamicconfig.BoolPropertyFn
 		pollMethods                       map[string]struct{}
 		pollWaitForToken                  dynamicconfig.BoolPropertyFnWithNamespaceFilter
@@ -53,7 +93,6 @@ var _ NamespaceRateLimitInterceptor = (*NamespaceRateLimitInterceptorImpl)(nil)
 func NewNamespaceRateLimitInterceptor(
 	namespaceRegistry namespace.Registry,
 	rateLimiter quotas.RequestRateLimiter,
-	tokens map[string]int,
 	pollMethods map[string]struct{},
 	pollWaitForToken dynamicconfig.BoolPropertyFnWithNamespaceFilter,
 	metricsHandler metrics.Handler,
@@ -61,7 +100,6 @@ func NewNamespaceRateLimitInterceptor(
 	return &NamespaceRateLimitInterceptorImpl{
 		namespaceRegistry: namespaceRegistry,
 		rateLimiter:       rateLimiter,
-		tokens:            tokens,
 		pollMethods:       pollMethods,
 		pollWaitForToken:  pollWaitForToken,
 		metricsHandler:    metricsHandler,
@@ -74,6 +112,16 @@ func (ni *NamespaceRateLimitInterceptorImpl) Intercept(
 	info *grpc.UnaryServerInfo,
 	handler grpc.UnaryHandler,
 ) (any, error) {
+	return ni.InterceptN(ctx, req, info, handler, NamespaceRateLimitDefaultToken)
+}
+
+func (ni *NamespaceRateLimitInterceptorImpl) InterceptN(
+	ctx context.Context,
+	req any,
+	info *grpc.UnaryServerInfo,
+	handler grpc.UnaryHandler,
+	numToken int,
+) (any, error) {
 	if ns := MustGetNamespaceName(ni.namespaceRegistry, req); ns != namespace.EmptyName {
 		method := info.FullMethod
 		if IsLongPollGetWorkflowExecutionHistoryRequest(req) {
@@ -81,15 +129,13 @@ func (ni *NamespaceRateLimitInterceptorImpl) Intercept(
 		} else if IsLongPollDescribeActivityExecutionRequest(req) {
 			method = configs.PollActivityExecutionAPIName
 		}
-		if ni.pollWaitForToken(ns.String()) {
-			if _, ok := ni.pollMethods[info.FullMethod]; ok {
-				if err := ni.Wait(ctx, ns, method, headers.NewGRPCHeaderGetter(ctx)); err != nil {
-					return nil, err
-				}
-				return handler(ctx, req)
+		if _, ok := ni.pollMethods[info.FullMethod]; ok && ni.pollWaitForToken(ns.String()) {
+			if err := ni.WaitN(ctx, ns, method, headers.NewGRPCHeaderGetter(ctx), numToken); err != nil {
+				return nil, err
 			}
+			return handler(ctx, req)
 		}
-		if err := ni.Allow(ns, method, headers.NewGRPCHeaderGetter(ctx)); err != nil {
+		if err := ni.AllowN(ctx, ns, method, headers.NewGRPCHeaderGetter(ctx), numToken); err != nil {
 			return nil, err
 		}
 	}
@@ -97,14 +143,25 @@ func (ni *NamespaceRateLimitInterceptorImpl) Intercept(
 	return handler(ctx, req)
 }
 
-func (ni *NamespaceRateLimitInterceptorImpl) Wait(ctx context.Context, namespaceName namespace.Name, methodName string, headerGetter headers.HeaderGetter) error {
-	token, ok := ni.tokens[methodName]
-	if !ok {
-		token = NamespaceRateLimitDefaultToken
-	}
+func (ni *NamespaceRateLimitInterceptorImpl) Wait(
+	ctx context.Context,
+	namespaceName namespace.Name,
+	methodName string,
+	headerGetter headers.HeaderGetter,
+) error {
+	return ni.WaitN(ctx, namespaceName, methodName, headerGetter, NamespaceRateLimitDefaultToken)
+}
+
+func (ni *NamespaceRateLimitInterceptorImpl) WaitN(
+	ctx context.Context,
+	namespaceName namespace.Name,
+	methodName string,
+	headerGetter headers.HeaderGetter,
+	numToken int,
+) error {
 	request := quotas.NewRequest(
 		methodName,
-		token,
+		numToken,
 		namespaceName.String(),
 		headerGetter.Get(headers.CallerTypeHeaderName),
 		0,  // this interceptor layer does not throttle based on caller segment
@@ -139,15 +196,25 @@ func (ni *NamespaceRateLimitInterceptorImpl) Wait(ctx context.Context, namespace
 	return ctx.Err()
 }
 
-func (ni *NamespaceRateLimitInterceptorImpl) Allow(namespaceName namespace.Name, methodName string, headerGetter headers.HeaderGetter) error {
-	token, ok := ni.tokens[methodName]
-	if !ok {
-		token = NamespaceRateLimitDefaultToken
-	}
+func (ni *NamespaceRateLimitInterceptorImpl) Allow(
+	ctx context.Context,
+	namespaceName namespace.Name,
+	methodName string,
+	headerGetter headers.HeaderGetter,
+) error {
+	return ni.AllowN(ctx, namespaceName, methodName, headerGetter, NamespaceRateLimitDefaultToken)
+}
 
+func (ni *NamespaceRateLimitInterceptorImpl) AllowN(
+	ctx context.Context,
+	namespaceName namespace.Name,
+	methodName string,
+	headerGetter headers.HeaderGetter,
+	numToken int,
+) error {
 	if !ni.rateLimiter.Allow(time.Now().UTC(), quotas.NewRequest(
 		methodName,
-		token,
+		numToken,
 		namespaceName.String(),
 		headerGetter.Get(headers.CallerTypeHeaderName),
 		0,  // this interceptor layer does not throttle based on caller segment

--- a/common/rpc/interceptor/namespace_rate_limit_test.go
+++ b/common/rpc/interceptor/namespace_rate_limit_test.go
@@ -46,7 +46,6 @@ func (s *namespaceRateLimitInterceptorSuite) newImpl(pollWaitForToken bool) *Nam
 	return &NamespaceRateLimitInterceptorImpl{
 		namespaceRegistry: s.mockRegistry,
 		rateLimiter:       s.mockRateLimiter,
-		tokens:            map[string]int{},
 		pollMethods: map[string]struct{}{
 			pollWorkflowTaskQueueMethod: {},
 		},

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -639,7 +639,6 @@ func NamespaceRateLimitInterceptorProvider(
 	return interceptor.NewNamespaceRateLimitInterceptor(
 		namespaceRegistry,
 		quotas.NewRoutingRateLimiter(mapping),
-		map[string]int{}, // no token overrides
 		configs.PollTaskAPISet,
 		serviceConfig.PollWaitForNamespaceRateLimitToken,
 		metricsHandler,

--- a/service/frontend/nexus_completion_http_handler.go
+++ b/service/frontend/nexus_completion_http_handler.go
@@ -655,7 +655,12 @@ func (c *requestContext) interceptRequest(ctx context.Context, request *nexusrpc
 		return commonnexus.ConvertGRPCError(err, false)
 	}
 
-	if err := c.NamespaceRateLimitInterceptor.Allow(c.namespace.Name(), nexusCompletionAPIName, request.HTTPRequest.Header); err != nil {
+	if err := c.NamespaceRateLimitInterceptor.Allow(
+		ctx,
+		c.namespace.Name(),
+		nexusCompletionAPIName,
+		request.HTTPRequest.Header,
+	); err != nil {
 		c.outcomeTag = metrics.OutcomeTag("namespace_rate_limited")
 		return commonnexus.ConvertGRPCError(err, true)
 	}

--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -234,7 +234,12 @@ func (c *operationContext) interceptRequest(
 		return commonnexus.ConvertGRPCError(err, false)
 	}
 
-	if err := c.namespaceRateLimitInterceptor.Allow(c.namespace.Name(), c.apiName, header); err != nil {
+	if err := c.namespaceRateLimitInterceptor.Allow(
+		ctx,
+		c.namespace.Name(),
+		c.apiName,
+		header,
+	); err != nil {
 		c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("namespace_rate_limited"))
 		return commonnexus.ConvertGRPCError(err, true)
 	}

--- a/service/frontend/nexus_handler_test.go
+++ b/service/frontend/nexus_handler_test.go
@@ -145,7 +145,6 @@ func newOperationContext(options contextOptions) *operationContext {
 	oc.namespaceRateLimitInterceptor = interceptor.NewNamespaceRateLimitInterceptor(
 		nil,
 		mockRateLimiter{options.namespaceRateLimitAllow},
-		make(map[string]int),
 		map[string]struct{}{},
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
 		metrics.NoopMetricsHandler,

--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -352,7 +352,6 @@ func NamespaceRateLimitInterceptorProvider(
 			namespaceRateFn,
 			serviceConfig.OperatorRPSRatio,
 		),
-		map[string]int{},      // no token overrides
 		map[string]struct{}{}, // no long polls on history service
 		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false), // no long poll methods
 		metricsHandler,

--- a/service/matching/fx.go
+++ b/service/matching/fx.go
@@ -134,7 +134,6 @@ func NamespaceRateLimitInterceptorProvider(
 			namespaceRateFn,
 			serviceConfig.OperatorRPSRatio,
 		),
-		map[string]int{},       // no token overrides
 		configs.PollTaskAPISet, // set of APIs that will wait for token instead of immediate rejection
 		serviceConfig.PollWaitForNamespaceRateLimitToken,
 		metricsHandler,


### PR DESCRIPTION
## What changed?
Refactor NamespaceRateLimitInterceptor with functions to consume N tokens:
- removed `tokens` overwrite argument as it's never used
- added functions to consume N tokens

The changes itself in this PR is no-op since it's introducing new functions to the interface.

## Why?
Added flexibility to wrap `NamespaceRateLimitInterceptor`.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
