### PR TITLE
Support NexusHandler-variant callbacks

### DIFF
--- a/chasm/lib/callback/component.go
+++ b/chasm/lib/callback/component.go
@@ -80,9 +80,11 @@ func (c *Callback) loadInvocationArgs(
 	ctx chasm.Context,
 	_ chasm.NoValue,
 ) (invocable, error) {
-	// Only Nexus-variant callbacks are supported for now.
-	callback := c.GetCallback().GetNexus()
-	if callback == nil {
+	// Reject unknown/unsupported callback variants.
+	switch c.GetCallback().GetVariant().(type) {
+	case *callbackspb.Callback_Nexus_, *callbackspb.Callback_NexusHandler_:
+		// OK
+	default:
 		return nil, queueserrors.NewUnprocessableTaskError(
 			fmt.Sprintf("unprocessable callback variant: %T", c.GetCallback().GetVariant()),
 		)
@@ -95,6 +97,21 @@ func (c *Callback) loadInvocationArgs(
 		return nil, err
 	}
 
+	// NexusHandler callbacks, deliver the result by invoking a Nexus handler.
+	if nexusHandler := c.GetCallback().GetNexusHandler(); nexusHandler != nil {
+		return invocableNexusHandler{
+			callback:            nexusHandler,
+			completion:          completion,
+			completionSourceTag: c.CompletionSource.Fqn(),
+			businessID:          ctx.ExecutionKey().BusinessID,
+			runID:               ctx.ExecutionKey().RunID,
+			requestID:           c.RequestId,
+			attempt:             c.Attempt,
+		}, nil
+	}
+
+	// Nexus callbacks deliver results by also invoking a Nexus handler, but using HTTP.
+	callback := c.GetCallback().GetNexus()
 	if callback.GetUrl() == chasm.NexusCompletionHandlerURL {
 		return invocableInternal{
 			callback:   callback,
@@ -107,7 +124,7 @@ func (c *Callback) loadInvocationArgs(
 		callback:            callback,
 		completion:          completion,
 		completionSourceTag: c.CompletionSource.Fqn(),
-		workflowID:          ctx.ExecutionKey().BusinessID,
+		businessID:          ctx.ExecutionKey().BusinessID,
 		runID:               ctx.ExecutionKey().RunID,
 		attempt:             c.Attempt,
 	}, nil
@@ -262,9 +279,6 @@ func FromAPICallback(cb *commonpb.Callback) (*callbackspb.Callback, error) {
 		}
 		return res, nil
 	case *commonpb.Callback_NexusHandler_:
-		// Conversion is implemented ahead of the rest of the feature, but is currently
-		// unreachable. If somehow this gets persisted, executing the callback will
-		// fail with an UnprocessableTaskError and retried until it is DLQ'd.
 		res.Variant = &callbackspb.Callback_NexusHandler_{
 			NexusHandler: &callbackspb.Callback_NexusHandler{
 				TaskQueueName: variant.NexusHandler.GetTaskQueueName(),

--- a/chasm/lib/callback/component_test.go
+++ b/chasm/lib/callback/component_test.go
@@ -135,29 +135,53 @@ func TestFromAPICallback(t *testing.T) {
 			})
 		}
 	})
+
+	// Confirm a malformed CHASM Callback fails to be converted into the api proto.
+	t.Run("UnsupportedVariant", func(t *testing.T) {
+		cb := &Callback{CallbackState: &callbackspb.CallbackState{
+			Callback: &callbackspb.Callback{},
+		}}
+		_, err := cb.ToAPICallback()
+		var internalErr *serviceerror.Internal
+		require.ErrorAs(t, err, &internalErr)
+		require.ErrorContains(t, err, "unsupported CHASM callback type")
+	})
 }
 
-// Asserts that CHASM Callbacks do not support the new NexusHandler callback variant.
-func TestNexusHandlerCallbacksNotSupported(t *testing.T) {
-	apiCb := &commonpb.Callback{
-		Variant: &commonpb.Callback_NexusHandler_{
-			NexusHandler: &commonpb.Callback_NexusHandler{},
-		},
-	}
-	chasmCB, err := FromAPICallback(apiCb)
-	require.NoError(t, err)
-
+// A callback whose variant this server doesn't know how to invoke can still be persisted (by a server that
+// does, or by a future version), so its invocation task has to be rejected rather than crash.
+func TestLoadInvocationArgsUnsupportedVariant(t *testing.T) {
 	cb := &Callback{
 		CallbackState: &callbackspb.CallbackState{
-			Callback: chasmCB,
+			Callback: &callbackspb.Callback{},
 		},
 	}
-	_, err = cb.loadInvocationArgs(&chasm.MockMutableContext{}, nil)
+	_, err := cb.loadInvocationArgs(&chasm.MockMutableContext{}, nil)
 
 	var unprocessableErr *queueserrors.UnprocessableTaskError
 	require.ErrorAs(t, err, &unprocessableErr)
 	require.ErrorContains(t, err, "unprocessable callback variant")
-	require.ErrorContains(t, err, "Callback_NexusHandler_")
+}
+
+// Confirm the request ID passed to NewCallback is persisited, and set in ToAPICallbackInfo.
+func TestToAPICallbackInfoCarriesTheRequestID(t *testing.T) {
+	ctx := &chasm.MockContext{}
+
+	cb := NewCallback(
+		"callback-request-id",
+		timestamppb.New(time.Unix(1, 0)),
+		&callbackspb.Callback{Variant: &callbackspb.Callback_NexusHandler_{
+			NexusHandler: &callbackspb.Callback_NexusHandler{
+				TaskQueueName: "completions-task-queue",
+				Service:       "HTTPAdapter",
+				Operation:     "DeliverAsWebhook",
+			},
+		}},
+	)
+
+	info, err := cb.ToAPICallbackInfo(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "callback-request-id", info.GetRequestId())
 }
 
 const (

--- a/chasm/lib/callback/invocable_internal.go
+++ b/chasm/lib/callback/invocable_internal.go
@@ -20,7 +20,6 @@ import (
 	"go.temporal.io/server/common/namespace"
 	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/nexus/nexusrpc"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -110,13 +109,8 @@ func (c invocableInternal) Invoke(
 	// RPC to History for cross-shard completion delivery.
 	_, err = h.historyClient.CompleteNexusOperationChasm(ctx, request)
 	if err != nil {
-		// GetRPCStatus, not status.Code: the internode interceptor returns serviceerror
-		// types, which expose Status() rather than GRPCStatus(), so status.Code reports
-		// Unknown for all of them. IsRetryableRPCError below reads the code the same way.
-		outcome = outcomeTag(errorOutcomePrefix + codes.Unknown.String())
-		if st, ok := common.GetRPCStatus(err); ok {
-			outcome = outcomeTag(errorOutcomePrefix + st.Code().String())
-		}
+		// Set the outcome tag based on the gRPC error received (if applicable).
+		outcome = grpcErrorOutcome(err)
 		if ctx.Err() != nil {
 			outcome = outcomeRequestTimeout
 		}
@@ -160,17 +154,10 @@ func (c invocableInternal) getHistoryRequest(
 			Completion: completion,
 		}
 	} else {
-		failure, err := nexusrpc.DefaultFailureConverter().ErrorToFailure(c.completion.Error)
+		// Convert the nexus.OperationError into a failurepb.Failure.
+		apiFailure, err := commonnexus.OperationErrorToTemporalFailure(c.completion.Error)
 		if err != nil {
-			return nil, fmt.Errorf("failed to convert error to failure: %w", err)
-		}
-		// Unwrap the operation error, the handler on the other side is expecting to receive the underlying cause.
-		if failure.Cause != nil {
-			failure = *failure.Cause
-		}
-		apiFailure, err := commonnexus.NexusFailureToTemporalFailure(failure)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert failure type: %w", err)
+			return nil, err
 		}
 
 		req = &historyservice.CompleteNexusOperationChasmRequest{

--- a/chasm/lib/callback/invocable_nexushandler.go
+++ b/chasm/lib/callback/invocable_nexushandler.go
@@ -15,7 +15,6 @@ import (
 	"go.temporal.io/server/api/matchingservice/v1"
 	"go.temporal.io/server/chasm"
 	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
-	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
@@ -52,7 +51,7 @@ type invocableNexusHandler struct {
 // operation's outcome and the context the callback was registered with.
 func (n invocableNexusHandler) buildOnCompleteRequest() (*notificationservice.OnCompleteRequest, error) {
 	onCompReq := &notificationservice.OnCompleteRequest{
-		SourceContext: common.CloneProto(n.callback.GetSourceContext()),
+		SourceContext: n.callback.GetSourceContext(),
 	}
 
 	if n.completion.Error != nil {
@@ -176,12 +175,8 @@ func (n invocableNexusHandler) Invoke(
 		metrics.OutcomeTag(string(outcome)),
 		metrics.NexusCompletionSourceTag(n.completionSourceTag),
 	}
-
-	reqCounter := h.metricsHandler.Counter(NexusHandlerRequestCounter.Name())
-	reqCounter.Record(1, tags...)
-
-	latencyHist := h.metricsHandler.Timer(NexusHandlerRequestLatencyHistogram.Name())
-	latencyHist.Record(time.Since(startTime), tags...)
+	NexusHandlerRequestCounter.With(h.metricsHandler).Record(1, tags...)
+	NexusHandlerRequestLatencyHistogram.With(h.metricsHandler).Record(time.Since(startTime), tags...)
 
 	return result
 }
@@ -208,7 +203,8 @@ func (n invocableNexusHandler) dispatch(
 		// The task never reached a worker, so this is a problem between history and matching.
 		// Every other dispatch error is internal to Temporal and not something the namespace's users can
 		// fix, so only a reference ID to the logged error is surfaced to them.
-		retryable := common.IsRetryableRPCError(rpcErr)
+		handlerErr := commonnexus.ConvertGRPCError(rpcErr, false)
+		retryable := isRetryableCallError(handlerErr)
 		logger = log.With(logger, tag.Bool("retryable", retryable))
 		userFacingErr := logInternalError(logger, "NexusHandler callback dispatch failed", rpcErr)
 
@@ -259,7 +255,7 @@ func (n invocableNexusHandler) classifyDispatchResult(
 		// resolved as failed or canceled. That is the handler's verdict on this completion rather than
 		// a delivery problem, and redelivering would collect the same verdict, so the callback fails
 		// permanently.
-		logger.Error("NexusHandler callback was rejected by the handler", tag.Error(err))
+		logger.Error("NexusHandler callback resulted in an operation error", tag.Error(err))
 		return invocationResultFail{err}
 
 	case commonnexus.DispatchOutcomeHandlerFailure,
@@ -271,17 +267,12 @@ func (n invocableNexusHandler) classifyDispatchResult(
 		// handler errors synthesized above, so all three ask the same question.
 		handlerErr, ok := errors.AsType[*nexus.HandlerError](err)
 		retryable := ok && handlerErr.Retryable()
-		logger.Error("NexusHandler callback delivery failed", tag.Error(err), tag.Bool("retryable", retryable))
+		logger.Error("NexusHandler callback resulted in a handler error", tag.Error(err), tag.Bool("retryable", retryable))
 		if retryable {
 			return invocationResultRetry{err}
 		}
 		return invocationResultFail{err}
 
-	case commonnexus.DispatchOutcomeWorkerFailure:
-		// the worker failed the task with a failure carrying no Nexus handler failure info. This is
-		// rejected by the RespondNexusTaskFailed operation, and so this shouldn't be reachable in
-		// outside of tests. Treat as some other unknown/unhandled response; and retry.
-		fallthrough
 	default:
 		// An outcome this build does not know about and that Succeeded() did not vouch for. Treat it
 		// like an unreadable response and keep retrying, in the hope the mismatch is transient.

--- a/chasm/lib/callback/invocable_nexushandler.go
+++ b/chasm/lib/callback/invocable_nexushandler.go
@@ -1,0 +1,316 @@
+package callback
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	nexuspb "go.temporal.io/api/nexus/v1"
+	"go.temporal.io/api/notificationservice/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	"go.temporal.io/server/api/matchingservice/v1"
+	"go.temporal.io/server/chasm"
+	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
+	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
+	commonnexus "go.temporal.io/server/common/nexus"
+	"go.temporal.io/server/common/nexus/nexusrpc"
+	"go.temporal.io/server/common/payload"
+	queueserrors "go.temporal.io/server/service/history/queues/errors"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// invocableNexusHandler is an invocable that delivers a completion to a Temporal worker by dispatching a Nexus
+// StartOperation task to the worker's task queue via MatchingService.DispatchNexusTask.
+//
+// Unlike invocableOutbound, which POSTs the completion to an arbitrary address, NexusHandler callbacks target a
+// Nexus service registered on a worker polling within the source operation's own namespace. This is faster
+// and more efficient than round tripping through the frontend's Nexus HTTP endpoint.
+type invocableNexusHandler struct {
+	callback   *callbackspb.Callback_NexusHandler
+	completion nexusrpc.CompleteOperationOptions
+
+	// completionSourceTag is the fully qualified name of the CHASM component that produced this
+	// completion, e.g. "workflow.workflow" or "activity.activity".
+	completionSourceTag string
+	businessID, runID   string
+
+	// requestID is sent as the Nexus request ID so that a redelivery of this callback is idempotent from
+	// the handler's perspective.
+	requestID string
+	attempt   int32
+}
+
+// buildOnCompleteRequest builds the input delivered to the worker's completion handler from the source
+// operation's outcome and the context the callback was registered with.
+func (n invocableNexusHandler) buildOnCompleteRequest() (*notificationservice.OnCompleteRequest, error) {
+	onCompReq := &notificationservice.OnCompleteRequest{
+		SourceContext: common.CloneProto(n.callback.GetSourceContext()),
+	}
+
+	if n.completion.Error != nil {
+		failure, err := commonnexus.OperationErrorToTemporalFailure(n.completion.Error)
+		if err != nil {
+			return nil, err
+		}
+		onCompReq.Result = &notificationservice.OnCompleteRequest_Failure{Failure: failure}
+		return onCompReq, nil
+	}
+
+	var result *commonpb.Payload
+	switch typed := n.completion.Result.(type) {
+	case nil:
+		// No payload present.
+	case *commonpb.Payload:
+		result = typed
+	default:
+		return nil, fmt.Errorf("invalid result, expected a payload, got: %T", n.completion.Result)
+	}
+
+	// A successful operation may legitimately have no result. The success variant always carries a
+	// payload on the wire, and a payload with no encoding fails the handler's data converter, so
+	// send the same binary/null representation of "no value" that the Nexus HTTP path produces.
+	if result == nil {
+		var err error
+		if result, err = payload.Encode(nil); err != nil {
+			return nil, fmt.Errorf("failed to encode empty NexusHandler callback result: %w", err)
+		}
+	}
+
+	onCompReq.Result = &notificationservice.OnCompleteRequest_Success{Success: result}
+	return onCompReq, nil
+}
+
+func (n invocableNexusHandler) buildDispatchRequest(
+	ns *namespace.Namespace,
+	scheduledTime time.Time,
+) (*matchingservice.DispatchNexusTaskRequest, error) {
+	taskQueueName := n.callback.GetTaskQueueName()
+	if taskQueueName == "" {
+		return nil, errors.New("NexusHandler callback is missing a task queue name")
+	}
+
+	onComplete, err := n.buildOnCompleteRequest()
+	if err != nil {
+		return nil, err
+	}
+	// The handler is a lang-SDK Nexus operation, so encode the input with the standard Temporal payload
+	// format (json/protobuf) that its data converter decodes back into an OnCompleteRequest.
+	//
+	// TODO(temporalio/temporal/issues/11891): Mark the Payload as a "system payload" to avoid the payload
+	// being decoded on the client-side by mistake.
+	input, err := payload.Encode(onComplete)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode NexusHandler callback input: %w", err)
+	}
+
+	req := &matchingservice.DispatchNexusTaskRequest{
+		NamespaceId: ns.ID().String(),
+		// The delivery lands on whatever version the task queue currently routes to by default:
+		// DispatchNexusTaskRequest carries no versioning directive, so matching decides, and it
+		// applies the task queue's assignment rules to every Nexus task alike.
+		//
+		// There is no way to pin a callback to the version that registered it, which is what a
+		// pinned workflow gets for its own activities. Wiring that through would mean carrying the
+		// version on the callback and adding a directive to this request; until then, a handler
+		// receiving completions has to stay compatible across the versions it is rolled through.
+		TaskQueue: &taskqueuepb.TaskQueue{
+			Name: taskQueueName,
+			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
+		},
+		Request: &nexuspb.Request{
+			ScheduledTime: timestamppb.New(scheduledTime),
+			Variant: &nexuspb.Request_StartOperation{
+				StartOperation: &nexuspb.StartOperationRequest{
+					Service:   n.callback.GetService(),
+					Operation: n.callback.GetOperation(),
+					RequestId: n.requestID,
+					Payload:   input,
+					// TODO(temporal/issues/11889): These links will be wrong. Backlinks to the source of the Nexus completion
+					// should be to the *callback attached* to the completion's source. Not the completion directly.
+					// e.g. a Link_Callback to "SANO xxx callback yyy", and not "SANO xxx".
+					Links: commonnexus.ConvertLinksToProto(n.completion.Links),
+				},
+			},
+			Capabilities: &nexuspb.Request_Capabilities{
+				TemporalFailureResponses: true,
+			},
+		},
+	}
+	return req, nil
+}
+
+func (n invocableNexusHandler) Invoke(
+	ctx context.Context,
+	ns *namespace.Namespace,
+	h *invocationTaskHandler,
+	task *callbackspb.InvocationTask,
+	taskAttr chasm.TaskAttributes,
+) invocationResult {
+	logger := log.With(h.logger,
+		tag.WorkflowNamespace(ns.Name().String()),
+		tag.Operation("DispatchNexusHandlerCallback"),
+		tag.WorkflowID(n.businessID),
+		tag.WorkflowRunID(n.runID),
+		tag.NexusCompletionSource(n.completionSourceTag),
+		tag.NewStringTag("task-queue", n.callback.GetTaskQueueName()),
+		tag.Attempt(n.attempt),
+	)
+
+	// nolint:forbidigo // Wall-clock RPC measurement, not component state; Invoke has no chasm.Context.
+	startTime := time.Now()
+
+	result, outcome := n.dispatch(ctx, startTime, logger, h, ns)
+
+	// Record metrics.
+	tags := []metrics.Tag{
+		metrics.NamespaceTag(ns.Name().String()),
+		metrics.DestinationTag(taskAttr.Destination),
+		metrics.OutcomeTag(string(outcome)),
+		metrics.NexusCompletionSourceTag(n.completionSourceTag),
+	}
+
+	reqCounter := h.metricsHandler.Counter(NexusHandlerRequestCounter.Name())
+	reqCounter.Record(1, tags...)
+
+	latencyHist := h.metricsHandler.Timer(NexusHandlerRequestLatencyHistogram.Name())
+	latencyHist.Record(time.Since(startTime), tags...)
+
+	return result
+}
+
+// dispatch hands the completion to matching and returns the invocationResult together with the value
+// of the metrics outcome tag to record for this attempt.
+func (n invocableNexusHandler) dispatch(
+	ctx context.Context,
+	startTime time.Time,
+	logger log.Logger,
+	h *invocationTaskHandler,
+	ns *namespace.Namespace,
+) (invocationResult, outcomeTag) {
+	// Build the DispatchNexusTaskRequest for the Matching Service.
+	dispatchReq, err := n.buildDispatchRequest(ns, startTime)
+	if err != nil {
+		logger.Error("Failed to build NexusHandler callback request", tag.Error(err))
+		return invocationResultFail{err}, outcomeRequestBuildError
+	}
+
+	// Send it to the worker.
+	resp, rpcErr := h.matchingClient.DispatchNexusTask(ctx, dispatchReq)
+	if rpcErr != nil {
+		// The task never reached a worker, so this is a problem between history and matching.
+		// Every other dispatch error is internal to Temporal and not something the namespace's users can
+		// fix, so only a reference ID to the logged error is surfaced to them.
+		retryable := common.IsRetryableRPCError(rpcErr)
+		logger = log.With(logger, tag.Bool("retryable", retryable))
+		userFacingErr := logInternalError(logger, "NexusHandler callback dispatch failed", rpcErr)
+
+		// Derive the outcome metric based on the gRPC error received.
+		outcome := grpcErrorOutcome(rpcErr)
+		if ctx.Err() != nil {
+			outcome = outcomeRequestTimeout
+		}
+
+		if retryable {
+			return invocationResultRetry{userFacingErr}, outcome
+		}
+		return invocationResultFail{userFacingErr}, outcome
+	}
+
+	// The RPC succeeded, so whatever the worker had to say is in the response.
+	dispatchResult := commonnexus.ClassifyStartOperationDispatch(resp)
+	outcome := dispatchResult.OutcomeTag().Value
+	// Collapse "sync_success" and "async_success" into outcomeSuccess for clarity.
+	// The Nexus handler code in the Frontend service is interested in that detail, but here
+	// the sync/async aspect is not relevant.
+	if dispatchResult.Outcome.Succeeded() {
+		outcome = string(outcomeSuccess)
+	}
+	return n.classifyDispatchResult(logger, dispatchResult), outcomeTag(outcome)
+}
+
+// classifyDispatchResult inspects the response from the Nexus handler to determine how to handle
+// the NexusHandler callback: delivered, worth another attempt, or permanently failed.
+func (n invocableNexusHandler) classifyDispatchResult(
+	logger log.Logger,
+	result commonnexus.DispatchResult,
+) invocationResult {
+	if result.Outcome.Succeeded() {
+		// Both flavors of success count as delivered. An async start means the worker accepted the
+		// completion and started an operation to process it; either way the callback is done, it does
+		// not wait for that operation to finish.
+		return invocationResultOK{}
+	}
+
+	// Every remaining outcome carries an error: what the worker reported, or one that
+	// DispatchResultToError synthesizes when nothing usable came back.
+	err := commonnexus.DispatchResultToError(result)
+
+	switch result.Outcome {
+	case commonnexus.DispatchOutcomeOperationFailure:
+		// The worker received the completion and answered with a failure of its own: an operation that
+		// resolved as failed or canceled. That is the handler's verdict on this completion rather than
+		// a delivery problem, and redelivering would collect the same verdict, so the callback fails
+		// permanently.
+		logger.Error("NexusHandler callback was rejected by the handler", tag.Error(err))
+		return invocationResultFail{err}
+
+	case commonnexus.DispatchOutcomeHandlerFailure,
+		commonnexus.DispatchOutcomeRequestTimeout,
+		commonnexus.DispatchOutcomeUnrecognized:
+		// The completion was never handled: the worker refused the task with a Nexus handler error,
+		// nobody answered it before matching gave up, or this build cannot read the response. Only a
+		// handler error says whether another attempt is worthwhile, and the latter two reach us as
+		// handler errors synthesized above, so all three ask the same question.
+		handlerErr, ok := errors.AsType[*nexus.HandlerError](err)
+		retryable := ok && handlerErr.Retryable()
+		logger.Error("NexusHandler callback delivery failed", tag.Error(err), tag.Bool("retryable", retryable))
+		if retryable {
+			return invocationResultRetry{err}
+		}
+		return invocationResultFail{err}
+
+	case commonnexus.DispatchOutcomeWorkerFailure:
+		// the worker failed the task with a failure carrying no Nexus handler failure info. This is
+		// rejected by the RespondNexusTaskFailed operation, and so this shouldn't be reachable in
+		// outside of tests. Treat as some other unknown/unhandled response; and retry.
+		fallthrough
+	default:
+		// An outcome this build does not know about and that Succeeded() did not vouch for. Treat it
+		// like an unreadable response and keep retrying, in the hope the mismatch is transient.
+		logger.Error("NexusHandler callback got an unhandled dispatch outcome",
+			tag.NewStringTag("dispatch-outcome", string(result.Outcome)), tag.Error(err))
+		return invocationResultRetry{err}
+	}
+}
+
+// isDestinationDown returns whether a retryable delivery failure indicates the destination is
+// unavailable for subsequent retries.
+func isDestinationDown(err error) bool {
+	handlerErr, ok := errors.AsType[*nexus.HandlerError](err)
+	if !ok {
+		// Was not a worker-produced error, so the RPC to matching itself failed.
+		return true
+	}
+	// Any other retryable handler error should be considered a DestinationDown error, and trip
+	// the circuit breaker. (HandlerErrorTypeResourceExhausted, HandlerErrorTypeUnavailable, etc.)
+	return handlerErr.Retryable()
+}
+
+func (n invocableNexusHandler) WrapError(result invocationResult, err error) error {
+	// A DestinationDownError counts against the outbound queue's circuit breaker for this task
+	// queue, which holds back every callback targeting it. Note that this means a single broken
+	// Nexus handler (e.g. always timing out) would open the circuit breaker and block every
+	// Nexus handler on the same task queue for delivering NexusHandler callbacks.
+	if retry, ok := result.(invocationResultRetry); ok && isDestinationDown(retry.err) {
+		return queueserrors.NewDestinationDownError(retry.err.Error(), err)
+	}
+	return err
+}

--- a/chasm/lib/callback/invocable_nexushandler.go
+++ b/chasm/lib/callback/invocable_nexushandler.go
@@ -282,25 +282,12 @@ func (n invocableNexusHandler) classifyDispatchResult(
 	}
 }
 
-// isDestinationDown returns whether a retryable delivery failure indicates the destination is
-// unavailable for subsequent retries.
-func isDestinationDown(err error) bool {
-	handlerErr, ok := errors.AsType[*nexus.HandlerError](err)
-	if !ok {
-		// Was not a worker-produced error, so the RPC to matching itself failed.
-		return true
-	}
-	// Any other retryable handler error should be considered a DestinationDown error, and trip
-	// the circuit breaker. (HandlerErrorTypeResourceExhausted, HandlerErrorTypeUnavailable, etc.)
-	return handlerErr.Retryable()
-}
-
 func (n invocableNexusHandler) WrapError(result invocationResult, err error) error {
 	// A DestinationDownError counts against the outbound queue's circuit breaker for this task
 	// queue, which holds back every callback targeting it. Note that this means a single broken
 	// Nexus handler (e.g. always timing out) would open the circuit breaker and block every
 	// Nexus handler on the same task queue for delivering NexusHandler callbacks.
-	if retry, ok := result.(invocationResultRetry); ok && isDestinationDown(retry.err) {
+	if retry, ok := result.(invocationResultRetry); ok {
 		return queueserrors.NewDestinationDownError(retry.err.Error(), err)
 	}
 	return err

--- a/chasm/lib/callback/invocable_nexushandler_test.go
+++ b/chasm/lib/callback/invocable_nexushandler_test.go
@@ -160,7 +160,7 @@ func TestExecuteInvocationTaskNexusHandler_Outcomes(t *testing.T) {
 		expectedOutcome outcomeTag
 		// Outcome tag for the aggregate InvocationEventCounter, InvocationAttemptsHistogram which
 		// is just one of outcomeEvent{ Success, RetryableError, NonRetryableError }.
-		expectedEventOutcome outcomeTag
+		expectedEventOutcome coarseOutcomeTag
 		assertOutcome        func(*testing.T, *Callback, error)
 	}{
 		{
@@ -268,15 +268,11 @@ func TestExecuteInvocationTaskNexusHandler_Outcomes(t *testing.T) {
 				},
 			},
 			expectedOutcome:      outcomeTag("handler_error:UNKNOWN"),
-			expectedEventOutcome: outcomeEventRetryableError,
+			expectedEventOutcome: outcomeEventNonRetryableError,
 			assertOutcome: func(t *testing.T, cb *Callback, err error) {
-				var destDown *queueserrors.DestinationDownError
-				require.ErrorAs(t, err, &destDown)
-				require.Equal(t, callbackspb.CALLBACK_STATUS_BACKING_OFF, cb.Status)
-
-				// The failure is recorded, but not as a terminal one: another attempt is scheduled.
+				require.Equal(t, callbackspb.CALLBACK_STATUS_FAILED, cb.Status)
 				require.Contains(t, cb.LastAttemptFailure.GetMessage(), "worker rejected the task")
-				require.False(t, cb.LastAttemptFailure.GetApplicationFailureInfo().GetNonRetryable())
+				require.True(t, cb.LastAttemptFailure.GetApplicationFailureInfo().GetNonRetryable())
 			},
 		},
 		{

--- a/chasm/lib/callback/invocable_nexushandler_test.go
+++ b/chasm/lib/callback/invocable_nexushandler_test.go
@@ -1,0 +1,731 @@
+package callback
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	failurepb "go.temporal.io/api/failure/v1"
+	nexuspb "go.temporal.io/api/nexus/v1"
+	"go.temporal.io/api/notificationservice/v1"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/api/matchingservice/v1"
+	"go.temporal.io/server/api/matchingservicemock/v1"
+	"go.temporal.io/server/chasm"
+	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
+	"go.temporal.io/server/common/backoff"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
+	commonnexus "go.temporal.io/server/common/nexus"
+	"go.temporal.io/server/common/nexus/nexusrpc"
+	"go.temporal.io/server/common/payload"
+	test "go.temporal.io/server/common/testing"
+	"go.temporal.io/server/common/testing/protorequire"
+	queueserrors "go.temporal.io/server/service/history/queues/errors"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const (
+	testNexusHandlerTaskQueue   = "completions-task-queue"
+	testNexusHandlerService     = "HTTPAdapter"
+	testNexusHandlerOperation   = "DeliverAsWebhook"
+	testNexusHandlerDestination = "nexus-handler://completions-task-queue"
+)
+
+func newNexusHandlerCallback(t *testing.T) *Callback {
+	t.Helper()
+
+	return &Callback{
+		CallbackState: &callbackspb.CallbackState{
+			RequestId:        "request-id",
+			RegistrationTime: timestamppb.New(time.Now()),
+			Callback: &callbackspb.Callback{
+				Variant: &callbackspb.Callback_NexusHandler_{
+					NexusHandler: &callbackspb.Callback_NexusHandler{
+						TaskQueueName: testNexusHandlerTaskQueue,
+						Service:       testNexusHandlerService,
+						Operation:     testNexusHandlerOperation,
+						SourceContext: &commonpb.Payload{Data: []byte("source-context")},
+					},
+				},
+			},
+			Status:  callbackspb.CALLBACK_STATUS_SCHEDULED,
+			Attempt: 0,
+		},
+	}
+}
+
+// startOperationResponse builds the response matching returns when a worker handled the Nexus task and
+// replied with the given StartOperation response.
+func startOperationResponse(start *nexuspb.StartOperationResponse) *matchingservice.DispatchNexusTaskResponse {
+	return &matchingservice.DispatchNexusTaskResponse{
+		Outcome: &matchingservice.DispatchNexusTaskResponse_Response{
+			Response: &nexuspb.Response{
+				Variant: &nexuspb.Response_StartOperation{StartOperation: start},
+			},
+		},
+	}
+}
+
+func syncSuccessResponse() *matchingservice.DispatchNexusTaskResponse {
+	return startOperationResponse(&nexuspb.StartOperationResponse{
+		Variant: &nexuspb.StartOperationResponse_SyncSuccess{
+			SyncSuccess: &nexuspb.StartOperationResponse_Sync{},
+		},
+	})
+}
+
+// handlerFailureResponse builds the response matching returns when a worker fails the Nexus task itself,
+// i.e. responds with RespondNexusTaskFailed.
+func handlerFailureResponse(errType string) *matchingservice.DispatchNexusTaskResponse {
+	return &matchingservice.DispatchNexusTaskResponse{
+		Outcome: &matchingservice.DispatchNexusTaskResponse_Failure{
+			Failure: &failurepb.Failure{
+				Message: "handler error (" + errType + "): worker said no",
+				FailureInfo: &failurepb.Failure_NexusHandlerFailureInfo{
+					NexusHandlerFailureInfo: &failurepb.NexusHandlerFailureInfo{
+						Type: errType,
+					},
+				},
+			},
+		},
+	}
+}
+
+// requireNilPayload asserts the payload is the binary/null representation of "no value", which is
+// what a worker's data converter decodes into a nil result.
+func requireNilPayload(t *testing.T, p *commonpb.Payload) {
+	t.Helper()
+
+	expected, err := payload.Encode(nil)
+	require.NoError(t, err)
+	protorequire.ProtoEqual(t, expected, p)
+}
+
+// wrappedOperationError builds the completion error a CHASM source component produces when its
+// operation fails: the source's own Temporal failure is carried as the error's cause, and the
+// enclosing nexus.OperationError is marked as a redundant wrapper so that consumers within the server
+// unwrap it. See nexusrpc.MarkAsWrapperError, and Operation.getNexusCompletion in the nexusoperation
+// library for the real thing.
+func wrappedOperationError(
+	t *testing.T,
+	state nexus.OperationState,
+	message string,
+	cause *failurepb.Failure,
+) *nexus.OperationError {
+	t.Helper()
+
+	nexusFailure, err := commonnexus.TemporalFailureToNexusFailure(cause)
+	require.NoError(t, err)
+
+	opErr := &nexus.OperationError{
+		State:   state,
+		Message: message,
+		Cause:   &nexus.FailureError{Failure: nexusFailure},
+	}
+	require.NoError(t, nexusrpc.MarkAsWrapperError(nexusrpc.DefaultFailureConverter(), opErr))
+	return opErr
+}
+
+// requireTerminalFailure asserts the callback permanently failed, recording a non-retryable failure
+// whose message contains want.
+func requireTerminalFailure(t *testing.T, cb *Callback, want string) {
+	t.Helper()
+
+	require.Equal(t, callbackspb.CALLBACK_STATUS_FAILED, cb.Status)
+	require.Contains(t, cb.LastAttemptFailure.GetMessage(), want)
+	require.True(t, cb.LastAttemptFailure.GetApplicationFailureInfo().GetNonRetryable())
+}
+
+// TestExecuteInvocationTaskNexusHandler_Outcomes runs the invocation task end-to-end against a CHASM tree with a
+// mocked matching client, covering how each dispatch outcome maps onto the callback's state.
+func TestExecuteInvocationTaskNexusHandler_Outcomes(t *testing.T) {
+	cases := []struct {
+		name        string
+		response    *matchingservice.DispatchNexusTaskResponse
+		responseErr error
+		// Outcome tag for the NexusHandler-specific metrics.
+		expectedOutcome outcomeTag
+		// Outcome tag for the aggregate InvocationEventCounter, InvocationAttemptsHistogram which
+		// is just one of outcomeEvent{ Success, RetryableError, NonRetryableError }.
+		expectedEventOutcome outcomeTag
+		assertOutcome        func(*testing.T, *Callback, error)
+	}{
+		{
+			name:                 "sync-success",
+			response:             syncSuccessResponse(),
+			expectedOutcome:      outcomeSuccess,
+			expectedEventOutcome: outcomeEventSuccess,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				require.NoError(t, err)
+				require.Equal(t, callbackspb.CALLBACK_STATUS_SUCCEEDED, cb.Status)
+			},
+		},
+		{
+			// The handler accepted the completion and started an operation to process it. Delivery is
+			// done as far as the callback is concerned; it doesn't wait for that operation.
+			name: "async-success",
+			response: startOperationResponse(&nexuspb.StartOperationResponse{
+				Variant: &nexuspb.StartOperationResponse_AsyncSuccess{
+					AsyncSuccess: &nexuspb.StartOperationResponse_Async{OperationToken: "operation-token"},
+				},
+			}),
+			expectedOutcome:      outcomeSuccess,
+			expectedEventOutcome: outcomeEventSuccess,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				require.NoError(t, err)
+				require.Equal(t, callbackspb.CALLBACK_STATUS_SUCCEEDED, cb.Status)
+			},
+		},
+		{
+			// The worker ran the completion handler and the operation failed. That verdict is
+			// deterministic, so the callback fails permanently rather than retrying.
+			name: "operation-failed",
+			response: startOperationResponse(&nexuspb.StartOperationResponse{
+				Variant: &nexuspb.StartOperationResponse_Failure{
+					Failure: &failurepb.Failure{
+						Message: "handler rejected the completion",
+						FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+							ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{},
+						},
+					},
+				},
+			}),
+			expectedOutcome:      outcomeFailure,
+			expectedEventOutcome: outcomeEventNonRetryableError,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				require.NoError(t, err)
+				requireTerminalFailure(t, cb, "handler rejected the completion")
+			},
+		},
+		{
+			// Older workers report a failed operation with the deprecated OperationError variant. It
+			// is just as deterministic as the Failure variant, so it must not be retried either.
+			name: "deprecated-operation-error",
+			response: startOperationResponse(&nexuspb.StartOperationResponse{
+				//nolint:staticcheck // Deprecated, still sent by older workers.
+				Variant: &nexuspb.StartOperationResponse_OperationError{
+					OperationError: &nexuspb.UnsuccessfulOperationError{
+						OperationState: string(nexus.OperationStateFailed),
+						Failure:        &nexuspb.Failure{Message: "handler rejected the completion"},
+					},
+				},
+			}),
+			expectedOutcome:      outcomeLegacyFailure,
+			expectedEventOutcome: outcomeEventNonRetryableError,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				require.NoError(t, err)
+				requireTerminalFailure(t, cb, "handler rejected the completion")
+			},
+		},
+		{
+			// Older workers report a handler error with the deprecated HandlerError outcome. Its type
+			// still decides whether the delivery is worth retrying.
+			name: "deprecated-non-retryable-handler-error",
+			response: &matchingservice.DispatchNexusTaskResponse{
+				//nolint:staticcheck // Deprecated, still sent by older workers.
+				Outcome: &matchingservice.DispatchNexusTaskResponse_HandlerError{
+					HandlerError: &nexuspb.HandlerError{
+						ErrorType: "BAD_REQUEST",
+						Failure:   &nexuspb.Failure{Message: "worker said no"},
+					},
+				},
+			},
+			expectedOutcome:      outcomeTag("handler_error:BAD_REQUEST"),
+			expectedEventOutcome: outcomeEventNonRetryableError,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				require.NoError(t, err)
+				requireTerminalFailure(t, cb, "BAD_REQUEST")
+			},
+		},
+		{
+			// A worker can fail the task with something other than a handler error, e.g. an
+			// application error. RespondNexusTaskFailed rejects a failure carrying no handler failure
+			// info, so this shouldn't be reachable outside of tests; it is treated like a response this
+			// build cannot interpret and kept retrying. There is no handler error type to report,
+			// hence the UNKNOWN suffix.
+			name: "non-handler-task-failure",
+			response: &matchingservice.DispatchNexusTaskResponse{
+				Outcome: &matchingservice.DispatchNexusTaskResponse_Failure{
+					Failure: &failurepb.Failure{
+						Message: "worker rejected the task",
+						FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+							ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{Type: "SomeError"},
+						},
+					},
+				},
+			},
+			expectedOutcome:      outcomeTag("handler_error:UNKNOWN"),
+			expectedEventOutcome: outcomeEventRetryableError,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				var destDown *queueserrors.DestinationDownError
+				require.ErrorAs(t, err, &destDown)
+				require.Equal(t, callbackspb.CALLBACK_STATUS_BACKING_OFF, cb.Status)
+
+				// The failure is recorded, but not as a terminal one: another attempt is scheduled.
+				require.Contains(t, cb.LastAttemptFailure.GetMessage(), "worker rejected the task")
+				require.False(t, cb.LastAttemptFailure.GetApplicationFailureInfo().GetNonRetryable())
+			},
+		},
+		{
+			name:                 "retryable-handler-error",
+			response:             handlerFailureResponse("INTERNAL"),
+			expectedOutcome:      outcomeTag("handler_error:INTERNAL"),
+			expectedEventOutcome: outcomeEventRetryableError,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				// Retryable handler errors will trip the circuit breaker. So we expect this to have
+				// be a DestinationDownError and open the circuit breaker if it persists.
+				var destDown *queueserrors.DestinationDownError
+				require.ErrorAs(t, err, &destDown)
+				require.Equal(t, callbackspb.CALLBACK_STATUS_BACKING_OFF, cb.Status)
+
+				// The failure is recorded, but not as a terminal one: another attempt is scheduled.
+				require.Contains(t, cb.LastAttemptFailure.GetMessage(), "INTERNAL")
+				require.False(t, cb.LastAttemptFailure.GetApplicationFailureInfo().GetNonRetryable())
+				require.NotNil(t, cb.NextAttemptScheduleTime)
+			},
+		},
+		{
+			name:                 "non-retryable-handler-error",
+			response:             handlerFailureResponse("BAD_REQUEST"),
+			expectedOutcome:      outcomeTag("handler_error:BAD_REQUEST"),
+			expectedEventOutcome: outcomeEventNonRetryableError,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				require.NoError(t, err)
+				requireTerminalFailure(t, cb, "BAD_REQUEST")
+			},
+		},
+		{
+			// Nobody is polling the task queue (or the worker died holding the task), so matching gave
+			// up waiting. A worker may show up later, so keep retrying.
+			name: "no-poller",
+			response: &matchingservice.DispatchNexusTaskResponse{
+				Outcome: &matchingservice.DispatchNexusTaskResponse_RequestTimeout{
+					RequestTimeout: &matchingservice.DispatchNexusTaskResponse_Timeout{},
+				},
+			},
+			expectedOutcome:      outcomeTag("handler_timeout"),
+			expectedEventOutcome: outcomeEventRetryableError,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				var destDownErr *queueserrors.DestinationDownError
+				require.ErrorAs(t, err, &destDownErr)
+				require.Equal(t, callbackspb.CALLBACK_STATUS_BACKING_OFF, cb.Status)
+			},
+		},
+		{
+			name:                 "retryable-rpc-error",
+			responseErr:          status.Error(codes.Unavailable, "matching unavailable"),
+			expectedOutcome:      outcomeTag("error:Unavailable"),
+			expectedEventOutcome: outcomeEventRetryableError,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				var destDownErr *queueserrors.DestinationDownError
+				require.ErrorAs(t, err, &destDownErr)
+				require.Equal(t, callbackspb.CALLBACK_STATUS_BACKING_OFF, cb.Status)
+			},
+		},
+		{
+			// Matching rejections aren't something users can fix, so they are blinded.
+			name:                 "rejected-rpc-request",
+			responseErr:          fmt.Errorf("wrapped gRPC error: %w", status.Error(codes.InvalidArgument, "malformed task queue name")),
+			expectedOutcome:      outcomeTag("error:InvalidArgument"),
+			expectedEventOutcome: outcomeEventNonRetryableError,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				require.NoError(t, err)
+				requireTerminalFailure(t, cb, "internal error, reference-id:")
+			},
+		},
+		{
+			// A throttle shares the status code but is a property of the server's state rather than
+			// of our bytes, so it clears on its own and stays retryable.
+			name: "throttled-rpc-request",
+			responseErr: serviceerror.NewResourceExhausted(
+				enumspb.RESOURCE_EXHAUSTED_CAUSE_RPS_LIMIT, "namespace rps limit exceeded"),
+			expectedOutcome:      outcomeTag("error:ResourceExhausted"),
+			expectedEventOutcome: outcomeEventRetryableError,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				var destDownErr *queueserrors.DestinationDownError
+				require.ErrorAs(t, err, &destDownErr)
+				require.Equal(t, callbackspb.CALLBACK_STATUS_BACKING_OFF, cb.Status)
+			},
+		},
+		{
+			// Any other RPC failure describes the state of the server, so it is hidden behind a
+			// reference ID and only the shape is asserted.
+			name:                 "non-retryable-rpc-error",
+			responseErr:          status.Error(codes.NotFound, "namespace not found"),
+			expectedOutcome:      outcomeTag("error:NotFound"),
+			expectedEventOutcome: outcomeEventNonRetryableError,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				require.NoError(t, err)
+				require.NotContains(t, cb.LastAttemptFailure.GetMessage(), "namespace not found")
+				requireTerminalFailure(t, cb, "internal error, reference-id:")
+			},
+		},
+		{
+			// A response this server cannot interpret is considered retryable. (In hopes that it is
+			// due to some version mismatch, and can be addressed.) Nothing about it came from a
+			// Nexus handler, but the shared outcome tag has always labeled it as a handler error.
+			name:                 "unrecognized-outcome",
+			response:             &matchingservice.DispatchNexusTaskResponse{},
+			expectedOutcome:      outcomeTag("handler_error:EMPTY_OUTCOME"),
+			expectedEventOutcome: outcomeEventRetryableError,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				var destDownErr *queueserrors.DestinationDownError
+				require.ErrorAs(t, err, &destDownErr)
+				require.Equal(t, callbackspb.CALLBACK_STATUS_BACKING_OFF, cb.Status)
+				require.False(t, cb.LastAttemptFailure.GetApplicationFailureInfo().GetNonRetryable())
+			},
+		},
+		{
+			// A handler error type outside the Nexus spec is collapsed so a worker cannot introduce
+			// unbounded metric cardinality.
+			name:                 "handler-error-with-an-unknown-type",
+			response:             handlerFailureResponse("SOMETHING_MADE_UP"),
+			expectedOutcome:      outcomeTag("handler_error:UNKNOWN"),
+			expectedEventOutcome: outcomeEventRetryableError,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				// The error is retryable by spec, so it gets wrapped as a DestinationDown to potentially
+				// open the circuit breaker as applicable.
+				var destDown *queueserrors.DestinationDownError
+				require.ErrorAs(t, err, &destDown)
+				require.Equal(t, callbackspb.CALLBACK_STATUS_BACKING_OFF, cb.Status)
+				require.Contains(t, cb.LastAttemptFailure.GetMessage(), "SOMETHING_MADE_UP")
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// The completion source, business ID, and run ID are all supplied by the
+			// CHASM Context.
+			const completionSrcTag = "activity.activity"
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			ns := test.NewNamespace(t)
+
+			metricsHandler := metrics.NewMockHandler(ctrl)
+			counter := metrics.NewMockCounterIface(ctrl)
+			timer := metrics.NewMockTimerIface(ctrl)
+
+			// NexusHandler-specific metrics that are emitted.
+			metricsHandler.EXPECT().Counter(NexusHandlerRequestCounter.Name()).Return(counter)
+			counter.EXPECT().Record(int64(1),
+				metrics.NamespaceTag(ns.Name().String()),
+				metrics.DestinationTag(testNexusHandlerDestination),
+				metrics.OutcomeTag(string(tc.expectedOutcome)),
+				metrics.NexusCompletionSourceTag(testCompletionSourceFqn),
+			)
+			metricsHandler.EXPECT().Timer(NexusHandlerRequestLatencyHistogram.Name()).Return(timer)
+			timer.EXPECT().Record(gomock.Any(),
+				metrics.NamespaceTag(ns.Name().String()),
+				metrics.DestinationTag(testNexusHandlerDestination),
+				metrics.OutcomeTag(string(tc.expectedOutcome)),
+				metrics.NexusCompletionSourceTag(testCompletionSourceFqn),
+			)
+
+			// Additional metrics, reported for all forms of completion callbacks.
+			// The outcomeTag for those metrics is based on the success/retryable/non-retryable
+			// nature of the result. Hence a differentoutcome tag on the testcase.
+			eventTags := []metrics.Tag{
+				metrics.NamespaceTag(ns.Name().String()),
+				metrics.DestinationTag(testNexusHandlerDestination),
+				metrics.OutcomeTag(string(tc.expectedEventOutcome)),
+			}
+			dispositionCounter := metrics.NewMockCounterIface(ctrl)
+			metricsHandler.EXPECT().Counter(InvocationEventCounter.Name()).Return(dispositionCounter)
+			dispositionCounter.EXPECT().Record(int64(1), eventTags)
+			if tc.expectedEventOutcome != outcomeEventRetryableError {
+				attemptHistogram := metrics.NewMockHistogramIface(ctrl)
+				metricsHandler.EXPECT().
+					Histogram(InvocationAttemptsHistogram.Name(), InvocationAttemptsHistogram.Unit()).
+					Return(attemptHistogram)
+				attemptHistogram.EXPECT().Record(int64(1), eventTags)
+			}
+
+			// Setup the mock Matching service to return the test's result.
+			matchingClient := matchingservicemock.NewMockMatchingServiceClient(ctrl)
+			matchingClient.EXPECT().DispatchNexusTask(gomock.Any(), gomock.Any()).
+				Return(tc.response, tc.responseErr)
+
+			nsRegistry := namespace.NewMockRegistry(ctrl)
+			nsRegistry.EXPECT().GetNamespaceByID(gomock.Any()).Return(ns, nil)
+
+			// Invoke the NexusHandler callback.
+			handler := &invocationTaskHandler{
+				config: &Config{
+					RequestTimeout: dynamicconfig.GetDurationPropertyFnFilteredByDestination(time.Second),
+					RetryPolicy: func() backoff.RetryPolicy {
+						return backoff.NewExponentialRetryPolicy(time.Second)
+					},
+				},
+				namespaceRegistry: nsRegistry,
+				metricsHandler:    metricsHandler,
+				logger:            log.NewTestLogger(),
+				matchingClient:    matchingClient,
+			}
+
+			callback := newNexusHandlerCallback(t)
+			engineCtx, callbackRef := newInvocationTaskTest(t, handler, callback, nexusrpc.CompleteOperationOptions{})
+
+			executeErr := handler.Execute(
+				engineCtx,
+				callbackRef,
+				chasm.TaskAttributes{Destination: testNexusHandlerDestination},
+				&callbackspb.InvocationTask{Attempt: 0},
+			)
+
+			readCallbackState(engineCtx, t, callbackRef, func(_ chasm.Context, c *Callback) {
+				t.Helper()
+				tc.assertOutcome(t, c, executeErr)
+			})
+		})
+	}
+}
+
+// TestExecuteInvocationTaskNexusHandler_DispatchedRequest covers what the worker actually receives: the task is
+// addressed to the callback's task queue, service, and operation, and its input carries the source
+// operation's outcome.
+func TestExecuteInvocationTaskNexusHandler_DispatchedRequest(t *testing.T) {
+	sourceURL, err := url.Parse("temporal:///namespaces/ns-name/operations/op-id/runs/run-id")
+	require.NoError(t, err)
+	sourceLink := nexus.Link{URL: sourceURL, Type: "temporal.api.common.v1.Link.NexusOperation"}
+
+	for _, tc := range []struct {
+		name       string
+		completion nexusrpc.CompleteOperationOptions
+		assertOn   func(*testing.T, *notificationservice.OnCompleteRequest)
+	}{
+		{
+			name: "successful-completion",
+			completion: nexusrpc.CompleteOperationOptions{
+				Result: &commonpb.Payload{Data: []byte("result-data")},
+				Links:  []nexus.Link{sourceLink},
+			},
+			assertOn: func(t *testing.T, req *notificationservice.OnCompleteRequest) {
+				require.Equal(t, []byte("result-data"), req.GetSuccess().GetData())
+				require.Nil(t, req.GetFailure())
+			},
+		},
+		{
+			// A successful operation without a result still reports success, carrying the
+			// binary/null representation of "no value".
+			name: "successful-completion-without-a-result",
+			completion: nexusrpc.CompleteOperationOptions{
+				Links: []nexus.Link{sourceLink},
+			},
+			assertOn: func(t *testing.T, req *notificationservice.OnCompleteRequest) {
+				require.IsType(t, &notificationservice.OnCompleteRequest_Success{}, req.GetResult())
+				requireNilPayload(t, req.GetSuccess())
+			},
+		},
+		{
+			// Completion sources report an absent result as a nil *commonpb.Payload rather than an
+			// untyped nil, which must be treated the same as no result at all.
+			name: "successful-completion-with-a-typed-nil-result",
+			completion: nexusrpc.CompleteOperationOptions{
+				Result: (*commonpb.Payload)(nil),
+				Links:  []nexus.Link{sourceLink},
+			},
+			assertOn: func(t *testing.T, req *notificationservice.OnCompleteRequest) {
+				require.IsType(t, &notificationservice.OnCompleteRequest_Success{}, req.GetResult())
+				requireNilPayload(t, req.GetSuccess())
+			},
+		},
+		{
+			// The completion of a failed source operation is a nexus.OperationError wrapping the
+			// source's own Temporal failure. Since the OnCompleteRequest carries a Temporal failure
+			// anyway, that wrapper is redundant, so the source marks it (see
+			// nexusrpc.MarkAsWrapperError) and the handler unwraps it: the worker is handed the
+			// failure the source operation actually failed with, not the "operation failed" wrapper.
+			name: "failed-completion-unwraps-the-operation-error",
+			completion: nexusrpc.CompleteOperationOptions{
+				Error: wrappedOperationError(t, nexus.OperationStateFailed, "operation failed", &failurepb.Failure{
+					Message: "widget exploded",
+					FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+						ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
+							Type:         "WidgetError",
+							NonRetryable: true,
+						},
+					},
+				}),
+				Links: []nexus.Link{sourceLink},
+			},
+			assertOn: func(t *testing.T, req *notificationservice.OnCompleteRequest) {
+				require.Nil(t, req.GetSuccess())
+
+				// What the worker sees is the source failure verbatim: its message, its application
+				// failure type, and no enclosing "operation failed" layer.
+				failure := req.GetFailure()
+				require.Equal(t, "widget exploded", failure.GetMessage())
+				require.Equal(t, "WidgetError", failure.GetApplicationFailureInfo().GetType())
+				require.True(t, failure.GetApplicationFailureInfo().GetNonRetryable())
+				require.Nil(t, failure.GetCause())
+			},
+		},
+		{
+			// A canceled source operation is delivered the same way, and unwrapping preserves the
+			// failure's Temporal type: the worker sees a canceled failure rather than an application
+			// failure that merely says "operation canceled".
+			name: "canceled-completion-unwraps-the-operation-error",
+			completion: nexusrpc.CompleteOperationOptions{
+				Error: wrappedOperationError(t, nexus.OperationStateCanceled, "operation canceled", &failurepb.Failure{
+					Message: "operation canceled by the caller",
+					FailureInfo: &failurepb.Failure_CanceledFailureInfo{
+						CanceledFailureInfo: &failurepb.CanceledFailureInfo{},
+					},
+				}),
+				Links: []nexus.Link{sourceLink},
+			},
+			assertOn: func(t *testing.T, req *notificationservice.OnCompleteRequest) {
+				failure := req.GetFailure()
+				require.Equal(t, "operation canceled by the caller", failure.GetMessage())
+				require.NotNil(t, failure.GetCanceledFailureInfo())
+			},
+		},
+		{
+			// An OperationError that was not marked as a wrapper is delivered as-is, since dropping a
+			// layer nobody said was redundant would lose the only thing that identifies the outcome as
+			// a failed operation. This is what an error originating outside the Temporal server looks
+			// like, e.g. relayed from a third-party Nexus handler.
+			//
+			// The worker gets the wrapper as a non-retryable ApplicationFailure of type
+			// "OperationError", and the handler's own failure hangs off it as the cause.
+			name: "failed-completion-keeps-an-unmarked-operation-error",
+			completion: nexusrpc.CompleteOperationOptions{
+				Error: &nexus.OperationError{
+					State:   nexus.OperationStateFailed,
+					Message: "operation failed",
+					Cause:   &nexus.FailureError{Failure: nexus.Failure{Message: "widget exploded"}},
+				},
+				Links: []nexus.Link{sourceLink},
+			},
+			assertOn: func(t *testing.T, req *notificationservice.OnCompleteRequest) {
+				failure := req.GetFailure()
+				require.Equal(t, "operation failed", failure.GetMessage())
+				require.Equal(t, "OperationError", failure.GetApplicationFailureInfo().GetType())
+				require.True(t, failure.GetApplicationFailureInfo().GetNonRetryable())
+				require.Equal(t, "widget exploded", failure.GetCause().GetMessage())
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			var dispatched *matchingservice.DispatchNexusTaskRequest
+			matchingClient := matchingservicemock.NewMockMatchingServiceClient(ctrl)
+			matchingClient.EXPECT().DispatchNexusTask(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, req *matchingservice.DispatchNexusTaskRequest, _ ...grpc.CallOption) (*matchingservice.DispatchNexusTaskResponse, error) {
+					dispatched = req
+					return syncSuccessResponse(), nil
+				})
+
+			ns := test.NewNamespace(t)
+			nsRegistry := namespace.NewMockRegistry(ctrl)
+			nsRegistry.EXPECT().GetNamespaceByID(gomock.Any()).Return(ns, nil)
+
+			handler := &invocationTaskHandler{
+				config: &Config{
+					RequestTimeout: dynamicconfig.GetDurationPropertyFnFilteredByDestination(time.Second),
+					RetryPolicy: func() backoff.RetryPolicy {
+						return backoff.NewExponentialRetryPolicy(time.Second)
+					},
+				},
+				namespaceRegistry: nsRegistry,
+				metricsHandler:    metrics.NoopMetricsHandler,
+				logger:            log.NewTestLogger(),
+				matchingClient:    matchingClient,
+			}
+
+			callback := newNexusHandlerCallback(t)
+			engineCtx, callbackRef := newInvocationTaskTest(t, handler, callback, tc.completion)
+			dispatchStart := time.Now()
+			require.NoError(t, handler.Execute(
+				engineCtx,
+				callbackRef,
+				chasm.TaskAttributes{Destination: testNexusHandlerDestination},
+				&callbackspb.InvocationTask{Attempt: 0},
+			))
+
+			require.NotNil(t, dispatched)
+			require.Equal(t, ns.ID().String(), dispatched.GetNamespaceId())
+			// The worker's poller measures task latencies against the scheduled time, so it has to
+			// reflect when this delivery attempt started.
+			require.WithinDuration(t, dispatchStart, dispatched.GetRequest().GetScheduledTime().AsTime(), time.Minute)
+			require.Equal(t, testNexusHandlerTaskQueue, dispatched.GetTaskQueue().GetName())
+			require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, dispatched.GetTaskQueue().GetKind())
+
+			start := dispatched.GetRequest().GetStartOperation()
+			require.Equal(t, testNexusHandlerService, start.GetService())
+			require.Equal(t, testNexusHandlerOperation, start.GetOperation())
+			// The callback's request ID doubles as the Nexus request ID, so a redelivery is idempotent
+			// from the handler's perspective.
+			require.Equal(t, "request-id", start.GetRequestId())
+			// The source operation is identified to the handler by the completion's links.
+			require.Len(t, start.GetLinks(), 1)
+			require.Equal(t, sourceLink.URL.String(), start.GetLinks()[0].GetUrl())
+
+			var onComplete notificationservice.OnCompleteRequest
+			require.NoError(t, payload.Decode(start.GetPayload(), &onComplete))
+			protorequire.ProtoEqual(t, &commonpb.Payload{Data: []byte("source-context")}, onComplete.GetSourceContext())
+			tc.assertOn(t, &onComplete)
+		})
+	}
+}
+
+// A NexusHandler callback that cannot be dispatched at all fails permanently, since no further attempt
+// would change the outcome.
+func TestInvocableNexusHandlerCannotDispatch(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		callback    *callbackspb.Callback_NexusHandler
+		completion  nexusrpc.CompleteOperationOptions
+		wantMessage string
+	}{
+		{
+			name:        "without a task queue",
+			callback:    &callbackspb.Callback_NexusHandler{Service: testNexusHandlerService},
+			wantMessage: "missing a task queue name",
+		},
+		{
+			name:        "with a result that isn't a payload",
+			callback:    &callbackspb.Callback_NexusHandler{TaskQueueName: testNexusHandlerTaskQueue, Service: testNexusHandlerService},
+			completion:  nexusrpc.CompleteOperationOptions{Result: "not-a-payload"},
+			wantMessage: "invalid result, expected a payload",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			handler := &invocationTaskHandler{
+				config:         &Config{},
+				metricsHandler: metrics.NoopMetricsHandler,
+				logger:         log.NewTestLogger(),
+				// Dispatch must not be attempted, so the mock is left without expectations.
+				matchingClient: matchingservicemock.NewMockMatchingServiceClient(ctrl),
+			}
+			invocable := invocableNexusHandler{callback: tc.callback, completion: tc.completion}
+
+			ns := test.NewNamespace(t)
+			result := invocable.Invoke(context.Background(), ns, handler, nil, chasm.TaskAttributes{})
+
+			require.IsType(t, invocationResultFail{}, result)
+			require.ErrorContains(t, result.error(), tc.wantMessage)
+		})
+	}
+}

