### PR TITLE
Recreate only the activity timers whose deadline actually moved (#11565)

### DIFF
--- a/service/history/workflow/activity.go
+++ b/service/history/workflow/activity.go
@@ -70,7 +70,7 @@ func UpdateActivityInfoForRetries(
 	ai.ScheduledTime = nextScheduledTime
 	ClearActivityStartedState(ai)
 	// Mark per-attempt timers for recreation.
-	ai.TimerTaskStatus &^= TimerTaskStatusCreatedHeartbeat | TimerTaskStatusCreatedStartToClose | TimerTaskStatusCreatedScheduleToStart
+	ai.TimerTaskStatus &^= TimerTaskStatusCreatedPerAttempt
 	ai.RetryLastWorkerIdentity = ai.StartedIdentity
 	ai.RetryLastFailure = failure
 	// this flag means the user resets the activity with "--reset-heartbeat" flag

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -9179,6 +9179,39 @@ func (ms *MutableStateImpl) ShouldResetActivityTimerTaskMask(current, incoming *
 	return false
 }
 
+// getActivityTimerTaskStatus returns the activity timer task status bits to carry over
+// when applying `incoming` on top of `current` during state-based replication. A bit is
+// kept only when the timer task already created for it is still valid, so that a
+// subsequent task refresh does not regenerate a timeout task that is already pending.
+//
+// Validity is decided purely by the deadline. An ActivityTimeoutTask is a wake-up at a
+// point in time: processSingleActivityTimeoutTask re-derives the whole timer sequence
+// from current mutable state and fires whatever has expired, without consulting the
+// task's attempt or stamp ("we don't need to check activity Stamps"). So a pending task
+// whose deadline is unchanged is still correct no matter what else moved, and a task
+// whose deadline moved is useless no matter what stayed put.
+//
+// Attempt and stamp are therefore deliberately not consulted here: they are only ever
+// proxies for "some deadline probably moved", and comparing the deadlines answers that
+// question directly. A new attempt, for instance, clears start-to-close and heartbeat
+// because clearing the started state removes those timers outright, and moves
+// schedule-to-start because its anchor advances — while schedule-to-close survives,
+// being anchored to the untouched FirstScheduledTime.
+//
+// The exception is a cross-cluster version change, which is about task provenance
+// rather than deadlines: tasks generated under the previous owning cluster are dropped
+// as stale at execution, so everything has to be recreated.
+func (ms *MutableStateImpl) getActivityTimerTaskStatus(current, incoming *persistencespb.ActivityInfo) int32 {
+	if current == nil {
+		return TimerTaskStatusNone
+	}
+	if !ms.clusterMetadata.IsVersionFromSameCluster(current.Version, incoming.Version) {
+		return TimerTaskStatusNone
+	}
+	return current.TimerTaskStatus &^
+		getActivityTimerDeadlines(current).changedMask(getActivityTimerDeadlines(incoming))
+}
+
 func (ms *MutableStateImpl) applyUpdatesToSubStateMachines(
 	updatedActivityInfos map[int64]*persistencespb.ActivityInfo,
 	updatedTimerInfos map[string]*persistencespb.TimerInfo,
@@ -9188,11 +9221,7 @@ func (ms *MutableStateImpl) applyUpdatesToSubStateMachines(
 	isSnapshot bool,
 ) error {
 	err := applyUpdatesToSubStateMachine(ms, ms.pendingActivityInfoIDs, ms.updateActivityInfos, updatedActivityInfos, isSnapshot, ms.DeleteActivity, func(current, incoming *persistencespb.ActivityInfo) {
-		if current == nil || ms.ShouldResetActivityTimerTaskMask(current, incoming) {
-			incoming.TimerTaskStatus = TimerTaskStatusNone
-		} else {
-			incoming.TimerTaskStatus = current.TimerTaskStatus
-		}
+		incoming.TimerTaskStatus = ms.getActivityTimerTaskStatus(current, incoming)
 	}, func(ai *persistencespb.ActivityInfo) {
 		ms.pendingActivityIDToEventID[ai.ActivityId] = ai.ScheduledEventId
 		ms.activityInfosUserDataUpdated[ai.ScheduledEventId] = struct{}{}

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -6274,6 +6274,155 @@ func (s *mutableStateSuite) TestRefreshTask_SameCluster_SameAttempt() {
 	s.False(shouldReset)
 }
 
+// startedActivityInfoForMask builds a started activity that has all four timer bits
+// set, so a test can assert precisely which ones survive an update.
+func startedActivityInfoForMask(version int64, attempt, stamp int32) *persistencespb.ActivityInfo {
+	scheduledTime := time.Date(2026, 8, 11, 0, 0, 0, 0, time.UTC)
+	return &persistencespb.ActivityInfo{
+		Version:                version,
+		Attempt:                attempt,
+		Stamp:                  stamp,
+		ScheduledEventId:       int64(7),
+		StartedEventId:         int64(8),
+		ScheduledTime:          timestamppb.New(scheduledTime),
+		FirstScheduledTime:     timestamppb.New(scheduledTime),
+		StartedTime:            timestamppb.New(scheduledTime.Add(time.Second)),
+		ScheduleToCloseTimeout: durationpb.New(time.Hour),
+		StartToCloseTimeout:    durationpb.New(10 * time.Minute),
+		HeartbeatTimeout:       durationpb.New(time.Minute),
+		// Schedule-to-start no longer applies once the activity has started, so only the
+		// other three timers can have a task outstanding.
+		TimerTaskStatus: TimerTaskStatusCreatedScheduleToClose |
+			TimerTaskStatusCreatedStartToClose |
+			TimerTaskStatusCreatedHeartbeat,
+	}
+}
+
+func (s *mutableStateSuite) TestNextActivityTimerTaskMask_DiffCluster_ResetsEverything() {
+	current := startedActivityInfoForMask(int64(100), 1, 1)
+	incoming := startedActivityInfoForMask(int64(99), 1, 1)
+
+	s.mockShard.Resource.ClusterMetadata.EXPECT().IsVersionFromSameCluster(current.Version, incoming.Version).Return(false)
+
+	// Tasks from the previous owning cluster are stale, so everything is recreated.
+	s.Equal(int32(TimerTaskStatusNone), s.mutableState.getActivityTimerTaskStatus(current, incoming))
+}
+
+// retryActivityInfoForMask applies to `ai` the same field changes the active side makes
+// on a retry (UpdateActivityInfoForRetries): next attempt, started state cleared, and
+// the schedule time advanced by the retry backoff. FirstScheduledTime is untouched.
+func retryActivityInfoForMask(ai *persistencespb.ActivityInfo, backoff time.Duration) *persistencespb.ActivityInfo {
+	ai.Attempt++
+	ai.StartedEventId = common.EmptyEventID
+	ai.StartedTime = nil
+	ai.ScheduledTime = timestamppb.New(ai.ScheduledTime.AsTime().Add(backoff))
+	return ai
+}
+
+func (s *mutableStateSuite) TestNextActivityTimerTaskMask_Retry_KeepsOnlyScheduleToClose() {
+	version := int64(99)
+	current := startedActivityInfoForMask(version, 1, 1)
+	incoming := retryActivityInfoForMask(startedActivityInfoForMask(version, 1, 1), 10*time.Second)
+
+	s.mockShard.Resource.ClusterMetadata.EXPECT().IsVersionFromSameCluster(version, version).Return(true)
+
+	// Clearing the started state removes the start-to-close and heartbeat timers, so
+	// their tasks are useless and the bits go. Schedule-to-close is anchored to the
+	// untouched FirstScheduledTime, so its pending task is still correct and survives.
+	// Note the attempt itself is never consulted: the deadlines carry the decision.
+	s.Equal(
+		int32(TimerTaskStatusCreatedScheduleToClose),
+		s.mutableState.getActivityTimerTaskStatus(current, incoming),
+	)
+}
+
+// Pre-FirstScheduledTime mutable state falls back to anchoring schedule-to-close on
+// ScheduledTime, which a retry does move. The deadline comparison notices and clears the
+// bit, where keying off the attempt alone would have preserved a task pointing at the
+// old, earlier instant.
+func (s *mutableStateSuite) TestNextActivityTimerTaskMask_Retry_LegacyAnchor_ClearsScheduleToClose() {
+	version := int64(99)
+	current := startedActivityInfoForMask(version, 1, 1)
+	current.FirstScheduledTime = nil
+	incoming := retryActivityInfoForMask(startedActivityInfoForMask(version, 1, 1), 10*time.Second)
+	incoming.FirstScheduledTime = nil
+
+	s.mockShard.Resource.ClusterMetadata.EXPECT().IsVersionFromSameCluster(version, version).Return(true)
+
+	s.Equal(int32(TimerTaskStatusNone), s.mutableState.getActivityTimerTaskStatus(current, incoming))
+}
+
+// Attempt moving on its own decides nothing; an unchanged deadline keeps its task.
+func (s *mutableStateSuite) TestNextActivityTimerTaskMask_AttemptChangedWithoutDeadlineMove_KeepsMask() {
+	version := int64(99)
+	current := startedActivityInfoForMask(version, 1, 1)
+	incoming := startedActivityInfoForMask(version, 2, 1)
+
+	s.mockShard.Resource.ClusterMetadata.EXPECT().IsVersionFromSameCluster(version, version).Return(true)
+
+	s.Equal(current.TimerTaskStatus, s.mutableState.getActivityTimerTaskStatus(current, incoming))
+}
+
+func (s *mutableStateSuite) TestNextActivityTimerTaskMask_ClearsOnlyMovedDeadlines() {
+	version := int64(99)
+	current := startedActivityInfoForMask(version, 1, 1)
+	// Activity options were updated, bumping the stamp; only the heartbeat timeout was
+	// shortened, so only that deadline moves.
+	incoming := startedActivityInfoForMask(version, 1, 2)
+	incoming.HeartbeatTimeout = durationpb.New(30 * time.Second)
+
+	s.mockShard.Resource.ClusterMetadata.EXPECT().IsVersionFromSameCluster(version, version).Return(true)
+
+	s.Equal(
+		int32(TimerTaskStatusCreatedScheduleToClose|TimerTaskStatusCreatedStartToClose),
+		s.mutableState.getActivityTimerTaskStatus(current, incoming),
+	)
+}
+
+func (s *mutableStateSuite) TestNextActivityTimerTaskMask_UnrelatedOptionChanged_KeepsMask() {
+	version := int64(99)
+	current := startedActivityInfoForMask(version, 1, 1)
+	// Stamp moved because some unrelated option changed; no deadline is affected, so
+	// every pending task is still correct.
+	incoming := startedActivityInfoForMask(version, 1, 2)
+
+	s.mockShard.Resource.ClusterMetadata.EXPECT().IsVersionFromSameCluster(version, version).Return(true)
+
+	s.Equal(current.TimerTaskStatus, s.mutableState.getActivityTimerTaskStatus(current, incoming))
+}
+
+func (s *mutableStateSuite) TestNextActivityTimerTaskMask_TimerDisappears() {
+	version := int64(99)
+	current := startedActivityInfoForMask(version, 1, 1)
+	incoming := startedActivityInfoForMask(version, 1, 2)
+	// Heartbeat timeout removed entirely: the timer no longer applies, so its bit goes.
+	incoming.HeartbeatTimeout = nil
+
+	s.mockShard.Resource.ClusterMetadata.EXPECT().IsVersionFromSameCluster(version, version).Return(true)
+
+	s.Equal(
+		int32(TimerTaskStatusCreatedScheduleToClose|TimerTaskStatusCreatedStartToClose),
+		s.mutableState.getActivityTimerTaskStatus(current, incoming),
+	)
+}
+
+func (s *mutableStateSuite) TestNextActivityTimerTaskMask_Unchanged_KeepsMask() {
+	version := int64(99)
+	current := startedActivityInfoForMask(version, 1, 1)
+	incoming := startedActivityInfoForMask(version, 1, 1)
+
+	s.mockShard.Resource.ClusterMetadata.EXPECT().IsVersionFromSameCluster(version, version).Return(true)
+
+	s.Equal(current.TimerTaskStatus, s.mutableState.getActivityTimerTaskStatus(current, incoming))
+}
+
+func (s *mutableStateSuite) TestNextActivityTimerTaskMask_NewActivity_NoMask() {
+	s.Equal(
+		int32(TimerTaskStatusNone),
+		s.mutableState.getActivityTimerTaskStatus(nil, startedActivityInfoForMask(int64(99), 1, 1)),
+	)
+}
+
 func (s *mutableStateSuite) TestUpdateActivityTaskStatusWithTimerHeartbeat() {
 	dbState := s.buildWorkflowMutableState()
 	scheduleEventId := int64(781)

--- a/service/history/workflow/timer_sequence.go
+++ b/service/history/workflow/timer_sequence.go
@@ -31,6 +31,15 @@ const (
 	TimerTaskStatusCreatedHeartbeat
 )
 
+// TimerTaskStatusCreatedPerAttempt is the set of activity timer task bits scoped to a
+// single attempt. They must be cleared when an activity moves to a new attempt so the
+// timers are recreated against the new deadlines. TimerTaskStatusCreatedScheduleToClose
+// is deliberately excluded: it is a whole-activity deadline that spans retries, so
+// clearing it would regenerate a timeout task that is already pending.
+const TimerTaskStatusCreatedPerAttempt = TimerTaskStatusCreatedStartToClose |
+	TimerTaskStatusCreatedScheduleToStart |
+	TimerTaskStatusCreatedHeartbeat
+
 type (
 	// TimerSequenceID represent a in mem timer
 	TimerSequenceID struct {
@@ -228,7 +237,65 @@ func (t *timerSequenceImpl) getUserTimerTimeout(
 	}
 }
 
+// activityTimerMasks is every activity timer task bit, ordered to match the entries of
+// activityTimerDeadlines.
+var activityTimerMasks = [4]int32{
+	TimerTaskStatusCreatedScheduleToClose,
+	TimerTaskStatusCreatedScheduleToStart,
+	TimerTaskStatusCreatedStartToClose,
+	TimerTaskStatusCreatedHeartbeat,
+}
+
+// activityTimerDeadlines holds, for each entry of activityTimerMasks, when that timer
+// fires. A nil entry means the timer does not currently apply to the activity: it is
+// not scheduled, not started, or has no timeout configured.
+type activityTimerDeadlines [4]*time.Time
+
+// getActivityTimerDeadlines computes all four timer deadlines for a single activity. It
+// goes through the same getters the timer sequence itself uses, so there is exactly one
+// definition of each deadline.
+func getActivityTimerDeadlines(activityInfo *persistencespb.ActivityInfo) activityTimerDeadlines {
+	var deadlines activityTimerDeadlines
+	for i, sequenceID := range [4]*TimerSequenceID{
+		getActivityScheduleToCloseTimeout(activityInfo),
+		getActivityScheduleToStartTimeout(activityInfo),
+		getActivityStartToCloseTimeout(activityInfo),
+		getActivityHeartbeatTimeout(activityInfo),
+	} {
+		if sequenceID != nil {
+			deadlines[i] = &sequenceID.Timestamp
+		}
+	}
+	return deadlines
+}
+
+// changedMask returns the timer task bits whose deadline differs between the two
+// snapshots, i.e. the timers whose already-created task no longer matches the activity
+// and has to be recreated. A timer that appears or disappears counts as changed; a
+// timer whose deadline is untouched keeps its bit, leaving its pending task alone.
+func (d activityTimerDeadlines) changedMask(other activityTimerDeadlines) int32 {
+	var changed int32
+	for i, mask := range activityTimerMasks {
+		curr, next := d[i], other[i]
+		if curr == nil && next == nil {
+			// timer applies to neither state, so there is nothing to recreate
+			continue
+		}
+		if curr == nil || next == nil || !curr.Equal(*next) {
+			// timer appeared, disappeared, or moved
+			changed |= mask
+		}
+	}
+	return changed
+}
+
 func (t *timerSequenceImpl) getActivityScheduleToStartTimeout(
+	activityInfo *persistencespb.ActivityInfo,
+) *TimerSequenceID {
+	return getActivityScheduleToStartTimeout(activityInfo)
+}
+
+func getActivityScheduleToStartTimeout(
 	activityInfo *persistencespb.ActivityInfo,
 ) *TimerSequenceID {
 
@@ -259,6 +326,12 @@ func (t *timerSequenceImpl) getActivityScheduleToStartTimeout(
 }
 
 func (t *timerSequenceImpl) getActivityScheduleToCloseTimeout(
+	activityInfo *persistencespb.ActivityInfo,
+) *TimerSequenceID {
+	return getActivityScheduleToCloseTimeout(activityInfo)
+}
+
+func getActivityScheduleToCloseTimeout(
 	activityInfo *persistencespb.ActivityInfo,
 ) *TimerSequenceID {
 
@@ -293,6 +366,12 @@ func (t *timerSequenceImpl) getActivityScheduleToCloseTimeout(
 func (t *timerSequenceImpl) getActivityStartToCloseTimeout(
 	activityInfo *persistencespb.ActivityInfo,
 ) *TimerSequenceID {
+	return getActivityStartToCloseTimeout(activityInfo)
+}
+
+func getActivityStartToCloseTimeout(
+	activityInfo *persistencespb.ActivityInfo,
+) *TimerSequenceID {
 
 	// activity is not scheduled yet, probably due to retry & backoff
 	if activityInfo.ScheduledEventId == common.EmptyEventID {
@@ -321,6 +400,12 @@ func (t *timerSequenceImpl) getActivityStartToCloseTimeout(
 }
 
 func (t *timerSequenceImpl) getActivityHeartbeatTimeout(
+	activityInfo *persistencespb.ActivityInfo,
+) *TimerSequenceID {
+	return getActivityHeartbeatTimeout(activityInfo)
+}
+
+func getActivityHeartbeatTimeout(
 	activityInfo *persistencespb.ActivityInfo,
 ) *TimerSequenceID {
 


### PR DESCRIPTION
## What changed?

Recreate only the activity timers whose deadline actually moved to avoid duplicated schedule to close timer task.

### Original PRs
https://github.com/temporalio/temporal/pull/11565

## Why is this necessary as a patch?
To reduce the risk of hot shard

## What testing or retesting is appropriate for this patch after merge?
We will run bench failover test against test cluster.
