### PR TITLE
[Visibility][Elasticsearch] Change datetime format to always include nanos component in pagination filter (#11564)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -340,7 +340,7 @@ jobs:
     needs: [pre-build, test-setup]
     runs-on: ${{ needs.test-setup.outputs.runner_arm }}
     env:
-      CONTAINERS: cassandra mysql postgresql
+      CONTAINERS: cassandra mysql postgresql elasticsearch
       TEST_TIMEOUT: 10m
       GITHUB_TIMEOUT: 15
     steps:

--- a/common/persistence/persistence-tests/elasticsearch_test_cluster.go
+++ b/common/persistence/persistence-tests/elasticsearch_test_cluster.go
@@ -1,0 +1,184 @@
+package persistencetests
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"path"
+	"time"
+
+	"go.temporal.io/server/common/backoff"
+	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	esclient "go.temporal.io/server/common/persistence/visibility/store/elasticsearch/client"
+	"go.temporal.io/server/temporal/environment"
+	"go.temporal.io/server/tests/testutils"
+)
+
+type esTestCluster struct {
+	cfg    *esclient.Config
+	logger log.Logger
+
+	indexName string
+}
+
+var _ PersistenceTestCluster = (*esTestCluster)(nil)
+
+func newEsTestCluster(
+	hostname string,
+	port int,
+	username string,
+	password string,
+	indexName string,
+	logger log.Logger,
+) *esTestCluster {
+	//nolint:revive // insecure scheme is fine in tests
+	addr, err := url.Parse(fmt.Sprintf("http://%s:%d", hostname, port))
+	if err != nil {
+		panic(err)
+	}
+	return &esTestCluster{
+		cfg: &esclient.Config{
+			Version:  environment.GetESVersion(),
+			URL:      *addr,
+			Username: username,
+			Password: password,
+			Indices: map[string]string{
+				esclient.VisibilityAppName: indexName,
+			},
+		},
+		logger:    logger,
+		indexName: indexName,
+	}
+}
+
+// Config implements [PersistenceTestCluster].
+func (c *esTestCluster) Config() config.Persistence {
+	return config.Persistence{
+		VisibilityStore: "test-es-visibility",
+		DataStores: map[string]config.DataStore{
+			"test-es-visibility": {
+				Elasticsearch: c.cfg,
+			},
+		},
+	}
+}
+
+// SetupTestDatabase implements [PersistenceTestCluster].
+func (c *esTestCluster) SetupTestDatabase() {
+	if err := SetupEsIndex(c.cfg, c.logger); err != nil {
+		panic(err)
+	}
+}
+
+// TearDownTestDatabase implements [PersistenceTestCluster].
+func (c *esTestCluster) TearDownTestDatabase() {
+	if err := DeleteEsIndex(c.cfg, c.logger); err != nil {
+		panic(err)
+	}
+}
+
+func SetupEsIndex(esConfig *esclient.Config, logger log.Logger) error {
+	ctx := context.Background()
+	var esClient esclient.IntegrationTestsClient
+	op := func() error {
+		var err error
+		esClient, err = esclient.NewFunctionalTestsClient(esConfig, logger)
+		if err != nil {
+			return err
+		}
+
+		return esClient.Ping(ctx)
+	}
+
+	err := backoff.ThrottleRetry(
+		op,
+		backoff.NewExponentialRetryPolicy(time.Second).WithExpirationInterval(time.Minute),
+		nil,
+	)
+	if err != nil {
+		logger.Fatal("Failed to connect to elasticsearch", tag.Error(err))
+	}
+
+	exists, err := esClient.IndexExists(ctx, esConfig.GetVisibilityIndex())
+	if err != nil {
+		return err
+	}
+	if exists {
+		logger.Info("Index already exists.", tag.ESIndex(esConfig.GetVisibilityIndex()))
+		err = DeleteEsIndex(esConfig, logger)
+		if err != nil {
+			return err
+		}
+	}
+
+	indexTemplateFile := path.Join(testutils.GetRepoRootDirectory(), "schema/elasticsearch/visibility/index_template_v7.json")
+	logger.Info("Creating index template.", tag.String("templatePath", indexTemplateFile))
+	template, err := os.ReadFile(indexTemplateFile)
+	if err != nil {
+		return err
+	}
+	// Template name doesn't matter.
+	// This operation is idempotent and won't return an error even if template already exists.
+	_, err = esClient.IndexPutTemplate(ctx, "temporal_visibility_v1_template", string(template))
+	if err != nil {
+		return err
+	}
+	logger.Info("Index template created.")
+
+	logger.Info("Creating index.", tag.ESIndex(esConfig.GetVisibilityIndex()))
+	_, err = esClient.CreateIndex(
+		ctx,
+		esConfig.GetVisibilityIndex(),
+		map[string]any{
+			"settings": map[string]any{
+				"index": map[string]any{
+					"number_of_replicas": 0,
+				},
+			},
+		},
+	)
+	if err != nil {
+		return err
+	}
+	if err := waitForYellowStatus(esClient, esConfig.GetVisibilityIndex()); err != nil {
+		return err
+	}
+	logger.Info("Index created.", tag.ESIndex(esConfig.GetVisibilityIndex()))
+
+	logger.Info("Add custom search attributes for tests.")
+	if err := waitForYellowStatus(esClient, esConfig.GetVisibilityIndex()); err != nil {
+		return err
+	}
+	logger.Info("Index setup complete.", tag.ESIndex(esConfig.GetVisibilityIndex()))
+
+	return nil
+}
+
+func waitForYellowStatus(esClient esclient.IntegrationTestsClient, index string) error {
+	status, err := esClient.WaitForYellowStatus(context.Background(), index)
+	if err != nil {
+		return err
+	}
+	if status == "red" {
+		return fmt.Errorf("elasticsearch index status for %s is red", index)
+	}
+	return nil
+}
+
+func DeleteEsIndex(esConfig *esclient.Config, logger log.Logger) error {
+	esClient, err := esclient.NewFunctionalTestsClient(esConfig, logger)
+	if err != nil {
+		return err
+	}
+
+	logger.Info("Deleting index.", tag.ESIndex(esConfig.GetVisibilityIndex()))
+	_, err = esClient.DeleteIndex(context.Background(), esConfig.GetVisibilityIndex())
+	if err != nil {
+		return err
+	}
+	logger.Info("Index deleted.", tag.ESIndex(esConfig.GetVisibilityIndex()))
+	return nil
+}

--- a/common/persistence/persistence-tests/persistence_test_base.go
+++ b/common/persistence/persistence-tests/persistence_test_base.go
@@ -131,7 +131,16 @@ func NewTestClusterForCassandra(options *TestBaseOptions, logger log.Logger) *ca
 	if options.DBName == "" {
 		options.DBName = GenerateRandomDBName()
 	}
-	testCluster := cassandra.NewTestCluster(options.DBName, options.DBUsername, options.DBPassword, options.DBHost, options.DBPort, options.SchemaDir, options.FaultInjection, logger)
+	testCluster := cassandra.NewTestCluster(
+		options.DBName,
+		options.DBUsername,
+		options.DBPassword,
+		options.DBHost,
+		options.DBPort,
+		options.SchemaDir,
+		options.FaultInjection,
+		logger,
+	)
 	return testCluster
 }
 
@@ -166,7 +175,42 @@ func NewTestBaseWithSQL(options *TestBaseOptions) *TestBase {
 			panic(fmt.Sprintf("unknown sql store driver: %v", options.SQLDBPluginName))
 		}
 	}
-	testCluster := sql.NewTestCluster(options.SQLDBPluginName, options.DBName, options.DBUsername, options.DBPassword, options.DBHost, options.DBPort, options.ConnectAttributes, options.SchemaDir, options.FaultInjection, logger)
+	testCluster := sql.NewTestCluster(
+		options.SQLDBPluginName,
+		options.DBName,
+		options.DBUsername,
+		options.DBPassword,
+		options.DBHost,
+		options.DBPort,
+		options.ConnectAttributes,
+		options.SchemaDir,
+		options.FaultInjection,
+		logger,
+	)
+	return NewTestBaseForCluster(testCluster, logger)
+}
+
+func NewTestBaseWithEs(options *TestBaseOptions) *TestBase {
+	logger := options.Logger
+	if logger == nil {
+		logger = log.NewTestLogger()
+	}
+
+	if options.DBHost == "" {
+		options.DBHost = environment.GetESAddress()
+	}
+	if options.DBPort == 0 {
+		options.DBPort = environment.GetESPort()
+	}
+
+	testCluster := newEsTestCluster(
+		options.DBHost,
+		options.DBPort,
+		options.DBUsername,
+		options.DBPassword,
+		options.DBName,
+		logger,
+	)
 	return NewTestBaseForCluster(testCluster, logger)
 }
 