--- a/chasm/lib/callback/invocable_outbound.go
+++ b/chasm/lib/callback/invocable_outbound.go
@@ -27,7 +27,7 @@ type invocableOutbound struct {
 	// completionSourceTag is the fully qualified name of the CHASM component that produced this
 	// completion, e.g. "workflow.workflow" or "activity.activity".
 	completionSourceTag string
-	workflowID, runID   string
+	businessID, runID   string
 	attempt             int32
 }
 
@@ -50,7 +50,7 @@ func (n invocableOutbound) Invoke(
 			tag.WorkflowNamespace(ns.Name().String()),
 			tag.Operation("CompleteNexusOperation"),
 			tag.Destination(taskAttr.Destination),
-			tag.WorkflowID(n.workflowID),
+			tag.WorkflowID(n.businessID),
 			tag.WorkflowRunID(n.runID),
 			tag.NexusCompletionSource(n.completionSourceTag),
 			tag.AttemptStart(time.Now().UTC()),
@@ -68,18 +68,21 @@ func (n invocableOutbound) Invoke(
 		}),
 		Serializer: commonnexus.PayloadSerializer,
 	})
-	// Make the call and record metrics.
-	startTime := time.Now()
 
+	// Make the call.
+	startTime := time.Now()
 	n.completion.Header = n.callback.Header
 	err := client.CompleteOperation(ctx, n.callback.Url, n.completion)
 
