### PR TITLE
Applies small fixes for chasm nexus operations

### DIFF
--- a/chasm/lib/nexusoperation/fx.go
+++ b/chasm/lib/nexusoperation/fx.go
@@ -168,7 +168,7 @@ func clientProviderFactory(
 				r.Header.Set(nexusCallbackSourceHeader, clusterID)
 			}
 			resp, callErr := httpClient.Do(r)
-			// nexusrpc.HTTPClient does not return the raw HTTP response, so copy its failure-source header into the call context.
+			// nexusrpc.HTTPClient does not return the raw HTTP response, so copy the failure-source header into the call context.
 			commonnexus.SetFailureSourceOnContext(ctx, resp)
 			return resp, callErr
 		}

--- a/chasm/lib/nexusoperation/fx.go
+++ b/chasm/lib/nexusoperation/fx.go
@@ -144,7 +144,7 @@ func clientProviderFactory(
 	return func(ctx context.Context, namespaceID string, entry *persistencespb.NexusEndpointEntry, service string) (*nexusrpc.HTTPClient, error) {
 		var url string
 		var httpClient *http.Client
-		httpCaller := httpClient.Do
+		var httpCaller func(*http.Request) (*http.Response, error)
 		switch variant := entry.Endpoint.Spec.Target.Variant.(type) {
 		case *persistencespb.NexusEndpointTarget_External_:
 			url = variant.External.GetUrl()
@@ -153,6 +153,7 @@ func clientProviderFactory(
 			if err != nil {
 				return nil, err
 			}
+			httpCaller = httpClient.Do
 			if clusterID != "" {
 				httpCaller = func(r *http.Request) (*http.Response, error) {
 					resp, callErr := httpClient.Do(r)
@@ -163,6 +164,7 @@ func clientProviderFactory(
 		case *persistencespb.NexusEndpointTarget_Worker_:
 			url = cl.BaseURL() + "/" + commonnexus.RouteDispatchNexusTaskByEndpoint.Path(entry.Id)
 			httpClient = &cl.Client
+			httpCaller = httpClient.Do
 			if clusterID != "" {
 				httpCaller = func(r *http.Request) (*http.Response, error) {
 					r.Header.Set(nexusCallbackSourceHeader, clusterID)

--- a/chasm/lib/nexusoperation/fx.go
+++ b/chasm/lib/nexusoperation/fx.go
@@ -144,7 +144,8 @@ func clientProviderFactory(
 	return func(ctx context.Context, namespaceID string, entry *persistencespb.NexusEndpointEntry, service string) (*nexusrpc.HTTPClient, error) {
 		var url string
 		var httpClient *http.Client
-		setCallbackSource := false
+		// Populate source header for worker targets, and route internally. Callback assumes external target if unset.
+		needsCallbackSourceHeader := false
 
 		switch variant := entry.Endpoint.Spec.Target.Variant.(type) {
 		case *persistencespb.NexusEndpointTarget_External_:
@@ -157,21 +158,19 @@ func clientProviderFactory(
 		case *persistencespb.NexusEndpointTarget_Worker_:
 			url = cl.BaseURL() + "/" + commonnexus.RouteDispatchNexusTaskByEndpoint.Path(entry.Id)
 			httpClient = &cl.Client
-			setCallbackSource = true
+			needsCallbackSourceHeader = true
 		default:
 			return nil, serviceerror.NewInternal("got unexpected endpoint target")
 		}
 
-		httpCaller := httpClient.Do
-		if clusterID != "" {
-			httpCaller = func(r *http.Request) (*http.Response, error) {
-				if setCallbackSource {
-					r.Header.Set(nexusCallbackSourceHeader, clusterID)
-				}
-				resp, callErr := httpClient.Do(r)
-				commonnexus.SetFailureSourceOnContext(ctx, resp)
-				return resp, callErr
+		httpCaller := func(r *http.Request) (*http.Response, error) {
+			if needsCallbackSourceHeader && clusterID != "" {
+				r.Header.Set(nexusCallbackSourceHeader, clusterID)
 			}
+			resp, callErr := httpClient.Do(r)
+			// nexusrpc.HTTPClient does not return the raw HTTP response, so copy its failure-source header into the call context.
+			commonnexus.SetFailureSourceOnContext(ctx, resp)
+			return resp, callErr
 		}
 
 		return nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{

--- a/chasm/lib/nexusoperation/fx.go
+++ b/chasm/lib/nexusoperation/fx.go
@@ -163,14 +163,17 @@ func clientProviderFactory(
 			return nil, serviceerror.NewInternal("got unexpected endpoint target")
 		}
 
-		httpCaller := func(r *http.Request) (*http.Response, error) {
-			if needsCallbackSourceHeader && clusterID != "" {
-				r.Header.Set(nexusCallbackSourceHeader, clusterID)
+		httpCaller := httpClient.Do
+		if clusterID != "" {
+			httpCaller = func(r *http.Request) (*http.Response, error) {
+				if needsCallbackSourceHeader {
+					r.Header.Set(nexusCallbackSourceHeader, clusterID)
+				}
+				resp, callErr := httpClient.Do(r)
+				// nexusrpc.HTTPClient does not return the raw HTTP response, so copy the failure-source header into the call context.
+				commonnexus.SetFailureSourceOnContext(ctx, resp)
+				return resp, callErr
 			}
-			resp, callErr := httpClient.Do(r)
-			// nexusrpc.HTTPClient does not return the raw HTTP response, so copy the failure-source header into the call context.
-			commonnexus.SetFailureSourceOnContext(ctx, resp)
-			return resp, callErr
 		}
 
 		return nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{

--- a/chasm/lib/nexusoperation/fx.go
+++ b/chasm/lib/nexusoperation/fx.go
@@ -144,7 +144,8 @@ func clientProviderFactory(
 	return func(ctx context.Context, namespaceID string, entry *persistencespb.NexusEndpointEntry, service string) (*nexusrpc.HTTPClient, error) {
 		var url string
 		var httpClient *http.Client
-		var httpCaller func(*http.Request) (*http.Response, error)
+		setCallbackSource := false
+
 		switch variant := entry.Endpoint.Spec.Target.Variant.(type) {
 		case *persistencespb.NexusEndpointTarget_External_:
 			url = variant.External.GetUrl()
@@ -153,29 +154,26 @@ func clientProviderFactory(
 			if err != nil {
 				return nil, err
 			}
-			httpCaller = httpClient.Do
-			if clusterID != "" {
-				httpCaller = func(r *http.Request) (*http.Response, error) {
-					resp, callErr := httpClient.Do(r)
-					commonnexus.SetFailureSourceOnContext(ctx, resp)
-					return resp, callErr
-				}
-			}
 		case *persistencespb.NexusEndpointTarget_Worker_:
 			url = cl.BaseURL() + "/" + commonnexus.RouteDispatchNexusTaskByEndpoint.Path(entry.Id)
 			httpClient = &cl.Client
-			httpCaller = httpClient.Do
-			if clusterID != "" {
-				httpCaller = func(r *http.Request) (*http.Response, error) {
-					r.Header.Set(nexusCallbackSourceHeader, clusterID)
-					resp, callErr := httpClient.Do(r)
-					commonnexus.SetFailureSourceOnContext(ctx, resp)
-					return resp, callErr
-				}
-			}
+			setCallbackSource = true
 		default:
 			return nil, serviceerror.NewInternal("got unexpected endpoint target")
 		}
+
+		httpCaller := httpClient.Do
+		if clusterID != "" {
+			httpCaller = func(r *http.Request) (*http.Response, error) {
+				if setCallbackSource {
+					r.Header.Set(nexusCallbackSourceHeader, clusterID)
+				}
+				resp, callErr := httpClient.Do(r)
+				commonnexus.SetFailureSourceOnContext(ctx, resp)
+				return resp, callErr
+			}
+		}
+
 		return nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{
 			BaseURL:    url,
 			Service:    service,

--- a/chasm/lib/nexusoperation/fx_test.go
+++ b/chasm/lib/nexusoperation/fx_test.go
@@ -1,0 +1,127 @@
+package nexusoperation
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"github.com/stretchr/testify/require"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/cluster"
+	"go.uber.org/mock/gomock"
+)
+
+type testRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f testRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+func TestClientProviderFactoryUsesSelectedHTTPClient(t *testing.T) {
+	errHTTPClientCalled := errors.New("HTTP client called")
+
+	tests := []struct {
+		name      string
+		clusterID string
+		target    *persistencespb.NexusEndpointTarget
+	}{
+		{
+			name: "external without cluster ID",
+			target: &persistencespb.NexusEndpointTarget{
+				Variant: &persistencespb.NexusEndpointTarget_External_{
+					External: &persistencespb.NexusEndpointTarget_External{
+						Url: "http://external.invalid",
+					},
+				},
+			},
+		},
+		{
+			name:      "external with cluster ID",
+			clusterID: "cluster-id",
+			target: &persistencespb.NexusEndpointTarget{
+				Variant: &persistencespb.NexusEndpointTarget_External_{
+					External: &persistencespb.NexusEndpointTarget_External{
+						Url: "http://external.invalid",
+					},
+				},
+			},
+		},
+		{
+			name: "worker without cluster ID",
+			target: &persistencespb.NexusEndpointTarget{
+				Variant: &persistencespb.NexusEndpointTarget_Worker_{
+					Worker: &persistencespb.NexusEndpointTarget_Worker{},
+				},
+			},
+		},
+		{
+			name:      "worker with cluster ID",
+			clusterID: "cluster-id",
+			target: &persistencespb.NexusEndpointTarget{
+				Variant: &persistencespb.NexusEndpointTarget_Worker_{
+					Worker: &persistencespb.NexusEndpointTarget_Worker{},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			transport := testRoundTripper(func(*http.Request) (*http.Response, error) {
+				return nil, errHTTPClientCalled
+			})
+
+			rpcFactory := common.NewMockRPCFactory(ctrl)
+			rpcFactory.EXPECT().CreateLocalFrontendHTTPClient().Return(
+				&common.FrontendHTTPClient{
+					Client:  http.Client{Transport: transport},
+					Address: "frontend.invalid",
+					Scheme:  "http",
+				},
+				nil,
+			)
+
+			clusterMetadata := cluster.NewMockMetadata(ctrl)
+			clusterMetadata.EXPECT().GetAllClusterInfo().Return(map[string]cluster.ClusterInformation{
+				"current": {ClusterID: test.clusterID},
+			})
+			clusterMetadata.EXPECT().GetCurrentClusterName().Return("current")
+
+			provider, err := clientProviderFactory(
+				func(string, string) http.RoundTripper {
+					return transport
+				},
+				clusterMetadata,
+				rpcFactory,
+			)
+			require.NoError(t, err)
+
+			client, err := provider(
+				context.Background(),
+				"namespace-id",
+				&persistencespb.NexusEndpointEntry{
+					Id: "endpoint-id",
+					Endpoint: &persistencespb.NexusEndpoint{
+						Spec: &persistencespb.NexusEndpointSpec{
+							Target: test.target,
+						},
+					},
+				},
+				"service",
+			)
+			require.NoError(t, err)
+
+			_, err = client.StartOperation(
+				context.Background(),
+				"operation",
+				nil,
+				nexus.StartOperationOptions{},
+			)
+			require.ErrorIs(t, err, errHTTPClientCalled)
+		})
+	}
+}

--- a/chasm/lib/nexusoperation/fx_test.go
+++ b/chasm/lib/nexusoperation/fx_test.go
@@ -106,6 +106,7 @@ func TestClientProviderFactoryUsesSelectedHTTPClient(t *testing.T) {
 				},
 				clusterMetadata,
 				rpcFactory,
+				nil,
 			)
 			require.NoError(t, err)
 

--- a/chasm/lib/nexusoperation/fx_test.go
+++ b/chasm/lib/nexusoperation/fx_test.go
@@ -21,12 +21,14 @@ func (f testRoundTripper) RoundTrip(request *http.Request) (*http.Response, erro
 }
 
 func TestClientProviderFactoryUsesSelectedHTTPClient(t *testing.T) {
-	errHTTPClientCalled := errors.New("HTTP client called")
+	errEndpointClientCalled := errors.New("endpoint client called")
+	errFrontendClientCalled := errors.New("frontend client called")
 
 	tests := []struct {
 		name      string
 		clusterID string
 		target    *persistencespb.NexusEndpointTarget
+		expected  error
 	}{
 		{
 			name: "external without cluster ID",
@@ -37,6 +39,7 @@ func TestClientProviderFactoryUsesSelectedHTTPClient(t *testing.T) {
 					},
 				},
 			},
+			expected: errEndpointClientCalled,
 		},
 		{
 			name:      "external with cluster ID",
@@ -48,6 +51,7 @@ func TestClientProviderFactoryUsesSelectedHTTPClient(t *testing.T) {
 					},
 				},
 			},
+			expected: errEndpointClientCalled,
 		},
 		{
 			name: "worker without cluster ID",
@@ -56,6 +60,7 @@ func TestClientProviderFactoryUsesSelectedHTTPClient(t *testing.T) {
 					Worker: &persistencespb.NexusEndpointTarget_Worker{},
 				},
 			},
+			expected: errFrontendClientCalled,
 		},
 		{
 			name:      "worker with cluster ID",
@@ -65,20 +70,24 @@ func TestClientProviderFactoryUsesSelectedHTTPClient(t *testing.T) {
 					Worker: &persistencespb.NexusEndpointTarget_Worker{},
 				},
 			},
+			expected: errFrontendClientCalled,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			transport := testRoundTripper(func(*http.Request) (*http.Response, error) {
-				return nil, errHTTPClientCalled
+			endpointTransport := testRoundTripper(func(*http.Request) (*http.Response, error) {
+				return nil, errEndpointClientCalled
+			})
+			frontendTransport := testRoundTripper(func(*http.Request) (*http.Response, error) {
+				return nil, errFrontendClientCalled
 			})
 
 			rpcFactory := common.NewMockRPCFactory(ctrl)
 			rpcFactory.EXPECT().CreateLocalFrontendHTTPClient().Return(
 				&common.FrontendHTTPClient{
-					Client:  http.Client{Transport: transport},
+					Client:  http.Client{Transport: frontendTransport},
 					Address: "frontend.invalid",
 					Scheme:  "http",
 				},
@@ -93,7 +102,7 @@ func TestClientProviderFactoryUsesSelectedHTTPClient(t *testing.T) {
 
 			provider, err := clientProviderFactory(
 				func(string, string) http.RoundTripper {
-					return transport
+					return endpointTransport
 				},
 				clusterMetadata,
 				rpcFactory,
@@ -121,7 +130,7 @@ func TestClientProviderFactoryUsesSelectedHTTPClient(t *testing.T) {
 				nil,
 				nexus.StartOperationOptions{},
 			)
-			require.ErrorIs(t, err, errHTTPClientCalled)
+			require.ErrorIs(t, err, test.expected)
 		})
 	}
 }

--- a/chasm/lib/nexusoperation/handler.go
+++ b/chasm/lib/nexusoperation/handler.go
@@ -11,6 +11,7 @@ import (
 	nexusoperationpb "go.temporal.io/server/chasm/lib/nexusoperation/gen/nexusoperationpb/v1"
 	"go.temporal.io/server/common/contextutil"
 	"go.temporal.io/server/common/log"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type handler struct {
@@ -207,9 +208,10 @@ func (h *handler) RequestCancelNexusOperation(
 		ref,
 		func(o *Operation, ctx chasm.MutableContext, req *nexusoperationpb.RequestCancelNexusOperationRequest) (*nexusoperationpb.RequestCancelNexusOperationResponse, error) {
 			if err := o.RequestCancel(ctx, &nexusoperationpb.CancellationState{
-				RequestId: req.GetFrontendRequest().GetRequestId(),
-				Identity:  req.GetFrontendRequest().GetIdentity(),
-				Reason:    req.GetFrontendRequest().GetReason(),
+				RequestId:     req.GetFrontendRequest().GetRequestId(),
+				Identity:      req.GetFrontendRequest().GetIdentity(),
+				Reason:        req.GetFrontendRequest().GetReason(),
+				RequestedTime: timestamppb.New(ctx.Now(o)),
 			}); err != nil {
 				return nil, err
 			}

--- a/chasm/lib/nexusoperation/operation.go
+++ b/chasm/lib/nexusoperation/operation.go
@@ -263,7 +263,7 @@ func (o *Operation) HandleNexusCompletion(
 	links := completion.GetLinks()
 
 	// For completion-before-start, apply the started transition first.
-	if o.GetStatus() == nexusoperationpb.OPERATION_STATUS_SCHEDULED {
+	if TransitionStarted.Possible(o) {
 		startTime := timestamp.TimeValuePtr(completion.GetStartTime())
 		if err := o.onStarted(ctx, completion.GetOperationToken(), startTime, links); err != nil {
 			return err

--- a/chasm/lib/nexusoperation/operation_test.go
+++ b/chasm/lib/nexusoperation/operation_test.go
@@ -13,6 +13,7 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/chasm"
 	nexusoperationpb "go.temporal.io/server/chasm/lib/nexusoperation/gen/nexusoperationpb/v1"
+	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
@@ -158,6 +159,17 @@ func TestHandleNexusCompletion(t *testing.T) {
 		require.NoError(t, TransitionStarted.Apply(op, ctx, EventStarted{OperationToken: "tok"}))
 		return op
 	}
+	newBackingOffOp := func(t *testing.T, ctx *chasm.MockMutableContext) *Operation {
+		t.Helper()
+		op := newScheduledTestOperation(t, ctx)
+		require.NoError(t, transitionAttemptFailed.Apply(op, ctx, EventAttemptFailed{
+			Failure: &failurepb.Failure{
+				Message: "retryable failure",
+			},
+			RetryPolicy: backoff.NewConstantDelayRetryPolicy(time.Minute),
+		}))
+		return op
+	}
 	ctrl := gomock.NewController(t)
 	nsRegistry := namespace.NewMockRegistry(ctrl)
 	nsRegistry.EXPECT().GetNamespaceName(namespace.ID("ns-id")).Return(namespace.Name("ns-name"), nil).AnyTimes()
@@ -225,6 +237,29 @@ func TestHandleNexusCompletion(t *testing.T) {
 			require.Equal(t, nexusoperationpb.OPERATION_STATUS_SUCCEEDED, op.GetStatus())
 			require.Equal(t, "tok", op.GetOperationToken())
 			require.Equal(t, defaultTime, op.GetStartedTime().AsTime())
+		})
+
+		t.Run("CompletionDuringRetryBackoff", func(t *testing.T) {
+			ctx := newCtx()
+			op := newBackingOffOp(t, ctx)
+			startTime := defaultTime.Add(-time.Second)
+
+			err := op.HandleNexusCompletion(ctx, &persistencespb.ChasmNexusCompletion{
+				StartTime:      timestamppb.New(startTime),
+				RequestId:      op.GetRequestId(),
+				OperationToken: "tok",
+				Outcome: &persistencespb.ChasmNexusCompletion_Success{
+					Success: mustToPayload(t, "result"),
+				},
+			})
+
+			require.NoError(t, err)
+			require.Equal(t, nexusoperationpb.OPERATION_STATUS_SUCCEEDED, op.GetStatus())
+			require.Equal(t, "tok", op.GetOperationToken())
+			require.Equal(t, startTime, op.GetStartedTime().AsTime())
+			require.Equal(t, startTime, op.GetLastAttemptCompleteTime().AsTime())
+			require.Nil(t, op.GetLastAttemptFailure())
+			require.Nil(t, op.GetNextAttemptScheduleTime())
 		})
 	})
 

--- a/chasm/lib/workflow/nexus_events.go
+++ b/chasm/lib/workflow/nexus_events.go
@@ -95,7 +95,8 @@ func (d CancelRequestedEventDefinition) Apply(ctx chasm.MutableContext, wf *Work
 	}
 
 	return op.RequestCancel(ctx, &nexusoperationpb.CancellationState{
-		ParentData: cancelParentData,
+		RequestedTime: event.GetEventTime(),
+		ParentData:    cancelParentData,
 	})
 }
 

--- a/chasm/lib/workflow/nexus_events_test.go
+++ b/chasm/lib/workflow/nexus_events_test.go
@@ -375,10 +375,11 @@ func TestCancelRequestedEventDefinitionApply(t *testing.T) {
 	t.Run("creates cancellation child", func(t *testing.T) {
 		tcx := newTestContext(t, defaultConfig)
 		event, key := scheduleOperation(t, tcx)
+		requestedTime := time.Now().UTC()
 
 		applyEventDefinition[CancelRequestedEventDefinition](t, tcx, &historypb.HistoryEvent{
 			EventId:   int64(20),
-			EventTime: timestamppb.Now(),
+			EventTime: timestamppb.New(requestedTime),
 			Attributes: &historypb.HistoryEvent_NexusOperationCancelRequestedEventAttributes{
 				NexusOperationCancelRequestedEventAttributes: &historypb.NexusOperationCancelRequestedEventAttributes{
 					ScheduledEventId: event.EventId,
@@ -389,8 +390,9 @@ func TestCancelRequestedEventDefinitionApply(t *testing.T) {
 		field, ok := tcx.wf.Operations[key]
 		require.True(t, ok)
 		op := field.Get(tcx.chasmCtx)
-		_, hasCancellation := op.Cancellation.TryGet(tcx.chasmCtx)
+		cancellation, hasCancellation := op.Cancellation.TryGet(tcx.chasmCtx)
 		require.True(t, hasCancellation)
+		require.Equal(t, requestedTime, cancellation.GetRequestedTime().AsTime())
 	})
 
 	t.Run("tolerates missing operation", func(t *testing.T) {

--- a/tests/nexus_standalone_test.go
+++ b/tests/nexus_standalone_test.go
@@ -868,6 +868,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCancel() {
 		})
 		s.NoError(err)
 
+		beforeCancelRequest := time.Now()
 		_, err = env.FrontendClient().RequestCancelNexusOperationExecution(s.Context(), &workflowservice.RequestCancelNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "test-op",
@@ -875,6 +876,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCancel() {
 			Reason:      "test cancellation",
 		})
 		s.NoError(err)
+		afterCancelRequest := time.Now()
 
 		// Verify state after cancel — operation is still running
 		descResp, err := env.FrontendClient().DescribeNexusOperationExecution(s.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
@@ -900,6 +902,8 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCancel() {
 		}, descResp.GetInfo(), protorequire.IgnoreFields("operation_token", "last_attempt_complete_time", "request_id", "schedule_time", "expiration_time", "execution_duration", "cancellation_info"))
 		cancellationInfo := descResp.GetInfo().GetCancellationInfo()
 		s.NotNil(cancellationInfo)
+		s.Require().NotNil(cancellationInfo.GetRequestedTime())
+		s.WithinRange(cancellationInfo.GetRequestedTime().AsTime(), beforeCancelRequest, afterCancelRequest)
 		s.NotEqual(enumspb.NEXUS_OPERATION_CANCELLATION_STATE_UNSPECIFIED, cancellationInfo.GetState())
 		protorequire.ProtoEqual(s.T(), &nexuspb.NexusOperationExecutionCancellationInfo{
 			Attempt: 1,

--- a/tests/nexus_standalone_test.go
+++ b/tests/nexus_standalone_test.go
@@ -902,7 +902,7 @@ func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationCancel() {
 		}, descResp.GetInfo(), protorequire.IgnoreFields("operation_token", "last_attempt_complete_time", "request_id", "schedule_time", "expiration_time", "execution_duration", "cancellation_info"))
 		cancellationInfo := descResp.GetInfo().GetCancellationInfo()
 		s.NotNil(cancellationInfo)
-		s.Require().NotNil(cancellationInfo.GetRequestedTime())
+		s.NotNil(cancellationInfo.GetRequestedTime())
 		s.WithinRange(cancellationInfo.GetRequestedTime().AsTime(), beforeCancelRequest, afterCancelRequest)
 		s.NotEqual(enumspb.NEXUS_OPERATION_CANCELLATION_STATE_UNSPECIFIED, cancellationInfo.GetState())
 		protorequire.ProtoEqual(s.T(), &nexuspb.NexusOperationExecutionCancellationInfo{


### PR DESCRIPTION
## What changed?
1. Binds httpCaller after setting httpClient
2. Uses TransitionStarted.Possible for complete-before-start
3. Records request time for nexus operation cancel

## Why?
1. Binds httpCaller after setting httpClient
When clusterID isn't set, a non-nil httpCaller with a nil receiver gets passed to `nexusrpc.NewHTTPClient`. Since the httpCaller is non-nil, it will skip the check that sets the nil httpCaller to the default caller.

2. Uses TransitionStarted.Possible for complete-before-start
Matches HSM, for if a start response is lost, and a completion lands while while the operation is in BACKING_OFF.

3. Records request time for nexus operation cancel
This just seems like it wasn't being recorded.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