--- a/common/persistence/persistence-tests/setup.go
+++ b/common/persistence/persistence-tests/setup.go
@@ -139,3 +139,13 @@ func GetSQLiteMemoryTestClusterOption() *TestBaseOptions {
 		ConnectAttributes: map[string]string{"mode": testSQLiteMode, "cache": testSQLiteCache},
 	}
 }
+
+func GetEsTestClusterOption() *TestBaseOptions {
+	return &TestBaseOptions{
+		DBName:     "temporal_visibility_v1_" + GenerateRandomDBName(),
+		DBUsername: "",
+		DBPassword: "",
+		DBHost:     environment.GetESAddress(),
+		DBPort:     environment.GetESPort(),
+	}
+}

--- a/common/persistence/tests/elasticsearch_test.go
+++ b/common/persistence/tests/elasticsearch_test.go
@@ -1,0 +1,29 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	persistencetests "go.temporal.io/server/common/persistence/persistence-tests"
+)
+
+type ElasticsearchSuite struct {
+	suite.Suite
+	pluginName   string
+	connectAttrs map[string]string
+}
+
+func (p *ElasticsearchSuite) TestVisibilityPersistenceSuite() {
+	s := &VisibilityPersistenceSuite{
+		TestBase: persistencetests.NewTestBaseWithEs(
+			persistencetests.GetEsTestClusterOption(),
+		),
+	}
+	suite.Run(p.T(), s)
+}
+
+func TestElasticsearch(t *testing.T) {
+	t.Parallel()
+	s := &ElasticsearchSuite{}
+	suite.Run(t, s)
+}

--- a/common/persistence/tests/visibility_persistence_suite.go
+++ b/common/persistence/tests/visibility_persistence_suite.go
@@ -23,10 +23,12 @@ import (
 	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/persistence/visibility"
 	"go.temporal.io/server/common/persistence/visibility/manager"
+	"go.temporal.io/server/common/persistence/visibility/store/elasticsearch"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/resolver"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/searchattribute/sadefs"
+	"go.temporal.io/server/common/testing/await"
 	"go.uber.org/mock/gomock"
 )
 
@@ -68,7 +70,14 @@ func (s *VisibilityPersistenceSuite) SetupSuite() {
 		cfg,
 		resolver.NewNoopResolver(),
 		s.CustomVisibilityStoreFactory,
-		nil,
+		&elasticsearch.ProcessorConfig{
+			IndexerConcurrency:       dynamicconfig.GetIntPropertyFn(10),
+			ESProcessorNumOfWorkers:  dynamicconfig.GetIntPropertyFn(2),
+			ESProcessorBulkActions:   dynamicconfig.GetIntPropertyFn(10),
+			ESProcessorBulkSize:      dynamicconfig.GetIntPropertyFn(1 * 1024 * 1024), // 1MB
+			ESProcessorFlushInterval: dynamicconfig.GetDurationPropertyFn(time.Second),
+			ESProcessorAckTimeout:    dynamicconfig.GetDurationPropertyFn(30 * time.Second),
+		},
 		s.SearchAttributesProvider,
 		s.SearchAttributesMapperProvider,
 		s.NamespaceRegistry,
@@ -125,21 +134,25 @@ func (s *VisibilityPersistenceSuite) TestBasicVisibility() {
 	)
 
 	// ListOpenWorkflowExecutions
-	resp, err1 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    1,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
-			sadefs.StartTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.StartTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-		),
-	})
-	s.NoError(err1)
-	s.Len(resp.Executions, 1)
-	s.assertOpenExecutionEquals(startReq, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    1,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
+				sadefs.StartTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.StartTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertOpenExecutionEquals(t, startReq, resp.Executions[0])
+		},
+	)
 
 	closeReq := s.createClosedWorkflowRecord(
 		startReq,
@@ -148,37 +161,45 @@ func (s *VisibilityPersistenceSuite) TestBasicVisibility() {
 	)
 
 	// ListOpenWorkflowExecutions
-	resp, err3 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    1,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
-			sadefs.StartTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.StartTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-		),
-	})
-	s.NoError(err3)
-	s.Empty(resp.Executions)
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    1,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
+				sadefs.StartTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.StartTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Empty(t, resp.Executions)
+		},
+	)
 
 	// ListClosedWorkflowExecutions
-	resp, err4 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    1,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s != '%s'",
-			sadefs.CloseTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.CloseTime,
-			time.Now().Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-		),
-	})
-	s.NoError(err4)
-	s.Len(resp.Executions, 1)
-	s.assertClosedExecutionEquals(closeReq, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    1,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s != '%s'",
+				sadefs.CloseTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.CloseTime,
+				time.Now().Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertClosedExecutionEquals(t, closeReq, resp.Executions[0])
+		},
+	)
 }
 
 // TestBasicVisibilityTimeSkew test
@@ -196,21 +217,25 @@ func (s *VisibilityPersistenceSuite) TestBasicVisibilityTimeSkew() {
 	)
 
 	// ListOpenWorkflowExecutions
-	resp, err1 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    1,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
-			sadefs.StartTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.StartTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-		),
-	})
-	s.NoError(err1)
-	s.Len(resp.Executions, 1)
-	s.assertOpenExecutionEquals(openRecord, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    1,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
+				sadefs.StartTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.StartTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertOpenExecutionEquals(t, openRecord, resp.Executions[0])
+		},
+	)
 
 	closedRecord := s.createClosedWorkflowRecord(
 		openRecord,
@@ -219,37 +244,45 @@ func (s *VisibilityPersistenceSuite) TestBasicVisibilityTimeSkew() {
 	)
 
 	// ListOpenWorkflowExecutions
-	resp, err3 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    1,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
-			sadefs.StartTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.StartTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-		),
-	})
-	s.NoError(err3)
-	s.Empty(resp.Executions)
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    1,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
+				sadefs.StartTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.StartTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Empty(t, resp.Executions)
+		},
+	)
 
 	// ListClosedWorkflowExecutions
-	resp, err4 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    1,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s != '%s'",
-			sadefs.CloseTime,
-			startTime.Add(-10*time.Millisecond).Format(time.RFC3339Nano),
-			sadefs.CloseTime,
-			startTime.Add(-10*time.Millisecond).Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-		),
-	})
-	s.NoError(err4)
-	s.Len(resp.Executions, 1)
-	s.assertClosedExecutionEquals(closedRecord, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    1,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s != '%s'",
+				sadefs.CloseTime,
+				startTime.Add(-10*time.Millisecond).Format(time.RFC3339Nano),
+				sadefs.CloseTime,
+				startTime.Add(-10*time.Millisecond).Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertClosedExecutionEquals(t, closedRecord, resp.Executions[0])
+		},
+	)
 }
 
 func (s *VisibilityPersistenceSuite) TestBasicVisibilityShortWorkflow() {
@@ -271,42 +304,51 @@ func (s *VisibilityPersistenceSuite) TestBasicVisibilityShortWorkflow() {
 	)
 
 	// ListOpenWorkflowExecutions
-	resp, err3 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    1,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
-			sadefs.StartTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.StartTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-		),
-	})
-	s.NoError(err3)
-	s.Empty(resp.Executions)
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    1,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
+				sadefs.StartTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.StartTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Empty(t, resp.Executions)
+		},
+	)
 
 	// ListClosedWorkflowExecutions
