### PR TITLE
Make standalone activity completion callback attachment idempotent after closure

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -434,6 +434,11 @@ func (a *Activity) addCompletionCallbacks(
 	if len(completionCallbacks) == 0 {
 		return nil
 	}
+	for _, callbackField := range a.Callbacks {
+		if callbackField.Get(ctx).GetRequestId() == requestID {
+			return nil
+		}
+	}
 	if a.LifecycleState(ctx).IsClosed() {
 		return serviceerror.NewFailedPrecondition("cannot attach callbacks to a closed activity")
 	}

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -449,6 +449,61 @@ func (s *standaloneActivityTestSuite) TestIDConflictPolicy() {
 				require.Len(t, descResp.Callbacks, 1)
 				require.Equal(t, "http://localhost/idempotent-cb", descResp.Callbacks[0].GetInfo().GetCallback().GetNexus().GetUrl())
 			})
+
+			t.Run("IdempotentWithSameRequestIdAfterClose", func(t *testing.T) {
+				activityID := testcore.RandomizeStr(t.Name())
+				taskQueue := testcore.RandomizeStr(t.Name())
+				requestID := env.Tv().Any().String()
+				ch, callbackAddress := newNexusCompletionHandler(t)
+				startReq := &workflowservice.StartActivityExecutionRequest{
+					Namespace:           env.Namespace().String(),
+					ActivityId:          activityID,
+					ActivityType:        env.Tv().ActivityType(),
+					Identity:            env.Tv().WorkerIdentity(),
+					Input:               defaultInput,
+					TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
+					StartToCloseTimeout: durationpb.New(time.Minute),
+					IdConflictPolicy:    enumspb.ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING,
+					RequestId:           requestID,
+					CompletionCallbacks: []*commonpb.Callback{{
+						Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: callbackAddress}},
+					}},
+					OnConflictOptions: onConflictOpts,
+				}
+
+				startResp, err := env.FrontendClient().StartActivityExecution(ctx, startReq)
+				require.NoError(t, err)
+				require.True(t, startResp.GetStarted())
+
+				pollResp := env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, startResp.GetRunId())
+				_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+					Namespace: env.Namespace().String(),
+					TaskToken: pollResp.GetTaskToken(),
+					Result:    defaultResult,
+					Identity:  defaultIdentity,
+				})
+				require.NoError(t, err)
+
+				select {
+				case <-ch.requestCh:
+				case <-ctx.Done():
+					require.Fail(t, "timed out waiting for completion callback")
+				}
+
+				retryResp, err := env.FrontendClient().StartActivityExecution(ctx, startReq)
+				require.NoError(t, err)
+				require.False(t, retryResp.GetStarted())
+				require.Equal(t, startResp.GetRunId(), retryResp.GetRunId())
+				ch.requestCompleteCh <- nil
+
+				descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+					Namespace:  env.Namespace().String(),
+					ActivityId: activityID,
+					RunId:      startResp.GetRunId(),
+				})
+				require.NoError(t, err)
+				require.Len(t, descResp.GetCallbacks(), 1)
+			})
 		})
 
 		t.Run("DoesNotApplyToCompletedActivity", func(t *testing.T) {


### PR DESCRIPTION
## What changed?
Fixing a bug identified by AI. Make standalone activity completion callback attachment idempotent after closure

## Why?
So we respect request ID and use it properly as an idempotency key

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [x] added new functional test(s)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral fix in standalone activity callback attachment with a dedicated functional test; no auth or broad API surface changes.
> 
> **Overview**
> **Standalone activity completion callbacks** now treat `requestId` as an idempotency key even when the activity is already closed.
> 
> `addCompletionCallbacks` checks existing callbacks for a matching `requestId` **before** rejecting closed activities, matching the pattern already used for `attachLinks`. Retries of `StartActivityExecution` with `USE_EXISTING` and the same `requestId` succeed without duplicating callbacks or returning `FailedPrecondition`.
> 
> A functional test covers completing an activity, then retrying start with the same `requestId` and completion callback after closure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2d70b9af3ca6abf9c396fc28b8675d35ccb8ce2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->