### PR TITLE
Fix: log for scanner hitting cap

### DIFF
--- a/service/worker/scanner/scheduleinvariants/invariants.go
+++ b/service/worker/scanner/scheduleinvariants/invariants.go
@@ -216,7 +216,10 @@ func (a *Activities) runOverdueScan(ctx context.Context, query string) error {
 			if checked >= int64(maxChecks) {
 				a.logger.Warn("overdue scan hit per-namespace check cap; remaining schedules left unchecked this pass",
 					tag.WorkflowNamespace(nsName),
-					tag.NewInt("cap", maxChecks))
+					tag.ScheduleID(scheduleID),
+					tag.NewInt64("checked", checked),
+					tag.NewInt("cap", maxChecks),
+					tag.NewInt64("anomalies-found-so-far", nsAnomalies))
 				metrics.ScheduleInvariantsScannerOverdueNextActionTimeCapHitCount.With(
 					a.metricsHandler.WithTags(metrics.NamespaceTag(nsName))).Record(1)
 				break


### PR DESCRIPTION
The "overdue scan hit per-namespace check cap" warning previously only logged the namespace and the cap value, giving no way to tell which schedule the scan stopped at or how much progress it had made before hitting the cap. Add the schedule ID it stopped on, how many schedules were checked this pass, and how many anomalies had already been found, so the log line is actionable on its own.

## What changed?
adds some logs 

## Why?
Trying to debug some odd results

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
very low, feature is turned off by default, log line only