-	namespaceTag := metrics.NamespaceTag(ns.Name().String())
-	destTag := metrics.DestinationTag(taskAttr.Destination)
-	outcomeMetricTag := metrics.OutcomeTag(string(outboundOutcome(ctx, err)))
-	completionSourceMetricTag := metrics.NexusCompletionSourceTag(n.completionSourceTag)
-	h.metricsHandler.Counter(RequestCounter.Name()).Record(1, namespaceTag, destTag, outcomeMetricTag, completionSourceMetricTag)
-	h.metricsHandler.Timer(RequestLatencyHistogram.Name()).Record(time.Since(startTime), namespaceTag, destTag, outcomeMetricTag, completionSourceMetricTag)
+	// Record metrics.
+	tags := []metrics.Tag{
+		metrics.NamespaceTag(ns.Name().String()),
+		metrics.DestinationTag(taskAttr.Destination),
+		metrics.OutcomeTag(string(outboundOutcome(ctx, err))),
+		metrics.NexusCompletionSourceTag(n.completionSourceTag),
+	}
+	h.metricsHandler.Counter(RequestCounter.Name()).Record(1, tags...)
+	h.metricsHandler.Timer(RequestLatencyHistogram.Name()).Record(time.Since(startTime), tags...)
 
 	if err != nil {
 		retryable := isRetryableCallError(err)
@@ -88,7 +91,7 @@ func (n invocableOutbound) Invoke(
 			tag.Error(err),
 			tag.WorkflowNamespace(ns.Name().String()),
 			tag.Destination(taskAttr.Destination),
-			tag.WorkflowID(n.workflowID),
+			tag.WorkflowID(n.businessID),
 			tag.WorkflowRunID(n.runID),
 			tag.NexusCompletionSource(n.completionSourceTag),
 			tag.Attempt(n.attempt),
@@ -120,8 +123,4 @@ func outboundOutcome(callCtx context.Context, callErr error) outcomeTag {
 		return outcomeUnknownError
 	}
 	return outcomeSuccess
-}
-
-func handlerErrorOutcome(handlerErr *nexus.HandlerError) outcomeTag {
-	return outcomeTag(handlerErrorOutcomePrefix + commonnexus.BoundHandlerErrorType(string(handlerErr.Type)))
 }

--- a/chasm/lib/callback/invocable_outbound.go
+++ b/chasm/lib/callback/invocable_outbound.go
@@ -69,8 +69,10 @@ func (n invocableOutbound) Invoke(
 		Serializer: commonnexus.PayloadSerializer,
 	})
 