-	resp, err4 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    1,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s != '%s'",
-			sadefs.CloseTime,
-			startTime.Add(10*time.Millisecond).Format(time.RFC3339Nano),
-			sadefs.CloseTime,
-			startTime.Add(10*time.Millisecond).Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-		),
-	})
-	s.NoError(err4)
-	s.Len(resp.Executions, 1)
-	s.assertClosedExecutionEquals(closedRecord, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    1,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s != '%s'",
+				sadefs.CloseTime,
+				startTime.Add(10*time.Millisecond).Format(time.RFC3339Nano),
+				sadefs.CloseTime,
+				startTime.Add(10*time.Millisecond).Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertClosedExecutionEquals(t, closedRecord, resp.Executions[0])
+		},
+	)
 }
 
 // TestVisibilityPagination test
 func (s *VisibilityPersistenceSuite) TestVisibilityPagination() {
 	testNamespaceUUID := namespace.ID(uuid.NewString())
+	var nextPageToken []byte
 
 	// Create 2 executions
 	startTime1 := time.Now().UTC()
@@ -330,44 +372,8 @@ func (s *VisibilityPersistenceSuite) TestVisibilityPagination() {
 	)
 
 	// Get the first one
-	resp, err2 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    1,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
-			sadefs.StartTime,
-			startTime1.Format(time.RFC3339Nano),
-			sadefs.StartTime,
-			startTime2.Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-		),
-	})
-	s.NoError(err2)
-	s.Len(resp.Executions, 1)
-	s.assertOpenExecutionEquals(openRecord2, resp.Executions[0])
-
-	// Use token to get the second one
-	resp, err3 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    1,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
-			sadefs.StartTime,
-			startTime1.Format(time.RFC3339Nano),
-			sadefs.StartTime,
-			startTime2.Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-		),
-		NextPageToken: resp.NextPageToken,
-	})
-	s.NoError(err3)
-	s.Len(resp.Executions, 1)
-	s.assertOpenExecutionEquals(openRecord1, resp.Executions[0])
-
-	// It is possible to not return non empty token which is going to return empty result
-	if len(resp.NextPageToken) != 0 {
-		// Now should get empty result by using token
-		resp, err4 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
 			NamespaceID: testNamespaceUUID,
 			PageSize:    1,
 			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
@@ -378,11 +384,142 @@ func (s *VisibilityPersistenceSuite) TestVisibilityPagination() {
 				sadefs.ExecutionStatus,
 				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
 			),
-			NextPageToken: resp.NextPageToken,
-		})
-		s.NoError(err4)
-		s.Empty(resp.Executions)
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertOpenExecutionEquals(t, openRecord2, resp.Executions[0])
+			nextPageToken = resp.NextPageToken
+		},
+	)
+
+	// Use token to get the second one
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    1,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
+				sadefs.StartTime,
+				startTime1.Format(time.RFC3339Nano),
+				sadefs.StartTime,
+				startTime2.Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			),
+			NextPageToken: nextPageToken,
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertOpenExecutionEquals(t, openRecord1, resp.Executions[0])
+			nextPageToken = resp.NextPageToken
+		},
+	)
+
+	// It is possible to not return non empty token which is going to return empty result
+	if len(nextPageToken) != 0 {
+		// Now should get empty result by using token
+		s.assertListWorkflowExecutions(
+			&manager.ListWorkflowExecutionsRequestV2{
+				NamespaceID: testNamespaceUUID,
+				PageSize:    1,
+				Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
+					sadefs.StartTime,
+					startTime1.Format(time.RFC3339Nano),
+					sadefs.StartTime,
+					startTime2.Format(time.RFC3339Nano),
+					sadefs.ExecutionStatus,
+					enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+				),
+				NextPageToken: nextPageToken,
+			},
+			func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+				require.NoError(t, err)
+				require.Empty(t, resp.Executions)
+			},
+		)
 	}
+}
+
+// TestPaginationEdgeCase verifies that the datatime filters works as expected
+// in the pagination filter.
+// Particularly, when a datetime is missing a component (eg: nanoseconds),
+// Elasticsearch fills it in unexpected ways.
+// Eg: if a workflow has CloseTime at 2023-04-05T06:07:08.100000000Z, a filter
+// like `CloseTime = '2023-04-05T06:07:08Z'` will match the workflow.
+// This can leads to unexpected behaviors during pagination.
+func (s *VisibilityPersistenceSuite) TestPaginationEdgeCase() {
+	testNamespaceUUID := namespace.ID(uuid.NewString())
+	startTime := time.Date(2023, 4, 5, 6, 7, 8, 0, time.UTC)
+	closeTime := startTime.Add(2 * time.Second)
+
+	// Generating workflows with oposite orders for CloseTime and StartTime.
+	// Eg: WF1 (CT1, ST1), WF2 (CT2, ST2), etc.
+	// We want ST1 < ST2 < ST3 < ... and CT1 > CT2 > CT3 > ...
+	// Furthermore, we want all of them to be within the same second and
+	// CTn must be an exact second, ie., no nanoseconds part.
+	// Since the step in time is 100ms, n must be less than 10.
+	n := 3
+	var startReqs []*manager.RecordWorkflowExecutionStartedRequest
+	for i := range n {
+		r := s.createOpenWorkflowRecord(
+			testNamespaceUUID,
+			fmt.Sprintf("visibility-datetime-filter-%d", i),
+			"visibility-datetime-filter",
+			startTime.Add(time.Duration(i)*100*time.Millisecond),
+			startTime.Add(time.Duration(i)*100*time.Millisecond),
+			"test-queue",
+		)
+		startReqs = append(startReqs, r)
+	}
+	for i := range startReqs {
+		r := s.createClosedWorkflowRecord(
+			startReqs[i],
+			closeTime.Add(time.Duration(n-i-1)*100*time.Millisecond),
+			enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+		)
+		fmt.Printf("FOO %d (%d, %d)\n", i, r.CloseTime.UTC().UnixNano(), r.StartTime.UTC().UnixNano())
+	}
+
+	s.assertCountWorkflowExecutions(
+		&manager.CountWorkflowExecutionsRequest{
+			NamespaceID: testNamespaceUUID,
+			Query:       "ExecutionStatus = 'Completed'",
+		},
+		func(t require.TestingT, resp *manager.CountWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Equal(t, int64(n), resp.Count)
+		},
+	)
+
+	pageSize := n
+	var nextPageToken []byte
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    pageSize,
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, pageSize)
+			require.NotEmpty(t, resp.NextPageToken)
+			nextPageToken = resp.NextPageToken
+		},
+	)
+
+	fmt.Printf("FOO page token: %s\n", nextPageToken)
+
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID:   testNamespaceUUID,
+			PageSize:      pageSize,
+			NextPageToken: nextPageToken,
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Empty(t, resp.Executions)
+		},
+	)
 }
 
 // TestFilteringByStartTime test
@@ -409,50 +546,76 @@ func (s *VisibilityPersistenceSuite) TestFilteringByStartTime() {
 	)
 
 	// List open workflows with start time filter
-	resp, err := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    2,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
-			sadefs.StartTime,
-			time.Now().Add(-time.Hour).Format(time.RFC3339Nano),
-			sadefs.StartTime,
-			time.Now().Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-		),
-	})
-	s.NoError(err)
-	s.Len(resp.Executions, 1)
-	s.assertOpenExecutionEquals(openRecord2, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    2,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
+				sadefs.StartTime,
+				time.Now().Add(-time.Hour).Format(time.RFC3339Nano),
+				sadefs.StartTime,
+				time.Now().Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertOpenExecutionEquals(t, openRecord2, resp.Executions[0])
+		},
+	)
 
 	// List with WorkflowType filter in query string
-	queryStr := fmt.Sprintf(`StartTime BETWEEN "%v" AND "%v"`, time.Now().Add(-time.Hour).Format(time.RFC3339Nano), time.Now().Format(time.RFC3339Nano))
-	resp, err = s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    2,
-		Query:       queryStr,
-	})
-	s.NoError(err)
-	s.Len(resp.Executions, 1)
-	s.assertOpenExecutionEquals(openRecord2, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    2,
+			Query: fmt.Sprintf(
+				`StartTime BETWEEN "%v" AND "%v"`,
+				time.Now().Add(-time.Hour).Format(time.RFC3339Nano),
+				time.Now().Format(time.RFC3339Nano),
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertOpenExecutionEquals(t, openRecord2, resp.Executions[0])
+		},
+	)
 
