### PR TITLE
Validate links on callbacks consistently.

### DIFF
--- a/chasm/lib/activity/frontend.go
+++ b/chasm/lib/activity/frontend.go
@@ -423,7 +423,7 @@ func (h *frontendHandler) validateAndPopulateStartRequest(
 		}
 	}
 
-	if err := h.linkValidator.ValidateRequest(req.GetNamespace(), req.GetLinks()); err != nil {
+	if err := h.linkValidator.ValidateStartRequest(req.GetNamespace(), req.GetLinks(), req.GetCompletionCallbacks()); err != nil {
 		return nil, err
 	}
 

--- a/chasm/lib/activity/link_validator.go
+++ b/chasm/lib/activity/link_validator.go
@@ -34,6 +34,20 @@ func (v *linkValidator) ValidateRequest(namespaceName string, links []*commonpb.
 	return commonlinks.Validate(links, v.maxLinksPerRequest(namespaceName), v.linkMaxSize(namespaceName))
 }
 
+// ValidateStartRequest also includes links embedded in completion callbacks.
+func (v *linkValidator) ValidateStartRequest(
+	namespaceName string,
+	links []*commonpb.Link,
+	callbacks []*commonpb.Callback,
+) error {
+	return commonlinks.ValidateRequest(
+		links,
+		callbacks,
+		v.maxLinksPerRequest(namespaceName),
+		v.linkMaxSize(namespaceName),
+	)
+}
+
 // ValidateComponentTotal checks that adding addingCount links to a component
 // already holding existingCount links would not exceed the per-component cap.
 func (v *linkValidator) ValidateComponentTotal(namespaceName string, existingCount, addingCount int) error {

--- a/chasm/lib/activity/validator_test.go
+++ b/chasm/lib/activity/validator_test.go
@@ -14,6 +14,7 @@ import (
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/chasm/lib/callback"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/namespace"
@@ -525,6 +526,80 @@ func TestRequestIDGeneratedWhenMissing(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, req.GetRequestId(), "server must generate a request ID when client omits it")
 		require.NoError(t, validateUUID(req.GetRequestId()), "generated request ID must be a valid UUID")
+	})
+}
+
+func TestValidateAndPopulateStartRequest_ValidatesCompletionCallbackLinks(t *testing.T) {
+	h := &frontendHandler{
+		config: &Config{
+			BlobSizeLimitError:         defaultBlobSizeLimitError,
+			BlobSizeLimitWarn:          defaultBlobSizeLimitWarn,
+			DefaultActivityRetryPolicy: getDefaultRetrySettings,
+			EnableCallbacks:            func(string) bool { return true },
+			MaxIDLengthLimit:           func() int { return defaultMaxIDLengthLimit },
+			MaxUserMetadataDetailsSize: defaultMaxUserMetadataDetailsSize,
+			MaxUserMetadataSummarySize: defaultMaxUserMetadataSummarySize,
+		},
+		callbackValidator: callback.NewValidator(
+			func(string) int { return 10 },
+			func(string) int { return 1000 },
+			func(string) int { return 4096 },
+			func(string) callback.AddressMatchRules { return callback.AddressMatchRules{} },
+		),
+		linkValidator: newLinkValidator(
+			func(string) int { return 1 },
+			func(string) int { return 2000 },
+			defaultLinkMaxSize,
+		),
+		logger: log.NewNoopLogger(),
+	}
+	newRequest := func(callbackLinks []*commonpb.Link) *workflowservice.StartActivityExecutionRequest {
+		return &workflowservice.StartActivityExecutionRequest{
+			Namespace:           defaultNamespaceID,
+			ActivityId:          defaultActivityID,
+			ActivityType:        &commonpb.ActivityType{Name: defaultActivityType},
+			TaskQueue:           &taskqueuepb.TaskQueue{Name: defaultTaskQueue},
+			StartToCloseTimeout: durationpb.New(10 * time.Second),
+			CompletionCallbacks: []*commonpb.Callback{{
+				Variant: &commonpb.Callback_Internal_{
+					Internal: &commonpb.Callback_Internal{},
+				},
+				Links: callbackLinks,
+			}},
+		}
+	}
+
+	t.Run("invalid callback link", func(t *testing.T) {
+		req := newRequest([]*commonpb.Link{{
+			Variant: &commonpb.Link_BatchJob_{
+				BatchJob: &commonpb.Link_BatchJob{},
+			},
+		}})
+
+		_, err := h.validateAndPopulateStartRequest(t.Context(), req, namespace.ID(defaultNamespaceID))
+
+		var invalidArgument *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgument)
+		require.ErrorContains(t, err, "batch job link must not have an empty job ID")
+	})
+
+	t.Run("too many combined links", func(t *testing.T) {
+		req := newRequest([]*commonpb.Link{{
+			Variant: &commonpb.Link_BatchJob_{
+				BatchJob: &commonpb.Link_BatchJob{JobId: "callback-job"},
+			},
+		}})
+		req.Links = []*commonpb.Link{{
+			Variant: &commonpb.Link_BatchJob_{
+				BatchJob: &commonpb.Link_BatchJob{JobId: "request-job"},
+			},
+		}}
+
+		_, err := h.validateAndPopulateStartRequest(t.Context(), req, namespace.ID(defaultNamespaceID))
+
+		var invalidArgument *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgument)
+		require.ErrorContains(t, err, "cannot attach more than 1 links per request, got 2")
 	})
 }
 