-	// Make the call.
+	// nolint:forbidigo // Wall-clock RPC measurement, not component state; Invoke has no chasm.Context.
 	startTime := time.Now()
+
+	// Make the call.
 	n.completion.Header = n.callback.Header
 	err := client.CompleteOperation(ctx, n.callback.Url, n.completion)
 

--- a/chasm/lib/callback/metrics.go
+++ b/chasm/lib/callback/metrics.go
@@ -1,6 +1,12 @@
 package callback
 
-import "go.temporal.io/server/common/metrics"
+import (
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/metrics"
+	commonnexus "go.temporal.io/server/common/nexus"
+	"google.golang.org/grpc/codes"
+)
 
 // CHASM callback metrics.
 // These are defined independently from HSM callbacks to avoid coupling between the two implementations.
@@ -25,7 +31,17 @@ var (
 		metrics.WithDescription("Latency histogram of internal (cross-shard) callback deliveries made by the history service."),
 	)
 
-	// Emitted for both the internal and outbound paths, once the transition has committed.
+	// NexusHandler-variant callback metrics.
+	NexusHandlerRequestCounter = metrics.NewCounterDef(
+		"callback_nexushandler_requests",
+		metrics.WithDescription("The number of NexusHandler callback deliveries made by the history service."),
+	)
+	NexusHandlerRequestLatencyHistogram = metrics.NewTimerDef(
+		"callback_nexushandler_latency",
+		metrics.WithDescription("Latency histogram of NexusHandler callback deliveries made by the history service."),
+	)
+
+	// Emitted for all forms of callbacks (internal, outbound, and NexusHandler-variant) once the transition has committed.
 	InvocationEventCounter = metrics.NewCounterDef(
 		"callback_invocation_events",
 		metrics.WithDescription("Committed callback invocation events. Per callback: (retryable-error)* (success | nonretryable-error)."),
@@ -37,31 +53,52 @@ var (
 )
 
 // outcomeTag is a value of the outcome tag carried by the metrics above.
+//
+// While CHASM Callback outcomes are distinct from the Frontend service's Nexus invocation outcomes,
+// the labels should match when applicable. See common/nexus.DispatchResult's metricOutcome.
 type outcomeTag string
 
-// Invocation events; the terminal success event is outcomeSuccess below.
+// The tags specific to InvocationEventCounter, which tracks the summary callback invocation event.
 const (
-	outcomeRetryableError    outcomeTag = "retryable-error"
-	outcomeNonretryableError outcomeTag = "nonretryable-error"
+	outcomeEventSuccess           outcomeTag = "success"
+	outcomeEventRetryableError    outcomeTag = "retryable-error"
+	outcomeEventNonRetryableError outcomeTag = "nonretryable-error"
 )
 
-// Internal-path delivery outcomes decided before the RPC is issued. Failures after it are tagged by
-// gRPC status code, under errorOutcomePrefix.
+// Outcome tags used for more granular tracing, used by InternalRequestCounter or NexusHandlerRequestLatencyHistogram.
+// This list is not exhaustive, handlerErrorOutcome and grpcErrorOutcome are used to generate outcome tags too.
 const (
 	// outcomeUnknown is the sentinel Invoke starts from, so a path that returns without
 	// setting an outcome shows up as unknown rather than as a success.
-	outcomeUnknown           outcomeTag = "unknown"
-	outcomeSuccess           outcomeTag = "success"
-	outcomeMissingToken      outcomeTag = "missing-token"
-	outcomeTokenDecodeError  outcomeTag = "token-decode-error"
-	outcomeInvalidRef        outcomeTag = "invalid-ref"
-	outcomeRequestBuildError outcomeTag = "request-build-error"
-	outcomeRequestTimeout    outcomeTag = "request-timeout"
+	outcomeUnknown outcomeTag = "unknown"
 	// An outbound failure that is not a Nexus handler error, e.g. a transport failure.
 	outcomeUnknownError outcomeTag = "unknown-error"
+
+	outcomeFailure           outcomeTag = "failure"
+	outcomeLegacyFailure     outcomeTag = "operation_error" // Emitted for clients sending older, deprecated error formats.
+	outcomeInvalidRef        outcomeTag = "invalid-ref"
+	outcomeMissingToken      outcomeTag = "missing-token"
+	outcomeRequestBuildError outcomeTag = "request-build-error"
+	outcomeRequestTimeout    outcomeTag = "request-timeout"
+	outcomeSuccess           outcomeTag = "success"
+	outcomeTokenDecodeError  outcomeTag = "token-decode-error"
 )
 
-const (
-	handlerErrorOutcomePrefix = "handler-error:"
-	errorOutcomePrefix        = "error:"
-)
+// handlerErrorOutcome generates the outcomeTag for a received Nexus HandlerError.
+func handlerErrorOutcome(handlerErr *nexus.HandlerError) outcomeTag {
+	// Only emit outcome tags for the error types defined in the spec.
+	// All others will be labeled as "handler-error:UNKNOWN", to prevent
+	// the metric from having unbounded cardinality.
+	boundedErrType := commonnexus.BoundHandlerErrorType(string(handlerErr.Type))
+	return outcomeTag("handler-error:" + boundedErrType)
+}
+
+// grpcErrorOutcome returns an outcomeTag derived from an error implementing
+// Statsui()/GRPCStatus(). Otherwise defaults to "error:Unknown".
+func grpcErrorOutcome(err error) outcomeTag {
+	tagSuffix := codes.Unknown.String()
+	if st, ok := common.GetRPCStatus(err); ok {
+		tagSuffix = st.Code().String()
+	}
+	return outcomeTag("error:" + tagSuffix)
+}

--- a/chasm/lib/callback/metrics.go
+++ b/chasm/lib/callback/metrics.go
@@ -52,18 +52,21 @@ var (
 	)
 )
 
