### PR TITLE
Fix SignalWithStart livelock on orphaned current-execution pointer

### DIFF
--- a/common/persistence/sql/execution_util.go
+++ b/common/persistence/sql/execution_util.go
@@ -580,6 +580,9 @@ func lockCurrentExecutionIfExists(
 	workflowID string,
 	archetypeID chasm.ArchetypeID,
 ) (*sqlplugin.CurrentExecutionsRow, error) {
+	// The join is a LEFT JOIN so a current_executions row whose executions record is
+	// gone still comes back. BrandNew can then return CurrentWorkflowConditionFailedError
+	// instead of failing the insert with a unique-constraint error.
 	rows, err := tx.LockCurrentExecutionsJoinExecutions(ctx, sqlplugin.CurrentExecutionsFilter{
 		ShardID:     shardID,
 		NamespaceID: namespaceID,

--- a/common/persistence/sql/sqlplugin/mysql/execution.go
+++ b/common/persistence/sql/sqlplugin/mysql/execution.go
@@ -49,14 +49,14 @@ shard_id, namespace_id, business_id as workflow_id, run_id, create_request_id, s
 FROM current_chasm_executions WHERE shard_id = ? AND namespace_id = ? AND business_id = ? AND archetype_id = ?`
 
 	lockCurrentExecutionJoinExecutionsQuery = `SELECT
-ce.shard_id, ce.namespace_id, ce.workflow_id, ce.run_id, ce.create_request_id, ce.state, ce.status, ce.start_time, e.last_write_version, ce.data, ce.data_encoding
+ce.shard_id, ce.namespace_id, ce.workflow_id, ce.run_id, ce.create_request_id, ce.state, ce.status, ce.start_time, COALESCE(e.last_write_version, ce.last_write_version) AS last_write_version, ce.data, ce.data_encoding
 FROM current_executions ce
-INNER JOIN executions e ON e.shard_id = ce.shard_id AND e.namespace_id = ce.namespace_id AND e.workflow_id = ce.workflow_id AND e.run_id = ce.run_id
+LEFT JOIN executions e ON e.shard_id = ce.shard_id AND e.namespace_id = ce.namespace_id AND e.workflow_id = ce.workflow_id AND e.run_id = ce.run_id
 WHERE ce.shard_id = ? AND ce.namespace_id = ? AND ce.workflow_id = ? FOR UPDATE`
 	lockCurrentChasmExecutionJoinExecutionsQuery = `SELECT
-ce.shard_id, ce.namespace_id, ce.business_id as workflow_id, ce.run_id, ce.create_request_id, ce.state, ce.status, ce.start_time, e.last_write_version, ce.data, ce.data_encoding
+ce.shard_id, ce.namespace_id, ce.business_id as workflow_id, ce.run_id, ce.create_request_id, ce.state, ce.status, ce.start_time, COALESCE(e.last_write_version, ce.last_write_version) AS last_write_version, ce.data, ce.data_encoding
 FROM current_chasm_executions ce
-INNER JOIN executions e ON e.shard_id = ce.shard_id AND e.namespace_id = ce.namespace_id AND e.workflow_id = ce.business_id AND e.run_id = ce.run_id
+LEFT JOIN executions e ON e.shard_id = ce.shard_id AND e.namespace_id = ce.namespace_id AND e.workflow_id = ce.business_id AND e.run_id = ce.run_id
 WHERE ce.shard_id = ? AND ce.namespace_id = ? AND ce.business_id = ? AND ce.archetype_id = ? FOR UPDATE`
 
 	lockCurrentExecutionQuery      = getCurrentExecutionQuery + ` FOR UPDATE`

--- a/common/persistence/sql/sqlplugin/postgresql/execution.go
+++ b/common/persistence/sql/sqlplugin/postgresql/execution.go
@@ -49,14 +49,14 @@ shard_id, namespace_id, business_id as workflow_id, run_id, create_request_id, s
 FROM current_chasm_executions WHERE shard_id = $1 AND namespace_id = $2 AND business_id = $3 AND archetype_id = $4`
 
 	lockCurrentExecutionJoinExecutionsQuery = `SELECT
-ce.shard_id, ce.namespace_id, ce.workflow_id, ce.run_id, ce.create_request_id, ce.state, ce.status, ce.start_time, e.last_write_version, ce.data, ce.data_encoding
+ce.shard_id, ce.namespace_id, ce.workflow_id, ce.run_id, ce.create_request_id, ce.state, ce.status, ce.start_time, COALESCE(e.last_write_version, ce.last_write_version) AS last_write_version, ce.data, ce.data_encoding
 FROM current_executions ce
-INNER JOIN executions e ON e.shard_id = ce.shard_id AND e.namespace_id = ce.namespace_id AND e.workflow_id = ce.workflow_id AND e.run_id = ce.run_id
+LEFT JOIN executions e ON e.shard_id = ce.shard_id AND e.namespace_id = ce.namespace_id AND e.workflow_id = ce.workflow_id AND e.run_id = ce.run_id
 WHERE ce.shard_id = $1 AND ce.namespace_id = $2 AND ce.workflow_id = $3 FOR UPDATE`
 	lockCurrentChasmExecutionJoinExecutionsQuery = `SELECT
-ce.shard_id, ce.namespace_id, ce.business_id as workflow_id, ce.run_id, ce.create_request_id, ce.state, ce.status, ce.start_time, e.last_write_version, ce.data, ce.data_encoding
+ce.shard_id, ce.namespace_id, ce.business_id as workflow_id, ce.run_id, ce.create_request_id, ce.state, ce.status, ce.start_time, COALESCE(e.last_write_version, ce.last_write_version) AS last_write_version, ce.data, ce.data_encoding
 FROM current_chasm_executions ce
-INNER JOIN executions e ON e.shard_id = ce.shard_id AND e.namespace_id = ce.namespace_id AND e.workflow_id = ce.business_id AND e.run_id = ce.run_id
+LEFT JOIN executions e ON e.shard_id = ce.shard_id AND e.namespace_id = ce.namespace_id AND e.workflow_id = ce.business_id AND e.run_id = ce.run_id
 WHERE ce.shard_id = $1 AND ce.namespace_id = $2 AND ce.business_id = $3 AND ce.archetype_id = $4 FOR UPDATE`
 
 	lockCurrentExecutionQuery      = getCurrentExecutionQuery + ` FOR UPDATE`

--- a/common/persistence/sql/sqlplugin/sqlite/execution.go
+++ b/common/persistence/sql/sqlplugin/sqlite/execution.go
@@ -49,14 +49,14 @@ shard_id, namespace_id, business_id as workflow_id, run_id, create_request_id, s
 FROM current_chasm_executions WHERE shard_id = ? AND namespace_id = ? AND business_id = ? AND archetype_id = ?`
 
 	lockCurrentExecutionJoinExecutionsQuery = `SELECT
-ce.shard_id, ce.namespace_id, ce.workflow_id, ce.run_id, ce.create_request_id, ce.state, ce.status, ce.start_time, e.last_write_version, ce.data, ce.data_encoding
+ce.shard_id, ce.namespace_id, ce.workflow_id, ce.run_id, ce.create_request_id, ce.state, ce.status, ce.start_time, COALESCE(e.last_write_version, ce.last_write_version) AS last_write_version, ce.data, ce.data_encoding
 FROM current_executions ce
-INNER JOIN executions e ON e.shard_id = ce.shard_id AND e.namespace_id = ce.namespace_id AND e.workflow_id = ce.workflow_id AND e.run_id = ce.run_id
+LEFT JOIN executions e ON e.shard_id = ce.shard_id AND e.namespace_id = ce.namespace_id AND e.workflow_id = ce.workflow_id AND e.run_id = ce.run_id
 WHERE ce.shard_id = ? AND ce.namespace_id = ? AND ce.workflow_id = ?`
 	lockCurrentChasmExecutionJoinExecutionsQuery = `SELECT
-ce.shard_id, ce.namespace_id, ce.business_id as workflow_id, ce.run_id, ce.create_request_id, ce.state, ce.status, ce.start_time, e.last_write_version, ce.data, ce.data_encoding
+ce.shard_id, ce.namespace_id, ce.business_id as workflow_id, ce.run_id, ce.create_request_id, ce.state, ce.status, ce.start_time, COALESCE(e.last_write_version, ce.last_write_version) AS last_write_version, ce.data, ce.data_encoding
 FROM current_chasm_executions ce
-INNER JOIN executions e ON e.shard_id = ce.shard_id AND e.namespace_id = ce.namespace_id AND e.workflow_id = ce.business_id AND e.run_id = ce.run_id
+LEFT JOIN executions e ON e.shard_id = ce.shard_id AND e.namespace_id = ce.namespace_id AND e.workflow_id = ce.business_id AND e.run_id = ce.run_id
 WHERE ce.shard_id = ? AND ce.namespace_id = ? AND ce.business_id = ? AND ce.archetype_id = ?`
 
 	lockCurrentExecutionQuery      = getCurrentExecutionQuery

--- a/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
+++ b/service/history/api/signalwithstartworkflow/signal_with_start_workflow.go
@@ -145,10 +145,11 @@ func startAndSignalWorkflow(
 	return startAndSignalWithoutCurrentWorkflow(
 		ctx,
 		shard,
+		namespaceEntry,
 		vrid,
 		newWorkflowLease,
 		currentWorkflowLease,
-		signalWithStartRequest.RequestId,
+		signalWithStartRequest,
 	)
 }
 
@@ -240,10 +241,11 @@ func startAndSignalWithCurrentWorkflow(
 func startAndSignalWithoutCurrentWorkflow(
 	ctx context.Context,
 	shardContext historyi.ShardContext,
+	namespaceEntry *namespace.Namespace,
 	vrid *api.VersionedRunID,
 	newWorkflowLease api.WorkflowLease,
 	currentWorkflowLease api.WorkflowLease,
-	requestID string,
+	signalWithStartRequest *workflowservice.SignalWithStartWorkflowExecutionRequest,
 ) (startOutcome, error) {
 	newWorkflow, newWorkflowEventsSeq, err := newWorkflowLease.GetMutableState().CloseTransactionAsSnapshot(
 		ctx,
@@ -289,6 +291,7 @@ func startAndSignalWithoutCurrentWorkflow(
 		runID := newWorkflowLease.GetContext().GetWorkflowKey().RunID
 		return startOutcome{runID: runID, firstExecutionRunID: runID, started: true}, nil
 	case *persistence.CurrentWorkflowConditionFailedError:
+		requestID := signalWithStartRequest.GetRequestId()
 		if _, ok := failedErr.RequestIDs[requestID]; ok {
 			// CurrentWorkflowConditionFailedError carries the persisted WorkflowExecutionState blob,
 			// which may not have first_execution_run_id populated on records written before that
@@ -303,10 +306,89 @@ func startAndSignalWithoutCurrentWorkflow(
 			}
 			return startOutcome{runID: failedErr.RunID, firstExecutionRunID: firstRunID, started: false}, nil
 		}
+		// BrandNew fails when a current_executions row already exists. If mutable state for that
+		// run is gone, the lease load looks like "no current workflow" and we take this path.
+		// StartWorkflow retries with UpdateCurrent for a completed pointer; do the same here
+		// instead of returning the conflict (the history handler would retry it until deadline).
+		if createMode == persistence.CreateWorkflowModeBrandNew {
+			if retryErr := retryBrandNewAsUpdateCurrent(
+				ctx,
+				shardContext,
+				namespaceEntry,
+				newWorkflowLease,
+				newWorkflow,
+				newWorkflowEventsSeq,
+				signalWithStartRequest,
+				failedErr,
+			); retryErr != nil {
+				return startOutcome{}, retryErr
+			}
+			runID := newWorkflowLease.GetContext().GetWorkflowKey().RunID
+			return startOutcome{runID: runID, firstExecutionRunID: runID, started: true}, nil
+		}
 		return startOutcome{}, err
 	default:
 		return startOutcome{}, err
 	}
+}
+
+func retryBrandNewAsUpdateCurrent(
+	ctx context.Context,
+	shardContext historyi.ShardContext,
+	namespaceEntry *namespace.Namespace,
+	newWorkflowLease api.WorkflowLease,
+	newWorkflow *persistence.WorkflowSnapshot,
+	newWorkflowEventsSeq []*persistence.WorkflowEvents,
+	signalWithStartRequest *workflowservice.SignalWithStartWorkflowExecutionRequest,
+	failedErr *persistence.CurrentWorkflowConditionFailedError,
+) error {
+	if failedErr.State != enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED {
+		return failedErr
+	}
+
+	currentWorkflowStartTime := time.Time{}
+	if shardContext.GetConfig().EnableWorkflowIdReuseStartTimeValidation(namespaceEntry.Name().String()) &&
+		failedErr.StartTime != nil {
+		currentWorkflowStartTime = *failedErr.StartTime
+	}
+
+	workflowKey := definition.NewWorkflowKey(
+		namespaceEntry.ID().String(),
+		signalWithStartRequest.GetWorkflowId(),
+		failedErr.RunID,
+	)
+	if err := api.ResolveWorkflowIDReusePolicy(
+		shardContext,
+		workflowKey,
+		namespaceEntry,
+		failedErr.Status,
+		failedErr.RequestIDs,
+		failedErr.FirstExecutionRunID,
+		signalWithStartRequest.GetWorkflowIdReusePolicy(),
+		currentWorkflowStartTime,
+	); err != nil {
+		return err
+	}
+
+	if err := api.NewWorkflowVersionCheck(
+		shardContext,
+		failedErr.LastWriteVersion,
+		newWorkflowLease.GetMutableState(),
+	); err != nil {
+		return err
+	}
+
+	return newWorkflowLease.GetContext().CreateWorkflowExecution(
+		ctx,
+		shardContext,
+		persistence.CreateWorkflowModeUpdateCurrent,
+		failedErr.RunID,
+		failedErr.LastWriteVersion,
+		newWorkflowLease.GetMutableState(),
+		newWorkflow,
+		newWorkflowEventsSeq,
+		historyi.TransactionPolicyActive,
+	)
 }
 
 func signalWorkflow(

--- a/service/history/history_engine2_test.go
+++ b/service/history/history_engine2_test.go
@@ -2264,6 +2264,199 @@ func (s *engine2Suite) TestSignalWithStartWorkflowExecution_Start_WorkflowAlread
 	s.NotNil(err)
 }
 
+func (s *engine2Suite) TestSignalWithStartWorkflowExecution_OrphanedCompletedCurrentExecution() {
+	s.config.EnableWorkflowIdReuseStartTimeValidation = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false)
+
+	namespaceID := tests.NamespaceID
+	workflowID := "wId"
+	orphanedRunID := tests.RunID
+	workflowType := "workflowType"
+	taskQueue := "testTaskQueue"
+	identity := "testIdentity"
+	signalName := "my signal name"
+	input := payloads.EncodeString("test input")
+	requestID := uuid.NewString()
+	lastWriteVersion := common.EmptyVersion
+
+	sRequest := &historyservice.SignalWithStartWorkflowExecutionRequest{
+		NamespaceId: namespaceID.String(),
+		SignalWithStartRequest: &workflowservice.SignalWithStartWorkflowExecutionRequest{
+			Namespace:                namespaceID.String(),
+			WorkflowId:               workflowID,
+			WorkflowType:             &commonpb.WorkflowType{Name: workflowType},
+			TaskQueue:                &taskqueuepb.TaskQueue{Name: taskQueue},
+			Input:                    input,
+			WorkflowExecutionTimeout: durationpb.New(1 * time.Second),
+			WorkflowTaskTimeout:      durationpb.New(2 * time.Second),
+			Identity:                 identity,
+			RequestId:                requestID,
+			WorkflowIdReusePolicy:    enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+			SignalName:               signalName,
+		},
+	}
+
+	brandNewExecutionRequest := mock.MatchedBy(func(request *persistence.CreateWorkflowExecutionRequest) bool {
+		return request.Mode == persistence.CreateWorkflowModeBrandNew
+	})
+	updateExecutionRequest := mock.MatchedBy(func(request *persistence.CreateWorkflowExecutionRequest) bool {
+		return request.Mode == persistence.CreateWorkflowModeUpdateCurrent &&
+			request.PreviousRunID == orphanedRunID &&
+			request.PreviousLastWriteVersion == lastWriteVersion
+	})
+	conditionFailedErr := &persistence.CurrentWorkflowConditionFailedError{
+		Msg: "random message",
+		RequestIDs: map[string]*persistencespb.RequestIDInfo{
+			"old request ID": {
+				EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+				EventId:   common.FirstEventID,
+			},
+		},
+		RunID:            orphanedRunID,
+		State:            enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED,
+		Status:           enumspb.WORKFLOW_EXECUTION_STATUS_TIMED_OUT,
+		LastWriteVersion: lastWriteVersion,
+		StartTime:        nil,
+	}
+
+	s.mockExecutionMgr.EXPECT().GetCurrentExecution(gomock.Any(), gomock.Any()).Return(
+		&persistence.GetCurrentExecutionResponse{RunID: orphanedRunID}, nil)
+	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(
+		nil, serviceerror.NewNotFound("mutable state missing"))
+	s.mockExecutionMgr.EXPECT().CreateWorkflowExecution(gomock.Any(), brandNewExecutionRequest).Return(
+		nil, conditionFailedErr)
+	s.mockExecutionMgr.EXPECT().CreateWorkflowExecution(gomock.Any(), updateExecutionRequest).Return(
+		tests.CreateWorkflowExecutionResponse, nil)
+
+	resp, err := s.historyEngine.SignalWithStartWorkflowExecution(metrics.AddMetricsContext(context.Background()), sRequest)
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+	s.Require().True(resp.Started)
+	s.Require().NotEmpty(resp.GetRunId())
+	s.Require().NotEqual(orphanedRunID, resp.GetRunId())
+}
+
+func (s *engine2Suite) TestSignalWithStartWorkflowExecution_OrphanedCompletedCurrentExecution_RejectDuplicate() {
+	s.config.EnableWorkflowIdReuseStartTimeValidation = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false)
+
+	namespaceID := tests.NamespaceID
+	workflowID := "wId"
+	orphanedRunID := tests.RunID
+	workflowType := "workflowType"
+	taskQueue := "testTaskQueue"
+	identity := "testIdentity"
+	signalName := "my signal name"
+	input := payloads.EncodeString("test input")
+	requestID := uuid.NewString()
+
+	sRequest := &historyservice.SignalWithStartWorkflowExecutionRequest{
+		NamespaceId: namespaceID.String(),
+		SignalWithStartRequest: &workflowservice.SignalWithStartWorkflowExecutionRequest{
+			Namespace:                namespaceID.String(),
+			WorkflowId:               workflowID,
+			WorkflowType:             &commonpb.WorkflowType{Name: workflowType},
+			TaskQueue:                &taskqueuepb.TaskQueue{Name: taskQueue},
+			Input:                    input,
+			WorkflowExecutionTimeout: durationpb.New(1 * time.Second),
+			WorkflowTaskTimeout:      durationpb.New(2 * time.Second),
+			Identity:                 identity,
+			RequestId:                requestID,
+			WorkflowIdReusePolicy:    enumspb.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE,
+			SignalName:               signalName,
+		},
+	}
+
+	brandNewExecutionRequest := mock.MatchedBy(func(request *persistence.CreateWorkflowExecutionRequest) bool {
+		return request.Mode == persistence.CreateWorkflowModeBrandNew
+	})
+	conditionFailedErr := &persistence.CurrentWorkflowConditionFailedError{
+		Msg: "random message",
+		RequestIDs: map[string]*persistencespb.RequestIDInfo{
+			"old request ID": {
+				EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+				EventId:   common.FirstEventID,
+			},
+		},
+		RunID:            orphanedRunID,
+		State:            enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED,
+		Status:           enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+		LastWriteVersion: common.EmptyVersion,
+		StartTime:        nil,
+	}
+
+	s.mockExecutionMgr.EXPECT().GetCurrentExecution(gomock.Any(), gomock.Any()).Return(
+		&persistence.GetCurrentExecutionResponse{RunID: orphanedRunID}, nil)
+	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(
+		nil, serviceerror.NewNotFound("mutable state missing"))
+	s.mockExecutionMgr.EXPECT().CreateWorkflowExecution(gomock.Any(), brandNewExecutionRequest).Return(
+		nil, conditionFailedErr)
+
+	resp, err := s.historyEngine.SignalWithStartWorkflowExecution(metrics.AddMetricsContext(context.Background()), sRequest)
+	s.Require().Nil(resp)
+	var alreadyStarted *serviceerror.WorkflowExecutionAlreadyStarted
+	s.Require().ErrorAs(err, &alreadyStarted)
+}
+
+func (s *engine2Suite) TestSignalWithStartWorkflowExecution_OrphanedRunningCurrentExecution() {
+	s.config.EnableWorkflowIdReuseStartTimeValidation = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false)
+
+	namespaceID := tests.NamespaceID
+	workflowID := "wId"
+	orphanedRunID := tests.RunID
+	workflowType := "workflowType"
+	taskQueue := "testTaskQueue"
+	identity := "testIdentity"
+	signalName := "my signal name"
+	input := payloads.EncodeString("test input")
+	requestID := uuid.NewString()
+
+	sRequest := &historyservice.SignalWithStartWorkflowExecutionRequest{
+		NamespaceId: namespaceID.String(),
+		SignalWithStartRequest: &workflowservice.SignalWithStartWorkflowExecutionRequest{
+			Namespace:                namespaceID.String(),
+			WorkflowId:               workflowID,
+			WorkflowType:             &commonpb.WorkflowType{Name: workflowType},
+			TaskQueue:                &taskqueuepb.TaskQueue{Name: taskQueue},
+			Input:                    input,
+			WorkflowExecutionTimeout: durationpb.New(1 * time.Second),
+			WorkflowTaskTimeout:      durationpb.New(2 * time.Second),
+			Identity:                 identity,
+			RequestId:                requestID,
+			WorkflowIdReusePolicy:    enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+			SignalName:               signalName,
+		},
+	}
+
+	brandNewExecutionRequest := mock.MatchedBy(func(request *persistence.CreateWorkflowExecutionRequest) bool {
+		return request.Mode == persistence.CreateWorkflowModeBrandNew
+	})
+	conditionFailedErr := &persistence.CurrentWorkflowConditionFailedError{
+		Msg: "random message",
+		RequestIDs: map[string]*persistencespb.RequestIDInfo{
+			"old request ID": {
+				EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+				EventId:   common.FirstEventID,
+			},
+		},
+		RunID:            orphanedRunID,
+		State:            enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING,
+		Status:           enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+		LastWriteVersion: common.EmptyVersion,
+		StartTime:        nil,
+	}
+
+	s.mockExecutionMgr.EXPECT().GetCurrentExecution(gomock.Any(), gomock.Any()).Return(
+		&persistence.GetCurrentExecutionResponse{RunID: orphanedRunID}, nil)
+	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(
+		nil, serviceerror.NewNotFound("mutable state missing"))
+	s.mockExecutionMgr.EXPECT().CreateWorkflowExecution(gomock.Any(), brandNewExecutionRequest).Return(
+		nil, conditionFailedErr)
+
+	resp, err := s.historyEngine.SignalWithStartWorkflowExecution(metrics.AddMetricsContext(context.Background()), sRequest)
+	s.Require().Nil(resp)
+	var conditionFailed *persistence.CurrentWorkflowConditionFailedError
+	s.Require().ErrorAs(err, &conditionFailed)
+}
+
 func (s *engine2Suite) TestRecordChildExecutionCompleted() {
 	childWorkflowID := "some random child workflow ID"
 	childRunID := uuid.NewString()

--- a/tests/signal_with_start_orphan_pointer_test.go
+++ b/tests/signal_with_start_orphan_pointer_test.go
@@ -1,0 +1,123 @@
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	commandpb "go.temporal.io/api/command/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/testing/parallelsuite"
+	"go.temporal.io/server/common/testing/taskpoller"
+	"go.temporal.io/server/common/testing/testvars"
+	"go.temporal.io/server/tests/testcore"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+type SignalWithStartOrphanPointerSuite struct {
+	parallelsuite.Suite[*SignalWithStartOrphanPointerSuite]
+}
+
+func TestSignalWithStartOrphanPointerSuite(t *testing.T) {
+	parallelsuite.Run(t, &SignalWithStartOrphanPointerSuite{})
+}
+
+// TestSignalWithStartAfterOrphanedCompletedPointer starts a workflow, completes it, then
+// deletes mutable state and history while leaving current_executions in place. That is the
+// corruption SignalWithStart used to livelock on. Closing the shard drops the cached copy
+// so the next request has to load from persistence.
+func (s *SignalWithStartOrphanPointerSuite) TestSignalWithStartAfterOrphanedCompletedPointer() {
+	env := testcore.NewEnv(s.T(), testcore.WithDedicatedCluster())
+	tv := testvars.New(s.T())
+	ctx := s.Context()
+
+	shardID := common.WorkflowIDToHistoryShard(
+		env.NamespaceID().String(),
+		tv.WorkflowID(),
+		env.GetTestClusterConfig().HistoryConfig.NumHistoryShards,
+	)
+	execMgr := env.GetTestCluster().ExecutionManager()
+	poller := taskpoller.New(s.T(), env.FrontendClient(), env.Namespace().String())
+
+	startResp, err := env.FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:    uuid.NewString(),
+		Namespace:    env.Namespace().String(),
+		WorkflowId:   tv.WorkflowID(),
+		WorkflowType: tv.WorkflowType(),
+		TaskQueue:    tv.TaskQueue(),
+	})
+	s.Require().NoError(err)
+	orphanedRunID := startResp.RunId
+
+	_, err = poller.PollAndHandleWorkflowTask(tv, func(_ *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{
+			Commands: []*commandpb.Command{{
+				CommandType: enumspb.COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION,
+				Attributes: &commandpb.Command_CompleteWorkflowExecutionCommandAttributes{
+					CompleteWorkflowExecutionCommandAttributes: &commandpb.CompleteWorkflowExecutionCommandAttributes{},
+				},
+			}},
+		}, nil
+	})
+	s.Require().NoError(err)
+
+	branchToken := captureCurrentBranchToken(ctx, env, tv.WorkflowID(), orphanedRunID)
+
+	s.Require().NoError(execMgr.DeleteWorkflowExecution(ctx, &persistence.DeleteWorkflowExecutionRequest{
+		ShardID:     shardID,
+		NamespaceID: env.NamespaceID().String(),
+		WorkflowID:  tv.WorkflowID(),
+		RunID:       orphanedRunID,
+		ArchetypeID: chasm.WorkflowArchetypeID,
+	}))
+	s.Require().NoError(execMgr.DeleteHistoryBranch(ctx, &persistence.DeleteHistoryBranchRequest{
+		ShardID:     shardID,
+		BranchToken: branchToken,
+	}))
+	waitForMutableStateGone(ctx, env, shardID, execMgr, tv.WorkflowID(), orphanedRunID)
+
+	current, err := execMgr.GetCurrentExecution(ctx, &persistence.GetCurrentExecutionRequest{
+		ShardID:     shardID,
+		NamespaceID: env.NamespaceID().String(),
+		WorkflowID:  tv.WorkflowID(),
+		ArchetypeID: chasm.WorkflowArchetypeID,
+	})
+	s.Require().NoError(err)
+	s.Require().Equal(orphanedRunID, current.RunID)
+	s.Require().Equal(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, current.Status)
+
+	env.CloseShard(env.NamespaceID().String(), tv.WorkflowID())
+
+	swsCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	swsResp, err := env.FrontendClient().SignalWithStartWorkflowExecution(swsCtx, &workflowservice.SignalWithStartWorkflowExecutionRequest{
+		RequestId:             uuid.NewString(),
+		Namespace:             env.Namespace().String(),
+		WorkflowId:            tv.WorkflowID(),
+		WorkflowType:          tv.WorkflowType(),
+		TaskQueue:             tv.TaskQueue(),
+		Identity:              "orphan-pointer-test",
+		SignalName:            "repro",
+		WorkflowIdReusePolicy: enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+		WorkflowRunTimeout:    durationpb.New(30 * time.Second),
+		WorkflowTaskTimeout:   durationpb.New(5 * time.Second),
+	})
+	s.Require().NoError(err)
+	s.Require().True(swsResp.Started)
+	s.Require().NotEmpty(swsResp.RunId)
+	s.Require().NotEqual(orphanedRunID, swsResp.RunId)
+
+	replaced, err := execMgr.GetCurrentExecution(ctx, &persistence.GetCurrentExecutionRequest{
+		ShardID:     shardID,
+		NamespaceID: env.NamespaceID().String(),
+		WorkflowID:  tv.WorkflowID(),
+		ArchetypeID: chasm.WorkflowArchetypeID,
+	})
+	s.Require().NoError(err)
+	s.Require().Equal(swsResp.RunId, replaced.RunID)
+}


### PR DESCRIPTION
Fixes #10841

## What changed?
When SignalWithStart can't load the current run because mutable state is gone, but `current_executions` still has a completed pointer, we now retry the create with UpdateCurrent. That's the same thing StartWorkflow already does on a completed BrandNew conflict.

On SQL, the lock query used to inner-join `executions`, so that orphan pointer was invisible and BrandNew failed with a unique constraint instead of a conflict error. I changed it to a left join so SQL can surface the same conflict Cassandra already returns from CAS.

## Why?
The history handler retries `CurrentWorkflowConditionFailedError` until the request deadline. That retry is meant for concurrent start races. In this corruption case the retry never succeeds, so SignalWithStart just hangs.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)

History engine unit tests cover the completed-pointer retry, reject-duplicate, and leaving a running conflict alone. There's also a functional test that completes a workflow, deletes mutable state and history while leaving the current pointer, closes the shard so cache can't hide it, then SignalWithStarts.

I also did a local sqlite-file repro. Started a workflow with a 2s run timeout, let it time out, stopped the server, deleted the `executions` row while leaving `current_executions`, then called `signal-with-start` with a 5s timeout.

On the unfixed binary that failed immediately with a unique constraint on `current_executions`. After rebuilding with this change, the same corrupted pointer started a new run in about half a second.

## Potential risks
We only do the UpdateCurrent retry when the conflicting pointer is completed. A running conflict still returns `CurrentWorkflowConditionFailedError`, so the existing handler retry for concurrent starts is unchanged.

The SQL left join is the part I'm least sure about. It should behave the same when both rows exist. The new behavior is only when `current_executions` is there and `executions` isn't, which is already a corrupt state.