--- a/common/links/validator.go
+++ b/common/links/validator.go
@@ -7,6 +7,21 @@ import (
 	"go.temporal.io/api/serviceerror"
 )
 
+// ValidateRequest validates all links attached directly to a request or embedded in its callbacks.
+func ValidateRequest(
+	links []*commonpb.Link,
+	callbacks []*commonpb.Callback,
+	maxAllowedLinks int,
+	maxSize int,
+) error {
+	allLinks := make([]*commonpb.Link, 0, len(links)+len(callbacks))
+	allLinks = append(allLinks, links...)
+	for _, callback := range callbacks {
+		allLinks = append(allLinks, callback.GetLinks()...)
+	}
+	return Validate(allLinks, maxAllowedLinks, maxSize)
+}
+
 // Validate checks that the given links do not exceed the configured count and
 // per-link size limits, and that each link's variant has its required fields
 // populated.

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -685,12 +685,12 @@ func (wh *WorkflowHandler) prepareStartWorkflowRequest(
 
 	request.Links = dedupLinksFromCallbacks(request.GetLinks(), request.GetCompletionCallbacks())
 
-	allLinks := make([]*commonpb.Link, 0, len(request.GetLinks())+len(request.GetCompletionCallbacks()))
-	allLinks = append(allLinks, request.GetLinks()...)
-	for _, cb := range request.GetCompletionCallbacks() {
-		allLinks = append(allLinks, cb.GetLinks()...)
-	}
-	if err := commonlinks.Validate(allLinks, wh.config.MaxLinksPerRequest(namespaceName.String()), wh.config.LinkMaxSize(namespaceName.String())); err != nil {
+	if err := commonlinks.ValidateRequest(
+		request.GetLinks(),
+		request.GetCompletionCallbacks(),
+		wh.config.MaxLinksPerRequest(namespaceName.String()),
+		wh.config.LinkMaxSize(namespaceName.String()),
+	); err != nil {
 		return nil, err
 	}
 
@@ -5478,7 +5478,12 @@ func (wh *WorkflowHandler) prepareUpdateWorkflowRequest(
 		}
 	}
 
-	return nil
+	return commonlinks.ValidateRequest(
+		request.GetRequest().GetLinks(),
+		request.GetRequest().GetCompletionCallbacks(),
+		wh.config.MaxLinksPerRequest(namespaceName.String()),
+		wh.config.LinkMaxSize(namespaceName.String()),
+	)
 }
 
 func (wh *WorkflowHandler) PollWorkflowExecutionUpdate(

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -5478,6 +5478,11 @@ func (wh *WorkflowHandler) prepareUpdateWorkflowRequest(
 		}
 	}
 