+// coarseOutcomeTag is the more coarse outcome only used by the InvocationEventCounter and InvocationAttemptsHistogram metrics.
+type coarseOutcomeTag string
+
+// The tags specific to InvocationEventCounter, which tracks the summary callback invocation event.
+const (
+	outcomeEventSuccess           coarseOutcomeTag = "success"
+	outcomeEventRetryableError    coarseOutcomeTag = "retryable-error"
+	outcomeEventNonRetryableError coarseOutcomeTag = "nonretryable-error"
+)
+
 // outcomeTag is a value of the outcome tag carried by the metrics above.
 //
 // While CHASM Callback outcomes are distinct from the Frontend service's Nexus invocation outcomes,
 // the labels should match when applicable. See common/nexus.DispatchResult's metricOutcome.
 type outcomeTag string
-
-// The tags specific to InvocationEventCounter, which tracks the summary callback invocation event.
-const (
-	outcomeEventSuccess           outcomeTag = "success"
-	outcomeEventRetryableError    outcomeTag = "retryable-error"
-	outcomeEventNonRetryableError outcomeTag = "nonretryable-error"
-)
 
 // Outcome tags used for more granular tracing, used by InternalRequestCounter or NexusHandlerRequestLatencyHistogram.
 // This list is not exhaustive, handlerErrorOutcome and grpcErrorOutcome are used to generate outcome tags too.

--- a/chasm/lib/callback/metrics_test.go
+++ b/chasm/lib/callback/metrics_test.go
@@ -1,0 +1,42 @@
+package callback
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestGRPCErrorOutcome(t *testing.T) {
+	cases := []struct {
+		Name string
+		E    error
+		Want string
+	}{
+		{
+			"status.Error",
+			status.Error(codes.Unavailable, "matching unavailable"),
+			"error:Unavailable",
+		},
+		{
+			"NotAGRPCError",
+			fmt.Errorf("doesn't implement %w", errors.New("the gRPC interfaces")),
+			"error:Unknown",
+		},
+		{
+			"WrappedGRPCError",
+			fmt.Errorf("first: %w", fmt.Errorf("second: %w", status.Error(codes.Internal, "third"))),
+			"error:Internal",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			got := grpcErrorOutcome(tc.E)
+			require.EqualValues(t, tc.Want, got)
+		})
+	}
+}

--- a/chasm/lib/callback/tasks.go
+++ b/chasm/lib/callback/tasks.go
@@ -80,6 +80,7 @@ type invocationTaskHandlerOptions struct {
 	HTTPCallerProvider HTTPCallerProvider
 	HTTPTraceProvider  commonnexus.HTTPClientTraceProvider
 	HistoryClient      resource.HistoryClient
+	MatchingClient     resource.MatchingClient
 }
 
 type invocationTaskHandler struct {
@@ -91,6 +92,7 @@ type invocationTaskHandler struct {
 	httpCallerProvider HTTPCallerProvider
 	httpTraceProvider  commonnexus.HTTPClientTraceProvider
 	historyClient      resource.HistoryClient
+	matchingClient     resource.MatchingClient
 }
 
 func newInvocationTaskHandler(opts invocationTaskHandlerOptions) *invocationTaskHandler {
@@ -102,6 +104,7 @@ func newInvocationTaskHandler(opts invocationTaskHandlerOptions) *invocationTask
 		httpCallerProvider: opts.HTTPCallerProvider,
 		httpTraceProvider:  opts.HTTPTraceProvider,
 		historyClient:      opts.HistoryClient,
+		matchingClient:     opts.MatchingClient,
 	}
 }
 
