### PR TITLE
Fix schedule action delay after refresh

### DIFF
--- a/service/worker/scheduler/buffer.go
+++ b/service/worker/scheduler/buffer.go
@@ -27,6 +27,18 @@ type (
 	}
 )
 
+// IgnoresRunningWorkflow reports whether a start with the given (already
+// resolved) overlap policy is started regardless of whether a workflow is
+// currently running for the schedule. This is only true for ALLOW_ALL: every
+// other policy either waits for the running workflow to finish, skips, or
+// cancels/terminates it first. Callers that need to know whether a buffered
+// start was actually blocked on a prior run finishing (as opposed to merely
+// following it in time) should use this instead of re-deriving the same
+// condition.
+func IgnoresRunningWorkflow(overlapPolicy enumspb.ScheduleOverlapPolicy) bool {
+	return overlapPolicy == enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL
+}
+
 func ProcessBuffer[T Overlappable](
 	buffer []T,
 	isRunning bool,
@@ -48,7 +60,7 @@ func ProcessBuffer[T Overlappable](
 		overlapPolicy := resolve(start.GetOverlapPolicy())
 
 		// For allow-all, just collect and start all at once
-		if overlapPolicy == enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL {
+		if IgnoresRunningWorkflow(overlapPolicy) {
 			action.OverlappingStarts = append(action.OverlappingStarts, start)
 			continue
 		}

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -1019,17 +1019,20 @@ func (s *scheduler) processWatcherResult(id string, f workflow.Future, long bool
 	// starting the next). The legacy path doesn't use deferred starts
 	// (Attempt == -1) like CHASM, so BufferedStarts[0] is always the next
 	// pending start.
+	//
+	// Branched by version explicitly (rather than folding hasMinVersion into
+	// shouldBackdateDesiredTime) so replay of histories recorded below
+	// RefreshCompletionDesiredTime keeps taking the old, unconditional-on-long-poll-only path
+	// byte-for-byte -- a mixed-fleet rolling deploy of this very change must not let a
+	// newer binary recompute a different DesiredTime, and therefore a different
+	// continue-as-new Input, than what an older binary already recorded for the same history.
 	if len(s.State.BufferedStarts) > 0 {
 		next := s.State.BufferedStarts[0]
-		// A refresh can discover a completion long after the fact, once an unrelated, later
-		// buffered start already exists. Only backdate DesiredTime when the close genuinely
-		// came after this start was due -- i.e. this start was actually blocked waiting on it
-		// (e.g. BUFFER_ONE/BUFFER_ALL/CANCEL_OTHER). Otherwise the start ran on time and
-		// DesiredTime must stay at ActualTime, or an on-time start gets misreported as delayed
-		// by the entire idle gap. The long-poll path predates this check and stays unconditional.
-		refreshBackdate := s.hasMinVersion(RefreshCompletionDesiredTime) &&
-			res.CloseTime != nil && res.CloseTime.AsTime().After(next.ActualTime.AsTime())
-		if long || refreshBackdate {
+		if s.hasMinVersion(RefreshCompletionDesiredTime) {
+			if shouldBackdateDesiredTime(long, res.CloseTime, next.ActualTime, s.resolveOverlapPolicy(next.OverlapPolicy)) {
+				next.DesiredTime = res.CloseTime
+			}
+		} else if long {
 			next.DesiredTime = res.CloseTime
 		}
 	}
@@ -1426,6 +1429,36 @@ func (s *scheduler) resolveOverlapPolicy(overlapPolicy enumspb.ScheduleOverlapPo
 		overlapPolicy = enumspb.SCHEDULE_OVERLAP_POLICY_SKIP
 	}
 	return overlapPolicy
+}
+
+// shouldBackdateDesiredTime reports whether a watcher result discovering a workflow's completion
+// should backdate the next buffered start's DesiredTime to that completion's CloseTime, for the
+// purpose of computing ScheduleActionDelay.
+//
+// The long-poll path predates this check and stays unconditional: it always backdates, since a
+// long-poll watcher is only ever installed to wait for the exact workflow the next buffered start
+// is blocked on.
+//
+// The refresh path is conditional: a refresh can discover a completion long after the fact, once
+// an unrelated, later buffered start already exists. Only backdate when the close genuinely came
+// after the next start's own due time (i.e. it was actually blocked waiting on this workflow,
+// e.g. under BUFFER_ONE/BUFFER_ALL/CANCEL_OTHER/TERMINATE_OTHER) and the next start's own resolved
+// overlap policy actually waits for a running workflow to finish. A start whose resolved policy
+// ignores running workflows (ALLOW_ALL, see IgnoresRunningWorkflow) is never blocked by this
+// close, no matter the timing, since processBuffer starts it regardless of isRunning -- and
+// backdating would understate its real delay.
+func shouldBackdateDesiredTime(
+	long bool,
+	closeTime *timestamppb.Timestamp,
+	nextActualTime *timestamppb.Timestamp,
+	nextResolvedOverlapPolicy enumspb.ScheduleOverlapPolicy,
+) bool {
+	if long {
+		return true
+	}
+	return closeTime != nil &&
+		closeTime.AsTime().After(nextActualTime.AsTime()) &&
+		!IgnoresRunningWorkflow(nextResolvedOverlapPolicy)
 }
 
 func (s *scheduler) addStart(nominalTime, actualTime time.Time, overlapPolicy enumspb.ScheduleOverlapPolicy, manual bool) {

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -1029,7 +1029,7 @@ func (s *scheduler) processWatcherResult(id string, f workflow.Future, long bool
 	if len(s.State.BufferedStarts) > 0 {
 		next := s.State.BufferedStarts[0]
 		if s.hasMinVersion(RefreshCompletionDesiredTime) {
-			if shouldBackdateDesiredTime(long, res.CloseTime, next.ActualTime, s.resolveOverlapPolicy(next.OverlapPolicy)) {
+			if shouldBackdateDesiredTime(long, res.CloseTime, next.DesiredTime, next.ActualTime, s.resolveOverlapPolicy(next.OverlapPolicy)) {
 				next.DesiredTime = res.CloseTime
 			}
 		} else if long {
@@ -1447,9 +1447,17 @@ func (s *scheduler) resolveOverlapPolicy(overlapPolicy enumspb.ScheduleOverlapPo
 // ignores running workflows (ALLOW_ALL, see IgnoresRunningWorkflow) is never blocked by this
 // close, no matter the timing, since processBuffer starts it regardless of isRunning -- and
 // backdating would understate its real delay.
+//
+// refreshWorkflows calls this once per tracked execution, so a run with multiple RunningWorkflows
+// (e.g. ALLOW_ALL runs inherited from before a pre-DontTrackOverlapping version ceiling was
+// lifted) can process several results against the same buffered start in one pass. On the refresh
+// path, only move currentDesiredTime forward -- never let a later-processed but earlier-closing
+// execution overwrite a genuinely later close already recorded this pass, or the start's real
+// blocked duration would be understated.
 func shouldBackdateDesiredTime(
 	long bool,
 	closeTime *timestamppb.Timestamp,
+	currentDesiredTime *timestamppb.Timestamp,
 	nextActualTime *timestamppb.Timestamp,
 	nextResolvedOverlapPolicy enumspb.ScheduleOverlapPolicy,
 ) bool {
@@ -1458,7 +1466,8 @@ func shouldBackdateDesiredTime(
 	}
 	return closeTime != nil &&
 		closeTime.AsTime().After(nextActualTime.AsTime()) &&
-		!IgnoresRunningWorkflow(nextResolvedOverlapPolicy)
+		!IgnoresRunningWorkflow(nextResolvedOverlapPolicy) &&
+		(currentDesiredTime == nil || closeTime.AsTime().After(currentDesiredTime.AsTime()))
 }
 
 func (s *scheduler) addStart(nominalTime, actualTime time.Time, overlapPolicy enumspb.ScheduleOverlapPolicy, manual bool) {

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -76,6 +76,8 @@ const (
 	//     from CHASM, preserving idempotency identity across the migration
 	//     handoff.
 	MigrationHandoffFixes = 13
+	// update the desired time for a buffered start when refresh discovers the prior action completed
+	RefreshCompletionDesiredTime = 14
 )
 
 const (
@@ -1017,8 +1019,19 @@ func (s *scheduler) processWatcherResult(id string, f workflow.Future, long bool
 	// starting the next). The legacy path doesn't use deferred starts
 	// (Attempt == -1) like CHASM, so BufferedStarts[0] is always the next
 	// pending start.
-	if long && len(s.State.BufferedStarts) > 0 {
-		s.State.BufferedStarts[0].DesiredTime = res.CloseTime
+	if len(s.State.BufferedStarts) > 0 {
+		next := s.State.BufferedStarts[0]
+		// A refresh can discover a completion long after the fact, once an unrelated, later
+		// buffered start already exists. Only backdate DesiredTime when the close genuinely
+		// came after this start was due -- i.e. this start was actually blocked waiting on it
+		// (e.g. BUFFER_ONE/BUFFER_ALL/CANCEL_OTHER). Otherwise the start ran on time and
+		// DesiredTime must stay at ActualTime, or an on-time start gets misreported as delayed
+		// by the entire idle gap. The long-poll path predates this check and stays unconditional.
+		refreshBackdate := s.hasMinVersion(RefreshCompletionDesiredTime) &&
+			res.CloseTime != nil && res.CloseTime.AsTime().After(next.ActualTime.AsTime())
+		if long || refreshBackdate {
+			next.DesiredTime = res.CloseTime
+		}
 	}
 
 	s.logger.Debug("started workflow finished", "workflow", id, "status", res.Status, "pause-after-failure", pauseOnFailure, "long", long)

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -533,10 +534,6 @@ func (s *workflowSuite) TestInitialPatch() {
 		return nil, nil
 	})
 
-	prevVersion := CurrentTweakablePolicies.Version
-	CurrentTweakablePolicies.Version = RefreshCompletionDesiredTime
-	defer func() { CurrentTweakablePolicies.Version = prevVersion }()
-
 	CurrentTweakablePolicies.IterationsBeforeContinueAsNew = 2
 	s.env.SetStartTime(baseStartTime)
 	s.env.ExecuteWorkflow(SchedulerWorkflow, &schedulespb.StartScheduleArgs{
@@ -661,12 +658,15 @@ func (s *workflowSuite) TestRefreshCompletionDesiredTimeBacklog() {
 	s.Equal([]time.Duration{5 * time.Minute}, s.metrics.timerValues(metrics.ScheduleActionDelay.Name()))
 }
 
-// TestInitialPatchRefreshCompletionAtOldVersion pins the pre-fix behavior for histories recorded
-// below RefreshCompletionDesiredTime: a refresh (non-long-poll) discovering the prior action's
-// completion must NOT populate BufferedStarts[0].DesiredTime, since that value flows into the
-// continue-as-new Input and any divergence there would be a replay nondeterminism break for
-// already-recorded histories, version-ceiling peers, or a rollback to older code.
-func (s *workflowSuite) TestInitialPatchRefreshCompletionAtOldVersion() {
+// TestRefreshCompletionDesiredTimeBacklogAtOldVersion pins the pre-fix behavior for histories
+// recorded below RefreshCompletionDesiredTime: it runs the exact same genuinely-blocked scenario
+// as TestRefreshCompletionDesiredTimeBacklog above (refresh discovers a close after the buffered
+// start's own due time), but at the old version, where the refresh path must stay a no-op even
+// though the close time would otherwise qualify for backdating. This is the case the version gate
+// exists to protect: without it, a mixed-fleet rolling deploy of this fix could have an old binary
+// record a continue-as-new Input with DesiredTime unset, and a new binary later replay that same
+// history and compute DesiredTime differently, breaking determinism.
+func (s *workflowSuite) TestRefreshCompletionDesiredTimeBacklogAtOldVersion() {
 	prevVersion := CurrentTweakablePolicies.Version
 	CurrentTweakablePolicies.Version = TriggerImmediatelyTimestamp
 	defer func() { CurrentTweakablePolicies.Version = prevVersion }()
@@ -680,27 +680,49 @@ func (s *workflowSuite) TestInitialPatchRefreshCompletionAtOldVersion() {
 		s.True(time.Date(2022, 6, 1, 0, 15, 0, 0, time.UTC).Equal(s.now()))
 		s.Equal("myid-2022-06-01T00:00:00Z", req.Execution.WorkflowId)
 		s.False(req.LongPoll)
+		return &schedulespb.WatchWorkflowResponse{Status: enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING}, nil
+	})
+	s.env.OnActivity(new(activities).WatchWorkflow, mock.Anything, mock.MatchedBy(func(req *schedulespb.WatchWorkflowRequest) bool {
+		return req.LongPoll
+	})).Once().AfterFn(func() time.Duration {
+		return 20 * time.Minute
+	}).Return(func(ctx context.Context, req *schedulespb.WatchWorkflowRequest) (*schedulespb.WatchWorkflowResponse, error) {
 		return &schedulespb.WatchWorkflowResponse{
 			Status:    enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
-			CloseTime: timestamppb.New(baseStartTime.Add(10 * time.Minute)),
+			CloseTime: timestamppb.New(baseStartTime.Add(20 * time.Minute)),
+		}, nil
+	})
+	s.env.RegisterDelayedCallback(func() {
+		s.env.SignalWorkflow(SignalNameRefresh, nil)
+	}, 25*time.Minute)
+	s.expectWatch(func(req *schedulespb.WatchWorkflowRequest) (*schedulespb.WatchWorkflowResponse, error) {
+		s.True(time.Date(2022, 6, 1, 0, 25, 0, 0, time.UTC).Equal(s.now()))
+		s.Equal("myid-2022-06-01T00:00:00Z", req.Execution.WorkflowId)
+		s.False(req.LongPoll)
+		return &schedulespb.WatchWorkflowResponse{
+			Status:    enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+			CloseTime: timestamppb.New(baseStartTime.Add(20 * time.Minute)),
 		}, nil
 	})
 	s.expectStart(func(req *schedulespb.StartWorkflowRequest) (*schedulespb.StartWorkflowResponse, error) {
-		s.True(time.Date(2022, 6, 1, 0, 15, 0, 0, time.UTC).Equal(s.now()))
+		s.True(time.Date(2022, 6, 1, 0, 25, 0, 0, time.UTC).Equal(s.now()))
 		s.Equal("myid-2022-06-01T00:15:00Z", req.Request.WorkflowId)
 		return nil, nil
 	})
 
-	CurrentTweakablePolicies.IterationsBeforeContinueAsNew = 2
+	CurrentTweakablePolicies.IterationsBeforeContinueAsNew = 3
 	s.env.SetStartTime(baseStartTime)
 	s.env.ExecuteWorkflow(SchedulerWorkflow, &schedulespb.StartScheduleArgs{
 		Schedule: &schedulepb.Schedule{
 			Spec: &schedulepb.ScheduleSpec{
 				Interval: []*schedulepb.IntervalSpec{{
-					Interval: durationpb.New(55 * time.Minute),
+					Interval: durationpb.New(15 * time.Minute),
 				}},
 			},
 			Action: s.defaultAction("myid"),
+			Policies: &schedulepb.SchedulePolicies{
+				OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE,
+			},
 		},
 		State: &schedulespb.InternalState{
 			Namespace:     "myns",
@@ -714,9 +736,114 @@ func (s *workflowSuite) TestInitialPatchRefreshCompletionAtOldVersion() {
 	})
 	s.True(s.env.IsWorkflowCompleted())
 	s.True(workflow.IsContinueAsNewError(s.env.GetWorkflowError()))
-	// Falls back to the scheduled (actual) time, not the prior action's close time: the pre-fix
-	// baseline, unchanged for histories below the version gate.
-	s.Equal([]time.Duration{0}, s.metrics.timerValues(metrics.ScheduleActionDelay.Name()))
+	// Falls back to the scheduled (actual) time, not the prior action's close time: due at :15,
+	// started at :25, a 10 minute delay -- the pre-fix baseline. If this ever comes back 5 minutes
+	// (the fixed value from the sibling test above), the version gate has stopped doing its job.
+	s.Equal([]time.Duration{10 * time.Minute}, s.metrics.timerValues(metrics.ScheduleActionDelay.Name()))
+}
+
+func TestShouldBackdateDesiredTime(t *testing.T) {
+	base := baseStartTime
+	dueAt15 := timestamppb.New(base.Add(15 * time.Minute))
+
+	testCases := []struct {
+		name                      string
+		long                      bool
+		closeTime                 *timestamppb.Timestamp
+		nextActualTime            *timestamppb.Timestamp
+		nextResolvedOverlapPolicy enumspb.ScheduleOverlapPolicy
+		want                      bool
+	}{
+		{
+			name: "long poll always backdates regardless of policy or timing",
+			long: true,
+			// close before due and ALLOW_ALL would both independently forbid backdating on the
+			// refresh path; the long-poll path predates and ignores both.
+			closeTime:                 timestamppb.New(base.Add(10 * time.Minute)),
+			nextActualTime:            dueAt15,
+			nextResolvedOverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+			want:                      true,
+		},
+		{
+			name:                      "refresh with nil close time never backdates",
+			long:                      false,
+			closeTime:                 nil,
+			nextActualTime:            dueAt15,
+			nextResolvedOverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE,
+			want:                      false,
+		},
+		{
+			name:                      "refresh with close before due time does not backdate: start ran on time",
+			long:                      false,
+			closeTime:                 timestamppb.New(base.Add(10 * time.Minute)),
+			nextActualTime:            dueAt15,
+			nextResolvedOverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE,
+			want:                      false,
+		},
+		{
+			name:                      "refresh with close after due time backdates under BUFFER_ONE: genuinely blocked",
+			long:                      false,
+			closeTime:                 timestamppb.New(base.Add(20 * time.Minute)),
+			nextActualTime:            dueAt15,
+			nextResolvedOverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE,
+			want:                      true,
+		},
+		{
+			name:                      "refresh with close after due time backdates under BUFFER_ALL",
+			long:                      false,
+			closeTime:                 timestamppb.New(base.Add(20 * time.Minute)),
+			nextActualTime:            dueAt15,
+			nextResolvedOverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ALL,
+			want:                      true,
+		},
+		{
+			name:                      "refresh with close after due time backdates under CANCEL_OTHER",
+			long:                      false,
+			closeTime:                 timestamppb.New(base.Add(20 * time.Minute)),
+			nextActualTime:            dueAt15,
+			nextResolvedOverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_CANCEL_OTHER,
+			want:                      true,
+		},
+		{
+			name:                      "refresh with close after due time backdates under TERMINATE_OTHER",
+			long:                      false,
+			closeTime:                 timestamppb.New(base.Add(20 * time.Minute)),
+			nextActualTime:            dueAt15,
+			nextResolvedOverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_TERMINATE_OTHER,
+			want:                      true,
+		},
+		{
+			name:                      "refresh with close after due time backdates under SKIP",
+			long:                      false,
+			closeTime:                 timestamppb.New(base.Add(20 * time.Minute)),
+			nextActualTime:            dueAt15,
+			nextResolvedOverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_SKIP,
+			want:                      true,
+		},
+		{
+			// The regression this test guards against: a schedule policy change to ALLOW_ALL
+			// means processBuffer starts this entry regardless of isRunning, so it was never
+			// blocked on the workflow whose close the refresh just discovered. Backdating here
+			// would understate schedule_action_delay by attributing an unrelated close time.
+			name:                      "refresh with close after due time does NOT backdate under ALLOW_ALL",
+			long:                      false,
+			closeTime:                 timestamppb.New(base.Add(20 * time.Minute)),
+			nextActualTime:            dueAt15,
+			nextResolvedOverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+			want:                      false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldBackdateDesiredTime(
+				tc.long,
+				tc.closeTime,
+				tc.nextActualTime,
+				tc.nextResolvedOverlapPolicy,
+			)
+			require.Equal(t, tc.want, got)
+		})
+	}
 }
 
 func (s *workflowSuite) TestCatchupWindow() {

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -17,10 +17,12 @@ import (
 	sdkpb "go.temporal.io/api/sdk/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
+	sdkclient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/testsuite"
 	"go.temporal.io/sdk/workflow"
 	schedulespb "go.temporal.io/server/api/schedule/v1"
 	schedulerpb "go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/searchattribute/sadefs"
@@ -33,7 +35,24 @@ type (
 	workflowSuite struct {
 		suite.Suite
 		testsuite.WorkflowTestSuite
-		env *testsuite.TestWorkflowEnvironment
+		env     *testsuite.TestWorkflowEnvironment
+		metrics *capturingMetricsHandler
+	}
+
+	capturingMetricsHandler struct {
+		timers []capturedTimer
+	}
+
+	capturedTimer struct {
+		name  string
+		value time.Duration
+	}
+
+	noopMetricsCounter    struct{}
+	noopMetricsGauge      struct{}
+	capturingMetricsTimer struct {
+		handler *capturingMetricsHandler
+		name    string
 	}
 )
 
@@ -46,7 +65,43 @@ func TestWorkflow(t *testing.T) {
 }
 
 func (s *workflowSuite) SetupTest() {
+	s.metrics = &capturingMetricsHandler{}
+	s.SetMetricsHandler(s.metrics)
 	s.env = s.NewTestWorkflowEnvironment()
+}
+
+func (h *capturingMetricsHandler) WithTags(map[string]string) sdkclient.MetricsHandler {
+	return h
+}
+
+func (h *capturingMetricsHandler) Counter(string) sdkclient.MetricsCounter {
+	return noopMetricsCounter{}
+}
+
+func (h *capturingMetricsHandler) Gauge(string) sdkclient.MetricsGauge {
+	return noopMetricsGauge{}
+}
+
+func (h *capturingMetricsHandler) Timer(name string) sdkclient.MetricsTimer {
+	return capturingMetricsTimer{handler: h, name: name}
+}
+
+func (h *capturingMetricsHandler) timerValues(name string) []time.Duration {
+	var values []time.Duration
+	for _, timer := range h.timers {
+		if timer.name == name {
+			values = append(values, timer.value)
+		}
+	}
+	return values
+}
+
+func (noopMetricsCounter) Inc(int64) {}
+
+func (noopMetricsGauge) Update(float64) {}
+
+func (t capturingMetricsTimer) Record(value time.Duration) {
+	t.handler.timers = append(t.handler.timers, capturedTimer{name: t.name, value: value})
 }
 
 func (s *workflowSuite) AfterTest(suiteName, testName string) {
@@ -467,7 +522,73 @@ func (s *workflowSuite) TestInitialPatch() {
 		s.True(time.Date(2022, 6, 1, 0, 15, 0, 0, time.UTC).Equal(s.now()))
 		s.Equal("myid-2022-06-01T00:00:00Z", req.Execution.WorkflowId)
 		s.False(req.LongPoll)
-		return &schedulespb.WatchWorkflowResponse{Status: enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED}, nil
+		return &schedulespb.WatchWorkflowResponse{
+			Status:    enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+			CloseTime: timestamppb.New(baseStartTime.Add(10 * time.Minute)),
+		}, nil
+	})
+	s.expectStart(func(req *schedulespb.StartWorkflowRequest) (*schedulespb.StartWorkflowResponse, error) {
+		s.True(time.Date(2022, 6, 1, 0, 15, 0, 0, time.UTC).Equal(s.now()))
+		s.Equal("myid-2022-06-01T00:15:00Z", req.Request.WorkflowId)
+		return nil, nil
+	})
+
+	prevVersion := CurrentTweakablePolicies.Version
+	CurrentTweakablePolicies.Version = RefreshCompletionDesiredTime
+	defer func() { CurrentTweakablePolicies.Version = prevVersion }()
+
+	CurrentTweakablePolicies.IterationsBeforeContinueAsNew = 2
+	s.env.SetStartTime(baseStartTime)
+	s.env.ExecuteWorkflow(SchedulerWorkflow, &schedulespb.StartScheduleArgs{
+		Schedule: &schedulepb.Schedule{
+			Spec: &schedulepb.ScheduleSpec{
+				Interval: []*schedulepb.IntervalSpec{{
+					Interval: durationpb.New(55 * time.Minute),
+				}},
+			},
+			Action: s.defaultAction("myid"),
+		},
+		State: &schedulespb.InternalState{
+			Namespace:     "myns",
+			NamespaceId:   "mynsid",
+			ScheduleId:    "myschedule",
+			ConflictToken: InitialConflictToken,
+		},
+		InitialPatch: &schedulepb.SchedulePatch{
+			TriggerImmediately: &schedulepb.TriggerImmediatelyRequest{},
+		},
+	})
+	s.True(s.env.IsWorkflowCompleted())
+	s.True(workflow.IsContinueAsNewError(s.env.GetWorkflowError()))
+	// The prior action closed (00:10) before the next start was even due (00:15), so the next
+	// start ran exactly on time -- it was never blocked waiting on the prior action. DesiredTime
+	// must stay at ActualTime, reporting zero delay, not the idle gap since the prior close.
+	s.Equal([]time.Duration{0}, s.metrics.timerValues(metrics.ScheduleActionDelay.Name()))
+}
+
+// TestInitialPatchRefreshCompletionAtOldVersion pins the pre-fix behavior for histories recorded
+// below RefreshCompletionDesiredTime: a refresh (non-long-poll) discovering the prior action's
+// completion must NOT populate BufferedStarts[0].DesiredTime, since that value flows into the
+// continue-as-new Input and any divergence there would be a replay nondeterminism break for
+// already-recorded histories, version-ceiling peers, or a rollback to older code.
+func (s *workflowSuite) TestInitialPatchRefreshCompletionAtOldVersion() {
+	prevVersion := CurrentTweakablePolicies.Version
+	CurrentTweakablePolicies.Version = TriggerImmediatelyTimestamp
+	defer func() { CurrentTweakablePolicies.Version = prevVersion }()
+
+	s.expectStart(func(req *schedulespb.StartWorkflowRequest) (*schedulespb.StartWorkflowResponse, error) {
+		s.True(time.Date(2022, 6, 1, 0, 0, 0, 0, time.UTC).Equal(s.now()))
+		s.Equal("myid-2022-06-01T00:00:00Z", req.Request.WorkflowId)
+		return nil, nil
+	})
+	s.expectWatch(func(req *schedulespb.WatchWorkflowRequest) (*schedulespb.WatchWorkflowResponse, error) {
+		s.True(time.Date(2022, 6, 1, 0, 15, 0, 0, time.UTC).Equal(s.now()))
+		s.Equal("myid-2022-06-01T00:00:00Z", req.Execution.WorkflowId)
+		s.False(req.LongPoll)
+		return &schedulespb.WatchWorkflowResponse{
+			Status:    enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+			CloseTime: timestamppb.New(baseStartTime.Add(10 * time.Minute)),
+		}, nil
 	})
 	s.expectStart(func(req *schedulespb.StartWorkflowRequest) (*schedulespb.StartWorkflowResponse, error) {
 		s.True(time.Date(2022, 6, 1, 0, 15, 0, 0, time.UTC).Equal(s.now()))
@@ -498,6 +619,9 @@ func (s *workflowSuite) TestInitialPatch() {
 	})
 	s.True(s.env.IsWorkflowCompleted())
 	s.True(workflow.IsContinueAsNewError(s.env.GetWorkflowError()))
+	// Falls back to the scheduled (actual) time, not the prior action's close time: the pre-fix
+	// baseline, unchanged for histories below the version gate.
+	s.Equal([]time.Duration{0}, s.metrics.timerValues(metrics.ScheduleActionDelay.Name()))
 }
 
 func (s *workflowSuite) TestCatchupWindow() {

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -566,6 +566,101 @@ func (s *workflowSuite) TestInitialPatch() {
 	s.Equal([]time.Duration{0}, s.metrics.timerValues(metrics.ScheduleActionDelay.Name()))
 }
 
+// TestRefreshCompletionDesiredTimeBacklog verifies the actual regression this fix targets: a
+// refresh discovering that the prior action closed AFTER the next buffered start's own due time
+// -- i.e. that start was genuinely blocked waiting on it -- backdates DesiredTime, so
+// ScheduleActionDelay measures from the real close instead of the start's original scheduled
+// time.
+//
+// A long-poll watcher gets installed as soon as a start is buffered behind a still-running
+// action, so that watcher (not a later refresh) is what normally discovers a genuine backlog's
+// completion. To exercise the refresh path specifically, this test never lets the long-poll
+// watcher resolve; discovery instead comes from an explicit refresh signal, mirroring the
+// watcher-interruption/worker-restart case described where refreshWorkflows finds a completion
+// the long-poll watcher missed.
+func (s *workflowSuite) TestRefreshCompletionDesiredTimeBacklog() {
+	prevVersion := CurrentTweakablePolicies.Version
+	CurrentTweakablePolicies.Version = RefreshCompletionDesiredTime
+	defer func() { CurrentTweakablePolicies.Version = prevVersion }()
+
+	s.expectStart(func(req *schedulespb.StartWorkflowRequest) (*schedulespb.StartWorkflowResponse, error) {
+		s.True(time.Date(2022, 6, 1, 0, 0, 0, 0, time.UTC).Equal(s.now()))
+		s.Equal("myid-2022-06-01T00:00:00Z", req.Request.WorkflowId)
+		return nil, nil
+	})
+	// The first scheduled tick (:15) buffers behind the still-running manual action.
+	s.expectWatch(func(req *schedulespb.WatchWorkflowRequest) (*schedulespb.WatchWorkflowResponse, error) {
+		s.True(time.Date(2022, 6, 1, 0, 15, 0, 0, time.UTC).Equal(s.now()))
+		s.Equal("myid-2022-06-01T00:00:00Z", req.Execution.WorkflowId)
+		s.False(req.LongPoll)
+		return &schedulespb.WatchWorkflowResponse{Status: enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING}, nil
+	})
+	// A long-poll watcher is installed right after. Resolve it well after the explicit refresh
+	// below is expected to have already discovered completion and started the buffered action,
+	// so discovery here is unambiguously via refresh; this resolution becomes a harmless,
+	// already-a-no-op duplicate (BufferedStarts is empty and the action is no longer running by
+	// then).
+	s.env.OnActivity(new(activities).WatchWorkflow, mock.Anything, mock.MatchedBy(func(req *schedulespb.WatchWorkflowRequest) bool {
+		return req.LongPoll
+	})).Once().AfterFn(func() time.Duration {
+		return 20 * time.Minute
+	}).Return(func(ctx context.Context, req *schedulespb.WatchWorkflowRequest) (*schedulespb.WatchWorkflowResponse, error) {
+		return &schedulespb.WatchWorkflowResponse{
+			Status:    enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+			CloseTime: timestamppb.New(baseStartTime.Add(20 * time.Minute)),
+		}, nil
+	})
+	// An explicit refresh signal at :25 discovers the manual action actually closed at :20 --
+	// after the buffered start's own due time of :15, i.e. genuinely blocked.
+	s.env.RegisterDelayedCallback(func() {
+		s.env.SignalWorkflow(SignalNameRefresh, nil)
+	}, 25*time.Minute)
+	s.expectWatch(func(req *schedulespb.WatchWorkflowRequest) (*schedulespb.WatchWorkflowResponse, error) {
+		s.True(time.Date(2022, 6, 1, 0, 25, 0, 0, time.UTC).Equal(s.now()))
+		s.Equal("myid-2022-06-01T00:00:00Z", req.Execution.WorkflowId)
+		s.False(req.LongPoll)
+		return &schedulespb.WatchWorkflowResponse{
+			Status:    enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+			CloseTime: timestamppb.New(baseStartTime.Add(20 * time.Minute)),
+		}, nil
+	})
+	s.expectStart(func(req *schedulespb.StartWorkflowRequest) (*schedulespb.StartWorkflowResponse, error) {
+		s.True(time.Date(2022, 6, 1, 0, 25, 0, 0, time.UTC).Equal(s.now()))
+		s.Equal("myid-2022-06-01T00:15:00Z", req.Request.WorkflowId)
+		return nil, nil
+	})
+
+	CurrentTweakablePolicies.IterationsBeforeContinueAsNew = 3
+	s.env.SetStartTime(baseStartTime)
+	s.env.ExecuteWorkflow(SchedulerWorkflow, &schedulespb.StartScheduleArgs{
+		Schedule: &schedulepb.Schedule{
+			Spec: &schedulepb.ScheduleSpec{
+				Interval: []*schedulepb.IntervalSpec{{
+					Interval: durationpb.New(15 * time.Minute),
+				}},
+			},
+			Action: s.defaultAction("myid"),
+			Policies: &schedulepb.SchedulePolicies{
+				OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE,
+			},
+		},
+		State: &schedulespb.InternalState{
+			Namespace:     "myns",
+			NamespaceId:   "mynsid",
+			ScheduleId:    "myschedule",
+			ConflictToken: InitialConflictToken,
+		},
+		InitialPatch: &schedulepb.SchedulePatch{
+			TriggerImmediately: &schedulepb.TriggerImmediatelyRequest{},
+		},
+	})
+	s.True(s.env.IsWorkflowCompleted())
+	s.True(workflow.IsContinueAsNewError(s.env.GetWorkflowError()))
+	// Blocked from :15 (its own due time) until :20 (when the prior action actually closed):
+	// zero delay here would hide the very bug this test exists to catch.
+	s.Equal([]time.Duration{5 * time.Minute}, s.metrics.timerValues(metrics.ScheduleActionDelay.Name()))
+}
+
 // TestInitialPatchRefreshCompletionAtOldVersion pins the pre-fix behavior for histories recorded
 // below RefreshCompletionDesiredTime: a refresh (non-long-poll) discovering the prior action's
 // completion must NOT populate BufferedStarts[0].DesiredTime, since that value flows into the

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -746,10 +746,15 @@ func TestShouldBackdateDesiredTime(t *testing.T) {
 	base := baseStartTime
 	dueAt15 := timestamppb.New(base.Add(15 * time.Minute))
 
+	dueAt10 := timestamppb.New(base.Add(10 * time.Minute))
+	dueAt20 := timestamppb.New(base.Add(20 * time.Minute))
+	dueAt25 := timestamppb.New(base.Add(25 * time.Minute))
+
 	testCases := []struct {
 		name                      string
 		long                      bool
 		closeTime                 *timestamppb.Timestamp
+		currentDesiredTime        *timestamppb.Timestamp
 		nextActualTime            *timestamppb.Timestamp
 		nextResolvedOverlapPolicy enumspb.ScheduleOverlapPolicy
 		want                      bool
@@ -832,12 +837,43 @@ func TestShouldBackdateDesiredTime(t *testing.T) {
 			nextResolvedOverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
 			want:                      false,
 		},
+		{
+			// refreshWorkflows calls this once per tracked RunningWorkflows execution. If a
+			// later-processed result closed earlier than one already recorded this pass, it must
+			// not overwrite the later (maximum) close time with an earlier one.
+			name:                      "refresh does NOT overwrite a later already-recorded close time with an earlier one",
+			long:                      false,
+			closeTime:                 dueAt20,
+			currentDesiredTime:        dueAt25,
+			nextActualTime:            dueAt10,
+			nextResolvedOverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ALL,
+			want:                      false,
+		},
+		{
+			name:                      "refresh DOES move the close time forward when the new one is later",
+			long:                      false,
+			closeTime:                 dueAt25,
+			currentDesiredTime:        dueAt20,
+			nextActualTime:            dueAt10,
+			nextResolvedOverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ALL,
+			want:                      true,
+		},
+		{
+			name:                      "refresh with no prior desired time set backdates normally",
+			long:                      false,
+			closeTime:                 dueAt20,
+			currentDesiredTime:        nil,
+			nextActualTime:            dueAt10,
+			nextResolvedOverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ALL,
+			want:                      true,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := shouldBackdateDesiredTime(
 				tc.long,
 				tc.closeTime,
+				tc.currentDesiredTime,
 				tc.nextActualTime,
 				tc.nextResolvedOverlapPolicy,
 			)

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -31,6 +31,7 @@ import (
 	schedulerpb "go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/headers"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/primitives"
@@ -508,6 +509,9 @@ func TestScheduleV1(t *testing.T) {
 	newContext := v1ContextFactory
 	t.Run("TestCreateScheduleDuplicateSdkError", func(t *testing.T) { t.Parallel(); testCreateScheduleDuplicateSdkError(t, false) })
 	t.Run("TestCHASMCanListV1Schedules", func(t *testing.T) { t.Parallel(); testCHASMCanListV1Schedules(t, newContext) })
+	// Not parallel: testActionDelayMetrics temporarily overrides the package-level
+	// scheduler.CurrentTweakablePolicies.Version, which every parallel sibling schedule shares.
+	t.Run("TestActionDelayMetrics", func(t *testing.T) { testActionDelayMetrics(t, newContext) })
 	t.Run("TestRefresh", func(t *testing.T) { t.Parallel(); testRefresh(t, newContext) })
 	t.Run("TestListBeforeRun", func(t *testing.T) { t.Parallel(); testListBeforeRun(t, newContext) })
 	t.Run("TestRateLimit", func(t *testing.T) { t.Parallel(); testRateLimit(t, newContext) })
@@ -515,6 +519,127 @@ func TestScheduleV1(t *testing.T) {
 	t.Run("TestCreatesCHASMSentinel", func(t *testing.T) { t.Parallel(); testCreatesCHASMSentinel(t, newContext) })
 	t.Run("TestSkipsCHASMSentinelWhenDisabled", func(t *testing.T) { t.Parallel(); testSkipsCHASMSentinelWhenDisabled(t, newContext) })
 	t.Run("TestUpdateScheduleMemoRejected", func(t *testing.T) { t.Parallel(); testUpdateScheduleMemoRejected(t, newContext) })
+}
+
+func testActionDelayMetrics(t *testing.T, newContext contextFactory) {
+	// The short-refresh DesiredTime path this test exercises is gated behind
+	// RefreshCompletionDesiredTime; the shipped default stays at TriggerImmediatelyTimestamp
+	// until a follow-up deploy activates it. Force it on for this run (see the caller: this
+	// subtest is intentionally not run with t.Parallel(), since this override is shared
+	// package state).
+	prevVersion := scheduler.CurrentTweakablePolicies.Version
+	scheduler.CurrentTweakablePolicies.Version = scheduler.RefreshCompletionDesiredTime
+	t.Cleanup(func() { scheduler.CurrentTweakablePolicies.Version = prevVersion })
+
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+
+	sid := testcore.RandomizeStr("sched-action-delay")
+	wid := testcore.RandomizeStr("sched-action-delay-wf")
+	wt := testcore.RandomizeStr("sched-action-delay-wt")
+
+	var activityCalls atomic.Int32
+	releaseFirstActivity := make(chan struct{})
+	activityFn := func(ctx context.Context) error {
+		if activityCalls.Add(1) != 1 {
+			return nil
+		}
+		select {
+		case <-releaseFirstActivity:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	s.SdkWorker().RegisterActivity(activityFn)
+	s.SdkWorker().RegisterWorkflowWithOptions(func(ctx workflow.Context) error {
+		ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+			StartToCloseTimeout: 30 * time.Second,
+		})
+		return workflow.ExecuteActivity(ctx, activityFn).Get(ctx, nil)
+	}, workflow.RegisterOptions{Name: wt})
+
+	ctx := newContext(testcontext.For(t))
+	metricCapture := s.StartNamespaceMetricCapture()
+	interval := 10 * time.Second
+	phaseOffset := 5 * time.Second
+	_, err := s.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+		Schedule: &schedulepb.Schedule{
+			Spec: &schedulepb.ScheduleSpec{
+				Interval: []*schedulepb.IntervalSpec{{
+					Interval: durationpb.New(interval),
+					Phase:    durationpb.New(time.Duration((time.Now().Unix()+int64(phaseOffset/time.Second))%int64(interval/time.Second)) * time.Second),
+				}},
+			},
+			Action: startWorkflowAction(s, wid, wt),
+			Policies: &schedulepb.SchedulePolicies{
+				OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE,
+			},
+			State: &schedulepb.ScheduleState{
+				LimitedActions:   true,
+				RemainingActions: 2,
+			},
+		},
+		InitialPatch: triggerPatch(enumspb.SCHEDULE_OVERLAP_POLICY_UNSPECIFIED),
+		Identity:     "test",
+		RequestId:    uuid.NewString(),
+	})
+	require.NoError(t, err)
+
+	// Query the scheduler workflow directly because DescribeSchedule signals a refresh, which
+	// would race the long-poll completion path this first buffered action is intended to cover.
+	await.RequireTruef(t, func() bool {
+		encoded, queryErr := s.SdkClient().QueryWorkflow(ctx, scheduler.WorkflowIDPrefix+sid, "", scheduler.QueryNameDescribe)
+		if queryErr != nil {
+			return false
+		}
+		var response schedulespb.DescribeResponse
+		if encoded.Get(&response) != nil {
+			return false
+		}
+		return activityCalls.Load() == 1 && response.GetInfo().GetBufferSize() == 1 &&
+			len(response.GetInfo().GetRunningWorkflows()) == 1
+	}, awaitTimeout, pollInterval, "manual action should be running with the first scheduled action buffered")
+	close(releaseFirstActivity)
+
+	// Do not describe the schedule while waiting. The second scheduled action must discover
+	// the prior completion through processBuffer's short refresh, not a DescribeSchedule signal.
+	await.RequireTruef(t, func() bool {
+		return activityCalls.Load() == 3 && len(metricCapture.Metric(metrics.ScheduleActionDelay.Name())) == 2
+	}, awaitTimeout, pollInterval, "manual action and two scheduled actions should start")
+	desc, err := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(3), desc.GetInfo().GetActionCount())
+	actions := desc.GetInfo().GetRecentActions()
+	require.Len(t, actions, 3)
+
+	closeTime := func(action *schedulepb.ScheduleActionResult) time.Time {
+		t.Helper()
+		events := s.GetHistory(s.Namespace().String(), action.GetStartWorkflowResult())
+		require.NotEmpty(t, events)
+		lastEvent := events[len(events)-1]
+		require.Equal(t, enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED, lastEvent.GetEventType())
+		return lastEvent.GetEventTime().AsTime()
+	}
+	// The prior action's close only backdates the desired time when it comes after this
+	// action's own scheduled time -- i.e. this action was actually blocked waiting on it.
+	// Otherwise the action ran on time and the desired time stays at its scheduled time.
+	expectedDesiredTime := func(priorClose time.Time, action *schedulepb.ScheduleActionResult) time.Time {
+		if scheduleTime := action.GetScheduleTime().AsTime(); priorClose.After(scheduleTime) {
+			return priorClose
+		}
+		return action.GetScheduleTime().AsTime()
+	}
+	recordings := metricCapture.Metric(metrics.ScheduleActionDelay.Name())
+	for _, recording := range recordings {
+		require.Equal(t, metrics.ScheduleBackendLegacy, recording.Tags[metrics.ScheduleBackendTag])
+	}
+	require.Equal(t, actions[1].GetActualTime().AsTime().Sub(expectedDesiredTime(closeTime(actions[0]), actions[1])), recordings[0].Value)
+	require.Equal(t, actions[2].GetActualTime().AsTime().Sub(expectedDesiredTime(closeTime(actions[1]), actions[2])), recordings[1].Value)
 }
 
 func runSharedScheduleTests(t *testing.T, newContext contextFactory) {

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -538,13 +538,20 @@ func testActionDelayMetrics(t *testing.T, newContext contextFactory) {
 	wt := testcore.RandomizeStr("sched-action-delay-wt")
 
 	var activityCalls atomic.Int32
-	releaseFirstActivity := make(chan struct{})
+	releaseManualActivity := make(chan struct{})
+	releaseFirstScheduledActivity := make(chan struct{})
 	activityFn := func(ctx context.Context) error {
-		if activityCalls.Add(1) != 1 {
+		var release chan struct{}
+		switch activityCalls.Add(1) {
+		case 1:
+			release = releaseManualActivity
+		case 2:
+			release = releaseFirstScheduledActivity
+		default:
 			return nil
 		}
 		select {
-		case <-releaseFirstActivity:
+		case <-release:
 			return nil
 		case <-ctx.Done():
 			return ctx.Err()
@@ -587,21 +594,39 @@ func testActionDelayMetrics(t *testing.T, newContext contextFactory) {
 	})
 	require.NoError(t, err)
 
-	// Query the scheduler workflow directly because DescribeSchedule signals a refresh, which
-	// would race the long-poll completion path this first buffered action is intended to cover.
-	await.RequireTruef(t, func() bool {
+	// Query the scheduler workflow directly (not DescribeSchedule, which signals a refresh and
+	// would race the completion-discovery path each stage below is intended to cover).
+	queryBufferAndRunning := func() (bufferSize int64, running int) {
 		encoded, queryErr := s.SdkClient().QueryWorkflow(ctx, scheduler.WorkflowIDPrefix+sid, "", scheduler.QueryNameDescribe)
 		if queryErr != nil {
-			return false
+			return -1, -1
 		}
 		var response schedulespb.DescribeResponse
 		if encoded.Get(&response) != nil {
-			return false
+			return -1, -1
 		}
-		return activityCalls.Load() == 1 && response.GetInfo().GetBufferSize() == 1 &&
-			len(response.GetInfo().GetRunningWorkflows()) == 1
+		return response.GetInfo().GetBufferSize(), len(response.GetInfo().GetRunningWorkflows())
+	}
+	await.RequireTruef(t, func() bool {
+		bufferSize, running := queryBufferAndRunning()
+		return activityCalls.Load() == 1 && bufferSize == 1 && running == 1
 	}, awaitTimeout, pollInterval, "manual action should be running with the first scheduled action buffered")
-	close(releaseFirstActivity)
+	close(releaseManualActivity)
+
+	// Hold the first scheduled action open past the second scheduled tick, so the second
+	// scheduled action is buffered behind a still-running (not yet closed) action -- i.e.
+	// genuinely blocked, not merely started after an unrelated, already-finished one. Note this
+	// exercises DesiredTime backdating end-to-end (via whichever path discovers the completion --
+	// a long-poll watcher is installed as soon as a start is buffered behind a running action, so
+	// that watcher, not a later refresh, is what normally wins here). The specific
+	// refresh-discovers-a-real-backlog branch (refreshBackdate == true in processWatcherResult) is
+	// pinned deterministically by TestRefreshCompletionDesiredTimeBacklog in workflow_test.go,
+	// which controls discovery timing directly instead of racing a real watcher.
+	await.RequireTruef(t, func() bool {
+		bufferSize, running := queryBufferAndRunning()
+		return activityCalls.Load() == 2 && bufferSize == 1 && running == 1
+	}, awaitTimeout, pollInterval, "first scheduled action should be running with the second scheduled action buffered")
+	close(releaseFirstScheduledActivity)
 
 	// Do not describe the schedule while waiting. The second scheduled action must discover
 	// the prior completion through processBuffer's short refresh, not a DescribeSchedule signal.


### PR DESCRIPTION
## What changed?
- Record a buffered start's desired time when a refresh (non-long-poll watch) observes the prior action complete, not just when the long-poll watcher does.
- Gate the new state mutation behind a new version, `RefreshCompletionDesiredTime` (14) -- `BufferedStarts[0].DesiredTime` flows into the continue-as-new `Input`, which is replay-checked history, so this can't be applied unconditionally to histories recorded below the gate. 13 is already claimed by the in-flight `MigrationHandoffFixes` work, so this is numbered 14; `CurrentTweakablePolicies.Version` is left at `TriggerImmediatelyTimestamp` (12), so this PR does not itself activate anything. `processWatcherResult` branches strictly on the version (old codepath unchanged, new codepath gated) rather than folding the version check into a boolean expression, so it's visually obvious the old path is untouched on replay.
- Only backdate `DesiredTime` on the refresh path when the prior action's `CloseTime` is genuinely after the next start's own due time -- i.e. it was actually blocked waiting on the prior action -- **and** the start's own resolved overlap policy actually waits for a running workflow to finish at all. A start resolved to `ALLOW_ALL` is never blocked by a running workflow (`processBuffer` starts it regardless of `isRunning`), so backdating it to an unrelated close time would understate its real delay. This check is shared with `ProcessBuffer` via a new `IgnoresRunningWorkflow` helper in `buffer.go`, so the two places that need to agree on "does this policy wait for a running workflow" can't drift apart.
- `refreshWorkflows` calls the backdate logic once per tracked execution in `RunningWorkflows`. If a run still has multiple tracked executions (e.g. `ALLOW_ALL` runs inherited from before a pre-`DontTrackOverlapping` version ceiling was lifted), only move the recorded close time forward -- a later-processed but earlier-closing execution must not overwrite a genuinely later close already recorded earlier in the same pass, or the reported delay understates how long the start was actually blocked.
- The whole backdate decision is extracted into a pure, directly unit-testable function, `shouldBackdateDesiredTime`.

## Why?
`processWatcherResult` only set `DesiredTime` when `long` was true (the long-poll path). When a refresh discovered the prior action had completed instead, `DesiredTime` stayed unset, so `ScheduleActionDelay` fell back to the scheduled time instead of the prior action's close time -- inflating the reported delay for back-to-back buffered actions. Review then surfaced two follow-on correctness gaps in the fix itself: it didn't account for `ALLOW_ALL` starts that were never actually blocked, and it could pick the wrong close time when refreshing multiple tracked executions in one pass.