-	queryStr = fmt.Sprintf(`StartTime BETWEEN "%v" AND "%v"`, time.Now().Add(-3*time.Hour).Format(time.RFC3339Nano), time.Now().Format(time.RFC3339Nano))
-	resp, err = s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    2,
-		Query:       queryStr,
-	})
-	s.NoError(err)
-	s.Len(resp.Executions, 2)
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    2,
+			Query: fmt.Sprintf(
+				`StartTime BETWEEN "%v" AND "%v"`,
+				time.Now().Add(-3*time.Hour).Format(time.RFC3339Nano),
+				time.Now().Format(time.RFC3339Nano),
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 2)
+		},
+	)
 
-	resp, err = s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    2,
-		Query:       queryStr + ` AND WorkflowType = "visibility-workflow-1"`,
-	})
-	s.NoError(err)
-	s.Len(resp.Executions, 1)
-	s.assertOpenExecutionEquals(openRecord1, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    2,
+			Query: fmt.Sprintf(
+				`StartTime BETWEEN "%v" AND "%v" AND WorkflowType = "visibility-workflow-1"`,
+				time.Now().Add(-3*time.Hour).Format(time.RFC3339Nano),
+				time.Now().Format(time.RFC3339Nano),
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertOpenExecutionEquals(s.T(), openRecord1, resp.Executions[0])
+		},
+	)
 }
 
 // TestFilteringByType test
@@ -479,33 +642,41 @@ func (s *VisibilityPersistenceSuite) TestFilteringByType() {
 	)
 
 	// List open with filtering: ListOpenWorkflowExecutionsByType
-	resp, err2 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    2,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s' AND %s = '%s'",
-			sadefs.StartTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.StartTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-			sadefs.WorkflowType,
-			"visibility-workflow-1",
-		),
-	})
-	s.NoError(err2)
-	s.Len(resp.Executions, 1)
-	s.assertOpenExecutionEquals(openRecord1, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    2,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s' AND %s = '%s'",
+				sadefs.StartTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.StartTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+				sadefs.WorkflowType,
+				"visibility-workflow-1",
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertOpenExecutionEquals(t, openRecord1, resp.Executions[0])
+		},
+	)
 
 	// List with WorkflowType filter in query string
-	resp, err := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    2,
-		Query:       `WorkflowType = "visibility-workflow-1"`,
-	})
-	s.NoError(err)
-	s.Len(resp.Executions, 1)
-	s.assertOpenExecutionEquals(openRecord1, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    2,
+			Query:       `WorkflowType = "visibility-workflow-1"`,
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertOpenExecutionEquals(t, openRecord1, resp.Executions[0])
+		},
+	)
 
 	// Close both executions
 	s.createClosedWorkflowRecord(openRecord1, time.Now(), enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED)
@@ -516,33 +687,41 @@ func (s *VisibilityPersistenceSuite) TestFilteringByType() {
 	)
 
 	// List closed with filtering: ListClosedWorkflowExecutionsByType
-	resp, err5 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    2,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s != '%s' AND %s = '%s'",
-			sadefs.CloseTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.CloseTime,
-			time.Now().Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-			sadefs.WorkflowType,
-			"visibility-workflow-2",
-		),
-	})
-	s.NoError(err5)
-	s.Len(resp.Executions, 1)
-	s.assertClosedExecutionEquals(closedRecord2, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    2,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s != '%s' AND %s = '%s'",
+				sadefs.CloseTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.CloseTime,
+				time.Now().Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+				sadefs.WorkflowType,
+				"visibility-workflow-2",
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertClosedExecutionEquals(t, closedRecord2, resp.Executions[0])
+		},
+	)
 
 	// List with WorkflowType filter in query string
-	resp, err = s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    2,
-		Query:       `WorkflowType = "visibility-workflow-2"`,
-	})
-	s.NoError(err)
-	s.Len(resp.Executions, 1)
-	s.assertClosedExecutionEquals(closedRecord2, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    2,
+			Query:       `WorkflowType = "visibility-workflow-2"`,
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertClosedExecutionEquals(t, closedRecord2, resp.Executions[0])
+		},
+	)
 }
 
 // TestFilteringByWorkflowID test
@@ -569,33 +748,41 @@ func (s *VisibilityPersistenceSuite) TestFilteringByWorkflowID() {
 	)
 
 	// List open with filtering: ListOpenWorkflowExecutionsByWorkflowID
-	resp, err2 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    2,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s' AND %s = '%s'",
-			sadefs.StartTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.StartTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-			sadefs.WorkflowID,
-			"visibility-filtering-test1",
-		),
-	})
-	s.NoError(err2)
-	s.Len(resp.Executions, 1)
-	s.assertOpenExecutionEquals(openRecord1, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    2,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s' AND %s = '%s'",
+				sadefs.StartTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.StartTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+				sadefs.WorkflowID,
+				"visibility-filtering-test1",
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertOpenExecutionEquals(t, openRecord1, resp.Executions[0])
+		},
+	)
 
 	// List workflow with workflowID filter in query string
-	resp, err := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    2,
-		Query:       `WorkflowId = "visibility-filtering-test1"`,
-	})
-	s.NoError(err)
-	s.Len(resp.Executions, 1)
-	s.assertOpenExecutionEquals(openRecord1, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    2,
+			Query:       `WorkflowId = "visibility-filtering-test1"`,
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertOpenExecutionEquals(t, openRecord1, resp.Executions[0])
+		},
+	)
 
 	// Close both executions
 	s.createClosedWorkflowRecord(openRecord1, time.Now(), enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED)
@@ -606,33 +793,41 @@ func (s *VisibilityPersistenceSuite) TestFilteringByWorkflowID() {
 	)
 
 	// List closed with filtering: ListClosedWorkflowExecutionsByWorkflowID
-	resp, err5 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    2,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s != '%s' AND %s = '%s'",
-			sadefs.CloseTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.CloseTime,
-			time.Now().Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-			sadefs.WorkflowID,
-			"visibility-filtering-test2",
-		),
-	})
-	s.NoError(err5)
-	s.Len(resp.Executions, 1)
-	s.assertClosedExecutionEquals(closedRecord2, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    2,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s != '%s' AND %s = '%s'",
+				sadefs.CloseTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.CloseTime,
+				time.Now().Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+				sadefs.WorkflowID,
+				"visibility-filtering-test2",
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertClosedExecutionEquals(t, closedRecord2, resp.Executions[0])
+		},
+	)
 
 	// List workflow with workflowID filter in query string
-	resp, err = s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    2,
-		Query:       `WorkflowId = "visibility-filtering-test2"`,
-	})
-	s.NoError(err)
-	s.Len(resp.Executions, 1)
-	s.assertClosedExecutionEquals(closedRecord2, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    2,
+			Query:       `WorkflowId = "visibility-filtering-test2"`,
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertClosedExecutionEquals(t, closedRecord2, resp.Executions[0])
+		},
+	)
 }
 
 // TestFilteringByStatus test
@@ -670,30 +865,38 @@ func (s *VisibilityPersistenceSuite) TestFilteringByStatus() {
 	)
 
 	// List closed with filtering: ListClosedWorkflowExecutionsByStatus
-	resp, err4 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    2,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
-			sadefs.CloseTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.CloseTime,
-			time.Now().Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_FAILED,
-		),
-	})
-	s.NoError(err4)
-	s.Len(resp.Executions, 1)
-	s.assertClosedExecutionEquals(closeRecord2, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    2,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
+				sadefs.CloseTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.CloseTime,
+				time.Now().Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_FAILED,
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertClosedExecutionEquals(t, closeRecord2, resp.Executions[0])
+		},
+	)
 
-	resp, err := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    5,
-		Query:       `ExecutionStatus = "Failed"`,
-	})
-	s.NoError(err)
-	s.Len(resp.Executions, 1)
-	s.assertClosedExecutionEquals(closeRecord2, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    5,
+			Query:       `ExecutionStatus = "Failed"`,
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertClosedExecutionEquals(t, closeRecord2, resp.Executions[0])
+		},
+	)
 }
 
 // TestDelete test
@@ -726,88 +929,109 @@ func (s *VisibilityPersistenceSuite) TestDeleteWorkflow() {
 	}
 
 	// ListClosedWorkflowExecutions
-	resp, err3 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    10,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s != '%s'",
-			sadefs.CloseTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.CloseTime,
-			closeTime.Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-		),
-	})
-	s.NoError(err3)
-	s.Len(resp.Executions, closedRows)
+	var executions []*workflowpb.WorkflowExecutionInfo
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    10,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s != '%s'",
+				sadefs.CloseTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.CloseTime,
+				closeTime.Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, closedRows)
+			executions = resp.Executions
+		},
+	)
 
 	// Delete closed workflow