@@ -163,11 +166,11 @@ func (h *invocationTaskHandler) recordInvocationEvent(
 	var outcome outcomeTag
 	switch result.(type) {
 	case invocationResultOK:
-		outcome = outcomeSuccess
+		outcome = outcomeEventSuccess
 	case invocationResultRetry:
-		outcome = outcomeRetryableError
+		outcome = outcomeEventRetryableError
 	case invocationResultFail:
-		outcome = outcomeNonretryableError
+		outcome = outcomeEventNonRetryableError
 	default:
 		// saveResult rejects anything else as an unprocessable task.
 		return
@@ -180,10 +183,10 @@ func (h *invocationTaskHandler) recordInvocationEvent(
 	}
 	h.metricsHandler.Counter(InvocationEventCounter.Name()).Record(1, tags...)
 
-	if outcome != outcomeRetryableError {
+	if outcome != outcomeEventRetryableError {
+		hist := h.metricsHandler.Histogram(InvocationAttemptsHistogram.Name(), InvocationAttemptsHistogram.Unit())
 		// Attempt is 0-based, so +1 is the count. Only terminal events have a final total.
-		h.metricsHandler.Histogram(InvocationAttemptsHistogram.Name(), InvocationAttemptsHistogram.Unit()).
-			Record(int64(task.GetAttempt())+1, tags...)
+		hist.Record(int64(task.GetAttempt())+1, tags...)
 	}
 }
 

--- a/chasm/lib/callback/tasks.go
+++ b/chasm/lib/callback/tasks.go
@@ -163,7 +163,7 @@ func (h *invocationTaskHandler) recordInvocationEvent(
 	task *callbackspb.InvocationTask,
 	result invocationResult,
 ) {
-	var outcome outcomeTag
+	var outcome coarseOutcomeTag
 	switch result.(type) {
 	case invocationResultOK:
 		outcome = outcomeEventSuccess
@@ -184,9 +184,8 @@ func (h *invocationTaskHandler) recordInvocationEvent(
 	h.metricsHandler.Counter(InvocationEventCounter.Name()).Record(1, tags...)
 
 	if outcome != outcomeEventRetryableError {
-		hist := h.metricsHandler.Histogram(InvocationAttemptsHistogram.Name(), InvocationAttemptsHistogram.Unit())
 		// Attempt is 0-based, so +1 is the count. Only terminal events have a final total.
-		hist.Record(int64(task.GetAttempt())+1, tags...)
+		InvocationAttemptsHistogram.With(h.metricsHandler).Record(int64(task.GetAttempt())+1, tags...)
 	}
 }
 

--- a/chasm/lib/callback/tasks_test.go
+++ b/chasm/lib/callback/tasks_test.go
@@ -30,6 +30,7 @@ import (
 	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/nexus/nexusrpc"
 	"go.temporal.io/server/common/resource"
+	test "go.temporal.io/server/common/testing"
 	"go.temporal.io/server/service/history/queues/common"
 	queueserrors "go.temporal.io/server/service/history/queues/errors"
 	"go.uber.org/mock/gomock"
@@ -82,6 +83,78 @@ func (l *mockNexusCompletionGetterLibrary) Components() []*chasm.RegistrableComp
 	return []*chasm.RegistrableComponent{
 		chasm.NewRegistrableComponent[*mockNexusCompletionGetterComponent]("nexusCompletionGetter"),
 	}
+}
+
+// newInvocationTaskTest builds a CHASM tree holding cb underneath a completion source that returns the
+// given completion, and returns an engine context plus a ref to the callback to invoke task handlers with.
+func newInvocationTaskTest(
+	t *testing.T,
+	handler *invocationTaskHandler,
+	cb *Callback,
+	completion nexusrpc.CompleteOperationOptions,
+) (context.Context, chasm.ComponentRef) {
+	t.Helper()
+
+	chasmRegistry := chasm.NewRegistry(log.NewTestLogger())
+	require.NoError(t, chasmRegistry.Register(&Library{InvocationTaskHandler: handler}))
+	require.NoError(t, chasmRegistry.Register(&mockNexusCompletionGetterLibrary{}))
+
+	executionKey := chasm.ExecutionKey{
+		NamespaceID: "namespace-id",
+		BusinessID:  "workflow-id",
+		RunID:       "run-id",
+	}
+	engineCtx := chasm.NewEngineContext(context.Background(), chasmtest.NewEngine(t, chasmRegistry))
+	_, err := chasm.StartExecution(
+		engineCtx,
+		executionKey,
+		func(ctx chasm.MutableContext, _ struct{}) (*mockNexusCompletionGetterComponent, error) {
+			return &mockNexusCompletionGetterComponent{
+				completion: completion,
+				Callback:   chasm.NewComponentField(ctx, cb),
+			}, nil
+		},
+		struct{}{},
+	)
+	require.NoError(t, err)
+
+	rootRef := chasm.NewComponentRef[*mockNexusCompletionGetterComponent](executionKey)
+	callbackRef, err := chasm.ReadComponent(
+		engineCtx,
+		rootRef,
+		func(_ *mockNexusCompletionGetterComponent, chasmCtx chasm.Context, _ struct{}) (chasm.ComponentRef, error) {
+			serialized, err := chasmCtx.Ref(cb)
+			if err != nil {
+				return chasm.ComponentRef{}, err
+			}
+			return chasm.DeserializeComponentRef(serialized)
+		},
+		struct{}{},
+	)
+	require.NoError(t, err)
+	return engineCtx, callbackRef
+}
+
+// readCallbackState runs assert against the persisted callback state, so that assertions see what the task
+// handler committed rather than the in-memory component it was handed.
+func readCallbackState(
+	engineCtx context.Context,
+	t *testing.T,
+	ref chasm.ComponentRef,
+	assert func(chasm.Context, *Callback),
+) {
+	t.Helper()
+
+	_, err := chasm.ReadComponent(
+		engineCtx,
+		ref,
+		func(c *Callback, chasmCtx chasm.Context, _ struct{}) (struct{}, error) {
+			assert(chasmCtx, c)
+			return struct{}{}, nil
+		},
+		struct{}{},
+	)
+	require.NoError(t, err)
 }
 
 // Test the full executeInvocationTask flow with direct handler calls
@@ -171,17 +244,7 @@ func TestExecuteInvocationTaskNexus_Outcomes(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			// Setup namespace
-			factory := namespace.NewDefaultReplicationResolverFactory()
-			detail := &persistencespb.NamespaceDetail{
-				Info: &persistencespb.NamespaceInfo{
-					Id:   "namespace-id",
-					Name: "namespace-name",
-				},
-				Config: &persistencespb.NamespaceConfig{},
-			}
-			ns, err := namespace.FromPersistentState(detail, factory(detail))
-			require.NoError(t, err)
+			ns := test.NewNamespace(t)
 
 			// Setup metrics expectations
 			metricsHandler := metrics.NewMockHandler(ctrl)
@@ -190,13 +253,13 @@ func TestExecuteInvocationTaskNexus_Outcomes(t *testing.T) {
 			timer := metrics.NewMockTimerIface(ctrl)
 			metricsHandler.EXPECT().Counter(RequestCounter.Name()).Return(counter)
 			counter.EXPECT().Record(int64(1),
-				metrics.NamespaceTag("namespace-name"),
+				metrics.NamespaceTag(ns.Name().String()),
 				metrics.DestinationTag("http://localhost"),
 				metrics.OutcomeTag(tc.expectedMetricOutcome),
 				metrics.NexusCompletionSourceTag(testCompletionSourceFqn))
 			metricsHandler.EXPECT().Timer(RequestLatencyHistogram.Name()).Return(timer)
 			timer.EXPECT().Record(gomock.Any(),
-				metrics.NamespaceTag("namespace-name"),
+				metrics.NamespaceTag(ns.Name().String()),
 				metrics.DestinationTag("http://localhost"),
 				metrics.OutcomeTag(tc.expectedMetricOutcome),
 				metrics.NexusCompletionSourceTag(testCompletionSourceFqn))
@@ -204,14 +267,14 @@ func TestExecuteInvocationTaskNexus_Outcomes(t *testing.T) {
 			// The committed event is recorded for the outbound path too, not just the
 			// internal one, so a permanently dropped external callback is also visible.
 			eventTags := []metrics.Tag{
-				metrics.NamespaceTag("namespace-name"),
+				metrics.NamespaceTag(ns.Name().String()),
 				metrics.DestinationTag("http://localhost"),
 				metrics.OutcomeTag(tc.expectedEvent),
 			}
 			eventCounter := metrics.NewMockCounterIface(ctrl)
 			metricsHandler.EXPECT().Counter(InvocationEventCounter.Name()).Return(eventCounter)
 			eventCounter.EXPECT().Record(int64(1), eventTags)
-			if tc.expectedEvent != string(outcomeRetryableError) {
+			if tc.expectedEvent != string(outcomeEventRetryableError) {
 				attemptHistogram := metrics.NewMockHistogramIface(ctrl)
 				metricsHandler.EXPECT().
 					Histogram(InvocationAttemptsHistogram.Name(), InvocationAttemptsHistogram.Unit()).
@@ -241,14 +304,6 @@ func TestExecuteInvocationTaskNexus_Outcomes(t *testing.T) {
 				},
 			}
 
-			chasmRegistry := chasm.NewRegistry(logger)
-			err = chasmRegistry.Register(&Library{
-				InvocationTaskHandler: handler,
-			})
-			require.NoError(t, err)
-			err = chasmRegistry.Register(&mockNexusCompletionGetterLibrary{})
-			require.NoError(t, err)
-
 			callback := &Callback{
 				CallbackState: &callbackspb.CallbackState{
 					RequestId:        "request-id",
@@ -265,43 +320,7 @@ func TestExecuteInvocationTaskNexus_Outcomes(t *testing.T) {
 				},
 			}
 
-			// Create completion
-			completion := nexusrpc.CompleteOperationOptions{}
-
-			executionKey := chasm.ExecutionKey{
-				NamespaceID: "namespace-id",
-				BusinessID:  "workflow-id",
-				RunID:       "run-id",
-			}
-			testEngine := chasmtest.NewEngine(t, chasmRegistry)
-			engineCtx := chasm.NewEngineContext(context.Background(), testEngine)
-			_, err = chasm.StartExecution(
-				engineCtx,
-				executionKey,
-				func(ctx chasm.MutableContext, _ struct{}) (*mockNexusCompletionGetterComponent, error) {
-					return &mockNexusCompletionGetterComponent{
-						completion: completion,
-						Callback:   chasm.NewComponentField(ctx, callback),
-					}, nil
-				},
-				struct{}{},
-			)
-			require.NoError(t, err)
-
-			rootRef := chasm.NewComponentRef[*mockNexusCompletionGetterComponent](executionKey)
-			callbackRef, err := chasm.ReadComponent(
-				engineCtx,
-				rootRef,
-				func(_ *mockNexusCompletionGetterComponent, chasmCtx chasm.Context, _ struct{}) (chasm.ComponentRef, error) {
-					serialized, err := chasmCtx.Ref(callback)
-					if err != nil {
-						return chasm.ComponentRef{}, err
-					}
-					return chasm.DeserializeComponentRef(serialized)
-				},
-				struct{}{},
-			)
-			require.NoError(t, err)
+			engineCtx, callbackRef := newInvocationTaskTest(t, handler, callback, nexusrpc.CompleteOperationOptions{})
 
 			executeErr := handler.Execute(
 				engineCtx,
@@ -311,16 +330,9 @@ func TestExecuteInvocationTaskNexus_Outcomes(t *testing.T) {
 			)
 
 			// Verify outcome by reading component state directly.
-			resultCallback, err := chasm.ReadComponent(
-				engineCtx,
-				callbackRef,
-				func(c *Callback, _ chasm.Context, _ struct{}) (*Callback, error) {
-					return c, nil
-				},
-				struct{}{},
-			)
-			require.NoError(t, err)
-			tc.assertOutcome(t, resultCallback, executeErr)
+			readCallbackState(engineCtx, t, callbackRef, func(chasmCtx chasm.Context, c *Callback) {
+				tc.assertOutcome(t, c, executeErr)
+			})
 		})
 	}
 }

--- a/chasm/lib/nexusoperation/task_handler_helpers.go
+++ b/chasm/lib/nexusoperation/task_handler_helpers.go
@@ -270,7 +270,7 @@ func newInvocationResult(
 	}
 
 	if opErr, ok := errors.AsType[*nexus.OperationError](callErr); ok {
-		failure, err := operationErrorToFailure(opErr)
+		failure, err := commonnexus.OperationErrorToTemporalFailure(opErr)
 		if err != nil {
 			return nil, err
 		}
@@ -307,20 +307,6 @@ func newInvocationResult(
 		return invocationResultFail{failure: failure}, nil
 	}
 	return invocationResultRetry{failure: failure}, nil
-}
-
-func operationErrorToFailure(opErr *nexus.OperationError) (*failurepb.Failure, error) {
-	var nf nexus.Failure
-	if opErr.OriginalFailure != nil {
-		nf = *opErr.OriginalFailure
-	} else {
-		var err error
-		nf, err = nexusrpc.DefaultFailureConverter().ErrorToFailure(opErr)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return commonnexus.NexusFailureToTemporalFailure(*nexusrpc.UnwrapFailure(&nf))
 }
 
 func buildCallbackURL(

--- a/chasm/lib/nexusoperation/validator_test.go
+++ b/chasm/lib/nexusoperation/validator_test.go
@@ -76,6 +76,21 @@ func newNexusCallback() *commonpb.Callback {
 	}
 }
 
+// newNexusHandlerCallback returns a NexusHandler-variant callback.
+func newNexusHandlerCallback() *commonpb.Callback {
+	sourceContext := &commonpb.Payload{Data: make([]byte, 1024)}
+	return &commonpb.Callback{
+		Variant: &commonpb.Callback_NexusHandler_{
+			NexusHandler: &commonpb.Callback_NexusHandler{
+				TaskQueueName: "wc-queue",
+				Service:       "Adapter",
+				Operation:     "Deliver",
+				SourceContext: sourceContext,
+			},
+		},
+	}
+}
+
 func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockVisibilityManager := manager.NewMockVisibilityManager(ctrl)
@@ -390,6 +405,36 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 			},
 		},
 		{
+			// The default for enabledCallbackKinds is empty, i.e. the feature is off.
+			name: "completion_callbacks - rejected when no kinds are enabled",
+			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
+				r.CompletionCallbacks = []*commonpb.Callback{newNexusCallback()}
+			},
+			mutateConfig: func(c *Config) {
+				c.EnabledCallbackKinds = func(string) []callbacks.Kind { return nil }
+			},
+			wantErr: "nexus callbacks are not enabled for this execution type",
+		},
+		{
+			name: "completion_callbacks - rejects a kind that is not enabled",
+			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
+				r.CompletionCallbacks = []*commonpb.Callback{newNexusHandlerCallback()}
+			},
+			wantErr: "nexusHandler callbacks are not enabled for this execution type",
+		},
+		{
+			name: "source_context - rejects a single callback over the per-callback limit",
+			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
+				r.CompletionCallbacks = []*commonpb.Callback{newNexusHandlerCallback()}
+			},
+			mutateConfig: func(c *Config) {
+				c.EnabledCallbackKinds = func(string) []callbacks.Kind {
+					return []callbacks.Kind{callbacks.KindNexus, callbacks.KindNexusHandler}
+				}
+			},
+			wantErr: "source_context exceeds size limit",
+		},
+		{
 			name: "links - accepts a valid link",
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.Links = []*commonpb.Link{testLink("wf-id")}
@@ -411,6 +456,43 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 				for i := range 11 {
 					r.Links = append(r.Links, testLink(fmt.Sprintf("wf-%d", i)))
 				}
+			},
+			wantErr: "cannot attach more than 10 links per request",
+		},
+		{
+			// Links ride along on callbacks as well as on the request, and are validated whether or
+			// not the request brought any of its own.
+			name: "links - rejects an incomplete variant carried by a callback",
+			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
+				cb := newNexusCallback()
+				cb.Links = []*commonpb.Link{{Variant: &commonpb.Link_WorkflowEvent_{
+					WorkflowEvent: &commonpb.Link_WorkflowEvent{WorkflowId: "wf-id", RunId: "wf-run-id"},
+				}}}
+				r.CompletionCallbacks = []*commonpb.Callback{cb}
+			},
+			wantErr: "must not have an empty namespace",
+		},
+		{
+			name: "links - rejects an oversized link carried by a callback",
+			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
+				// newTestLinkValidator sets a default 4000 bytes per link limit.
+				cb := newNexusCallback()
+				cb.Links = []*commonpb.Link{testLink(strings.Repeat("x", 4001))}
+				r.CompletionCallbacks = []*commonpb.Callback{cb}
+			},
+			wantErr: "link exceeds allowed size of 4000",
+		},
+		{
+			// A callback's links count toward the same per-request limit as the request's own, so
+			// neither side can smuggle links past it by splitting them across the two.
+			name: "links - counts callback links toward the per-request limit",
+			mutate: func(req *workflowservice.StartNexusOperationExecutionRequest) {
+				cb := newNexusCallback()
+				for i := range 6 {
+					req.Links = append(req.Links, testLink(fmt.Sprintf("req-wf-%d", i)))
+					cb.Links = append(cb.Links, testLink(fmt.Sprintf("cb-wf-%d", i)))
+				}
+				req.CompletionCallbacks = []*commonpb.Callback{cb}
 			},
 			wantErr: "cannot attach more than 10 links per request",
 		},
