### PR TITLE
Add subqueue-id tag to some logs

### DIFF
--- a/service/matching/db.go
+++ b/service/matching/db.go
@@ -420,6 +420,7 @@ func (db *taskQueueDB) updateBacklogStatsLocked(subqueue subqueueIndex, countDel
 	count := &db.subqueues[subqueue].ApproximateBacklogCount
 	if *count+countDelta < 0 {
 		db.logger.Info("ApproximateBacklogCount could have under-counted.",
+			tag.Int("subqueue-id", int(subqueue)),
 			tag.WorkerVersion(db.queue.Version().MetricsTagValue()),
 			tag.WorkflowNamespaceID(db.queue.Partition().NamespaceId()))
 		*count = 0
@@ -755,6 +756,7 @@ func (db *taskQueueDB) CompleteTasksLessThan(
 		db.logger.Error("Persistent store operation failure",
 			tag.StoreOperationCompleteTasksLessThan,
 			tag.Error(err),
+			tag.Int("subqueue-id", int(subqueue)),
 			tag.TaskID(exclusiveMaxTaskID),
 			tag.WorkflowTaskQueueType(db.queue.TaskType()),
 			tag.WorkflowTaskQueueName(db.queue.PersistenceName()),
@@ -785,6 +787,7 @@ func (db *taskQueueDB) CompleteFairTasksLessThan(
 		db.logger.Error("Persistent store operation failure",
 			tag.StoreOperationCompleteTasksLessThan,
 			tag.Error(err),
+			tag.Int("subqueue-id", int(subqueue)),
 			tag.AckLevel(exclusiveMaxLevel),
 			tag.WorkflowTaskQueueType(db.queue.TaskType()),
 			tag.WorkflowTaskQueueName(db.queue.PersistenceName()),

--- a/service/matching/fair_task_reader.go
+++ b/service/matching/fair_task_reader.go
@@ -25,9 +25,10 @@ import (
 
 type (
 	fairTaskReader struct {
-		backlogMgr *fairBacklogManagerImpl
-		subqueue   subqueueIndex
-		logger     log.Logger
+		backlogMgr      *fairBacklogManagerImpl
+		subqueue        subqueueIndex
+		logger          log.Logger
+		throttledLogger log.ThrottledLogger
 
 		lock sync.Mutex
 
@@ -105,10 +106,12 @@ func newFairTaskReader(
 	subqueue subqueueIndex,
 	initialAckLevel fairLevel,
 ) *fairTaskReader {
+	subqueueTag := tag.Int("subqueue-id", int(subqueue))
 	return &fairTaskReader{
-		backlogMgr: backlogMgr,
-		subqueue:   subqueue,
-		logger:     backlogMgr.logger,
+		backlogMgr:      backlogMgr,
+		subqueue:        subqueue,
+		logger:          log.With(backlogMgr.logger, subqueueTag),
+		throttledLogger: log.With(backlogMgr.throttledLogger, subqueueTag),
 		retrier: backoff.NewRetrier(
 			backoff.NewExponentialRetryPolicy(50*time.Millisecond).
 				WithMaximumInterval(10*time.Second).
@@ -353,11 +356,11 @@ func (tr *fairTaskReader) addErrorBehavior(err error) (drop, retry bool) {
 	var invalid *serviceerror.InvalidArgument
 	var internal *serviceerror.Internal
 	if errors.As(err, &invalid) || errors.As(err, &internal) {
-		tr.backlogMgr.throttledLogger.Error("nonretryable error processing spooled task", tag.Error(err))
+		tr.throttledLogger.Error("nonretryable error processing spooled task", tag.Error(err))
 		return true, false // drop the task
 	}
 	// For any other error (this should be very rare), we can retry.
-	tr.backlogMgr.throttledLogger.Error("retryable error processing spooled task", tag.Error(err))
+	tr.throttledLogger.Error("retryable error processing spooled task", tag.Error(err))
 	return false, true
 }
 

--- a/service/matching/pri_task_reader.go
+++ b/service/matching/pri_task_reader.go
@@ -33,10 +33,11 @@ const (
 
 type (
 	priTaskReader struct {
-		backlogMgr *priBacklogManagerImpl
-		subqueue   subqueueIndex
-		notifyC    chan struct{} // Used as signal to notify pump of new tasks
-		logger     log.Logger
+		backlogMgr      *priBacklogManagerImpl
+		subqueue        subqueueIndex
+		notifyC         chan struct{} // Used as signal to notify pump of new tasks
+		logger          log.Logger
+		throttledLogger log.ThrottledLogger
 
 		lock sync.Mutex
 
@@ -68,11 +69,13 @@ func newPriTaskReader(
 	subqueue subqueueIndex,
 	initialAckLevel int64,
 ) *priTaskReader {
+	subqueueTag := tag.Int("subqueue-id", int(subqueue))
 	return &priTaskReader{
-		backlogMgr: backlogMgr,
-		subqueue:   subqueue,
-		notifyC:    make(chan struct{}, 1),
-		logger:     backlogMgr.logger,
+		backlogMgr:      backlogMgr,
+		subqueue:        subqueue,
+		notifyC:         make(chan struct{}, 1),
+		logger:          log.With(backlogMgr.logger, subqueueTag),
+		throttledLogger: log.With(backlogMgr.throttledLogger, subqueueTag),
 		retrier: backoff.NewRetrier(
 			common.CreateReadTaskRetryPolicy(),
 			clock.NewRealTimeSource(),
@@ -260,9 +263,8 @@ func (tr *priTaskReader) processTaskBatch(tasks []*persistencespb.AllocatedTaskI
 		// It's even possible for a task from signalNewTasks to be acked, and the ack level
 		// advanced, before we see it here. This would show up as a task below the ack level.
 		if t.TaskId <= tr.ackLevel {
-			tr.backlogMgr.throttledLogger.Info("ignoring already-acked task read from persistence",
+			tr.throttledLogger.Info("ignoring already-acked task read from persistence",
 				tag.TaskID(t.TaskId),
-				tag.Int("subqueue-id", int(tr.subqueue)),
 				tag.Any("ack-level", tr.ackLevel))
 			return true
 		}
@@ -342,11 +344,11 @@ func (tr *priTaskReader) addErrorBehavior(err error) (drop, retry bool) {
 	var invalid *serviceerror.InvalidArgument
 	var internal *serviceerror.Internal
 	if errors.As(err, &invalid) || errors.As(err, &internal) {
-		tr.backlogMgr.throttledLogger.Error("nonretryable error processing spooled task", tag.Error(err))
+		tr.throttledLogger.Error("nonretryable error processing spooled task", tag.Error(err))
 		return true, false // drop the task
 	}
 	// For any other error (this should be very rare), we can retry.
-	tr.backlogMgr.throttledLogger.Error("retryable error processing spooled task", tag.Error(err))
+	tr.throttledLogger.Error("retryable error processing spooled task", tag.Error(err))
 	return false, true
 }
 


### PR DESCRIPTION
## What changed?
Add `subqueue-id` tag to logs: all task reader logs (with a tagged logger) and several db logs where it was missing.

## Why?
Better debugability.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
