### PR TITLE
replication: emit lifecycle error events

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1720,7 +1720,7 @@ leaves the membership ring, giving in-flight long-polls time to drain before the
 	EmitReplicationLifecycleEvents = NewGlobalBoolSetting(
 		"history.emitReplicationLifecycleEvents",
 		false,
-		`EmitReplicationLifecycleEvents controls whether the history service emits ReplicationLifecycle wide events (sent/executing/applied phases). Cluster-level; default off.`,
+		`EmitReplicationLifecycleEvents controls whether the history service emits ReplicationLifecycle wide events (sent/executing/applied/skipped/error phases). Cluster-level; default off.`,
 	)
 	EnableCloseInboundReplicationStreamOnShutdown = NewGlobalBoolSetting(
 		"history.enableCloseInboundReplicationStreamOnShutdown",

--- a/common/wideevents/context.go
+++ b/common/wideevents/context.go
@@ -4,11 +4,12 @@ import "context"
 
 type replicationTaskOriginCtxKey struct{}
 
-// ReplicationTaskOrigin identifies where a replicated artifact came from; diagnostic only. TaskID is
-// unset when the applied artifact was re-fetched rather than being that queue entry's own payload.
+// ReplicationTaskOrigin identifies the source task whose processing produced an event.
 type ReplicationTaskOrigin struct {
-	ShardID int32
-	TaskID  int64
+	ClusterName    string
+	ShardID        int32
+	TaskID         int64
+	ArtifactOrigin string
 }
 
 // SetReplicationTaskOrigin stamps origin onto ctx.

--- a/common/wideevents/context.go
+++ b/common/wideevents/context.go
@@ -6,10 +6,10 @@ type replicationTaskOriginCtxKey struct{}
 
 // ReplicationTaskOrigin identifies the source task whose processing produced an event.
 type ReplicationTaskOrigin struct {
-	ClusterName    string
-	ShardID        int32
-	TaskID         int64
-	ArtifactOrigin string
+	ClusterName         string
+	ShardID             int32
+	TaskID              int64
+	ApplyArtifactSource ReplicationApplyArtifactSource
 }
 
 // SetReplicationTaskOrigin stamps origin onto ctx.

--- a/common/wideevents/replication_events.go
+++ b/common/wideevents/replication_events.go
@@ -56,6 +56,7 @@ const (
 	ReplOperationPassiveTaskExecution             = "passive_task_execution"
 	ReplOperationPassiveApply                     = "passive_apply"
 	ReplOperationStandbyVerification              = "standby_verification"
+	ReplOperationStandbyTaskExecution             = "standby_task_execution"
 	ReplOperationSyncState                        = "sync_state"
 	ReplOperationSyncStateApply                   = "sync_state_apply"
 	ReplOperationSyncVersionedTransitionSyncState = "sync_versioned_transition_sync_state"

--- a/common/wideevents/replication_events.go
+++ b/common/wideevents/replication_events.go
@@ -14,6 +14,9 @@ const ReplicationLifecycleEventName = "replication_lifecycle"
 
 type ReplicationPhase string
 
+// ReplicationDisposition is the stable action or outcome vocabulary stored in details.disposition.
+type ReplicationDisposition string
+
 const (
 	ReplicationSent      ReplicationPhase = "sent"
 	ReplicationExecuting ReplicationPhase = "executing"
@@ -24,6 +27,20 @@ const (
 	// ends. See StreamSenderImpl.recordStuckTaskSkipped.
 	ReplicationSkipped ReplicationPhase = "skipped"
 	ReplicationError   ReplicationPhase = "error"
+)
+
+const (
+	ReplDispositionError         ReplicationDisposition = "error"
+	ReplDispositionRetry         ReplicationDisposition = "retry"
+	ReplDispositionDiscarded     ReplicationDisposition = "discarded"
+	ReplDispositionDropped       ReplicationDisposition = "dropped"
+	ReplDispositionCleanup       ReplicationDisposition = "cleanup"
+	ReplDispositionSkipped       ReplicationDisposition = "skipped"
+	ReplDispositionAbandoned     ReplicationDisposition = "abandoned"
+	ReplDispositionEnqueued      ReplicationDisposition = "enqueued"
+	ReplDispositionSyncState     ReplicationDisposition = "sync_state"
+	ReplDispositionResendHistory ReplicationDisposition = "resend_history"
+	ReplDispositionDuplicate     ReplicationDisposition = "duplicate"
 )
 
 const (

--- a/common/wideevents/replication_events.go
+++ b/common/wideevents/replication_events.go
@@ -14,8 +14,15 @@ const ReplicationLifecycleEventName = "replication_lifecycle"
 
 type ReplicationPhase string
 
-// ReplicationDisposition is the stable action or outcome vocabulary stored in details.disposition.
+// ReplicationDisposition records what the task owner will do with the original replication task
+// after the error. It does not describe where the error occurred, its cause, or a recovery action.
 type ReplicationDisposition string
+
+// ReplicationRecoveryAction records a compensating action selected in response to an error.
+type ReplicationRecoveryAction string
+
+// ReplicationErrorClassification adds a queryable semantic classification to an error.
+type ReplicationErrorClassification string
 
 const (
 	ReplicationSent      ReplicationPhase = "sent"
@@ -30,17 +37,19 @@ const (
 )
 
 const (
-	ReplDispositionError         ReplicationDisposition = "error"
-	ReplDispositionRetry         ReplicationDisposition = "retry"
-	ReplDispositionDiscarded     ReplicationDisposition = "discarded"
-	ReplDispositionDropped       ReplicationDisposition = "dropped"
-	ReplDispositionCleanup       ReplicationDisposition = "cleanup"
-	ReplDispositionSkipped       ReplicationDisposition = "skipped"
-	ReplDispositionAbandoned     ReplicationDisposition = "abandoned"
-	ReplDispositionEnqueued      ReplicationDisposition = "enqueued"
-	ReplDispositionSyncState     ReplicationDisposition = "sync_state"
-	ReplDispositionResendHistory ReplicationDisposition = "resend_history"
-	ReplDispositionDuplicate     ReplicationDisposition = "duplicate"
+	ReplDispositionRetry     ReplicationDisposition = "retry"
+	ReplDispositionDiscarded ReplicationDisposition = "discarded"
+	ReplDispositionDLQ       ReplicationDisposition = "dlq"
+)
+
+const (
+	ReplRecoveryActionCleanup       ReplicationRecoveryAction = "cleanup"
+	ReplRecoveryActionSyncState     ReplicationRecoveryAction = "sync_state"
+	ReplRecoveryActionResendHistory ReplicationRecoveryAction = "resend_history"
+)
+
+const (
+	ReplErrorClassificationDuplicate ReplicationErrorClassification = "duplicate"
 )
 
 const (
@@ -63,8 +72,9 @@ const (
 	ArtifactKindMutation = "mutation"
 )
 
-// Stable values stored in the details column for replication error events. Details remains
-// extensible, but these values form the small queryable vocabulary shared by all emitters.
+// Replication operation identifies the stage or action that encountered the error. Disposition,
+// recovery_action, and classification describe what happens next and how to interpret the error;
+// they are independent of operation and remain optional fields in details.
 const (
 	ReplOperationTaskExecution                    = "task_execution"
 	ReplOperationTaskConversion                   = "task_conversion"

--- a/common/wideevents/replication_events.go
+++ b/common/wideevents/replication_events.go
@@ -1,12 +1,15 @@
 package wideevents
 
 import (
+	"maps"
+
 	"go.opentelemetry.io/otel/log"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/util"
 )
 
 // ReplicationLifecycleEventName is the stable event name for the ReplicationLifecycle wide event,
-// which traces a replication task sent -> executing -> applied.
+// which traces a replication task through sent, executing, applied, skipped, and error phases.
 const ReplicationLifecycleEventName = "replication_lifecycle"
 
 type ReplicationPhase string
@@ -20,6 +23,7 @@ const (
 	// wedging the stream. Such a task never reaches executing/applied, so this is where its trace
 	// ends. See StreamSenderImpl.recordStuckTaskSkipped.
 	ReplicationSkipped ReplicationPhase = "skipped"
+	ReplicationError   ReplicationPhase = "error"
 )
 
 const (
@@ -42,8 +46,57 @@ const (
 	ArtifactKindMutation = "mutation"
 )
 
+// Stable values stored in the details column for replication error events. Details remains
+// extensible, but these values form the small queryable vocabulary shared by all emitters.
+const (
+	ReplOperationTaskExecution                    = "task_execution"
+	ReplOperationTaskConversion                   = "task_conversion"
+	ReplOperationRateLimit                        = "rate_limit"
+	ReplOperationStreamSend                       = "stream_send"
+	ReplOperationPassiveTaskExecution             = "passive_task_execution"
+	ReplOperationPassiveApply                     = "passive_apply"
+	ReplOperationStandbyVerification              = "standby_verification"
+	ReplOperationSyncState                        = "sync_state"
+	ReplOperationSyncStateApply                   = "sync_state_apply"
+	ReplOperationSyncVersionedTransitionSyncState = "sync_versioned_transition_sync_state"
+	ReplOperationSyncWorkflowStateSyncState       = "sync_workflow_state_sync_state"
+	ReplOperationStandbyVerificationSyncState     = "standby_verification_sync_state"
+	ReplOperationHistoryBackfill                  = "history_backfill"
+	ReplOperationHistoryResend                    = "history_resend"
+	ReplOperationHistoryBranchCleanup             = "history_branch_cleanup"
+	ReplOperationNamespaceSync                    = "namespace_sync"
+	ReplOperationDLQWrite                         = "dlq_write"
+	ReplArtifactOriginTaskPayload                 = "task_payload"
+	ReplArtifactOriginSyncStateRefetch            = "sync_state_refetch"
+)
+
+// EmitReplicationError normalizes the common error envelope and emits it into the existing
+// replication_lifecycle event, not a separate event table.
+func EmitReplicationError(
+	logger log.Logger,
+	payload ReplicationLifecyclePayload,
+	operation string,
+	message string,
+	err error,
+	extraDetails map[string]any,
+) {
+	details := make(map[string]any, len(payload.Details)+len(extraDetails)+4)
+	maps.Copy(details, payload.Details)
+	maps.Copy(details, extraDetails)
+	details["operation"] = operation
+	details["message"] = message
+	if err != nil {
+		details["error"] = err.Error()
+		details["error_type"] = util.ErrorType(err)
+	}
+
+	payload.Phase = ReplicationError
+	payload.Details = details
+	Emit(logger, payload)
+}
+
 type ReplicationLifecyclePayload struct {
-	// Phase is sent, executing, applied or skipped.
+	// Phase is sent, executing, applied, skipped or error.
 	Phase ReplicationPhase
 	// TaskType is which replication task this is.
 	TaskType string

--- a/common/wideevents/replication_events.go
+++ b/common/wideevents/replication_events.go
@@ -24,6 +24,9 @@ type ReplicationRecoveryAction string
 // ReplicationErrorClassification adds a queryable semantic classification to an error.
 type ReplicationErrorClassification string
 
+// ReplicationApplyArtifactSource records how the state artifact supplied to an apply was obtained.
+type ReplicationApplyArtifactSource string
+
 const (
 	ReplicationSent      ReplicationPhase = "sent"
 	ReplicationExecuting ReplicationPhase = "executing"
@@ -50,6 +53,11 @@ const (
 
 const (
 	ReplErrorClassificationDuplicate ReplicationErrorClassification = "duplicate"
+)
+
+const (
+	ReplApplyArtifactSourceTaskPayload      ReplicationApplyArtifactSource = "task_payload"
+	ReplApplyArtifactSourceSyncStateRefetch ReplicationApplyArtifactSource = "sync_state_refetch"
 )
 
 const (
@@ -94,8 +102,6 @@ const (
 	ReplOperationHistoryBranchCleanup             = "history_branch_cleanup"
 	ReplOperationNamespaceSync                    = "namespace_sync"
 	ReplOperationDLQWrite                         = "dlq_write"
-	ReplArtifactOriginTaskPayload                 = "task_payload"
-	ReplArtifactOriginSyncStateRefetch            = "sync_state_refetch"
 )
 
 // EmitReplicationError normalizes the common error envelope and emits it into the existing

--- a/service/history/ndc/workflow_state_replicator.go
+++ b/service/history/ndc/workflow_state_replicator.go
@@ -415,8 +415,8 @@ func (r *WorkflowStateReplicatorImpl) emitReplicationVersionedTransitionApplied(
 		SourceShard:   origin.ShardID,
 		SourceTaskID:  origin.TaskID,
 	}
-	if origin.ArtifactOrigin != "" {
-		payload.Details = map[string]any{"artifact_origin": origin.ArtifactOrigin}
+	if origin.ApplyArtifactSource != "" {
+		payload.Details = map[string]any{"apply_artifact_source": origin.ApplyArtifactSource}
 	}
 	if ms != nil {
 		info := ms.GetExecutionInfo()
@@ -530,8 +530,8 @@ func (r *WorkflowStateReplicatorImpl) emitReplicationError(
 	payload.Details = map[string]any{
 		"target_cluster": r.clusterMetadata.GetCurrentClusterName(),
 	}
-	if origin.ArtifactOrigin != "" {
-		payload.Details["artifact_origin"] = origin.ArtifactOrigin
+	if origin.ApplyArtifactSource != "" {
+		payload.Details["apply_artifact_source"] = origin.ApplyArtifactSource
 	}
 	wideevents.EmitReplicationError(r.eventLogger, payload, operation, message, err, details)
 }

--- a/service/history/ndc/workflow_state_replicator.go
+++ b/service/history/ndc/workflow_state_replicator.go
@@ -117,9 +117,8 @@ func (r *WorkflowStateReplicatorImpl) SyncWorkflowState(
 	namespaceID := namespace.ID(executionInfo.GetNamespaceId())
 	wid := executionInfo.GetWorkflowId()
 	rid := executionState.GetRunId()
-	emitError := r.eventLogger != nil && r.shardContext.GetConfig().EmitReplicationLifecycleEvents()
 	defer func() {
-		if emitError && retError != nil {
+		if retError != nil {
 			r.emitReplicationApplyError(
 				ctx, wideevents.ReplTaskSyncWorkflowState, request.GetRemoteCluster(), executionInfo, executionState,
 				"snapshot", "Failed to apply replicated workflow state", retError)
@@ -516,6 +515,10 @@ func (r *WorkflowStateReplicatorImpl) emitReplicationError(
 	err error,
 	details map[string]any,
 ) {
+	if r.eventLogger == nil || !r.shardContext.GetConfig().EmitReplicationLifecycleEvents() {
+		return
+	}
+
 	origin := wideevents.ReplicationTaskOriginFromContext(ctx)
 	if name, nsErr := r.namespaceRegistry.GetNamespaceName(namespace.ID(payload.NamespaceID)); nsErr == nil {
 		payload.Namespace = name.String()
@@ -868,16 +871,14 @@ func (r *WorkflowStateReplicatorImpl) deleteNewBranchWhenError(
 			tag.WorkflowID(workflowID),
 			tag.WorkflowRunID(runID),
 			tag.ShardID(r.shardContext.GetShardID()))
-		if r.shardContext.GetConfig().EmitReplicationLifecycleEvents() {
-			r.emitReplicationError(ctx, wideevents.ReplicationLifecyclePayload{
-				TaskType:    wideevents.ReplTaskSyncVersionedTransition,
-				NamespaceID: namespaceID.String(),
-				WorkflowID:  workflowID,
-				RunID:       runID,
-			}, "", wideevents.ReplOperationHistoryBranchCleanup, "History branch cleanup skipped after apply error; branch may be orphaned", err, map[string]any{
-				"archetype_id": archetypeID,
-			})
-		}
+		r.emitReplicationError(ctx, wideevents.ReplicationLifecyclePayload{
+			TaskType:    wideevents.ReplTaskSyncVersionedTransition,
+			NamespaceID: namespaceID.String(),
+			WorkflowID:  workflowID,
+			RunID:       runID,
+		}, "", wideevents.ReplOperationHistoryBranchCleanup, "History branch cleanup skipped after apply error; branch may be orphaned", err, map[string]any{
+			"archetype_id": archetypeID,
+		})
 	}
 }
 

--- a/service/history/ndc/workflow_state_replicator.go
+++ b/service/history/ndc/workflow_state_replicator.go
@@ -419,6 +419,9 @@ func (r *WorkflowStateReplicatorImpl) emitReplicationVersionedTransitionApplied(
 		SourceShard:   origin.ShardID,
 		SourceTaskID:  origin.TaskID,
 	}
+	if origin.ArtifactOrigin != "" {
+		payload.Details = map[string]any{"artifact_origin": origin.ArtifactOrigin}
+	}
 	if ms != nil {
 		info := ms.GetExecutionInfo()
 		state := ms.GetExecutionState()

--- a/service/history/ndc/workflow_state_replicator.go
+++ b/service/history/ndc/workflow_state_replicator.go
@@ -501,7 +501,7 @@ func (r *WorkflowStateReplicatorImpl) emitReplicationApplyError(
 		"artifact_kind": artifactKind,
 	}
 	if errors.Is(err, consts.ErrDuplicate) {
-		details["disposition"] = "duplicate"
+		details["disposition"] = wideevents.ReplDispositionDuplicate
 	}
 	r.emitReplicationError(ctx, payload, sourceClusterName, wideevents.ReplOperationPassiveApply, message, err, details)
 }

--- a/service/history/ndc/workflow_state_replicator.go
+++ b/service/history/ndc/workflow_state_replicator.go
@@ -117,6 +117,14 @@ func (r *WorkflowStateReplicatorImpl) SyncWorkflowState(
 	namespaceID := namespace.ID(executionInfo.GetNamespaceId())
 	wid := executionInfo.GetWorkflowId()
 	rid := executionState.GetRunId()
+	emitError := r.eventLogger != nil && r.shardContext.GetConfig().EmitReplicationLifecycleEvents()
+	defer func() {
+		if emitError && retError != nil && !errors.Is(retError, consts.ErrDuplicate) {
+			r.emitReplicationApplyError(
+				ctx, wideevents.ReplTaskSyncWorkflowState, request.GetRemoteCluster(), executionInfo, executionState,
+				"snapshot", "Failed to apply replicated workflow state", retError)
+		}
+	}()
 	if executionState.State != enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED {
 		return serviceerror.NewInternal("Replicate non completed workflow state is not supported.")
 	}
@@ -240,18 +248,26 @@ func (r *WorkflowStateReplicatorImpl) ReplicateVersionedTransition(
 	wid := executionInfo.GetWorkflowId()
 	rid := executionState.GetRunId()
 
-	// emitApplied gates the best-effort "applied" lifecycle event; computed once here so the gate
-	// lives at the call site, like the other replication lifecycle emitters.
-	emitApplied := r.eventLogger != nil && r.shardContext.GetConfig().EmitReplicationLifecycleEvents()
+	// emitLifecycle gates the best-effort applied/error lifecycle event; computed once here so the
+	// gate lives at the call site, like the other replication lifecycle emitters.
+	emitLifecycle := r.eventLogger != nil && r.shardContext.GetConfig().EmitReplicationLifecycleEvents()
 	// ms is the mutable state being applied; appliedMS is a snapshot of its post-apply state taken
 	// under the workflow lock (see the releaseFn wrapper below) for the deferred emit. Reading the
 	// live ms after the lock is released would race with the next writer.
 	var ms historyi.MutableState
 	var appliedMS *persistencespb.WorkflowMutableState
 	origin := wideevents.ReplicationTaskOriginFromContext(ctx)
+	artifactKind := "mutation"
+	if snapshot != nil {
+		artifactKind = "snapshot"
+	}
 	defer func() {
-		if emitApplied && retError == nil {
+		if emitLifecycle && retError == nil {
 			r.emitReplicationVersionedTransitionApplied(namespaceID, wid, rid, appliedMS, sourceClusterName, origin)
+		} else if emitLifecycle && !errors.Is(retError, consts.ErrDuplicate) {
+			r.emitReplicationApplyError(
+				ctx, wideevents.ReplTaskSyncVersionedTransition, sourceClusterName, executionInfo, executionState,
+				artifactKind, "Failed to apply replicated versioned transition", retError)
 		}
 	}()
 
@@ -269,7 +285,7 @@ func (r *WorkflowStateReplicatorImpl) ReplicateVersionedTransition(
 	if err != nil {
 		return err
 	}
-	if emitApplied {
+	if emitLifecycle {
 		// Snapshot the post-apply mutable state at release time: the only point that is both after
 		// the apply (which mutates ms in place) and still under the workflow lock, since the apply
 		// releases via the transaction manager.
@@ -442,6 +458,62 @@ func (r *WorkflowStateReplicatorImpl) emitReplicationVersionedTransitionApplied(
 	}
 
 	wideevents.Emit(r.eventLogger, payload)
+}
+
+// emitReplicationApplyError extracts artifact identity before delegating to the apply-side adapter.
+func (r *WorkflowStateReplicatorImpl) emitReplicationApplyError(
+	ctx context.Context,
+	taskType string,
+	sourceClusterName string,
+	info *persistencespb.WorkflowExecutionInfo,
+	state *persistencespb.WorkflowExecutionState,
+	artifactKind string,
+	message string,
+	err error,
+) {
+	payload := wideevents.ReplicationLifecyclePayload{
+		TaskType:    taskType,
+		NamespaceID: info.GetNamespaceId(),
+		WorkflowID:  info.GetWorkflowId(),
+		RunID:       state.GetRunId(),
+	}
+	if vt := transitionhistory.LastVersionedTransition(info.GetTransitionHistory()); vt != nil {
+		payload.FailoverVersion = vt.GetNamespaceFailoverVersion()
+		payload.TransitionCount = vt.GetTransitionCount()
+	}
+	r.emitReplicationError(ctx, payload, sourceClusterName, wideevents.ReplOperationPassiveApply, message, err, map[string]any{
+		"artifact_kind": artifactKind,
+	})
+}
+
+// emitReplicationError supplies fields authoritative on the applying cluster.
+func (r *WorkflowStateReplicatorImpl) emitReplicationError(
+	ctx context.Context,
+	payload wideevents.ReplicationLifecyclePayload,
+	sourceClusterName string,
+	operation string,
+	message string,
+	err error,
+	details map[string]any,
+) {
+	origin := wideevents.ReplicationTaskOriginFromContext(ctx)
+	if name, nsErr := r.namespaceRegistry.GetNamespaceName(namespace.ID(payload.NamespaceID)); nsErr == nil {
+		payload.Namespace = name.String()
+	}
+	payload.Shard = r.shardContext.GetShardID()
+	if sourceClusterName == "" {
+		sourceClusterName = origin.ClusterName
+	}
+	payload.SourceCluster = sourceClusterName
+	payload.SourceShard = origin.ShardID
+	payload.SourceTaskID = origin.TaskID
+	payload.Details = map[string]any{
+		"target_cluster": r.clusterMetadata.GetCurrentClusterName(),
+	}
+	if origin.ArtifactOrigin != "" {
+		payload.Details["artifact_origin"] = origin.ArtifactOrigin
+	}
+	wideevents.EmitReplicationError(r.eventLogger, payload, operation, message, err, details)
 }
 
 // populateAppliedExecutionSummary fills the post-apply mutable-state summary fields shared across
@@ -776,6 +848,16 @@ func (r *WorkflowStateReplicatorImpl) deleteNewBranchWhenError(
 			tag.WorkflowID(workflowID),
 			tag.WorkflowRunID(runID),
 			tag.ShardID(r.shardContext.GetShardID()))
+		if r.shardContext.GetConfig().EmitReplicationLifecycleEvents() {
+			r.emitReplicationError(ctx, wideevents.ReplicationLifecyclePayload{
+				TaskType:    wideevents.ReplTaskSyncVersionedTransition,
+				NamespaceID: namespaceID.String(),
+				WorkflowID:  workflowID,
+				RunID:       runID,
+			}, "", wideevents.ReplOperationHistoryBranchCleanup, "History branch cleanup skipped after apply error; branch may be orphaned", err, map[string]any{
+				"archetype_id": archetypeID,
+			})
+		}
 	}
 }
 

--- a/service/history/ndc/workflow_state_replicator.go
+++ b/service/history/ndc/workflow_state_replicator.go
@@ -501,7 +501,7 @@ func (r *WorkflowStateReplicatorImpl) emitReplicationApplyError(
 		"artifact_kind": artifactKind,
 	}
 	if errors.Is(err, consts.ErrDuplicate) {
-		details["disposition"] = wideevents.ReplDispositionDuplicate
+		details["classification"] = wideevents.ReplErrorClassificationDuplicate
 	}
 	r.emitReplicationError(ctx, payload, sourceClusterName, wideevents.ReplOperationPassiveApply, message, err, details)
 }

--- a/service/history/ndc/workflow_state_replicator.go
+++ b/service/history/ndc/workflow_state_replicator.go
@@ -119,7 +119,7 @@ func (r *WorkflowStateReplicatorImpl) SyncWorkflowState(
 	rid := executionState.GetRunId()
 	emitError := r.eventLogger != nil && r.shardContext.GetConfig().EmitReplicationLifecycleEvents()
 	defer func() {
-		if emitError && retError != nil && !errors.Is(retError, consts.ErrDuplicate) {
+		if emitError && retError != nil {
 			r.emitReplicationApplyError(
 				ctx, wideevents.ReplTaskSyncWorkflowState, request.GetRemoteCluster(), executionInfo, executionState,
 				"snapshot", "Failed to apply replicated workflow state", retError)
@@ -260,7 +260,7 @@ func (r *WorkflowStateReplicatorImpl) ReplicateVersionedTransition(
 	defer func() {
 		if emitLifecycle && retError == nil {
 			r.emitReplicationVersionedTransitionApplied(namespaceID, wid, rid, appliedMS, sourceClusterName, origin)
-		} else if emitLifecycle && !errors.Is(retError, consts.ErrDuplicate) {
+		} else if emitLifecycle {
 			r.emitReplicationVersionedTransitionApplyError(
 				ctx, wideevents.ReplTaskSyncVersionedTransition, sourceClusterName, executionInfo, executionState,
 				versionedTransitionArtifact, "Failed to apply replicated versioned transition", retError)
@@ -497,9 +497,13 @@ func (r *WorkflowStateReplicatorImpl) emitReplicationApplyError(
 		payload.FailoverVersion = vt.GetNamespaceFailoverVersion()
 		payload.TransitionCount = vt.GetTransitionCount()
 	}
-	r.emitReplicationError(ctx, payload, sourceClusterName, wideevents.ReplOperationPassiveApply, message, err, map[string]any{
+	details := map[string]any{
 		"artifact_kind": artifactKind,
-	})
+	}
+	if errors.Is(err, consts.ErrDuplicate) {
+		details["disposition"] = "duplicate"
+	}
+	r.emitReplicationError(ctx, payload, sourceClusterName, wideevents.ReplOperationPassiveApply, message, err, details)
 }
 
 // emitReplicationError supplies fields authoritative on the applying cluster.

--- a/service/history/ndc/workflow_state_replicator.go
+++ b/service/history/ndc/workflow_state_replicator.go
@@ -257,17 +257,13 @@ func (r *WorkflowStateReplicatorImpl) ReplicateVersionedTransition(
 	var ms historyi.MutableState
 	var appliedMS *persistencespb.WorkflowMutableState
 	origin := wideevents.ReplicationTaskOriginFromContext(ctx)
-	artifactKind := "mutation"
-	if snapshot != nil {
-		artifactKind = "snapshot"
-	}
 	defer func() {
 		if emitLifecycle && retError == nil {
 			r.emitReplicationVersionedTransitionApplied(namespaceID, wid, rid, appliedMS, sourceClusterName, origin)
 		} else if emitLifecycle && !errors.Is(retError, consts.ErrDuplicate) {
-			r.emitReplicationApplyError(
+			r.emitReplicationVersionedTransitionApplyError(
 				ctx, wideevents.ReplTaskSyncVersionedTransition, sourceClusterName, executionInfo, executionState,
-				artifactKind, "Failed to apply replicated versioned transition", retError)
+				versionedTransitionArtifact, "Failed to apply replicated versioned transition", retError)
 		}
 	}()
 
@@ -461,6 +457,23 @@ func (r *WorkflowStateReplicatorImpl) emitReplicationVersionedTransitionApplied(
 	}
 
 	wideevents.Emit(r.eventLogger, payload)
+}
+
+func (r *WorkflowStateReplicatorImpl) emitReplicationVersionedTransitionApplyError(
+	ctx context.Context,
+	taskType string,
+	sourceClusterName string,
+	info *persistencespb.WorkflowExecutionInfo,
+	state *persistencespb.WorkflowExecutionState,
+	artifact *replicationspb.VersionedTransitionArtifact,
+	message string,
+	err error,
+) {
+	artifactKind := wideevents.ArtifactKindMutation
+	if artifact.GetSyncWorkflowStateSnapshotAttributes() != nil {
+		artifactKind = wideevents.ArtifactKindSnapshot
+	}
+	r.emitReplicationApplyError(ctx, taskType, sourceClusterName, info, state, artifactKind, message, err)
 }
 
 // emitReplicationApplyError extracts artifact identity before delegating to the apply-side adapter.

--- a/service/history/outbound_queue_standby_task_executor.go
+++ b/service/history/outbound_queue_standby_task_executor.go
@@ -69,6 +69,7 @@ func (e *outboundQueueStandbyTaskExecutor) Execute(
 		executable.GetWorkflowID(),
 	)
 	respond := func(err error) queues.ExecuteResponse {
+		emitStandbyTaskError(e.shardContext, executable, taskType, err)
 		metricsTags := []metrics.Tag{
 			namespaceTag,
 			metrics.TaskTypeTag(taskType),

--- a/service/history/replication/executable_sync_versioned_transition_task.go
+++ b/service/history/replication/executable_sync_versioned_transition_task.go
@@ -103,7 +103,7 @@ func (e *ExecutableSyncVersionedTransitionTask) Execute() error {
 
 	ctx, cancel := newTaskContext(namespaceName, e.Config.ReplicationTaskApplyTimeout(), callerInfo)
 	defer cancel()
-	ctx = setReplicationTaskOrigin(ctx, e.ExecutableTask, wideevents.ReplArtifactOriginTaskPayload)
+	ctx = setReplicationTaskOrigin(ctx, e.ExecutableTask, wideevents.ReplApplyArtifactSourceTaskPayload)
 	shardContext, err := e.ShardController.GetShardByNamespaceWorkflow(
 		namespace.ID(e.NamespaceID),
 		e.WorkflowID,

--- a/service/history/replication/executable_sync_versioned_transition_task.go
+++ b/service/history/replication/executable_sync_versioned_transition_task.go
@@ -103,10 +103,7 @@ func (e *ExecutableSyncVersionedTransitionTask) Execute() error {
 
 	ctx, cancel := newTaskContext(namespaceName, e.Config.ReplicationTaskApplyTimeout(), callerInfo)
 	defer cancel()
-	ctx = wideevents.SetReplicationTaskOrigin(ctx, wideevents.ReplicationTaskOrigin{
-		ShardID: e.SourceShardKey().ShardID,
-		TaskID:  e.TaskID(),
-	})
+	ctx = setReplicationTaskOrigin(ctx, e.ExecutableTask, wideevents.ReplArtifactOriginTaskPayload)
 	shardContext, err := e.ShardController.GetShardByNamespaceWorkflow(
 		namespace.ID(e.NamespaceID),
 		e.WorkflowID,
@@ -144,6 +141,7 @@ func (e *ExecutableSyncVersionedTransitionTask) HandleErr(err error) error {
 		tag.TaskID(e.TaskID()),
 		tag.Error(err),
 	)
+	emitExecutableTaskError(e.ExecutableTask, wideevents.ReplOperationPassiveTaskExecution, "SyncVersionedTransition replication task encountered error", err, nil)
 	callerInfo := getReplicaitonCallerInfo(e.GetPriority())
 	switch taskErr := err.(type) {
 	case *serviceerrors.SyncState:
@@ -170,6 +168,7 @@ func (e *ExecutableSyncVersionedTransitionTask) HandleErr(err error) error {
 					tag.TaskID(e.TaskID()),
 					tag.Error(syncStateErr),
 				)
+				emitExecutableTaskError(e.ExecutableTask, wideevents.ReplOperationSyncVersionedTransitionSyncState, "SyncVersionedTransition recovery failed during sync state", syncStateErr, nil)
 				return err
 			}
 			return nil
@@ -226,6 +225,10 @@ func (e *ExecutableSyncVersionedTransitionTask) HandleErr(err error) error {
 			endEventVersion,
 			"",
 		); resendErr != nil {
+			emitExecutableTaskError(e.ExecutableTask, wideevents.ReplOperationHistoryBackfill, "SyncVersionedTransition history backfill failed", resendErr, map[string]any{
+				"first_event_id": startEvent,
+				"last_event_id":  endEvent,
+			})
 			return err
 		}
 		return e.Execute()

--- a/service/history/replication/executable_task.go
+++ b/service/history/replication/executable_task.go
@@ -752,7 +752,7 @@ func (e *ExecutableTaskImpl) SyncState(
 		if errors.As(err, &workflowNotReady) {
 			logger.Info("Dropped replication task as source mutable state has buffered events.", tag.Error(err))
 			e.emitReplicationTaskError(wideevents.ReplOperationSyncState, "Dropped replication task because source mutable state has buffered events", err, map[string]any{
-				"disposition": "dropped",
+				"disposition": wideevents.ReplDispositionDropped,
 			})
 			return false, nil
 		}
@@ -761,7 +761,7 @@ func (e *ExecutableTaskImpl) SyncState(
 			logger.Error(
 				"workflow not found in source cluster, proceed to cleanup")
 			e.emitReplicationTaskError(wideevents.ReplOperationSyncState, "Workflow not found in source cluster; cleaning up target", err, map[string]any{
-				"disposition": "cleanup",
+				"disposition": wideevents.ReplDispositionCleanup,
 			})
 			// workflow is not found in source cluster, cleanup workflow in target cluster
 			return false, e.DeleteWorkflow(
@@ -785,7 +785,7 @@ func (e *ExecutableTaskImpl) SyncState(
 			// Just drop the task since there's nothing to replicate in event-based stack.
 			logger.Info("Dropped replication task as there's no event-based replication task equivalent.")
 			e.emitReplicationTaskError(wideevents.ReplOperationSyncState, "Dropped replication task because no event-based equivalent exists", err, map[string]any{
-				"disposition": "dropped",
+				"disposition": wideevents.ReplDispositionDropped,
 			})
 			return false, nil
 		}
@@ -886,7 +886,7 @@ func (e *ExecutableTaskImpl) GetNamespaceInfo(
 		if err != nil {
 			e.ThrottledLogger.Error("Failed to SyncNamespaceFromSourceCluster", tag.Error(err))
 			e.emitReplicationTaskError(wideevents.ReplOperationNamespaceSync, "Failed to refresh namespace from source cluster; replication task skipped", err, map[string]any{
-				"disposition": "skipped",
+				"disposition": wideevents.ReplDispositionSkipped,
 			})
 			return "", false, nil
 		}
@@ -928,7 +928,7 @@ func (e *ExecutableTaskImpl) MarkPoisonPill() error {
 		)
 		e.emitReplicationTaskError(wideevents.ReplOperationDLQWrite, "Writing replication task to DLQ reached maximum attempts", nil, map[string]any{
 			"dlq_attempt": e.markPoisonPillAttempts,
-			"disposition": "abandoned",
+			"disposition": wideevents.ReplDispositionAbandoned,
 			"terminal":    true,
 		})
 		return nil
@@ -970,7 +970,7 @@ func (e *ExecutableTaskImpl) MarkPoisonPill() error {
 	}
 	e.emitReplicationTaskError(wideevents.ReplOperationDLQWrite, "Enqueued replication task to DLQ", nil, map[string]any{
 		"target_shard": shardContext.GetShardID(),
-		"disposition":  "enqueued",
+		"disposition":  wideevents.ReplDispositionEnqueued,
 		"terminal":     true,
 	})
 	return nil

--- a/service/history/replication/executable_task.go
+++ b/service/history/replication/executable_task.go
@@ -198,6 +198,9 @@ func (e *ExecutableTaskImpl) Nack(err error) {
 		"replication task: %v encountered nack event",
 		e.taskID,
 	), tag.Error(err))
+	e.emitReplicationTaskError(wideevents.ReplOperationTaskExecution, "Replication task encountered nack event", err, map[string]any{
+		"terminal": true,
+	})
 	now := time.Now().UTC()
 	e.emitFinishMetrics(now)
 
@@ -733,6 +736,9 @@ func (e *ExecutableTaskImpl) SyncState(
 	if err != nil {
 		var resourceExhaustedError *serviceerror.ResourceExhausted
 		if errors.As(err, &resourceExhaustedError) {
+			e.emitReplicationTaskError(wideevents.ReplOperationSyncState, "Sync workflow state request exceeded resource limits", err, map[string]any{
+				"request_payload_size": req.Size(),
+			})
 			return false, serviceerror.NewInvalidArgumentf("sync workflow state failed due to resource exhausted: %v, request payload size: %v", err, req.Size())
 		}
 		logger := log.With(e.Logger,
@@ -745,12 +751,18 @@ func (e *ExecutableTaskImpl) SyncState(
 		var workflowNotReady *serviceerror.WorkflowNotReady
 		if errors.As(err, &workflowNotReady) {
 			logger.Info("Dropped replication task as source mutable state has buffered events.", tag.Error(err))
+			e.emitReplicationTaskError(wideevents.ReplOperationSyncState, "Dropped replication task because source mutable state has buffered events", err, map[string]any{
+				"disposition": "dropped",
+			})
 			return false, nil
 		}
 		var notFoundErr *serviceerror.NotFound
 		if errors.As(err, &notFoundErr) {
 			logger.Error(
 				"workflow not found in source cluster, proceed to cleanup")
+			e.emitReplicationTaskError(wideevents.ReplOperationSyncState, "Workflow not found in source cluster; cleaning up target", err, map[string]any{
+				"disposition": "cleanup",
+			})
 			// workflow is not found in source cluster, cleanup workflow in target cluster
 			return false, e.DeleteWorkflow(
 				ctx,
@@ -772,6 +784,9 @@ func (e *ExecutableTaskImpl) SyncState(
 		if len(taskEquivalents) == 0 {
 			// Just drop the task since there's nothing to replicate in event-based stack.
 			logger.Info("Dropped replication task as there's no event-based replication task equivalent.")
+			e.emitReplicationTaskError(wideevents.ReplOperationSyncState, "Dropped replication task because no event-based equivalent exists", err, map[string]any{
+				"disposition": "dropped",
+			})
 			return false, nil
 		}
 
@@ -788,10 +803,21 @@ func (e *ExecutableTaskImpl) SyncState(
 			})
 		}
 
+		fallbackCause := err
 		_, err := remoteAdminClient.AddTasks(ctx, &adminservice.AddTasksRequest{
 			ShardId: e.sourceShardKey.ShardID,
 			Tasks:   tasksToAdd,
 		})
+		if err != nil {
+			e.emitReplicationTaskError(wideevents.ReplOperationSyncState, "Failed to enqueue event-based replication task equivalents", err, map[string]any{
+				"equivalent_count": len(tasksToAdd),
+			})
+		} else {
+			e.emitReplicationTaskError(wideevents.ReplOperationSyncState, "Fell back to event-based replication task equivalents", fallbackCause, map[string]any{
+				"disposition":      "fallback_enqueued",
+				"equivalent_count": len(tasksToAdd),
+			})
+		}
 		return false, err
 	}
 
@@ -806,12 +832,14 @@ func (e *ExecutableTaskImpl) SyncState(
 	if err != nil {
 		return false, err
 	}
-	// No TaskID: this artifact was re-fetched from the source, so it is not this task's payload.
-	ctx = wideevents.SetReplicationTaskOrigin(ctx, wideevents.ReplicationTaskOrigin{ShardID: e.sourceShardKey.ShardID})
+	ctx = setReplicationTaskOrigin(ctx, e, wideevents.ReplArtifactOriginSyncStateRefetch)
 	err = engine.ReplicateVersionedTransition(ctx, syncStateErr.ArchetypeId, resp.VersionedTransitionArtifact, e.SourceClusterName())
 	if err == nil || errors.Is(err, consts.ErrDuplicate) {
 		return true, nil
 	}
+	e.emitReplicationTaskError(wideevents.ReplOperationSyncStateApply, "Failed to apply mutable state refetched from source", err, map[string]any{
+		"artifact_origin": wideevents.ReplArtifactOriginSyncStateRefetch,
+	})
 	return false, err
 }
 
@@ -863,6 +891,9 @@ func (e *ExecutableTaskImpl) GetNamespaceInfo(
 		_, err = e.EagerNamespaceRefresher.SyncNamespaceFromSourceCluster(ctx, namespace.ID(namespaceID), e.sourceClusterName)
 		if err != nil {
 			e.ThrottledLogger.Error("Failed to SyncNamespaceFromSourceCluster", tag.Error(err))
+			e.emitReplicationTaskError(wideevents.ReplOperationNamespaceSync, "Failed to refresh namespace from source cluster; replication task skipped", err, map[string]any{
+				"disposition": "skipped",
+			})
 			return "", false, nil
 		}
 	default:
@@ -901,6 +932,11 @@ func (e *ExecutableTaskImpl) MarkPoisonPill() error {
 			tag.SourceCluster(e.SourceClusterName()),
 			tag.ReplicationTask(taskInfo),
 		)
+		e.emitReplicationTaskError(wideevents.ReplOperationDLQWrite, "Writing replication task to DLQ reached maximum attempts", nil, map[string]any{
+			"dlq_attempt": e.markPoisonPillAttempts,
+			"disposition": "abandoned",
+			"terminal":    true,
+		})
 		return nil
 	}
 	e.markPoisonPillAttempts++
@@ -931,7 +967,19 @@ func (e *ExecutableTaskImpl) MarkPoisonPill() error {
 	)
 	defer cancel()
 
-	return writeTaskToDLQ(ctx, e.DLQWriter, e.sourceShardKey.ShardID, e.SourceClusterName(), shardContext.GetShardID(), taskInfo)
+	err = writeTaskToDLQ(ctx, e.DLQWriter, e.sourceShardKey.ShardID, e.SourceClusterName(), shardContext.GetShardID(), taskInfo)
+	if err != nil {
+		e.emitReplicationTaskError(wideevents.ReplOperationDLQWrite, "Failed to enqueue replication task to DLQ", err, map[string]any{
+			"target_shard": shardContext.GetShardID(),
+		})
+		return err
+	}
+	e.emitReplicationTaskError(wideevents.ReplOperationDLQWrite, "Enqueued replication task to DLQ", nil, map[string]any{
+		"target_shard": shardContext.GetShardID(),
+		"disposition":  "enqueued",
+		"terminal":     true,
+	})
+	return nil
 }
 
 func newTaskContext(

--- a/service/history/replication/executable_task.go
+++ b/service/history/replication/executable_task.go
@@ -826,13 +826,13 @@ func (e *ExecutableTaskImpl) SyncState(
 	if err != nil {
 		return false, err
 	}
-	ctx = setReplicationTaskOrigin(ctx, e, wideevents.ReplArtifactOriginSyncStateRefetch)
+	ctx = setReplicationTaskOrigin(ctx, e, wideevents.ReplApplyArtifactSourceSyncStateRefetch)
 	err = engine.ReplicateVersionedTransition(ctx, syncStateErr.ArchetypeId, resp.VersionedTransitionArtifact, e.SourceClusterName())
 	if err == nil || errors.Is(err, consts.ErrDuplicate) {
 		return true, nil
 	}
 	e.emitReplicationTaskError(wideevents.ReplOperationSyncStateApply, "Failed to apply mutable state refetched from source", err, map[string]any{
-		"artifact_origin": wideevents.ReplArtifactOriginSyncStateRefetch,
+		"apply_artifact_source": wideevents.ReplApplyArtifactSourceSyncStateRefetch,
 	})
 	return false, err
 }

--- a/service/history/replication/executable_task.go
+++ b/service/history/replication/executable_task.go
@@ -943,7 +943,7 @@ func (e *ExecutableTaskImpl) MarkPoisonPill() error {
 		return err
 	}
 
-	e.Logger.Error("Enqueued replication task to DLQ",
+	dlqLogger := log.With(e.Logger,
 		tag.TargetShardID(shardContext.GetShardID()),
 		tag.SourceShardID(e.sourceShardKey.ShardID),
 		tag.WorkflowNamespaceID(e.replicationTask.RawTaskInfo.NamespaceId),
@@ -963,11 +963,13 @@ func (e *ExecutableTaskImpl) MarkPoisonPill() error {
 
 	err = writeTaskToDLQ(ctx, e.DLQWriter, e.sourceShardKey.ShardID, e.SourceClusterName(), shardContext.GetShardID(), taskInfo)
 	if err != nil {
+		dlqLogger.Error("Failed to enqueue replication task to DLQ", tag.Error(err))
 		e.emitReplicationTaskError(wideevents.ReplOperationDLQWrite, "Failed to enqueue replication task to DLQ", err, map[string]any{
 			"target_shard": shardContext.GetShardID(),
 		})
 		return err
 	}
+	dlqLogger.Error("Enqueued replication task to DLQ")
 	e.emitReplicationTaskError(wideevents.ReplOperationDLQWrite, "Enqueued replication task to DLQ", nil, map[string]any{
 		"target_shard": shardContext.GetShardID(),
 		"disposition":  wideevents.ReplDispositionEnqueued,

--- a/service/history/replication/executable_task.go
+++ b/service/history/replication/executable_task.go
@@ -752,7 +752,7 @@ func (e *ExecutableTaskImpl) SyncState(
 		if errors.As(err, &workflowNotReady) {
 			logger.Info("Dropped replication task as source mutable state has buffered events.", tag.Error(err))
 			e.emitReplicationTaskError(wideevents.ReplOperationSyncState, "Dropped replication task because source mutable state has buffered events", err, map[string]any{
-				"disposition": wideevents.ReplDispositionDropped,
+				"disposition": wideevents.ReplDispositionDiscarded,
 			})
 			return false, nil
 		}
@@ -761,7 +761,7 @@ func (e *ExecutableTaskImpl) SyncState(
 			logger.Error(
 				"workflow not found in source cluster, proceed to cleanup")
 			e.emitReplicationTaskError(wideevents.ReplOperationSyncState, "Workflow not found in source cluster; cleaning up target", err, map[string]any{
-				"disposition": wideevents.ReplDispositionCleanup,
+				"recovery_action": wideevents.ReplRecoveryActionCleanup,
 			})
 			// workflow is not found in source cluster, cleanup workflow in target cluster
 			return false, e.DeleteWorkflow(
@@ -785,7 +785,7 @@ func (e *ExecutableTaskImpl) SyncState(
 			// Just drop the task since there's nothing to replicate in event-based stack.
 			logger.Info("Dropped replication task as there's no event-based replication task equivalent.")
 			e.emitReplicationTaskError(wideevents.ReplOperationSyncState, "Dropped replication task because no event-based equivalent exists", err, map[string]any{
-				"disposition": wideevents.ReplDispositionDropped,
+				"disposition": wideevents.ReplDispositionDiscarded,
 			})
 			return false, nil
 		}
@@ -886,7 +886,7 @@ func (e *ExecutableTaskImpl) GetNamespaceInfo(
 		if err != nil {
 			e.ThrottledLogger.Error("Failed to SyncNamespaceFromSourceCluster", tag.Error(err))
 			e.emitReplicationTaskError(wideevents.ReplOperationNamespaceSync, "Failed to refresh namespace from source cluster; replication task skipped", err, map[string]any{
-				"disposition": wideevents.ReplDispositionSkipped,
+				"disposition": wideevents.ReplDispositionDiscarded,
 			})
 			return "", false, nil
 		}
@@ -928,7 +928,7 @@ func (e *ExecutableTaskImpl) MarkPoisonPill() error {
 		)
 		e.emitReplicationTaskError(wideevents.ReplOperationDLQWrite, "Writing replication task to DLQ reached maximum attempts", nil, map[string]any{
 			"dlq_attempt": e.markPoisonPillAttempts,
-			"disposition": wideevents.ReplDispositionAbandoned,
+			"disposition": wideevents.ReplDispositionDiscarded,
 			"terminal":    true,
 		})
 		return nil
@@ -972,7 +972,7 @@ func (e *ExecutableTaskImpl) MarkPoisonPill() error {
 	dlqLogger.Error("Enqueued replication task to DLQ")
 	e.emitReplicationTaskError(wideevents.ReplOperationDLQWrite, "Enqueued replication task to DLQ", nil, map[string]any{
 		"target_shard": shardContext.GetShardID(),
-		"disposition":  wideevents.ReplDispositionEnqueued,
+		"disposition":  wideevents.ReplDispositionDLQ,
 		"terminal":     true,
 	})
 	return nil

--- a/service/history/replication/executable_task.go
+++ b/service/history/replication/executable_task.go
@@ -803,18 +803,12 @@ func (e *ExecutableTaskImpl) SyncState(
 			})
 		}
 
-		fallbackCause := err
 		_, err := remoteAdminClient.AddTasks(ctx, &adminservice.AddTasksRequest{
 			ShardId: e.sourceShardKey.ShardID,
 			Tasks:   tasksToAdd,
 		})
 		if err != nil {
 			e.emitReplicationTaskError(wideevents.ReplOperationSyncState, "Failed to enqueue event-based replication task equivalents", err, map[string]any{
-				"equivalent_count": len(tasksToAdd),
-			})
-		} else {
-			e.emitReplicationTaskError(wideevents.ReplOperationSyncState, "Fell back to event-based replication task equivalents", fallbackCause, map[string]any{
-				"disposition":      "fallback_enqueued",
 				"equivalent_count": len(tasksToAdd),
 			})
 		}

--- a/service/history/replication/executable_verify_versioned_transition_task.go
+++ b/service/history/replication/executable_verify_versioned_transition_task.go
@@ -310,7 +310,7 @@ func (e *ExecutableVerifyVersionedTransitionTask) HandleErr(err error) error {
 	)
 	details := map[string]any{}
 	if _, ok := err.(*serviceerrors.SyncState); ok {
-		details["disposition"] = wideevents.ReplDispositionSyncState
+		details["recovery_action"] = wideevents.ReplRecoveryActionSyncState
 	}
 	emitExecutableTaskError(e.ExecutableTask, wideevents.ReplOperationStandbyVerification, "Standby versioned transition verification failed", err, details)
 	switch taskErr := err.(type) {

--- a/service/history/replication/executable_verify_versioned_transition_task.go
+++ b/service/history/replication/executable_verify_versioned_transition_task.go
@@ -310,7 +310,7 @@ func (e *ExecutableVerifyVersionedTransitionTask) HandleErr(err error) error {
 	)
 	details := map[string]any{}
 	if _, ok := err.(*serviceerrors.SyncState); ok {
-		details["disposition"] = "sync_state"
+		details["disposition"] = wideevents.ReplDispositionSyncState
 	}
 	emitExecutableTaskError(e.ExecutableTask, wideevents.ReplOperationStandbyVerification, "Standby versioned transition verification failed", err, details)
 	switch taskErr := err.(type) {

--- a/service/history/replication/executable_verify_versioned_transition_task.go
+++ b/service/history/replication/executable_verify_versioned_transition_task.go
@@ -308,6 +308,11 @@ func (e *ExecutableVerifyVersionedTransitionTask) HandleErr(err error) error {
 		tag.TaskID(e.TaskID()),
 		tag.Error(err),
 	)
+	details := map[string]any{}
+	if _, ok := err.(*serviceerrors.SyncState); ok {
+		details["disposition"] = "sync_state"
+	}
+	emitExecutableTaskError(e.ExecutableTask, wideevents.ReplOperationStandbyVerification, "Standby versioned transition verification failed", err, details)
 	switch taskErr := err.(type) {
 	case *serviceerrors.SyncState:
 		callerInfo := getReplicaitonCallerInfo(e.GetPriority())
@@ -334,6 +339,7 @@ func (e *ExecutableVerifyVersionedTransitionTask) HandleErr(err error) error {
 					tag.TaskID(e.TaskID()),
 					tag.Error(syncStateErr),
 				)
+				emitExecutableTaskError(e.ExecutableTask, wideevents.ReplOperationStandbyVerificationSyncState, "Standby verification recovery failed during sync state", syncStateErr, nil)
 				return err
 			}
 			return nil

--- a/service/history/replication/executable_workflow_state_task.go
+++ b/service/history/replication/executable_workflow_state_task.go
@@ -109,7 +109,7 @@ func (e *ExecutableWorkflowStateTask) Execute() error {
 	}
 	ctx, cancel := newTaskContext(namespaceName, e.Config.ReplicationTaskApplyTimeout(), callerInfo)
 	defer cancel()
-	ctx = setReplicationTaskOrigin(ctx, e.ExecutableTask, wideevents.ReplArtifactOriginTaskPayload)
+	ctx = setReplicationTaskOrigin(ctx, e.ExecutableTask, wideevents.ReplApplyArtifactSourceTaskPayload)
 
 	shardContext, err := e.ShardController.GetShardByNamespaceWorkflow(
 		namespace.ID(e.NamespaceID),

--- a/service/history/replication/executable_workflow_state_task.go
+++ b/service/history/replication/executable_workflow_state_task.go
@@ -141,9 +141,9 @@ func (e *ExecutableWorkflowStateTask) HandleErr(err error) error {
 		details := map[string]any{}
 		switch err.(type) {
 		case *serviceerrors.SyncState:
-			details["disposition"] = wideevents.ReplDispositionSyncState
+			details["recovery_action"] = wideevents.ReplRecoveryActionSyncState
 		case *serviceerrors.RetryReplication:
-			details["disposition"] = wideevents.ReplDispositionResendHistory
+			details["recovery_action"] = wideevents.ReplRecoveryActionResendHistory
 		default:
 		}
 		emitExecutableTaskError(e.ExecutableTask, wideevents.ReplOperationPassiveTaskExecution, "SyncWorkflowState replication task encountered error", err, details)

--- a/service/history/replication/executable_workflow_state_task.go
+++ b/service/history/replication/executable_workflow_state_task.go
@@ -109,6 +109,7 @@ func (e *ExecutableWorkflowStateTask) Execute() error {
 	}
 	ctx, cancel := newTaskContext(namespaceName, e.Config.ReplicationTaskApplyTimeout(), callerInfo)
 	defer cancel()
+	ctx = setReplicationTaskOrigin(ctx, e.ExecutableTask, wideevents.ReplArtifactOriginTaskPayload)
 
 	shardContext, err := e.ShardController.GetShardByNamespaceWorkflow(
 		namespace.ID(e.NamespaceID),
@@ -134,6 +135,18 @@ func (e *ExecutableWorkflowStateTask) HandleErr(err error) error {
 	if errors.Is(err, consts.ErrDuplicate) {
 		e.MarkTaskDuplicated()
 		return nil
+	}
+	var notFoundErr *serviceerror.NotFound
+	if err != nil && !errors.As(err, &notFoundErr) {
+		details := map[string]any{}
+		switch err.(type) {
+		case *serviceerrors.SyncState:
+			details["disposition"] = "sync_state"
+		case *serviceerrors.RetryReplication:
+			details["disposition"] = "resend_history"
+		default:
+		}
+		emitExecutableTaskError(e.ExecutableTask, wideevents.ReplOperationPassiveTaskExecution, "SyncWorkflowState replication task encountered error", err, details)
 	}
 	callerInfo := getReplicaitonCallerInfo(e.GetPriority())
 	switch retryErr := err.(type) {
@@ -161,6 +174,7 @@ func (e *ExecutableWorkflowStateTask) HandleErr(err error) error {
 					tag.TaskID(e.TaskID()),
 					tag.Error(syncStateErr),
 				)
+				emitExecutableTaskError(e.ExecutableTask, wideevents.ReplOperationSyncWorkflowStateSyncState, "SyncWorkflowState recovery failed during sync state", syncStateErr, nil)
 				return err
 			}
 			return nil
@@ -185,6 +199,9 @@ func (e *ExecutableWorkflowStateTask) HandleErr(err error) error {
 			retryErr,
 			ResendAttempt,
 		); resendErr != nil || !doContinue {
+			if resendErr != nil {
+				emitExecutableTaskError(e.ExecutableTask, wideevents.ReplOperationHistoryResend, "SyncWorkflowState history resend failed", resendErr, nil)
+			}
 			return err
 		}
 		return e.Execute()

--- a/service/history/replication/executable_workflow_state_task.go
+++ b/service/history/replication/executable_workflow_state_task.go
@@ -141,9 +141,9 @@ func (e *ExecutableWorkflowStateTask) HandleErr(err error) error {
 		details := map[string]any{}
 		switch err.(type) {
 		case *serviceerrors.SyncState:
-			details["disposition"] = "sync_state"
+			details["disposition"] = wideevents.ReplDispositionSyncState
 		case *serviceerrors.RetryReplication:
-			details["disposition"] = "resend_history"
+			details["disposition"] = wideevents.ReplDispositionResendHistory
 		default:
 		}
 		emitExecutableTaskError(e.ExecutableTask, wideevents.ReplOperationPassiveTaskExecution, "SyncWorkflowState replication task encountered error", err, details)

--- a/service/history/replication/replication_events.go
+++ b/service/history/replication/replication_events.go
@@ -1,7 +1,9 @@
 package replication
 
 import (
+	"context"
 	"errors"
+	"maps"
 
 	commonpb "go.temporal.io/api/common/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
@@ -19,6 +21,185 @@ import (
 	"go.temporal.io/server/common/wideevents"
 	"go.temporal.io/server/service/history/tasks"
 )
+
+func replicationLifecycleTaskType(taskType enumsspb.ReplicationTaskType) (string, bool) {
+	switch taskType {
+	case enumsspb.REPLICATION_TASK_TYPE_SYNC_WORKFLOW_STATE_TASK:
+		return wideevents.ReplTaskSyncWorkflowState, true
+	case enumsspb.REPLICATION_TASK_TYPE_SYNC_VERSIONED_TRANSITION_TASK:
+		return wideevents.ReplTaskSyncVersionedTransition, true
+	case enumsspb.REPLICATION_TASK_TYPE_VERIFY_VERSIONED_TRANSITION_TASK:
+		return wideevents.ReplTaskVerifyVersionedTransition, true
+	default:
+		return "", false
+	}
+}
+
+func stateBasedTaskTypeFromHistoryTask(taskType enumsspb.TaskType) (string, bool) {
+	switch taskType {
+	case enumsspb.TASK_TYPE_REPLICATION_SYNC_WORKFLOW_STATE:
+		return wideevents.ReplTaskSyncWorkflowState, true
+	case enumsspb.TASK_TYPE_REPLICATION_SYNC_VERSIONED_TRANSITION:
+		return wideevents.ReplTaskSyncVersionedTransition, true
+	default:
+		return "", false
+	}
+}
+
+// emitReplicationTaskError emits a context-rich error phase for an executable task. Identity is
+// resolved here so individual error sites cannot accidentally omit source or target context.
+func (e *ExecutableTaskImpl) emitReplicationTaskError(
+	operation string,
+	message string,
+	err error,
+	details map[string]any,
+) {
+	if !e.Config.EmitReplicationLifecycleEvents() {
+		return
+	}
+	if e.replicationTask == nil {
+		return
+	}
+	taskType, ok := replicationLifecycleTaskType(e.replicationTask.GetTaskType())
+	if !ok {
+		return
+	}
+
+	namespaceID, workflowID, runID := e.workflowKeyFromTask()
+	if namespaceID == "" || workflowID == "" {
+		return
+	}
+	shardContext, shardErr := e.ShardController.GetShardByNamespaceWorkflow(
+		namespace.ID(namespaceID),
+		workflowID,
+	)
+	if shardErr != nil || shardContext.GetEventLogger() == nil {
+		return
+	}
+
+	namespaceName := e.NamespaceName()
+	if namespaceName == "" {
+		if name, nsErr := e.NamespaceCache.GetNamespaceName(namespace.ID(namespaceID)); nsErr == nil {
+			namespaceName = name.String()
+		}
+	}
+	if details == nil {
+		details = make(map[string]any, 4)
+	} else {
+		details = maps.Clone(details)
+	}
+	details["attempt"] = e.Attempt()
+	details["priority"] = e.GetPriority().String()
+	details["target_cluster"] = e.ClusterMetadata.GetCurrentClusterName()
+	if _, ok := details["artifact_origin"]; !ok {
+		details["artifact_origin"] = wideevents.ReplArtifactOriginTaskPayload
+	}
+	sourceTaskID := e.replicationTask.GetSourceTaskId()
+	if sourceTaskID == 0 {
+		sourceTaskID = e.TaskID()
+	}
+
+	payload := wideevents.ReplicationLifecyclePayload{
+		TaskType:      taskType,
+		Shard:         shardContext.GetShardID(),
+		Namespace:     namespaceName,
+		NamespaceID:   namespaceID,
+		WorkflowID:    workflowID,
+		RunID:         runID,
+		SourceCluster: e.SourceClusterName(),
+		SourceShard:   e.SourceShardKey().ShardID,
+		SourceTaskID:  sourceTaskID,
+	}
+	if vt := e.replicationTask.GetVersionedTransition(); vt != nil {
+		payload.FailoverVersion = vt.GetNamespaceFailoverVersion()
+		payload.TransitionCount = vt.GetTransitionCount()
+	}
+	wideevents.EmitReplicationError(shardContext.GetEventLogger(), payload, operation, message, err, details)
+}
+
+type replicationErrorEmitter interface {
+	emitReplicationTaskError(string, string, error, map[string]any)
+}
+
+func setReplicationTaskOrigin(
+	ctx context.Context,
+	task ExecutableTask,
+	artifactOrigin string,
+) context.Context {
+	taskImpl, ok := task.(*ExecutableTaskImpl)
+	if !ok {
+		return ctx
+	}
+	return wideevents.SetReplicationTaskOrigin(ctx, wideevents.ReplicationTaskOrigin{
+		ClusterName:    taskImpl.sourceClusterName,
+		ShardID:        taskImpl.sourceShardKey.ShardID,
+		TaskID:         taskImpl.taskID,
+		ArtifactOrigin: artifactOrigin,
+	})
+}
+
+func emitExecutableTaskError(
+	task ExecutableTask,
+	operation string,
+	message string,
+	err error,
+	details map[string]any,
+) {
+	if emitter, ok := task.(replicationErrorEmitter); ok {
+		emitter.emitReplicationTaskError(operation, message, err, details)
+	}
+}
+
+func (s *StreamSenderImpl) emitReplicationSenderError(
+	item tasks.Task,
+	replicationTaskType enumsspb.ReplicationTaskType,
+	priority enumsspb.TaskPriority,
+	attempt int64,
+	operation string,
+	message string,
+	err error,
+) {
+	taskType, ok := stateBasedTaskTypeFromHistoryTask(item.GetType())
+	if !ok {
+		return
+	}
+	if convertedTaskType, ok := replicationLifecycleTaskType(replicationTaskType); ok {
+		taskType = convertedTaskType
+	}
+	logger := s.shardContext.GetEventLogger()
+	if logger == nil {
+		return
+	}
+	namespaceID := item.GetNamespaceID()
+	namespaceName := ""
+	if name, nsErr := s.shardContext.GetNamespaceRegistry().GetNamespaceName(namespace.ID(namespaceID)); nsErr == nil {
+		namespaceName = name.String()
+	}
+	details := map[string]any{
+		"attempt":        attempt,
+		"priority":       priority.String(),
+		"target_cluster": s.clientClusterName,
+		"target_shard":   s.clientShardKey.ShardID,
+	}
+	wideevents.EmitReplicationError(
+		logger,
+		wideevents.ReplicationLifecyclePayload{
+			TaskType:      taskType,
+			Shard:         s.serverShardKey.ShardID,
+			Namespace:     namespaceName,
+			NamespaceID:   namespaceID,
+			WorkflowID:    item.GetWorkflowID(),
+			RunID:         item.GetRunID(),
+			SourceCluster: s.shardContext.GetClusterMetadata().GetCurrentClusterName(),
+			SourceShard:   s.serverShardKey.ShardID,
+			SourceTaskID:  item.GetTaskID(),
+		},
+		operation,
+		message,
+		err,
+		details,
+	)
+}
 
 // emitReplicationExecuting emits a best-effort "executing" ReplicationLifecycle event when an
 // executable replication task is picked up to execute on the target cluster. It never affects

--- a/service/history/replication/replication_events.go
+++ b/service/history/replication/replication_events.go
@@ -91,8 +91,8 @@ func (e *ExecutableTaskImpl) emitReplicationTaskError(
 	details["attempt"] = e.Attempt()
 	details["priority"] = e.GetPriority().String()
 	details["target_cluster"] = e.ClusterMetadata.GetCurrentClusterName()
-	if _, ok := details["artifact_origin"]; !ok {
-		details["artifact_origin"] = wideevents.ReplArtifactOriginTaskPayload
+	if _, ok := details["apply_artifact_source"]; !ok {
+		details["apply_artifact_source"] = wideevents.ReplApplyArtifactSourceTaskPayload
 	}
 	sourceTaskID := e.replicationTask.GetSourceTaskId()
 	if sourceTaskID == 0 {
@@ -124,17 +124,17 @@ type replicationErrorEmitter interface {
 func setReplicationTaskOrigin(
 	ctx context.Context,
 	task ExecutableTask,
-	artifactOrigin string,
+	applyArtifactSource wideevents.ReplicationApplyArtifactSource,
 ) context.Context {
 	taskImpl, ok := task.(*ExecutableTaskImpl)
 	if !ok {
 		return ctx
 	}
 	return wideevents.SetReplicationTaskOrigin(ctx, wideevents.ReplicationTaskOrigin{
-		ClusterName:    taskImpl.sourceClusterName,
-		ShardID:        taskImpl.sourceShardKey.ShardID,
-		TaskID:         taskImpl.taskID,
-		ArtifactOrigin: artifactOrigin,
+		ClusterName:         taskImpl.sourceClusterName,
+		ShardID:             taskImpl.sourceShardKey.ShardID,
+		TaskID:              taskImpl.taskID,
+		ApplyArtifactSource: applyArtifactSource,
 	})
 }
 

--- a/service/history/replication/stream_sender.go
+++ b/service/history/replication/stream_sender.go
@@ -28,6 +28,7 @@ import (
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/quotas"
+	"go.temporal.io/server/common/wideevents"
 	"go.temporal.io/server/service/history/configs"
 	historyi "go.temporal.io/server/service/history/interfaces"
 	"go.temporal.io/server/service/history/shard"
@@ -591,7 +592,14 @@ Loop:
 				// Wrap as convertError so isSkippable can tell "the task could not be built"
 				// (its source info is corrupt/unusable) apart from transient send/rate-limit
 				// failures, which must not be skipped.
-				return s.recordRetry(item, attempt, &convertError{err: fmt.Errorf("convert: %w", err)})
+				return s.recordRetry(
+					item,
+					enumsspb.REPLICATION_TASK_TYPE_UNSPECIFIED,
+					priority,
+					attempt,
+					wideevents.ReplOperationTaskConversion,
+					&convertError{err: fmt.Errorf("convert: %w", err)},
+				)
 			}
 			if task == nil {
 				return nil
@@ -622,7 +630,7 @@ Loop:
 					0,
 					"",
 				)); err != nil {
-					return s.recordRetry(item, attempt, fmt.Errorf("rate_limit: %w", err))
+					return s.recordRetry(item, task.GetTaskType(), priority, attempt, wideevents.ReplOperationRateLimit, fmt.Errorf("rate_limit: %w", err))
 				}
 				metrics.ReplicationRateLimitLatency.With(s.metrics).Record(time.Since(rlStartTime), metrics.OperationTag(TaskOperationTag(task)))
 			}
@@ -639,7 +647,7 @@ Loop:
 					},
 				},
 			}); err != nil {
-				return s.recordRetry(item, attempt, fmt.Errorf("send: %w", err))
+				return s.recordRetry(item, task.GetTaskType(), priority, attempt, wideevents.ReplOperationStreamSend, fmt.Errorf("send: %w", err))
 			}
 			skipCount = 0
 			metrics.ReplicationTasksSend.With(s.metrics).Record(
@@ -792,7 +800,10 @@ func (s *StreamSenderImpl) getTaskTargetCluster(task tasks.Task) []string {
 
 func (s *StreamSenderImpl) recordRetry(
 	item tasks.Task,
+	replicationTaskType enumsspb.ReplicationTaskType,
+	priority enumsspb.TaskPriority,
 	attempt int64,
+	operation string,
 	err error,
 ) error {
 	s.shardContext.GetThrottledLogger().Warn("Replication task send retry",
@@ -802,6 +813,9 @@ func (s *StreamSenderImpl) recordRetry(
 		tag.Counter(int(attempt)),
 		tag.Error(err),
 	)
+	if s.config.EmitReplicationLifecycleEvents() {
+		s.emitReplicationSenderError(item, replicationTaskType, priority, attempt, operation, "Replication task send retry", err)
+	}
 	return err
 }
 

--- a/service/history/standby_task_events.go
+++ b/service/history/standby_task_events.go
@@ -34,21 +34,19 @@ func emitStandbyTaskError(
 		activeCluster = entry.ActiveClusterName(namespace.RoutingKey{ID: task.GetWorkflowID()})
 	}
 
-	disposition := wideevents.ReplDispositionError
-	if errors.Is(err, consts.ErrTaskRetry) {
-		disposition = wideevents.ReplDispositionRetry
-	} else if errors.Is(err, consts.ErrTaskDiscarded) {
-		disposition = wideevents.ReplDispositionDiscarded
-	}
 	details := map[string]any{
 		"active_cluster":  activeCluster,
 		"attempt":         executable.Attempt(),
 		"category":        task.GetCategory().Name(),
-		"disposition":     disposition,
 		"local_task_id":   task.GetTaskID(),
 		"local_task_type": task.GetType().String(),
 		"target_cluster":  shardContext.GetClusterMetadata().GetCurrentClusterName(),
 		"visibility_time": task.GetVisibilityTime().Format(time.RFC3339Nano),
+	}
+	if errors.Is(err, consts.ErrTaskRetry) {
+		details["disposition"] = wideevents.ReplDispositionRetry
+	} else if errors.Is(err, consts.ErrTaskDiscarded) {
+		details["disposition"] = wideevents.ReplDispositionDiscarded
 	}
 	if versionedTask, ok := task.(tasks.HasVersion); ok {
 		details["version"] = versionedTask.GetVersion()

--- a/service/history/standby_task_events.go
+++ b/service/history/standby_task_events.go
@@ -34,11 +34,11 @@ func emitStandbyTaskError(
 		activeCluster = entry.ActiveClusterName(namespace.RoutingKey{ID: task.GetWorkflowID()})
 	}
 
-	disposition := "error"
+	disposition := wideevents.ReplDispositionError
 	if errors.Is(err, consts.ErrTaskRetry) {
-		disposition = "retry"
+		disposition = wideevents.ReplDispositionRetry
 	} else if errors.Is(err, consts.ErrTaskDiscarded) {
-		disposition = "discarded"
+		disposition = wideevents.ReplDispositionDiscarded
 	}
 	details := map[string]any{
 		"active_cluster":  activeCluster,

--- a/service/history/standby_task_events.go
+++ b/service/history/standby_task_events.go
@@ -1,0 +1,68 @@
+package history
+
+import (
+	"errors"
+	"time"
+
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/wideevents"
+	"go.temporal.io/server/service/history/consts"
+	historyi "go.temporal.io/server/service/history/interfaces"
+	"go.temporal.io/server/service/history/queues"
+	"go.temporal.io/server/service/history/tasks"
+)
+
+func emitStandbyTaskError(
+	shardContext historyi.ShardContext,
+	executable queues.Executable,
+	taskType string,
+	err error,
+) {
+	if err == nil || !shardContext.GetConfig().EmitReplicationLifecycleEvents() {
+		return
+	}
+	eventLogger := shardContext.GetEventLogger()
+	if eventLogger == nil {
+		return
+	}
+
+	task := executable.GetTask()
+	namespaceName := ""
+	activeCluster := ""
+	if entry, nsErr := shardContext.GetNamespaceRegistry().GetNamespaceByID(namespace.ID(task.GetNamespaceID())); nsErr == nil {
+		namespaceName = entry.Name().String()
+		activeCluster = entry.ActiveClusterName(namespace.RoutingKey{ID: task.GetWorkflowID()})
+	}
+
+	disposition := "error"
+	if errors.Is(err, consts.ErrTaskRetry) {
+		disposition = "retry"
+	} else if errors.Is(err, consts.ErrTaskDiscarded) {
+		disposition = "discarded"
+	}
+	details := map[string]any{
+		"active_cluster":  activeCluster,
+		"attempt":         executable.Attempt(),
+		"category":        task.GetCategory().Name(),
+		"disposition":     disposition,
+		"local_task_id":   task.GetTaskID(),
+		"local_task_type": task.GetType().String(),
+		"target_cluster":  shardContext.GetClusterMetadata().GetCurrentClusterName(),
+		"visibility_time": task.GetVisibilityTime().Format(time.RFC3339Nano),
+	}
+	if versionedTask, ok := task.(tasks.HasVersion); ok {
+		details["version"] = versionedTask.GetVersion()
+	}
+	if destinationTask, ok := task.(tasks.HasDestination); ok {
+		details["destination"] = destinationTask.GetDestination()
+	}
+
+	wideevents.EmitReplicationError(eventLogger, wideevents.ReplicationLifecyclePayload{
+		TaskType:    taskType,
+		Shard:       shardContext.GetShardID(),
+		Namespace:   namespaceName,
+		NamespaceID: task.GetNamespaceID(),
+		WorkflowID:  task.GetWorkflowID(),
+		RunID:       task.GetRunID(),
+	}, wideevents.ReplOperationStandbyTaskExecution, "Standby queue task execution failed", err, details)
+}

--- a/service/history/timer_queue_standby_task_executor.go
+++ b/service/history/timer_queue_standby_task_executor.go
@@ -115,6 +115,7 @@ func (t *timerQueueStandbyTaskExecutor) Execute(
 	default:
 		err = queueserrors.NewUnprocessableTaskError("unknown task type")
 	}
+	emitStandbyTaskError(t.shardContext, executable, taskTypeTagValue, err)
 
 	return queues.ExecuteResponse{
 		ExecutionMetricTags: metricsTags,

--- a/service/history/transfer_queue_standby_task_executor.go
+++ b/service/history/transfer_queue_standby_task_executor.go
@@ -112,6 +112,7 @@ func (t *transferQueueStandbyTaskExecutor) Execute(
 	default:
 		err = errUnknownTransferTask
 	}
+	emitStandbyTaskError(t.shardContext, executable, taskType, err)
 
 	return queues.ExecuteResponse{
 		ExecutionMetricTags: metricsTags,


### PR DESCRIPTION
## What changed?

- Adds `phase=error` to the existing `replication_lifecycle` wide event; no new event type or table.
- Covers state-based replication (`SyncVersionedTransition`, `VerifyVersionedTransition`, and `SyncWorkflowState`) plus standby transfer, timer, and outbound queue failures.
- Captures sender, passive execution/apply, verification, recovery/refetch, namespace refresh, Nack, DLQ, and history-branch cleanup boundaries.
- Uses one shared error builder with small sender, executable-task, NDC, and standby-queue adapters.
- Records workflow identity, source task identity, target context, operation, error, attempt/priority, disposition/recovery, and extensible diagnostics in `details`.
- Identifies apply provenance as `apply_artifact_source=task_payload` or `sync_state_refetch`.
- Remains gated by `history.emitReplicationLifecycleEvents` (default off).

## Why?

Replication failures span the sender, passive executor, recovery loop, and apply layer. Recording these boundaries in the existing lifecycle event makes the path of a workflow or replication task directly traceable without adding another event schema.

## Example traces

The examples below are abridged records captured from the two-cluster XDC test. Events for the same task correlate on `source_cluster`, `source_shard`, and `source_task_id`; workflow identity is present on every record.

A state task that fails on the passive cluster and is written to the DLQ:

```json
{"phase":"sent","task_type":"sync_versioned_transition","workflow_id":"example-workflow","source_cluster":"active","source_shard":1,"source_task_id":1048581,"priority":"High"}
{"phase":"error","task_type":"sync_versioned_transition","workflow_id":"example-workflow","source_cluster":"active","source_shard":1,"source_task_id":1048581,"details":{"operation":"passive_task_execution","error":"failed to apply replication task","error_type":"serviceerror.InvalidArgument","apply_artifact_source":"task_payload","attempt":1,"priority":"High","target_cluster":"standby"}}
{"phase":"error","task_type":"sync_versioned_transition","workflow_id":"example-workflow","source_cluster":"active","source_shard":1,"source_task_id":1048581,"details":{"operation":"task_execution","error":"failed to apply replication task","terminal":true,"priority":"High","target_cluster":"standby"}}
{"phase":"error","task_type":"sync_versioned_transition","workflow_id":"example-workflow","source_cluster":"active","source_shard":1,"source_task_id":1048581,"details":{"operation":"dlq_write","disposition":"dlq","terminal":true,"priority":"High","target_cluster":"standby","target_shard":1}}
```

A verification task that detects missing state, refetches it, and then verifies successfully:

```json
{"phase":"sent","task_type":"verify_versioned_transition","workflow_id":"example-workflow","source_cluster":"active","source_shard":1,"source_task_id":1048595,"priority":"High"}
{"phase":"executing","task_type":"verify_versioned_transition","workflow_id":"example-workflow","source_cluster":"active","source_shard":1,"source_task_id":1048595,"attempt":1}
{"phase":"applied","task_type":"verify_versioned_transition","workflow_id":"example-workflow","source_cluster":"active","source_shard":1,"source_task_id":1048595,"outcome":"resend_needed"}
{"phase":"error","task_type":"verify_versioned_transition","workflow_id":"example-workflow","source_cluster":"active","source_shard":1,"source_task_id":1048595,"details":{"operation":"standby_verification","error":"missing mutable state, resend","error_type":"serviceerror.SyncState","recovery_action":"sync_state","priority":"High","target_cluster":"standby"}}
{"phase":"applied","task_type":"sync_versioned_transition","workflow_id":"example-workflow","source_cluster":"active","source_shard":1,"source_task_id":1048595,"outcome":"applied","details":{"apply_artifact_source":"sync_state_refetch"}}
{"phase":"executing","task_type":"verify_versioned_transition","workflow_id":"example-workflow","source_cluster":"active","source_shard":1,"source_task_id":1048595,"attempt":1}
{"phase":"applied","task_type":"verify_versioned_transition","workflow_id":"example-workflow","source_cluster":"active","source_shard":1,"source_task_id":1048595,"outcome":"verified"}
```

## How was it tested?

- `go test -tags test_dep ./common/wideevents ./service/history/replication ./service/history/ndc ./service/history ./tests/testcore`
- Changed-lines `golangci-lint`: 0 issues.
- Temporary, uncommitted two-cluster XDC tests forced passive task failures, DLQ handling, standby verification, and SyncState refetch/recovery with lifecycle events both enabled and disabled.
- A tiered-processing run confirmed concrete `High` priority on sent and error records.

## Risks

- Enabling the dynamic config increases event volume; retries and recovery can produce several error phases for one source task.
- `details.operation`, `details.disposition`, and `details.recovery_action` distinguish those boundaries.
- Emission is best effort and does not change replication error propagation, retry, or recovery behavior.