@@ -474,9 +556,12 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 			if tc.mutateConfig != nil {
 				tc.mutateConfig(&caseConfig)
 			}
+
 			cbValidator := mustNewCallbackValidator()
-			err := newValidator(&caseConfig, log.NewNoopLogger(), nil, saValidator, cbValidator, newTestLinkValidator(10, 10)).
-				validateAndNormalizeStartRequest(context.Background(), req)
+			logger := log.NewNoopLogger()
+			v := newValidator(&caseConfig, logger, nil, saValidator, cbValidator, newTestLinkValidator(10, 10))
+
+			err := v.validateAndNormalizeStartRequest(context.Background(), req)
 			if tc.wantErr != "" {
 				var invalidArgErr *serviceerror.InvalidArgument
 				require.ErrorAs(t, err, &invalidArgErr)

--- a/common/namespace/namespace_test.go
+++ b/common/namespace/namespace_test.go
@@ -7,38 +7,13 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	namespacepb "go.temporal.io/api/namespace/v1"
-	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/primitives/timestamp"
+	test "go.temporal.io/server/common/testing"
 )
 
-func base(t *testing.T) *namespace.Namespace {
-	detail := &persistencespb.NamespaceDetail{
-		Info: &persistencespb.NamespaceInfo{
-			Id:   namespace.NewID().String(),
-			Name: t.Name(),
-			Data: make(map[string]string),
-		},
-		Config: &persistencespb.NamespaceConfig{
-			BadBinaries: &namespacepb.BadBinaries{
-				Binaries: make(map[string]*namespacepb.BadBinaryInfo),
-			},
-		},
-		ReplicationConfig: &persistencespb.NamespaceReplicationConfig{
-			ActiveClusterName: "foo",
-			Clusters:          []string{"foo", "bar"},
-		},
-	}
-	factory := namespace.NewDefaultReplicationResolverFactory()
-	resolver := factory(detail)
-	ns, err := namespace.FromPersistentState(detail, resolver)
-	require.NoError(t, err)
-	return ns
-}
-
 func TestActiveInCluster(t *testing.T) {
-	base := base(t)
+	base := test.NewNamespace(t)
 
 	for _, tt := range [...]struct {
 		name        string
@@ -87,7 +62,7 @@ func TestActiveInCluster(t *testing.T) {
 
 func Test_GetRetentionDays(t *testing.T) {
 	const defaultRetention = 7 * 24 * time.Hour
-	base := base(t).Clone(namespace.WithRetention(timestamp.DurationFromDays(7)))
+	base := test.NewNamespace(t).Clone(namespace.WithRetention(timestamp.DurationFromDays(7)))
 	for _, tt := range [...]struct {
 		name       string
 		retention  string
@@ -115,7 +90,7 @@ func Test_GetRetentionDays(t *testing.T) {
 }
 
 func TestNamespace_GetCustomData(t *testing.T) {
-	base := base(t)
+	base := test.NewNamespace(t)
 	ns := base.Clone(namespace.WithData("foo", "bar"))
 	data := ns.GetCustomData("foo")
 	assert.Equal(t, "bar", data)

--- a/common/nexus/dispatch_outcome.go
+++ b/common/nexus/dispatch_outcome.go
@@ -50,12 +50,6 @@ const (
 	//     nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "cannot deserialize input")
 	DispatchOutcomeHandlerFailure DispatchOutcome = "nexus-handler-failure"
 
-	// DispatchOutcomeWorkerFailure means the worker failed the task with a failure carrying no Nexus
-	// handler failure info. RespondNexusTaskFailed rejects such a response, so matching cannot produce
-	// this outcome today. It exists so that a malformed response is classified rather than read as a
-	// handler error with no type.
-	DispatchOutcomeWorkerFailure DispatchOutcome = "worker-failure"
-
 	// DispatchOutcomeRequestTimeout means matching gave up before the task was answered: no worker
 	// was polling the task queue, or a worker took the task and never responded.
 	DispatchOutcomeRequestTimeout DispatchOutcome = "request-timeout"
@@ -88,8 +82,8 @@ type DispatchResult struct {
 	// DispatchOutcomeSyncSuccess and DispatchOutcomeAsyncSuccess.
 	Links []*nexuspb.Link
 
-	// Failure is the Temporal failure the worker reported. Set for DispatchOutcomeHandlerFailure,
-	// DispatchOutcomeWorkerFailure and DispatchOutcomeOperationFailure.
+	// Failure is the Temporal failure the worker reported. Set for DispatchOutcomeHandlerFailure
+	// and DispatchOutcomeOperationFailure.
 	//
 	// IMPORTANT: For the current response formats this aliases the proto inside the response rather
 	// than copying it, so callers that convert it in place mutate the response too.
@@ -112,11 +106,7 @@ func baseClassifyDispatchNexusTaskResponse(
 	case *matchingservice.DispatchNexusTaskResponse_Failure:
 		// A handler error is a Nexus-level refusal whose retry behavior is meaningful; anything else
 		// is an arbitrary failure the worker chose to report.
-		outcome := DispatchOutcomeWorkerFailure
-		if t.Failure.GetNexusHandlerFailureInfo() != nil {
-			outcome = DispatchOutcomeHandlerFailure
-		}
-		return DispatchResult{Outcome: outcome, Failure: t.Failure}
+		return DispatchResult{Outcome: DispatchOutcomeHandlerFailure, Failure: t.Failure}
 
 	case *matchingservice.DispatchNexusTaskResponse_HandlerError: //nolint:staticcheck // Deprecated, still sent by older workers.
 		return DispatchResult{
@@ -284,8 +274,7 @@ func (r DispatchResult) metricOutcome() string {
 			return "operation_error"
 		}
 		return "failure"
-	case DispatchOutcomeHandlerFailure,
-		DispatchOutcomeWorkerFailure:
+	case DispatchOutcomeHandlerFailure:
 		// A worker failure has no handler error type to report and will map to UNKNOWN.
 		hErrType := r.Failure.GetNexusHandlerFailureInfo().GetType()
 		return "handler_error:" + BoundHandlerErrorType(hErrType)

--- a/common/nexus/dispatch_outcome_test.go
+++ b/common/nexus/dispatch_outcome_test.go
@@ -365,23 +365,6 @@ func TestClassifyOperationDispatch(t *testing.T) {
 			},
 		},
 
-		// DispatchOutcomeWorkerFailure
-		{
-			Name:     "worker error",
-			Response: taskFailureResponse(applicationFailure("worker exploded", "ErrTypeStr")),
-			Want: DispatchResult{
-				Outcome: DispatchOutcomeWorkerFailure,
-				Failure: &failurepb.Failure{
-					Message: "worker exploded",
-					FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
-						ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
-							Type: "ErrTypeStr",
-						},
-					},
-				},
-			},
-		},
-
 		// DispatchOutcomeUnrecognized
 		{
 			Name:     "unrecognized (no outcome)",

--- a/common/nexus/dispatch_response.go
+++ b/common/nexus/dispatch_response.go
@@ -33,9 +33,7 @@ func DispatchResultToError(result DispatchResult) error {
 	}
 
 	switch result.Outcome {
-	case DispatchOutcomeHandlerFailure,
-		DispatchOutcomeWorkerFailure,
-		DispatchOutcomeOperationFailure:
+	case DispatchOutcomeHandlerFailure, DispatchOutcomeOperationFailure:
 		// The worker either failed the task (via RespondNexusTaskFailed) or answered with a failed
 		// operation. Either way the failure reports what the worker said.
 		return temporal.GetDefaultFailureConverter().FailureToError(result.Failure)

--- a/common/nexus/failure.go
+++ b/common/nexus/failure.go
@@ -15,6 +15,7 @@ import (
 	nexuspb "go.temporal.io/api/nexus/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/nexus/nexusrpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
@@ -432,4 +433,22 @@ func AdaptAuthorizeError(permissionDeniedError *serviceerror.PermissionDenied) e
 		return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeUnauthorized, "permission denied: %s", permissionDeniedError.Reason)
 	}
 	return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeUnauthorized, "permission denied")
+}
+
+func OperationErrorToTemporalFailure(opErr *nexus.OperationError) (*failurepb.Failure, error) {
+	var nf nexus.Failure
+	if opErr.OriginalFailure != nil {
+		nf = *opErr.OriginalFailure
+	} else {
+		var err error
+		nf, err = nexusrpc.DefaultFailureConverter().ErrorToFailure(opErr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// The Nexus failure may contain a metadata key requesting that the unwrapped
+	// [Cause] of the failure is sent, to avoid an unnecessary layer of indirection.
+	unwrappedFailure := nexusrpc.UnwrapFailure(&nf)
+	return NexusFailureToTemporalFailure(*unwrappedFailure)
 }

--- a/common/testing/namespace.go
+++ b/common/testing/namespace.go
@@ -1,0 +1,37 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	namespacepb "go.temporal.io/api/namespace/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/namespace"
+)
+
+// NewNamespace returns a Namespace named after the running test, with a generated
+// ID and a two-cluster replication config active in "foo".
+func NewNamespace(t *testing.T) *namespace.Namespace {
+	t.Helper()
+	detail := &persistencespb.NamespaceDetail{
+		Info: &persistencespb.NamespaceInfo{
+			Id:   namespace.NewID().String(),
+			Name: t.Name(),
+			Data: make(map[string]string),
+		},
+		Config: &persistencespb.NamespaceConfig{
+			BadBinaries: &namespacepb.BadBinaries{
+				Binaries: make(map[string]*namespacepb.BadBinaryInfo),
+			},
+		},
+		ReplicationConfig: &persistencespb.NamespaceReplicationConfig{
+			ActiveClusterName: "foo",
+			Clusters:          []string{"foo", "bar"},
+		},
+	}
+	factory := namespace.NewDefaultReplicationResolverFactory()
+	resolver := factory(detail)
+	ns, err := namespace.FromPersistentState(detail, resolver)
+	require.NoError(t, err)
+	return ns
+}

--- a/service/frontend/nexus_dispatch_result.go
+++ b/service/frontend/nexus_dispatch_result.go
@@ -75,7 +75,7 @@ func (c *operationContext) failedDispatchToNexusError(
 	operation string,
 ) error {
 	switch result.Outcome {
-	case commonnexus.DispatchOutcomeHandlerFailure, commonnexus.DispatchOutcomeWorkerFailure:
+	case commonnexus.DispatchOutcomeHandlerFailure:
 		// A handler error round-trips as a handler error. Anything else the worker used to fail the
 		// task converts to an opaque failure error, which the SDK reports to the caller as internal.
 		// Neither is wrapped, so both errors are reported to the caller unchanged.

--- a/tests/comp_callbacks.go
+++ b/tests/comp_callbacks.go
@@ -99,13 +99,14 @@ func (nct *nexusCompletionCallbackTarget) newCallback() *commonpb.Callback {
 
 // CompleteOperation implements the nexusrpc handler interface.
 func (nct *nexusCompletionCallbackTarget) CompleteOperation(_ context.Context, _ *nexusrpc.CompletionRequest) error {
-	// NOTE: deliver returns a typed *nexus.HandlerError. Returning it directly would hand back a
-	// non-nil error interface wrapping a nil pointer, and the handler would treat every successful
-	// delivery as a failure.
-	if err := nct.deliver(); err != nil {
-		return err
+	handlerErr := nct.deliver()
+	if handlerErr == nil {
+		// NOTE: deliver returns a typed *nexus.HandlerError, so it can't be returned unconditionally:
+		// a nil pointer becomes a non-nil error interface, and the handler would treat every
+		// successful delivery as a failure.
+		return nil
 	}
-	return nil
+	return handlerErr
 }
 
 // newNexusCompletionCallbackTarget creates a new Nexus-variant callback target.

--- a/tests/comp_callbacks.go
+++ b/tests/comp_callbacks.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http/httptest"
 	"slices"
@@ -15,10 +16,13 @@ import (
 	commandpb "go.temporal.io/api/command/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	nexuspb "go.temporal.io/api/nexus/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/common/nexus/nexusrpc"
+	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/payloads"
+	"go.temporal.io/server/common/rpc"
 	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/tests/testcore"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -35,8 +39,8 @@ type completionCallbackTarget interface {
 	deliveries() int
 }
 
-// completionCallbackBehavior determines how a baseCompletionCallbackTarget should respond to
-// the CompleteOperation method.
+// completionCallbackBehavior determines how a baseCompletionCallbackTarget should answer a
+// delivery reaching it.
 type completionCallbackBehavior int32
 
 const (
@@ -60,7 +64,9 @@ func (ct *baseCompletionCallbackTarget) changeBehavior(newBehavior completionCal
 	ct.behavior.Store(int32(newBehavior))
 }
 
-func (ct *baseCompletionCallbackTarget) CompleteOperation(_ context.Context, _ *nexusrpc.CompletionRequest) error {
+// deliver records a delivery having reached the target and returns how the target answers it.
+// A return value of nil means accepts the delivery, otherwise fail.
+func (ct *baseCompletionCallbackTarget) deliver() *nexus.HandlerError {
 	received := ct.deliveryCount.Add(1)
 	switch ct.behavior.Load() {
 	case int32(completionCallbackBehaviorSuccess):
@@ -91,6 +97,17 @@ func (nct *nexusCompletionCallbackTarget) newCallback() *commonpb.Callback {
 	}
 }
 
+// CompleteOperation implements the nexusrpc handler interface.
+func (nct *nexusCompletionCallbackTarget) CompleteOperation(_ context.Context, _ *nexusrpc.CompletionRequest) error {
+	// NOTE: deliver returns a typed *nexus.HandlerError. Returning it directly would hand back a
+	// non-nil error interface wrapping a nil pointer, and the handler would treat every successful
+	// delivery as a failure.
+	if err := nct.deliver(); err != nil {
+		return err
+	}
+	return nil
+}
+
 // newNexusCompletionCallbackTarget creates a new Nexus-variant callback target.
 // Starts a new HTTP server, will be cleaned up with the testcase.
 func newNexusCompletionCallbackTarget(t *testing.T, _ *testcore.TestEnv, behavior completionCallbackBehavior) completionCallbackTarget {
@@ -102,6 +119,152 @@ func newNexusCompletionCallbackTarget(t *testing.T, _ *testcore.TestEnv, behavio
 	}))
 	t.Cleanup(srv.Close)
 	target.url = srv.URL
+
+	return target
+}
+
+// nexusHandlerCompletionCallbackTarget provides an implementation of callbackTarget for receiving NexusHandler-variant callbacks.
+type nexusHandlerCompletionCallbackTarget struct {
+	baseCompletionCallbackTarget
+	// taskQueue the target's worker polls on. Distinct per nexusHandlerCompletionCallbackTarget so that
+	// an open circuitbreaker doesn't block all potential callback targets.
+	taskQueue string
+}
+
+func (nhct *nexusHandlerCompletionCallbackTarget) newCallback() *commonpb.Callback {
+	return &commonpb.Callback{
+		Variant: &commonpb.Callback_NexusHandler_{
+			NexusHandler: &commonpb.Callback_NexusHandler{
+				TaskQueueName: nhct.taskQueue,
+				Service:       "NexusHandlerService",
+				Operation:     "OnComplete",
+				SourceContext: &commonpb.Payload{
+					Data: []byte("source context payload"),
+				},
+			},
+		},
+	}
+}
+
+// pollAndRespond is the worker side of a NexusHandler callback. It polls the target's task queue and
+// answers every task it is handed according to the target's behavior at that moment.
+//
+// Runs until ctx is canceled.
+func (nhct *nexusHandlerCompletionCallbackTarget) pollAndRespond(ctx context.Context, t *testing.T, env *NexusTestEnv) {
+	for ctx.Err() == nil {
+		// Issue a long-poll request.
+		pollCtx, cancelPoll := rpc.NewContextFromParentWithTimeoutAndVersionHeaders(ctx, 30*time.Second)
+
+		task, err := env.FrontendClient().PollNexusTaskQueue(pollCtx, &workflowservice.PollNexusTaskQueueRequest{
+			Namespace: env.Namespace().String(),
+			Identity:  env.Tv().WorkerIdentity(),
+			TaskQueue: &taskqueuepb.TaskQueue{Name: nhct.taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		})
+		cancelPoll()
+
+		if err != nil {
+			// Cancelation is how the loop is stopped, so it isn't worth reporting.
+			if ctx.Err() != nil {
+				return
+			}
+			if errors.Is(err, context.DeadlineExceeded) {
+				// The long poll ran out of time without a task, which is business as usual.
+				continue
+			}
+			t.Logf("failed to poll Nexus task queue %q: %v", nhct.taskQueue, err)
+
+			// If the context is still valid, pause a beat and retry.
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(50 * time.Millisecond):
+			}
+			continue
+		}
+
+		// An empty task token means the long poll timed out without a task being dispatched.
+		if len(task.GetTaskToken()) == 0 {
+			continue
+		}
+
+		// Otherwise, respond to the Nexus invocation task.
+		if err := nhct.respond(ctx, env, task); err != nil {
+			t.Logf("failed to respond to Nexus task on %q: %v", nhct.taskQueue, err)
+		}
+	}
+}
+
+// respond answers a single delivered Nexus task the way the target's behavior dictates.
+func (nhct *nexusHandlerCompletionCallbackTarget) respond(
+	ctx context.Context,
+	env *NexusTestEnv,
+	task *workflowservice.PollNexusTaskQueueResponse,
+) error {
+	// The poller's own context has no deadline, it lives as long as the test does.
+	ctx, cancel := rpc.NewContextFromParentWithTimeoutAndVersionHeaders(ctx, 10*time.Second)
+	defer cancel()
+
+	startOp := task.GetRequest().GetStartOperation()
+	if startOp == nil {
+		msg := fmt.Sprintf("got unexpected NexusTask: %v", task.GetRequest())
+		panic(msg)
+	}
+
+	// Determine the right response based on the current behavior, and respond.
+	if deliveryErr := nhct.deliver(); deliveryErr != nil {
+		return env.respondNexusTaskFailed(ctx, task.GetTaskToken(), deliveryErr)
+	}
+
+	// The handler accepted the completion. Report back as if it returned a sync response.
+	result, err := payload.Encode("NexusHandler callback delivered")
+	if err != nil {
+		return err
+	}
+	_, err = env.FrontendClient().RespondNexusTaskCompleted(ctx, &workflowservice.RespondNexusTaskCompletedRequest{
+		Namespace: env.Namespace().String(),
+		Identity:  env.Tv().WorkerIdentity(),
+		TaskToken: task.GetTaskToken(),
+		Response: &nexuspb.Response{
+			Variant: &nexuspb.Response_StartOperation{
+				StartOperation: &nexuspb.StartOperationResponse{
+					Variant: &nexuspb.StartOperationResponse_SyncSuccess{
+						SyncSuccess: &nexuspb.StartOperationResponse_Sync{Payload: result},
+					},
+				},
+			},
+		},
+	})
+	return err
+}
+
+// newNexusHandlerCompletionCallbackTarget creates a new NexusHandler-variant callback target.
+func newNexusHandlerCompletionCallbackTarget(t *testing.T, env *testcore.TestEnv, behavior completionCallbackBehavior) completionCallbackTarget {
+	target := &nexusHandlerCompletionCallbackTarget{
+		taskQueue: testcore.RandomizeStr("nh-callback-tq"),
+	}
+	target.behavior.Store(int32(behavior))
+
+	// A NexusHandler callback is delivered as a Nexus task on the callback's task queue, in the
+	// source execution's own namespace. So the "worker" here is a bare poll loop against that task
+	// queue. It answers as the registered Nexus service, no endpoint required.
+
+	// The poller needs a context of its own: t.Context is canceled before cleanups run, and the
+	// poll loop has to outlive it long enough to be shut down in an orderly way.
+	pollerCtx, stopPolling := context.WithCancel(context.Background())
+	pollerDone := make(chan struct{})
+	go func() {
+		defer close(pollerDone)
+		nexusEnv := &NexusTestEnv{
+			TestEnv:             env,
+			useTemporalFailures: true,
+		}
+		target.pollAndRespond(pollerCtx, t, nexusEnv)
+	}()
+	t.Cleanup(func() {
+		stopPolling()
+		// The poll loop may report failures to t, so the poller must stop before the test does.
+		<-pollerDone
+	})
 
 	return target
 }

--- a/tests/comp_callbacks_test.go
+++ b/tests/comp_callbacks_test.go
@@ -37,23 +37,24 @@ func TestCompletionCallbacksSuite(t *testing.T) {
 // execution types, and the retry policy dialed down so failures can accumulate within the tests's
 // lifetime. The retry policy is a global setting, hence the dedicated cluster.
 func (s *CompletionCallbacksSuite) newTestEnv() *testcore.TestEnv {
+	allCallbackKinds := []callbacks.Kind{callbacks.KindNexus, callbacks.KindNexusHandler}
 	opts := []testcore.TestOption{
 		testcore.WithDedicatedCluster(),
 		// Workflows
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
-		testcore.WithDynamicConfig(workflow.EnabledCallbackKinds, []callbacks.Kind{callbacks.KindNexus}),
+		testcore.WithDynamicConfig(workflow.EnabledCallbackKinds, allCallbackKinds),
 		// Standalone Activities
 		testcore.WithDynamicConfig(activity.Enabled, true),
 		testcore.WithDynamicConfig(activity.EnableCallbacks, true),
-		testcore.WithDynamicConfig(activity.EnabledCallbackKinds, []callbacks.Kind{callbacks.KindNexus}),
+		testcore.WithDynamicConfig(activity.EnabledCallbackKinds, allCallbackKinds),
 		// Standalone Nexus operations
 		testcore.WithDynamicConfig(nexusoperation.Enabled, true),
-		testcore.WithDynamicConfig(nexusoperation.EnabledCallbackKinds, []callbacks.Kind{callbacks.KindNexus}),
+		testcore.WithDynamicConfig(nexusoperation.EnabledCallbackKinds, allCallbackKinds),
 		// All Callbacks and Retry policy
 		testcore.WithDynamicConfig(callback.AllowedAddresses,
 			[]any{map[string]any{"Pattern": "*", "AllowInsecure": true}}),
 		testcore.WithDynamicConfig(callback.RetryPolicyInitialInterval, 10*time.Millisecond),
-		testcore.WithDynamicConfig(callback.RetryPolicyMaximumInterval, 20*time.Millisecond),
+		testcore.WithDynamicConfig(callback.RetryPolicyMaximumInterval, 50*time.Millisecond),
 		// Circuit breaker. Timeout is how long the breaker stays open before half-opening
 		// (and trying to send a request again). It defaults to 60s which is too long for a
 		// unit test to observe. But 1s is too short, and tests couldn't detect the BLOCKED
@@ -85,12 +86,12 @@ func (s *CompletionCallbacksSuite) forEachTestCombination(testFn completionCallb
 	}
 
 	// Types of callback targets.
-	// COMING SOON: The NexusHandler-variant.
 	callbackTargets := []struct {
 		Name                string
 		CBTargetConstructor newCompletionCallbackTargetFn
 	}{
 		{"Nexus", newNexusCompletionCallbackTarget},
+		{"NexusHandler", newNexusHandlerCompletionCallbackTarget},
 	}
 
 	// Run the testcase against all combinations of execution types and callback variants.
@@ -170,17 +171,7 @@ func (s *CompletionCallbacksSuite) TestUnsupportedVariants() {
 					&commonpb.Callback{Variant: nil},
 					"unknown callback variant: <nil>",
 				},
-				{
-					"NexusHandler",
-					&commonpb.Callback{
-						Variant: &commonpb.Callback_NexusHandler_{
-							NexusHandler: &commonpb.Callback_NexusHandler{
-								// Should be rejected based on type, not its contents.
-							},
-						},
-					},
-					"nexusHandler callbacks are not enabled for this execution type",
-				},
+				// All other variants are enabled by default for this test suite.
 			}
 
 			for _, tc := range cases {


### PR DESCRIPTION
⚠️ This is part of a stacked PR set, to be merged into `feature/worker-callbacks`. This will not go directly into `main`, until the overall feature is code complete.

---

## What changed?

THIS IS IT! The actual PR that implements `NexusHandler`-variant callbacks!

This PR provides the implementation of the `NexusHandler`-variant callback in the CHASM Callback component. A `NexusHandler`-variant completion callback attached to a Workflow, Workflow Update, standalone Activity, or standalone Nexus Operation will result in a Nexus operation being invoked within the same namespace.

**Additional changes/refactorings**

The `CallbackInfo.BlockedReason` is now properly set. Previously it was left unimplemented in CHASM, and only callbacks attached to Workflows would report their status. We now wire through a `destinationBlocked DestinationBlockedFn` with the CHASM context for Callbacks, and inject it via `CallbackDestinationBlockedProvider ` in `service/history/fx.go`.

**Quirks/issues**

We deliver all completion callbacks using the same request ID. This means however, that if multiple completion callbacks to the same (task queue, service, operation) were added in the same request (e.g. to `StartNexusOperationExecution`.) then all of the worker callback invocations would carry the same request ID. The Nexus handler could interpret subsequent calls as duplicates and ignore them.

This is something we can fix, by persisting a little more information in `CallbackState` but it didn't seem like a realistic scenario; attaching multiple worker callbacks, in the same request, to the same taskqueue/operation.


## Why?

This is the new worker callbacks feature that will make developing "Nexus Connectors" (AKA fronting a Nexus service by a different API protocol) easier.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)

## Potential risks

While behind configuration flags, it's possible to attach a Worker-variant callback to Workflows, Workflow Updates, standalone Activities, and standalone Nexus Operations. In all cases they should behave the exact same. But there is opportunity for some subtle difference to cause problems.

NOTE: Worker-variant callbacks are NOT supported for HSM-backed workflows. Attaching a Worker callback to an HSM workflow will fail in glorious ways.