+	request.GetRequest().Links = dedupLinksFromCallbacks(
+		request.GetRequest().GetLinks(),
+		request.GetRequest().GetCompletionCallbacks(),
+	)
+
 	return commonlinks.ValidateRequest(
 		request.GetRequest().GetLinks(),
 		request.GetRequest().GetCompletionCallbacks(),

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -5718,7 +5718,9 @@ func (s *WorkflowHandlerSuite) TestUpdateWorkflowExecutionOptions_TimeSkipping_D
 }
 
 func (s *WorkflowHandlerSuite) TestPrepareUpdateWorkflowRequest_ValidatesCompletionCallbacks() {
-	wh := s.getWorkflowHandler(s.newConfig())
+	config := s.newConfig()
+	config.MaxLinksPerRequest = dc.GetIntPropertyFnFilteredByNamespace(1)
+	wh := s.getWorkflowHandler(config)
 	newRequest := func(callbacks []*commonpb.Callback) *workflowservice.UpdateWorkflowExecutionRequest {
 		return &workflowservice.UpdateWorkflowExecutionRequest{
 			Namespace:         s.testNamespace.String(),
@@ -5758,6 +5760,51 @@ func (s *WorkflowHandlerSuite) TestPrepareUpdateWorkflowRequest_ValidatesComplet
 
 		s.NoError(err)
 		s.Equal(map[string]string{"x-request-id": "value"}, request.GetRequest().GetCompletionCallbacks()[0].GetNexus().GetHeader())
+	})
+
+	s.Run("rejects invalid callback links", func() {
+		err := wh.prepareUpdateWorkflowRequest(
+			context.Background(),
+			s.testNamespace,
+			newRequest([]*commonpb.Callback{{
+				Variant: &commonpb.Callback_Internal_{
+					Internal: &commonpb.Callback_Internal{},
+				},
+				Links: []*commonpb.Link{{
+					Variant: &commonpb.Link_BatchJob_{
+						BatchJob: &commonpb.Link_BatchJob{},
+					},
+				}},
+			}}),
+		)
+
+		var invalidArgument *serviceerror.InvalidArgument
+		s.ErrorAs(err, &invalidArgument)
+		s.ErrorContains(err, "batch job link must not have an empty job ID")
+	})
+
+	s.Run("rejects too many combined links", func() {
+		request := newRequest([]*commonpb.Callback{{
+			Variant: &commonpb.Callback_Internal_{
+				Internal: &commonpb.Callback_Internal{},
+			},
+			Links: []*commonpb.Link{{
+				Variant: &commonpb.Link_BatchJob_{
+					BatchJob: &commonpb.Link_BatchJob{JobId: "callback-job"},
+				},
+			}},
+		}})
+		request.Request.Links = []*commonpb.Link{{
+			Variant: &commonpb.Link_BatchJob_{
+				BatchJob: &commonpb.Link_BatchJob{JobId: "request-job"},
+			},
+		}}
+
+		err := wh.prepareUpdateWorkflowRequest(context.Background(), s.testNamespace, request)
+
+		var invalidArgument *serviceerror.InvalidArgument
+		s.ErrorAs(err, &invalidArgument)
+		s.ErrorContains(err, "cannot attach more than 1 links per request, got 2")
 	})
 }
 

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -5762,6 +5762,26 @@ func (s *WorkflowHandlerSuite) TestPrepareUpdateWorkflowRequest_ValidatesComplet
 		s.Equal(map[string]string{"x-request-id": "value"}, request.GetRequest().GetCompletionCallbacks()[0].GetNexus().GetHeader())
 	})
 
+	s.Run("deduplicates links from Nexus callbacks", func() {
+		callbackLink := &commonpb.Link{
+			Variant: &commonpb.Link_BatchJob_{
+				BatchJob: &commonpb.Link_BatchJob{JobId: "job-id"},
+			},
+		}
+		request := newRequest([]*commonpb.Callback{{
+			Variant: &commonpb.Callback_Nexus_{
+				Nexus: &commonpb.Callback_Nexus{Url: "http://localhost/callback"},
+			},
+			Links: []*commonpb.Link{callbackLink},
+		}})
+		request.Request.Links = []*commonpb.Link{common.CloneProto(callbackLink)}
+
+		err := wh.prepareUpdateWorkflowRequest(context.Background(), s.testNamespace, request)
+
+		s.NoError(err)
+		s.Empty(request.GetRequest().GetLinks())
+	})
+
 	s.Run("rejects invalid callback links", func() {
 		err := wh.prepareUpdateWorkflowRequest(
 			context.Background(),


### PR DESCRIPTION
## What changed?
Validate links on callbacks consistently.

## Why?
Some links on callbacks for some requests are not being validated properly 

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens request validation on frontend APIs; clients sending invalid or over-limit callback links may now get errors where requests were previously accepted.
> 
> **Overview**
> **Start activity** and **start workflow** now validate links embedded in `completion_callbacks` under the same per-request count and size limits as top-level request links, via `commonlinks.ValidateRequest` and activity `ValidateStartRequest`.
> 
> **Update workflow execution** previously skipped combined link validation; it now deduplicates Nexus callback links from request links (matching start workflow) and runs the same `ValidateRequest` checks.
> 
> Shared helper `commonlinks.ValidateRequest` merges direct request links with links on each callback before calling existing `Validate` logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb168f7f73e403716e594c89eef41c937eeee457. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->