-	for _, row := range resp.Executions {
-		err4 := s.VisibilityMgr.DeleteWorkflowExecution(s.ctx, &manager.VisibilityDeleteWorkflowExecutionRequest{
-			NamespaceID: testNamespaceUUID,
-			WorkflowID:  row.GetExecution().GetWorkflowId(),
-			RunID:       row.GetExecution().GetRunId(),
-		})
-		s.NoError(err4)
+	for _, row := range executions {
+		s.deleteWorkflowRecord(
+			testNamespaceUUID,
+			row.GetExecution().GetWorkflowId(),
+			row.GetExecution().GetRunId(),
+		)
 	}
 
 	// ListClosedWorkflowExecutions
-	resp, err5 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    10,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s != '%s'",
-			sadefs.CloseTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.CloseTime,
-			closeTime.Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-		),
-	})
-	s.NoError(err5)
-	s.Empty(resp.Executions)
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    10,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s != '%s'",
+				sadefs.CloseTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.CloseTime,
+				closeTime.Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Empty(t, resp.Executions)
+		},
+	)
 
 	// ListOpenWorkflowExecutions
-	resp, err6 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s'AND %s = '%s'",
-			sadefs.StartTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.StartTime,
-			closeTime.Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-		),
-		PageSize: 10,
-	})
-	s.NoError(err6)
-	s.Len(resp.Executions, openRows-closedRows)
-	// Delete open workflow
-	for _, row := range resp.Executions {
-		err7 := s.VisibilityMgr.DeleteWorkflowExecution(s.ctx, &manager.VisibilityDeleteWorkflowExecutionRequest{
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
 			NamespaceID: testNamespaceUUID,
-			WorkflowID:  row.GetExecution().GetWorkflowId(),
-			RunID:       row.GetExecution().GetRunId(),
-		})
-		s.NoError(err7)
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s'AND %s = '%s'",
+				sadefs.StartTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.StartTime,
+				closeTime.Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			),
+			PageSize: 10,
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, openRows-closedRows)
+			executions = resp.Executions
+		},
+	)
+
+	// Delete open workflow
+	for _, row := range executions {
+		s.deleteWorkflowRecord(
+			testNamespaceUUID,
+			row.GetExecution().GetWorkflowId(),
+			row.GetExecution().GetRunId(),
+		)
 	}
