### PR TITLE
Fix panic in computeFutureActionTimes on negative RemainingActions

### DIFF
--- a/chasm/lib/scheduler/backfiller_lifecycle_test.go
+++ b/chasm/lib/scheduler/backfiller_lifecycle_test.go
@@ -35,14 +35,9 @@ func TestBackfiller_ProcessedContinuationDoesNotRunAgain(t *testing.T) {
 	// crosses the same transaction boundary as a production task.
 	logger := testlogger.NewTestLogger(t, testlogger.FailOnExpectedErrorOnly)
 	specProcessor := scheduler.NewSpecProcessor(defaultConfig(), metrics.NoopMetricsHandler, logger, newLegacySpecBuilder(0, 0))
-	registry := chasm.NewRegistry(logger)
-	require.NoError(t, registry.Register(&chasm.CoreLibrary{}))
-	require.NoError(t, registry.Register(newTestLibrary(logger, specProcessor)))
-
 	timeSource := clock.NewEventTimeSource()
 	timeSource.Update(time.Now())
-	engine := chasmtest.NewEngine(t, registry, chasmtest.WithTimeSource(timeSource))
-	engineCtx := chasm.NewEngineContext(context.Background(), engine)
+	engine, engineCtx := newTestEngineContext(t, logger, withEngineSpecProcessor(specProcessor), withEngineTimeSource(timeSource))
 	rootRef := chasm.NewComponentRef[*scheduler.Scheduler](chasm.ExecutionKey{
 		NamespaceID: namespaceID,
 		BusinessID:  scheduleID,
@@ -158,14 +153,9 @@ func TestBackfiller_FutureRangeDoesNotStall(t *testing.T) {
 	// Use the full task lifecycle so validation runs after each committed batch.
 	logger := testlogger.NewTestLogger(t, testlogger.FailOnExpectedErrorOnly)
 	specProcessor := scheduler.NewSpecProcessor(defaultConfig(), metrics.NoopMetricsHandler, logger, newLegacySpecBuilder(0, 0))
-	registry := chasm.NewRegistry(logger)
-	require.NoError(t, registry.Register(&chasm.CoreLibrary{}))
-	require.NoError(t, registry.Register(newTestLibrary(logger, specProcessor)))
-
 	timeSource := clock.NewEventTimeSource()
 	timeSource.Update(time.Now())
-	engine := chasmtest.NewEngine(t, registry, chasmtest.WithTimeSource(timeSource))
-	engineCtx := chasm.NewEngineContext(context.Background(), engine)
+	engine, engineCtx := newTestEngineContext(t, logger, withEngineSpecProcessor(specProcessor), withEngineTimeSource(timeSource))
 	rootRef := chasm.NewComponentRef[*scheduler.Scheduler](chasm.ExecutionKey{
 		NamespaceID: namespaceID,
 		BusinessID:  scheduleID,
@@ -251,14 +241,9 @@ func TestBackfiller_Validate_AcceptsOnlyCurrentStamp(t *testing.T) {
 	// initial task are produced by the same path used in production.
 	logger := testlogger.NewTestLogger(t, testlogger.FailOnExpectedErrorOnly)
 	specProcessor := scheduler.NewSpecProcessor(defaultConfig(), metrics.NoopMetricsHandler, logger, newLegacySpecBuilder(0, 0))
-	registry := chasm.NewRegistry(logger)
-	require.NoError(t, registry.Register(&chasm.CoreLibrary{}))
-	require.NoError(t, registry.Register(newTestLibrary(logger, specProcessor)))
-
 	timeSource := clock.NewEventTimeSource()
 	timeSource.Update(time.Now())
-	engine := chasmtest.NewEngine(t, registry, chasmtest.WithTimeSource(timeSource))
-	engineCtx := chasm.NewEngineContext(context.Background(), engine)
+	engine, engineCtx := newTestEngineContext(t, logger, withEngineSpecProcessor(specProcessor), withEngineTimeSource(timeSource))
 	rootRef := chasm.NewComponentRef[*scheduler.Scheduler](chasm.ExecutionKey{
 		NamespaceID: namespaceID,
 		BusinessID:  scheduleID,
@@ -370,14 +355,9 @@ func TestBackfiller_Validate_AcceptsOnlyCurrentStamp(t *testing.T) {
 func TestBackfiller_LegacyTaskSchedulesStampedSuccessor(t *testing.T) {
 	logger := testlogger.NewTestLogger(t, testlogger.FailOnExpectedErrorOnly)
 	specProcessor := scheduler.NewSpecProcessor(defaultConfig(), metrics.NoopMetricsHandler, logger, newLegacySpecBuilder(0, 0))
-	registry := chasm.NewRegistry(logger)
-	require.NoError(t, registry.Register(&chasm.CoreLibrary{}))
-	require.NoError(t, registry.Register(newTestLibrary(logger, specProcessor)))
-
 	timeSource := clock.NewEventTimeSource()
 	timeSource.Update(time.Now())
-	engine := chasmtest.NewEngine(t, registry, chasmtest.WithTimeSource(timeSource))
-	engineCtx := chasm.NewEngineContext(context.Background(), engine)
+	engine, engineCtx := newTestEngineContext(t, logger, withEngineSpecProcessor(specProcessor), withEngineTimeSource(timeSource))
 	rootRef := chasm.NewComponentRef[*scheduler.Scheduler](chasm.ExecutionKey{
 		NamespaceID: namespaceID,
 		BusinessID:  scheduleID,

--- a/chasm/lib/scheduler/generator.go
+++ b/chasm/lib/scheduler/generator.go
@@ -92,7 +92,7 @@ func (g *Generator) computeFutureActionTimes(
 
 	count := recentActionCount
 	if sched.Schedule.State.LimitedActions {
-		count = min(int(sched.Schedule.State.RemainingActions), recentActionCount)
+		count = max(min(int(sched.Schedule.State.RemainingActions), recentActionCount), 0)
 	}
 
 	futureTimes := make([]*timestamppb.Timestamp, 0, count)

--- a/chasm/lib/scheduler/generator_tasks_test.go
+++ b/chasm/lib/scheduler/generator_tasks_test.go
@@ -13,6 +13,7 @@ import (
 	"go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/metrics/metricstest"
+	"go.temporal.io/server/common/testing/testlogger"
 	queueerrors "go.temporal.io/server/service/history/queues/errors"
 	"go.temporal.io/server/service/history/tasks"
 	legacyscheduler "go.temporal.io/server/service/worker/scheduler"
@@ -228,6 +229,41 @@ func TestGeneratorTask_UpdateFutureActionTimes_LimitedActions(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, generator.FutureActionTimes, 2)
+}
+
+func TestGeneratorTask_UpdateFutureActionTimes_NegativeRemainingActionsDoesNotPanic(t *testing.T) {
+	logger := testlogger.NewTestLogger(t, testlogger.FailOnExpectedErrorOnly)
+	engine, engineCtx := newTestEngineContext(t, logger)
+
+	input := defaultSchedule()
+	input.State.LimitedActions = true
+	input.State.RemainingActions = -1
+
+	result, err := chasm.StartExecution(
+		engineCtx,
+		chasm.ExecutionKey{NamespaceID: namespaceID, BusinessID: scheduleID},
+		scheduler.CreateScheduler,
+		&schedulerpb.CreateScheduleRequest{
+			NamespaceId: namespaceID,
+			FrontendRequest: &workflowservice.CreateScheduleRequest{
+				Namespace:  namespace,
+				ScheduleId: scheduleID,
+				Schedule:   input,
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	rootRef := chasm.NewComponentRef[*scheduler.Scheduler](result.ExecutionKey)
+	_, err = engine.FirePureTasks(rootRef, time.Now())
+	require.NoError(t, err)
+
+	_, err = chasm.ReadComponent(engineCtx, rootRef,
+		func(s *scheduler.Scheduler, ctx chasm.Context, _ struct{}) (struct{}, error) {
+			require.Empty(t, s.Generator.Get(ctx).FutureActionTimes)
+			return struct{}{}, nil
+		}, struct{}{})
+	require.NoError(t, err)
 }
 
 func TestGeneratorTask_Idle_SetsIdleCloseTime(t *testing.T) {

--- a/chasm/lib/scheduler/handler_test.go
+++ b/chasm/lib/scheduler/handler_test.go
@@ -1,19 +1,16 @@
 package scheduler_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/chasm"
-	"go.temporal.io/server/chasm/chasmtest"
 	"go.temporal.io/server/chasm/lib/scheduler"
 	schedulerpb "go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
 	"go.temporal.io/server/common/log"
 	legacyscheduler "go.temporal.io/server/service/worker/scheduler"
-	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -111,15 +108,9 @@ func TestSentinelHandler_MigrateToWorkflow(t *testing.T) {
 }
 
 func TestHandler_CreateFromMigrationState_Sentinel(t *testing.T) {
-	ctrl := gomock.NewController(t)
 	logger := log.NewTestLogger()
-	registry := chasm.NewRegistry(logger)
-	require.NoError(t, registry.Register(&chasm.CoreLibrary{}))
-	require.NoError(t, registry.Register(newTestLibrary(logger, newRealSpecProcessor(ctrl, logger))))
-
 	h := scheduler.NewTestHandler(logger)
-	testEngine := chasmtest.NewEngine(t, registry)
-	engineCtx := chasm.NewEngineContext(context.Background(), testEngine)
+	_, engineCtx := newTestEngineContext(t, logger)
 	_, err := chasm.StartExecution(
 		engineCtx,
 		chasm.ExecutionKey{
@@ -149,15 +140,9 @@ func TestHandler_CreateFromMigrationState_Sentinel(t *testing.T) {
 }
 
 func TestHandler_MigrateToWorkflow_Sentinel(t *testing.T) {
-	ctrl := gomock.NewController(t)
 	logger := log.NewTestLogger()
-	registry := chasm.NewRegistry(logger)
-	require.NoError(t, registry.Register(&chasm.CoreLibrary{}))
-	require.NoError(t, registry.Register(newTestLibrary(logger, newRealSpecProcessor(ctrl, logger))))
-
 	h := scheduler.NewTestHandler(logger)
-	testEngine := chasmtest.NewEngine(t, registry)
-	engineCtx := chasm.NewEngineContext(context.Background(), testEngine)
+	_, engineCtx := newTestEngineContext(t, logger)
 	_, err := chasm.StartExecution(
 		engineCtx,
 		chasm.ExecutionKey{

--- a/chasm/lib/scheduler/helper_test.go
+++ b/chasm/lib/scheduler/helper_test.go
@@ -6,11 +6,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
 	schedulepb "go.temporal.io/api/schedule/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/chasmtest"
 	"go.temporal.io/server/chasm/lib/scheduler"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/clock"
@@ -183,6 +185,54 @@ func newRealSpecProcessor(ctrl *gomock.Controller, logger log.Logger) scheduler.
 		logger,
 		newLegacySpecBuilder(0, 0),
 	)
+}
+
+// engineTestConfig holds configuration options for newTestEngineContext.
+type engineTestConfig struct {
+	specProcessor scheduler.SpecProcessor
+	engineOpts    []chasmtest.EngineOption
+}
+
+// engineTestOption is a functional option for configuring newTestEngineContext.
+type engineTestOption func(*engineTestConfig)
+
+// withEngineSpecProcessor configures newTestEngineContext with a custom
+// SpecProcessor, instead of the default real one.
+func withEngineSpecProcessor(sp scheduler.SpecProcessor) engineTestOption {
+	return func(c *engineTestConfig) {
+		c.specProcessor = sp
+	}
+}
+
+// withEngineTimeSource configures the CHASM test engine with a controllable
+// time source, for tests that need to advance time explicitly.
+func withEngineTimeSource(ts *clock.EventTimeSource) engineTestOption {
+	return func(c *engineTestConfig) {
+		c.engineOpts = append(c.engineOpts, chasmtest.WithTimeSource(ts))
+	}
+}
+
+// newTestEngineContext builds a CHASM registry with the core and scheduler
+// libraries registered, wraps it in a chasmtest.Engine, and returns the
+// engine along with an engine-bound context ready for chasm.StartExecution /
+// ReadComponent / etc.
+func newTestEngineContext(t *testing.T, logger log.Logger, opts ...engineTestOption) (*chasmtest.Engine, context.Context) {
+	config := &engineTestConfig{}
+	for _, opt := range opts {
+		opt(config)
+	}
+
+	specProcessor := config.specProcessor
+	if specProcessor == nil {
+		specProcessor = newRealSpecProcessor(gomock.NewController(t), logger)
+	}
+
+	registry := chasm.NewRegistry(logger)
+	require.NoError(t, registry.Register(&chasm.CoreLibrary{}))
+	require.NoError(t, registry.Register(newTestLibrary(logger, specProcessor)))
+
+	engine := chasmtest.NewEngine(t, registry, config.engineOpts...)
+	return engine, chasm.NewEngineContext(context.Background(), engine)
 }
 
 // newTestEnv creates a new test environment with the given options.

--- a/chasm/lib/scheduler/scheduler_test.go
+++ b/chasm/lib/scheduler/scheduler_test.go
@@ -15,7 +15,6 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 	schedulespb "go.temporal.io/server/api/schedule/v1"
 	"go.temporal.io/server/chasm"
-	"go.temporal.io/server/chasm/chasmtest"
 	"go.temporal.io/server/chasm/lib/scheduler"
 	schedulerpb "go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
 	"go.temporal.io/server/common/payload"
@@ -77,13 +76,8 @@ func TestCreateScheduler_InitialPauseState(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
 			logger := testlogger.NewTestLogger(t, testlogger.FailOnExpectedErrorOnly)
-			registry := chasm.NewRegistry(logger)
-			require.NoError(t, registry.Register(&chasm.CoreLibrary{}))
-			require.NoError(t, registry.Register(newTestLibrary(logger, newRealSpecProcessor(ctrl, logger))))
-			testEngine := chasmtest.NewEngine(t, registry)
-			engineCtx := chasm.NewEngineContext(context.Background(), testEngine)
+			_, engineCtx := newTestEngineContext(t, logger)
 			input := defaultSchedule()
 			input.State.Paused = tc.initialPaused
 


### PR DESCRIPTION
## Summary
- `computeFutureActionTimes` computed `count = min(RemainingActions, recentActionCount)` and passed it directly to `make()` as a slice capacity. A negative `RemainingActions` (e.g. corrupted/invalid persisted or operator-supplied schedule state) produced a negative capacity and panicked with `makeslice: cap out of range` instead of degrading gracefully.
- Clamp `count` to zero so invalid negative action counts no longer panic scheduler reads or tasks.
- Added a shared `newTestEngineContext` helper for CHASM-test-engine-backed scheduler tests and reused it in the existing tests that were each hand-rolling the same registry/engine setup.