-	resp, err8 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s'",
-			sadefs.StartTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.StartTime,
-			closeTime.Format(time.RFC3339Nano),
-		),
-		PageSize: 10,
-	})
-	s.NoError(err8)
-	s.Empty(resp.Executions)
+
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s'",
+				sadefs.StartTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.StartTime,
+				closeTime.Format(time.RFC3339Nano),
+			),
+			PageSize: 10,
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Empty(t, resp.Executions)
+		},
+	)
 }
 
 // TestUpsertWorkflowExecution test
 func (s *VisibilityPersistenceSuite) TestUpsertWorkflowExecution() {
+	testNamespaceUUID := namespace.ID(uuid.NewString())
 	temporalChangeVersionPayload, _ := payload.Encode([]string{"dummy"})
+	now := time.Now()
 	tests := []struct {
 		request  *manager.UpsertWorkflowExecutionRequest
 		expected error
@@ -815,13 +1039,15 @@ func (s *VisibilityPersistenceSuite) TestUpsertWorkflowExecution() {
 		{
 			request: &manager.UpsertWorkflowExecutionRequest{
 				VisibilityRequestBase: &manager.VisibilityRequestBase{
-					NamespaceID:      "",
-					Namespace:        "",
-					Execution:        &commonpb.WorkflowExecution{},
-					WorkflowTypeName: "",
-					StartTime:        time.Time{},
-					ExecutionTime:    time.Time{},
-					TaskID:           0,
+					NamespaceID: testNamespaceUUID,
+					Execution: &commonpb.WorkflowExecution{
+						WorkflowId: "upsert-workflow-1",
+						RunId:      uuid.NewString(),
+					},
+					WorkflowTypeName: "upsert-workflow",
+					StartTime:        now,
+					ExecutionTime:    now,
+					TaskID:           1,
 					Memo:             nil,
 					SearchAttributes: &commonpb.SearchAttributes{
 						IndexedFields: map[string]*commonpb.Payload{
@@ -836,13 +1062,15 @@ func (s *VisibilityPersistenceSuite) TestUpsertWorkflowExecution() {
 		{
 			request: &manager.UpsertWorkflowExecutionRequest{
 				VisibilityRequestBase: &manager.VisibilityRequestBase{
-					NamespaceID:      "",
-					Namespace:        "",
-					Execution:        &commonpb.WorkflowExecution{},
-					WorkflowTypeName: "",
-					StartTime:        time.Time{},
-					ExecutionTime:    time.Time{},
-					TaskID:           0,
+					NamespaceID: testNamespaceUUID,
+					Execution: &commonpb.WorkflowExecution{
+						WorkflowId: "upsert-workflow-2",
+						RunId:      uuid.NewString(),
+					},
+					WorkflowTypeName: "upsert-workflow",
+					StartTime:        now,
+					ExecutionTime:    now,
+					TaskID:           2,
 					Memo:             nil,
 					SearchAttributes: nil,
 					Status:           enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
@@ -881,34 +1109,42 @@ func (s *VisibilityPersistenceSuite) TestGetWorkflowExecution() {
 		)
 	}
 	for _, req := range startRequests {
-		resp, err := s.VisibilityMgr.GetWorkflowExecution(
-			s.ctx,
+		s.assertGetWorkflowExecution(
 			&manager.GetWorkflowExecutionRequest{
 				NamespaceID: testNamespaceUUID,
+				WorkflowID:  req.Execution.WorkflowId,
 				RunID:       req.Execution.RunId,
 			},
+			func(t require.TestingT, resp *manager.GetWorkflowExecutionResponse, err error) {
+				require.NoErrorf(t, err, "execution %s not found", req.Execution.RunId)
+				s.assertOpenExecutionEquals(t, req, resp.Execution)
+			},
 		)
-		s.NoError(err)
-		s.assertOpenExecutionEquals(req, resp.Execution)
 	}
 
 	var closeRequests []*manager.RecordWorkflowExecutionClosedRequest
 	for _, startReq := range startRequests {
 		closeRequests = append(
 			closeRequests,
-			s.createClosedWorkflowRecord(startReq, closeTime, enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED),
+			s.createClosedWorkflowRecord(
+				startReq,
+				closeTime,
+				enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+			),
 		)
 	}
 	for _, req := range closeRequests {
-		resp, err := s.VisibilityMgr.GetWorkflowExecution(
-			s.ctx,
+		s.assertGetWorkflowExecution(
 			&manager.GetWorkflowExecutionRequest{
 				NamespaceID: testNamespaceUUID,
+				WorkflowID:  req.Execution.WorkflowId,
 				RunID:       req.Execution.RunId,
 			},
+			func(t require.TestingT, resp *manager.GetWorkflowExecutionResponse, err error) {
+				require.NoError(t, err)
+				s.assertClosedExecutionEquals(t, req, resp.Execution)
+			},
 		)
-		s.NoError(err)
-		s.assertClosedExecutionEquals(req, resp.Execution)
 	}
 }
 
@@ -941,6 +1177,41 @@ func (s *VisibilityPersistenceSuite) TestAdvancedVisibilityPagination() {
 		}
 	}
 
+	// Wait until all workflows are persisted.
+	s.assertCountWorkflowExecutions(
+		&manager.CountWorkflowExecutionsRequest{
+			NamespaceID: testNamespaceUUID,
+			Query:       "GROUP BY ExecutionStatus",
+		},
+		func(t require.TestingT, resp *manager.CountWorkflowExecutionsResponse, err error) {
+			require.Equal(t, int64(5), resp.Count)
+			require.Len(t, resp.Groups, 2)
+			require.Subset(t, []int64{2, 3}, []int64{resp.Groups[0].Count, resp.Groups[1].Count})
+			var openGroup, closedGroup *workflowservice.CountWorkflowExecutionsResponse_AggregationGroup
+			if resp.Groups[0].Count == 2 {
+				openGroup = resp.Groups[0]
+				closedGroup = resp.Groups[1]
+			} else {
+				openGroup = resp.Groups[1]
+				closedGroup = resp.Groups[0]
+			}
+			require.Equal(t,
+				sadefs.MustEncodeValue(
+					enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING.String(),
+					enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+				),
+				openGroup.GroupValues[0],
+			)
+			require.Equal(t,
+				sadefs.MustEncodeValue(
+					enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED.String(),
+					enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+				),
+				closedGroup.GroupValues[0],
+			)
+		},
+	)
+
 	for pageSize := 1; pageSize <= 5; pageSize++ {
 		executions := make(map[string]*workflowpb.WorkflowExecutionInfo)
 		for _, e := range s.listWithPagination(testNamespaceUUID, 5) {
@@ -952,14 +1223,14 @@ func (s *VisibilityPersistenceSuite) TestAdvancedVisibilityPagination() {
 			id := r.Execution.GetWorkflowId()
 			e, ok := executions[id]
 			s.True(ok)
-			s.assertOpenExecutionEquals(r, e)
+			s.assertOpenExecutionEquals(s.T(), r, e)
 			delete(executions, id)
 		}
 		for _, r := range closeReqs {
 			id := r.Execution.GetWorkflowId()
 			e, ok := executions[id]
 			s.True(ok)
-			s.assertClosedExecutionEquals(r, e)
+			s.assertClosedExecutionEquals(s.T(), r, e)
 			delete(executions, id)
 		}
 		s.Empty(executions, "Unexpected executions returned from list method")
@@ -982,16 +1253,17 @@ func (s *VisibilityPersistenceSuite) TestCountWorkflowExecutions() {
 		)
 	}
 
-	resp, err := s.VisibilityMgr.CountWorkflowExecutions(
-		s.ctx,
+	s.assertCountWorkflowExecutions(
 		&manager.CountWorkflowExecutionsRequest{
 			NamespaceID: testNamespaceUUID,
 			Query:       "",
 		},
+		func(t require.TestingT, resp *manager.CountWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Equal(t, int64(5), resp.Count)
+			require.Nil(t, resp.Groups)
+		},
 	)
-	s.NoError(err)
-	s.Equal(int64(5), resp.Count)
-	s.Nil(resp.Groups)
 }
 
 func (s *VisibilityPersistenceSuite) TestCountGroupByWorkflowExecutions() {
@@ -1014,27 +1286,30 @@ func (s *VisibilityPersistenceSuite) TestCountGroupByWorkflowExecutions() {
 		)
 	}
 
-	runningStatusPayload, _ := sadefs.EncodeValue(
-		enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING.String(),
-		enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-	)
-	resp, err := s.VisibilityMgr.CountWorkflowExecutions(
-		s.ctx,
+	s.assertCountWorkflowExecutions(
 		&manager.CountWorkflowExecutionsRequest{
 			NamespaceID: testNamespaceUUID,
 			Query:       "GROUP BY ExecutionStatus",
 		},
-	)
-	s.NoError(err)
-	s.Equal(int64(5), resp.Count)
-	s.Equal(
-		[]*workflowservice.CountWorkflowExecutionsResponse_AggregationGroup{
-			{
-				GroupValues: []*commonpb.Payload{runningStatusPayload},
-				Count:       int64(5),
-			},
+		func(t require.TestingT, resp *manager.CountWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Equal(t, int64(5), resp.Count)
+			require.Equal(
+				t,
+				[]*workflowservice.CountWorkflowExecutionsResponse_AggregationGroup{
+					{
+						GroupValues: []*commonpb.Payload{
+							sadefs.MustEncodeValue(
+								enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING.String(),
+								enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+							),
+						},
+						Count: int64(5),
+					},
+				},
+				resp.Groups,
+			)
 		},
-		resp.Groups,
 	)
 
 	for i := range 2 {
@@ -1045,18 +1320,22 @@ func (s *VisibilityPersistenceSuite) TestCountGroupByWorkflowExecutions() {
 		)
 	}
 
-	resp, err = s.VisibilityMgr.CountWorkflowExecutions(
-		s.ctx,
+	s.assertCountWorkflowExecutions(
 		&manager.CountWorkflowExecutionsRequest{
 			NamespaceID: testNamespaceUUID,
 			Query:       "GROUP BY ExecutionStatus",
 		},
+		func(t require.TestingT, resp *manager.CountWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Equal(t, int64(5), resp.Count)
+		},
 	)
-	s.NoError(err)
-	s.Equal(int64(5), resp.Count)
 }
 
-func (s *VisibilityPersistenceSuite) listWithPagination(namespaceID namespace.ID, pageSize int) []*workflowpb.WorkflowExecutionInfo {
+func (s *VisibilityPersistenceSuite) listWithPagination(
+	namespaceID namespace.ID,
+	pageSize int,
+) []*workflowpb.WorkflowExecutionInfo {
 	var executions []*workflowpb.WorkflowExecutionInfo
 	resp, err := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
 		NamespaceID: namespaceID,
@@ -1135,25 +1414,95 @@ func (s *VisibilityPersistenceSuite) createOpenWorkflowRecord(
 	return startReq
 }
 
+func (s *VisibilityPersistenceSuite) deleteWorkflowRecord(
+	namespaceID namespace.ID,
+	workflowID string,
+	runID string,
+) {
+	s.taskID++
+	deleteReq := &manager.VisibilityDeleteWorkflowExecutionRequest{
+		NamespaceID: namespaceID,
+		WorkflowID:  workflowID,
+		RunID:       runID,
+		TaskID:      s.taskID,
+	}
+	err := s.VisibilityMgr.DeleteWorkflowExecution(s.ctx, deleteReq)
+	s.NoError(err)
+}
+
 func (s *VisibilityPersistenceSuite) assertClosedExecutionEquals(
-	req *manager.RecordWorkflowExecutionClosedRequest, resp *workflowpb.WorkflowExecutionInfo) {
-	s.Equal(req.Execution.RunId, resp.Execution.RunId)
-	s.Equal(req.Execution.WorkflowId, resp.Execution.WorkflowId)
-	s.Equal(req.WorkflowTypeName, resp.GetType().GetName())
-	s.Equal(persistence.UnixMilliseconds(req.StartTime), persistence.UnixMilliseconds(timestamp.TimeValue(resp.GetStartTime())))
-	s.Equal(persistence.UnixMilliseconds(req.CloseTime), persistence.UnixMilliseconds(timestamp.TimeValue(resp.GetCloseTime())))
-	s.Equal(req.Status, resp.GetStatus())
-	s.Equal(req.HistoryLength, resp.HistoryLength)
-	s.Equal(req.ExecutionDuration, resp.GetExecutionDuration().AsDuration())
+	t require.TestingT,
+	req *manager.RecordWorkflowExecutionClosedRequest,
+	resp *workflowpb.WorkflowExecutionInfo,
+) {
+	require.Equal(t, req.Execution.RunId, resp.Execution.RunId)
+	require.Equal(t, req.Execution.WorkflowId, resp.Execution.WorkflowId)
+	require.Equal(t, req.WorkflowTypeName, resp.GetType().GetName())
+	require.Equal(t, persistence.UnixMilliseconds(req.StartTime), persistence.UnixMilliseconds(timestamp.TimeValue(resp.GetStartTime())))
+	require.Equal(t, persistence.UnixMilliseconds(req.CloseTime), persistence.UnixMilliseconds(timestamp.TimeValue(resp.GetCloseTime())))
+	require.Equal(t, req.Status, resp.GetStatus())
+	require.Equal(t, req.HistoryLength, resp.HistoryLength)
+	require.Equal(t, req.ExecutionDuration, resp.GetExecutionDuration().AsDuration())
 }
 
 func (s *VisibilityPersistenceSuite) assertOpenExecutionEquals(
-	req *manager.RecordWorkflowExecutionStartedRequest, resp *workflowpb.WorkflowExecutionInfo) {
-	s.Equal(req.Execution.GetRunId(), resp.Execution.GetRunId())
-	s.Equal(req.Execution.WorkflowId, resp.Execution.WorkflowId)
-	s.Equal(req.WorkflowTypeName, resp.GetType().GetName())
-	s.Equal(persistence.UnixMilliseconds(req.StartTime), persistence.UnixMilliseconds(timestamp.TimeValue(resp.GetStartTime())))
-	s.Nil(resp.CloseTime)
-	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, resp.Status)
-	s.Zero(resp.HistoryLength)
+	t require.TestingT,
+	req *manager.RecordWorkflowExecutionStartedRequest,
+	resp *workflowpb.WorkflowExecutionInfo,
+) {
+	require.Equal(t, req.Execution.GetRunId(), resp.Execution.GetRunId())
+	require.Equal(t, req.Execution.WorkflowId, resp.Execution.WorkflowId)
+	require.Equal(t, req.WorkflowTypeName, resp.GetType().GetName())
+	require.Equal(t, persistence.UnixMilliseconds(req.StartTime), persistence.UnixMilliseconds(timestamp.TimeValue(resp.GetStartTime())))
+	require.Nil(t, resp.CloseTime)
+	require.Equal(t, enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, resp.Status)
+	require.Zero(t, resp.HistoryLength)
+}
+
+func (s *VisibilityPersistenceSuite) assertListWorkflowExecutions(
+	request *manager.ListWorkflowExecutionsRequestV2,
+	assertFn func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error),
+) {
+	await.Require(
+		s.ctx,
+		s.T(),
+		func(t *await.T) {
+			resp, err := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, request)
+			assertFn(t, resp, err)
+		},
+		4*time.Second,
+		200*time.Millisecond,
+	)
+}
+
+func (s *VisibilityPersistenceSuite) assertCountWorkflowExecutions(
+	request *manager.CountWorkflowExecutionsRequest,
+	assertFn func(t require.TestingT, resp *manager.CountWorkflowExecutionsResponse, err error),
+) {
+	await.Require(
+		s.ctx,
+		s.T(),
+		func(t *await.T) {
+			resp, err := s.VisibilityMgr.CountWorkflowExecutions(s.ctx, request)
+			assertFn(t, resp, err)
+		},
+		4*time.Second,
+		200*time.Millisecond,
+	)
+}
+
+func (s *VisibilityPersistenceSuite) assertGetWorkflowExecution(
+	request *manager.GetWorkflowExecutionRequest,
+	assertFn func(t require.TestingT, resp *manager.GetWorkflowExecutionResponse, err error),
+) {
+	await.Require(
+		s.ctx,
+		s.T(),
+		func(t *await.T) {
+			resp, err := s.VisibilityMgr.GetWorkflowExecution(s.ctx, request)
+			assertFn(t, resp, err)
+		},
+		4*time.Second,
+		200*time.Millisecond,
+	)
 }

--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -38,6 +38,11 @@ const (
 	PersistenceName = "elasticsearch"
 
 	delimiter = "~"
+
+	// paginationDatetimeFormat is a copy from time.RFC3339Nano, but always writes
+	// the nanos component.
+	// Used only for formatting time.Time in the pagination filter.
+	paginationDatetimeFormat = "2006-01-02T15:04:05.000000000Z07:00"
 )
 
 type (
@@ -743,8 +748,7 @@ func (s *VisibilityStore) convertQuery(
 	defer func() {
 		// Convert ConverterError to InvalidArgument and pass through all other errors (which should be
 		// only mapper errors).
-		var converterErr *query.ConverterError
-		if errors.As(err, &converterErr) {
+		if converterErr, ok := errors.AsType[*query.ConverterError](err); ok {
 			err = converterErr.ToInvalidArgument()
 		}
 	}()
@@ -831,8 +835,7 @@ func (s *VisibilityStore) convertQueryLegacy(
 	queryParams, err := queryConverter.ConvertWhereOrderBy(requestQueryStr)
 	if err != nil {
 		// Convert ConverterError to InvalidArgument and pass through all other errors (which should be only mapper errors).
-		var converterErr *query.ConverterError
-		if errors.As(err, &converterErr) {
+		if converterErr, ok := errors.AsType[*query.ConverterError](err); ok {
 			return nil, converterErr.ToInvalidArgument()
 		}
 		return nil, err
@@ -1436,12 +1439,13 @@ func buildPaginationQuery(
 //   - double: "Infinity" (desc) or "-Infinity" (asc)
 //   - keyword: nil
 //
-// Furthermore, for bool and datetime, they need to be converted to boolean or the RFC3339Nano
-// formats respectively.
+// Furthermore, for bool and datetime, they need to be converted to bool or string
+// types respectively.
 //
 //nolint:revive // cyclomatic complexity
 func parsePageTokenValue(
-	fieldName string, jsonValue any,
+	fieldName string,
+	jsonValue any,
 	tp enumspb.IndexedValueType,
 ) (any, error) {
 	switch tp {
@@ -1465,7 +1469,7 @@ func parsePageTokenValue(
 			return num != 0, nil
 		}
 		if tp == enumspb.INDEXED_VALUE_TYPE_DATETIME {
-			return time.Unix(0, num).UTC().Format(time.RFC3339Nano), nil
+			return time.Unix(0, num).UTC().Format(paginationDatetimeFormat), nil
 		}
 		return num, nil
 

--- a/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
@@ -1650,7 +1650,7 @@ func (s *ESVisibilitySuite) Test_buildPaginationQuery() {
 			searchAfter:  []any{json.Number(fmt.Sprintf("%d", startTime.UnixNano()))},
 			res: []elastic.Query{
 				elastic.NewBoolQuery().Filter(
-					elastic.NewRangeQuery(sadefs.StartTime).Lt(startTime.Format(time.RFC3339Nano)),
+					elastic.NewRangeQuery(sadefs.StartTime).Lt(startTime.Format(paginationDatetimeFormat)),
 				),
 			},
 			err: nil,
@@ -1670,7 +1670,7 @@ func (s *ESVisibilitySuite) Test_buildPaginationQuery() {
 				elastic.NewBoolQuery().
 					MustNot(elastic.NewExistsQuery(sadefs.CloseTime)).
 					Filter(
-						elastic.NewRangeQuery(sadefs.StartTime).Lt(startTime.Format(time.RFC3339Nano)),
+						elastic.NewRangeQuery(sadefs.StartTime).Lt(startTime.Format(paginationDatetimeFormat)),
 					),
 			},
 			err: nil,
@@ -1687,12 +1687,12 @@ func (s *ESVisibilitySuite) Test_buildPaginationQuery() {
 			},
 			res: []elastic.Query{
 				elastic.NewBoolQuery().Filter(
-					elastic.NewRangeQuery(sadefs.CloseTime).Lt(closeTime.Format(time.RFC3339Nano)),
+					elastic.NewRangeQuery(sadefs.CloseTime).Lt(closeTime.Format(paginationDatetimeFormat)),
 				),
 				elastic.NewBoolQuery().
 					Filter(
-						elastic.NewTermQuery(sadefs.CloseTime, closeTime.Format(time.RFC3339Nano)),
-						elastic.NewRangeQuery(sadefs.StartTime).Lt(startTime.Format(time.RFC3339Nano)),
+						elastic.NewTermQuery(sadefs.CloseTime, closeTime.Format(paginationDatetimeFormat)),
+						elastic.NewRangeQuery(sadefs.StartTime).Lt(startTime.Format(paginationDatetimeFormat)),
 					),
 			},
 			err: nil,
@@ -1711,17 +1711,17 @@ func (s *ESVisibilitySuite) Test_buildPaginationQuery() {
 			},
 			res: []elastic.Query{
 				elastic.NewBoolQuery().Filter(
-					elastic.NewRangeQuery(sadefs.CloseTime).Lt(closeTime.Format(time.RFC3339Nano)),
+					elastic.NewRangeQuery(sadefs.CloseTime).Lt(closeTime.Format(paginationDatetimeFormat)),
 				),
 				elastic.NewBoolQuery().
 					Filter(
-						elastic.NewTermQuery(sadefs.CloseTime, closeTime.Format(time.RFC3339Nano)),
-						elastic.NewRangeQuery(sadefs.StartTime).Lt(startTime.Format(time.RFC3339Nano)),
+						elastic.NewTermQuery(sadefs.CloseTime, closeTime.Format(paginationDatetimeFormat)),
+						elastic.NewRangeQuery(sadefs.StartTime).Lt(startTime.Format(paginationDatetimeFormat)),
 					),
 				elastic.NewBoolQuery().
 					Filter(
-						elastic.NewTermQuery(sadefs.CloseTime, closeTime.Format(time.RFC3339Nano)),
-						elastic.NewTermQuery(sadefs.StartTime, startTime.Format(time.RFC3339Nano)),
+						elastic.NewTermQuery(sadefs.CloseTime, closeTime.Format(paginationDatetimeFormat)),
+						elastic.NewTermQuery(sadefs.StartTime, startTime.Format(paginationDatetimeFormat)),
 						elastic.NewRangeQuery(sadefs.RunID).Gt("random-run-id"),
 					),
 			},
@@ -2354,4 +2354,61 @@ func (s *ESVisibilitySuite) TestValuesInterceptor_ChasmMapper() {
 	s.Error(err)
 	var converterErr *query.ConverterError
 	s.ErrorAs(err, &converterErr)
+}
+
+func TestPaginationDatetimeFormat(t *testing.T) {
+	testCases := []struct {
+		name string
+		in   time.Time
+		out  string
+	}{
+		{
+			name: "zero nanos",
+			in:   time.Date(2023, 4, 5, 6, 7, 8, 0, time.UTC),
+			out:  "2023-04-05T06:07:08.000000000Z",
+		},
+		{
+			name: "full nanos",
+			in:   time.Date(2023, 4, 5, 6, 7, 8, 123456789, time.UTC),
+			out:  "2023-04-05T06:07:08.123456789Z",
+		},
+		{
+			name: "trailing zeros in nanos",
+			in:   time.Date(2023, 4, 5, 6, 7, 8, 123000000, time.UTC),
+			out:  "2023-04-05T06:07:08.123000000Z",
+		},
+		{
+			name: "leading zeros in nanos",
+			in:   time.Date(2023, 4, 5, 6, 7, 8, 42, time.UTC),
+			out:  "2023-04-05T06:07:08.000000042Z",
+		},
+		{
+			name: "unix epoch",
+			in:   time.Unix(0, 0).UTC(),
+			out:  "1970-01-01T00:00:00.000000000Z",
+		},
+		{
+			name: "positive timezone offset",
+			in:   time.Date(2023, 4, 5, 6, 7, 8, 0, time.FixedZone("", 2*60*60+30*60)),
+			out:  "2023-04-05T06:07:08.000000000+02:30",
+		},
+		{
+			name: "negative timezone offset",
+			in:   time.Date(2023, 4, 5, 6, 7, 8, 123456789, time.FixedZone("", -5*60*60)),
+			out:  "2023-04-05T06:07:08.123456789-05:00",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := require.New(t)
+			out := tc.in.Format(paginationDatetimeFormat)
+			r.Equal(tc.out, out)
+			// The formatted value must remain a valid RFC3339 datetime, and parsing it back must
+			// return the original instant.
+			parsed, err := time.Parse(time.RFC3339Nano, out)
+			r.NoError(err)
+			r.True(tc.in.Equal(parsed), "expected %v, got %v", tc.in, parsed)
+		})
+	}
 }

--- a/tests/testcore/test_cluster.go
+++ b/tests/testcore/test_cluster.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"path"
 	"testing"
 	"time"
 
@@ -21,7 +20,6 @@ import (
 	"go.temporal.io/server/api/matchingservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	schedulerpb "go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
-	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -214,7 +212,7 @@ func newClusterWithPersistenceTestBaseFactory(
 			DisableGzip: true, // lowers memory and CPU usage significantly in tests
 		}
 
-		err = setupIndex(clusterConfig.ESConfig, logger)
+		err = persistencetests.SetupEsIndex(clusterConfig.ESConfig, logger)
 		if err != nil {
 			return nil, err
 		}
@@ -342,109 +340,6 @@ func newClusterWithPersistenceTestBaseFactory(
 	return &TestCluster{testBase: testBase, host: host}, nil
 }
 
-func setupIndex(esConfig *esclient.Config, logger log.Logger) error {
-	ctx := context.Background()
-	var esClient esclient.IntegrationTestsClient
-	op := func() error {
-		var err error
-		esClient, err = esclient.NewFunctionalTestsClient(esConfig, logger)
-		if err != nil {
-			return err
-		}
-
-		return esClient.Ping(ctx)
-	}
-
-	err := backoff.ThrottleRetry(
-		op,
-		backoff.NewExponentialRetryPolicy(time.Second).WithExpirationInterval(time.Minute),
-		nil,
-	)
-	if err != nil {
-		logger.Fatal("Failed to connect to elasticsearch", tag.Error(err))
-	}
-
-	exists, err := esClient.IndexExists(ctx, esConfig.GetVisibilityIndex())
-	if err != nil {
-		return err
-	}
-	if exists {
-		logger.Info("Index already exists.", tag.ESIndex(esConfig.GetVisibilityIndex()))
-		err = deleteIndex(esConfig, logger)
-		if err != nil {
-			return err
-		}
-	}
-
-	indexTemplateFile := path.Join(testutils.GetRepoRootDirectory(), "schema/elasticsearch/visibility/index_template_v7.json")
-	logger.Info("Creating index template.", tag.String("templatePath", indexTemplateFile))
-	template, err := os.ReadFile(indexTemplateFile)
-	if err != nil {
-		return err
-	}
-	// Template name doesn't matter.
-	// This operation is idempotent and won't return an error even if template already exists.
-	_, err = esClient.IndexPutTemplate(ctx, "temporal_visibility_v1_template", string(template))
-	if err != nil {
-		return err
-	}
-	logger.Info("Index template created.")
-
-	logger.Info("Creating index.", tag.ESIndex(esConfig.GetVisibilityIndex()))
-	_, err = esClient.CreateIndex(
-		ctx,
-		esConfig.GetVisibilityIndex(),
-		map[string]any{
-			"settings": map[string]any{
-				"index": map[string]any{
-					"number_of_replicas": 0,
-				},
-			},
-		},
-	)
-	if err != nil {
-		return err
-	}
-	if err := waitForYellowStatus(esClient, esConfig.GetVisibilityIndex()); err != nil {
-		return err
-	}
-	logger.Info("Index created.", tag.ESIndex(esConfig.GetVisibilityIndex()))
-
-	logger.Info("Add custom search attributes for tests.")
-	if err := waitForYellowStatus(esClient, esConfig.GetVisibilityIndex()); err != nil {
-		return err
-	}
-	logger.Info("Index setup complete.", tag.ESIndex(esConfig.GetVisibilityIndex()))
-
-	return nil
-}
-
-func waitForYellowStatus(esClient esclient.IntegrationTestsClient, index string) error {
-	status, err := esClient.WaitForYellowStatus(context.Background(), index)
-	if err != nil {
-		return err
-	}
-	if status == "red" {
-		return fmt.Errorf("Elasticsearch index status for %s is red", index)
-	}
-	return nil
-}
-
-func deleteIndex(esConfig *esclient.Config, logger log.Logger) error {
-	esClient, err := esclient.NewFunctionalTestsClient(esConfig, logger)
-	if err != nil {
-		return err
-	}
-
-	logger.Info("Deleting index.", tag.ESIndex(esConfig.GetVisibilityIndex()))
-	_, err = esClient.DeleteIndex(context.Background(), esConfig.GetVisibilityIndex())
-	if err != nil {
-		return err
-	}
-	logger.Info("Index deleted.", tag.ESIndex(esConfig.GetVisibilityIndex()))
-	return nil
-}
-
 func newPProfInitializerImpl(logger log.Logger, port int) *pprof.PProfInitializerImpl {
 	return &pprof.PProfInitializerImpl{
 		PProf: &config.PProf{
@@ -491,7 +386,7 @@ func (tc *TestCluster) TearDownCluster() error {
 	tc.testBase.TearDownWorkflowStore()
 	if !UseSQLVisibility() {
 		if esConfig := tc.host.serverConfig.Persistence.DataStores[tc.host.serverConfig.Persistence.VisibilityStore].Elasticsearch; esConfig != nil {
-			if err := deleteIndex(esConfig, tc.host.logger); err != nil {
+			if err := persistencetests.DeleteEsIndex(esConfig, tc.host.logger); err != nil {
 				errs = multierr.Combine(errs, err)
 			}
 		}


### PR DESCRIPTION
## What changed?
Cherry pick #11564 to `cloud/v1.32.0-161` branch.

## Why?
^

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
