### PR TITLE
fix: floor future action times at generator watermark

### DIFF
--- a/chasm/lib/scheduler/generator.go
+++ b/chasm/lib/scheduler/generator.go
@@ -7,6 +7,7 @@ import (
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
 	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/util"
 	"go.temporal.io/server/service/worker/scheduler"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -99,13 +100,7 @@ func (g *Generator) computeFutureActionTimes(
 	// Start from max(now, updateTime, lastProcessedTime) to ensure we skip times
 	// before the last update and times already processed (or skipped) by the
 	// generator's high water mark.
-	t := ctx.Now(g)
-	if updateTime := sched.Info.GetUpdateTime().AsTime(); updateTime.After(t) {
-		t = updateTime
-	}
-	if lastProcessedTime := g.GetLastProcessedTime().AsTime(); lastProcessedTime.After(t) {
-		t = lastProcessedTime
-	}
+	t := util.MaxTime(ctx.Now(g), sched.Info.GetUpdateTime().AsTime(), g.GetLastProcessedTime().AsTime())
 	for len(futureTimes) < count {
 		res, err := spec.GetNextTime(sched.jitterSeed(), t)
 		if err != nil || res.Next.IsZero() {

--- a/chasm/lib/scheduler/generator.go
+++ b/chasm/lib/scheduler/generator.go
@@ -96,10 +96,15 @@ func (g *Generator) computeFutureActionTimes(
 	}
 
 	futureTimes := make([]*timestamppb.Timestamp, 0, count)
-	// Start from max(now, updateTime) to ensure we skip times before the last update.
+	// Start from max(now, updateTime, lastProcessedTime) to ensure we skip times
+	// before the last update and times already processed (or skipped) by the
+	// generator's high water mark.
 	t := ctx.Now(g)
 	if updateTime := sched.Info.GetUpdateTime().AsTime(); updateTime.After(t) {
 		t = updateTime
+	}
+	if lastProcessedTime := g.GetLastProcessedTime().AsTime(); lastProcessedTime.After(t) {
+		t = lastProcessedTime
 	}
 	for len(futureTimes) < count {
 		res, err := spec.GetNextTime(sched.jitterSeed(), t)

--- a/chasm/lib/scheduler/generator_tasks.go
+++ b/chasm/lib/scheduler/generator_tasks.go
@@ -9,6 +9,7 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/util"
 	queueerrors "go.temporal.io/server/service/history/queues/errors"
 	"go.temporal.io/server/service/worker/scheduler"
 	"go.uber.org/fx"
@@ -73,9 +74,8 @@ func (g *GeneratorTaskHandler) Execute(
 
 	// If the high water mark is earlier than when a schedule was updated, we must skip any actions that hadn't
 	// yet been processed.
-	if scheduler.Info.GetUpdateTime().AsTime().After(generator.LastProcessedTime.AsTime()) {
-		generator.LastProcessedTime = scheduler.Info.GetUpdateTime()
-	}
+	generator.LastProcessedTime = timestamppb.New(
+		util.MaxTime(generator.LastProcessedTime.AsTime(), scheduler.Info.GetUpdateTime().AsTime()))
 
 	// Process time range between last high water mark and system time.
 	t1 := generator.LastProcessedTime.AsTime()

--- a/chasm/lib/scheduler/generator_tasks_test.go
+++ b/chasm/lib/scheduler/generator_tasks_test.go
@@ -322,14 +322,9 @@ func TestGeneratorTask_NonIdle_ClearsIdleCloseTime(t *testing.T) {
 func TestGeneratorTask_FutureActionTimesRespectLastProcessedTimeWatermark(t *testing.T) {
 	logger := testlogger.NewTestLogger(t, testlogger.FailOnExpectedErrorOnly)
 	specProcessor := scheduler.NewSpecProcessor(defaultConfig(), metrics.NoopMetricsHandler, logger, newLegacySpecBuilder(0, 0))
-	registry := chasm.NewRegistry(logger)
-	require.NoError(t, registry.Register(&chasm.CoreLibrary{}))
-	require.NoError(t, registry.Register(newTestLibrary(logger, specProcessor)))
-
 	timeSource := clock.NewEventTimeSource()
 	timeSource.Update(time.Now())
-	engine := chasmtest.NewEngine(t, registry, chasmtest.WithTimeSource(timeSource))
-	engineCtx := chasm.NewEngineContext(context.Background(), engine)
+	engine, engineCtx := newTestEngineContext(t, logger, withEngineSpecProcessor(specProcessor), withEngineTimeSource(timeSource))
 	rootRef := chasm.NewComponentRef[*scheduler.Scheduler](chasm.ExecutionKey{
 		NamespaceID: namespaceID,
 		BusinessID:  scheduleID,

--- a/chasm/lib/scheduler/generator_tasks_test.go
+++ b/chasm/lib/scheduler/generator_tasks_test.go
@@ -1,6 +1,7 @@
 package scheduler_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -9,10 +10,13 @@ import (
 	schedulepb "go.temporal.io/api/schedule/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/chasmtest"
 	"go.temporal.io/server/chasm/lib/scheduler"
 	"go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
+	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/metrics/metricstest"
+	"go.temporal.io/server/common/testing/testlogger"
 	queueerrors "go.temporal.io/server/service/history/queues/errors"
 	"go.temporal.io/server/service/history/tasks"
 	legacyscheduler "go.temporal.io/server/service/worker/scheduler"
@@ -269,6 +273,80 @@ func TestGeneratorTask_NonIdle_ClearsIdleCloseTime(t *testing.T) {
 
 	require.NotEmpty(t, generator.FutureActionTimes)
 	require.Nil(t, sched.IdleCloseTime, "expected IdleCloseTime to be cleared when the schedule has work")
+}
+
+// TestGeneratorTask_FutureActionTimesRespectLastProcessedTimeWatermark pins the
+// fix for advertised future actions preceding the generator's own high water
+// mark. Generator execution clamps its processed range to LastProcessedTime,
+// so any occurrence at or before it has already been processed (or skipped) -
+// UpdateFutureActionTimes must not advertise it as still upcoming.
+//
+// Uses the CHASM test engine directly, rather than the scheduler-specific
+// newTestEnv harness, so the watermark mutation and the task execution that
+// reads it cross the same transaction boundary as production.
+func TestGeneratorTask_FutureActionTimesRespectLastProcessedTimeWatermark(t *testing.T) {
+	logger := testlogger.NewTestLogger(t, testlogger.FailOnExpectedErrorOnly)
+	specProcessor := scheduler.NewSpecProcessor(defaultConfig(), metrics.NoopMetricsHandler, logger, newLegacySpecBuilder(0, 0))
+	registry := chasm.NewRegistry(logger)
+	require.NoError(t, registry.Register(&chasm.CoreLibrary{}))
+	require.NoError(t, registry.Register(newTestLibrary(logger, specProcessor)))
+
+	timeSource := clock.NewEventTimeSource()
+	timeSource.Update(time.Now())
+	engine := chasmtest.NewEngine(t, registry, chasmtest.WithTimeSource(timeSource))
+	engineCtx := chasm.NewEngineContext(context.Background(), engine)
+	rootRef := chasm.NewComponentRef[*scheduler.Scheduler](chasm.ExecutionKey{
+		NamespaceID: namespaceID,
+		BusinessID:  scheduleID,
+	})
+
+	createHandler := scheduler.NewTestHandler(logger)
+	_, err := createHandler.CreateSchedule(engineCtx, &schedulerpb.CreateScheduleRequest{
+		NamespaceId: namespaceID,
+		FrontendRequest: &workflowservice.CreateScheduleRequest{
+			Namespace:  namespace,
+			ScheduleId: scheduleID,
+			Schedule:   defaultSchedule(),
+			RequestId:  "req-create",
+		},
+	})
+	require.NoError(t, err)
+
+	// Push the generator's high water mark ten intervals ahead of "now",
+	// simulating a watermark that execution has already advanced past.
+	watermark := timeSource.Now().Add(10 * defaultInterval)
+	var generator *scheduler.Generator
+	_, _, err = chasm.UpdateComponent(engineCtx, rootRef,
+		func(s *scheduler.Scheduler, ctx chasm.MutableContext, _ struct{}) (struct{}, error) {
+			generator = s.Generator.Get(ctx)
+			generator.LastProcessedTime = timestamppb.New(watermark)
+			return struct{}{}, nil
+		}, struct{}{})
+	require.NoError(t, err)
+
+	handler := scheduler.NewGeneratorTaskHandler(scheduler.GeneratorTaskHandlerOptions{
+		Config:         defaultConfig(),
+		MetricsHandler: metrics.NoopMetricsHandler,
+		BaseLogger:     logger,
+		SpecProcessor:  specProcessor,
+		SpecBuilder:    newLegacySpecBuilder(0, 0),
+	})
+	dropped, err := chasmtest.ExecutePureTask(
+		context.Background(), engine, generator, handler, chasm.TaskAttributes{}, &schedulerpb.GeneratorTask{})
+	require.NoError(t, err)
+	require.False(t, dropped)
+
+	_, err = chasm.ReadComponent(engineCtx, rootRef,
+		func(s *scheduler.Scheduler, ctx chasm.Context, _ struct{}) (struct{}, error) {
+			generator := s.Generator.Get(ctx)
+			require.NotEmpty(t, generator.GetFutureActionTimes())
+			for _, future := range generator.GetFutureActionTimes() {
+				require.True(t, future.AsTime().After(watermark),
+					"advertised future action %v is not after watermark %v", future.AsTime(), watermark)
+			}
+			return struct{}{}, nil
+		}, struct{}{})
+	require.NoError(t, err)
 }
 
 func TestGeneratorTask_UpdateFutureActionTimes_SkipsBeforeUpdateTime(t *testing.T) {

--- a/chasm/lib/scheduler/generator_tasks_test.go
+++ b/chasm/lib/scheduler/generator_tasks_test.go
@@ -13,7 +13,6 @@ import (
 	"go.temporal.io/server/chasm/chasmtest"
 	"go.temporal.io/server/chasm/lib/scheduler"
 	"go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
-	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/metrics/metricstest"
 	"go.temporal.io/server/common/testing/testlogger"
@@ -316,67 +315,43 @@ func TestGeneratorTask_NonIdle_ClearsIdleCloseTime(t *testing.T) {
 // so any occurrence at or before it has already been processed (or skipped) -
 // UpdateFutureActionTimes must not advertise it as still upcoming.
 //
-// Uses the CHASM test engine directly, rather than the scheduler-specific
-// newTestEnv harness, so the watermark mutation and the task execution that
-// reads it cross the same transaction boundary as production.
+// Uses the scheduler-specific chasm test engine helper, rather than the
+// newTestEnv rapid harness, so the watermark mutation and the task execution
+// that reads it cross the same transaction boundary as production.
 func TestGeneratorTask_FutureActionTimesRespectLastProcessedTimeWatermark(t *testing.T) {
-	logger := testlogger.NewTestLogger(t, testlogger.FailOnExpectedErrorOnly)
-	specProcessor := scheduler.NewSpecProcessor(defaultConfig(), metrics.NoopMetricsHandler, logger, newLegacySpecBuilder(0, 0))
-	timeSource := clock.NewEventTimeSource()
-	timeSource.Update(time.Now())
-	engine, engineCtx := newTestEngineContext(t, logger, withEngineSpecProcessor(specProcessor), withEngineTimeSource(timeSource))
-	rootRef := chasm.NewComponentRef[*scheduler.Scheduler](chasm.ExecutionKey{
-		NamespaceID: namespaceID,
-		BusinessID:  scheduleID,
-	})
-
-	createHandler := scheduler.NewTestHandler(logger)
-	_, err := createHandler.CreateSchedule(engineCtx, &schedulerpb.CreateScheduleRequest{
-		NamespaceId: namespaceID,
-		FrontendRequest: &workflowservice.CreateScheduleRequest{
-			Namespace:  namespace,
-			ScheduleId: scheduleID,
-			Schedule:   defaultSchedule(),
-			RequestId:  "req-create",
-		},
-	})
-	require.NoError(t, err)
+	env := newSchedulerTestEngine(t, defaultSchedule())
 
 	// Push the generator's high water mark ten intervals ahead of "now",
 	// simulating a watermark that execution has already advanced past.
-	watermark := timeSource.Now().Add(10 * defaultInterval)
+	watermark := env.timeSource.Now().Add(10 * defaultInterval)
 	var generator *scheduler.Generator
-	_, _, err = chasm.UpdateComponent(engineCtx, rootRef,
-		func(s *scheduler.Scheduler, ctx chasm.MutableContext, _ struct{}) (struct{}, error) {
-			generator = s.Generator.Get(ctx)
-			generator.LastProcessedTime = timestamppb.New(watermark)
-			return struct{}{}, nil
-		}, struct{}{})
-	require.NoError(t, err)
+	require.NoError(t, env.updateScheduler(func(s *scheduler.Scheduler, ctx chasm.MutableContext) error {
+		generator = s.Generator.Get(ctx)
+		generator.LastProcessedTime = timestamppb.New(watermark)
+		return nil
+	}))
 
 	handler := scheduler.NewGeneratorTaskHandler(scheduler.GeneratorTaskHandlerOptions{
 		Config:         defaultConfig(),
 		MetricsHandler: metrics.NoopMetricsHandler,
-		BaseLogger:     logger,
-		SpecProcessor:  specProcessor,
+		BaseLogger:     env.logger,
+		SpecProcessor:  scheduler.NewSpecProcessor(defaultConfig(), metrics.NoopMetricsHandler, env.logger, newLegacySpecBuilder(0, 0)),
 		SpecBuilder:    newLegacySpecBuilder(0, 0),
 	})
 	dropped, err := chasmtest.ExecutePureTask(
-		context.Background(), engine, generator, handler, chasm.TaskAttributes{}, &schedulerpb.GeneratorTask{})
+		context.Background(), env.engine, generator, handler, chasm.TaskAttributes{}, &schedulerpb.GeneratorTask{})
 	require.NoError(t, err)
 	require.False(t, dropped)
 
-	_, err = chasm.ReadComponent(engineCtx, rootRef,
-		func(s *scheduler.Scheduler, ctx chasm.Context, _ struct{}) (struct{}, error) {
-			generator := s.Generator.Get(ctx)
-			require.NotEmpty(t, generator.GetFutureActionTimes())
-			for _, future := range generator.GetFutureActionTimes() {
-				require.True(t, future.AsTime().After(watermark),
-					"advertised future action %v is not after watermark %v", future.AsTime(), watermark)
-			}
-			return struct{}{}, nil
-		}, struct{}{})
-	require.NoError(t, err)
+	require.NoError(t, env.readScheduler(func(s *scheduler.Scheduler, ctx chasm.Context) error {
+		generator := s.Generator.Get(ctx)
+		require.NotEmpty(t, generator.GetFutureActionTimes())
+		for _, future := range generator.GetFutureActionTimes() {
+			require.True(t, future.AsTime().After(watermark),
+				"advertised future action %v is not after watermark %v", future.AsTime(), watermark)
+		}
+		return nil
+	}))
 }
 
 func TestGeneratorTask_UpdateFutureActionTimes_SkipsBeforeUpdateTime(t *testing.T) {

--- a/chasm/lib/scheduler/helper_test.go
+++ b/chasm/lib/scheduler/helper_test.go
@@ -10,10 +10,12 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	schedulepb "go.temporal.io/api/schedule/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
+	"go.temporal.io/api/workflowservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/chasmtest"
 	"go.temporal.io/server/chasm/lib/scheduler"
+	"go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/log"
@@ -190,6 +192,7 @@ func newRealSpecProcessor(ctrl *gomock.Controller, logger log.Logger) scheduler.
 // engineTestConfig holds configuration options for newTestEngineContext.
 type engineTestConfig struct {
 	specProcessor scheduler.SpecProcessor
+	timeSource    *clock.EventTimeSource
 	engineOpts    []chasmtest.EngineOption
 }
 
@@ -208,8 +211,17 @@ func withEngineSpecProcessor(sp scheduler.SpecProcessor) engineTestOption {
 // time source, for tests that need to advance time explicitly.
 func withEngineTimeSource(ts *clock.EventTimeSource) engineTestOption {
 	return func(c *engineTestConfig) {
+		c.timeSource = ts
 		c.engineOpts = append(c.engineOpts, chasmtest.WithTimeSource(ts))
 	}
+}
+
+func newEngineTestConfig(opts ...engineTestOption) *engineTestConfig {
+	config := &engineTestConfig{}
+	for _, opt := range opts {
+		opt(config)
+	}
+	return config
 }
 
 // newTestEngineContext builds a CHASM registry with the core and scheduler
@@ -217,11 +229,14 @@ func withEngineTimeSource(ts *clock.EventTimeSource) engineTestOption {
 // engine along with an engine-bound context ready for chasm.StartExecution /
 // ReadComponent / etc.
 func newTestEngineContext(t *testing.T, logger log.Logger, opts ...engineTestOption) (*chasmtest.Engine, context.Context) {
-	config := &engineTestConfig{}
-	for _, opt := range opts {
-		opt(config)
-	}
+	return newTestEngineContextFromConfig(t, logger, newEngineTestConfig(opts...))
+}
 
+func newTestEngineContextFromConfig(
+	t *testing.T,
+	logger log.Logger,
+	config *engineTestConfig,
+) (*chasmtest.Engine, context.Context) {
 	specProcessor := config.specProcessor
 	if specProcessor == nil {
 		specProcessor = newRealSpecProcessor(gomock.NewController(t), logger)
@@ -233,6 +248,91 @@ func newTestEngineContext(t *testing.T, logger log.Logger, opts ...engineTestOpt
 
 	engine := chasmtest.NewEngine(t, registry, config.engineOpts...)
 	return engine, chasm.NewEngineContext(context.Background(), engine)
+}
+
+// schedulerTestEngine bundles a CHASM test engine, a created Scheduler root
+// component, and convenience accessors, for tests that drive a Scheduler
+// through its actual task handlers rather than the newTestEnv rapid harness.
+type schedulerTestEngine struct {
+	engine     *chasmtest.Engine
+	engineCtx  context.Context
+	rootRef    chasm.ComponentRef
+	logger     log.Logger
+	timeSource *clock.EventTimeSource
+}
+
+// newSchedulerTestEngine builds a schedulerTestEngine and creates a schedule
+// on it via the real CreateSchedule handler path. If no time source is
+// supplied via withEngineTimeSource, a controllable one is created and
+// wired in automatically.
+func newSchedulerTestEngine(
+	t *testing.T,
+	schedule *schedulepb.Schedule,
+	opts ...engineTestOption,
+) *schedulerTestEngine {
+	t.Helper()
+
+	logger := testlogger.NewTestLogger(t, testlogger.FailOnExpectedErrorOnly)
+	config := newEngineTestConfig(opts...)
+	if config.timeSource == nil {
+		config.timeSource = clock.NewEventTimeSource()
+		config.timeSource.Update(time.Now())
+		config.engineOpts = append(config.engineOpts, chasmtest.WithTimeSource(config.timeSource))
+	}
+	engine, engineCtx := newTestEngineContextFromConfig(t, logger, config)
+	rootRef := chasm.NewComponentRef[*scheduler.Scheduler](chasm.ExecutionKey{
+		NamespaceID: namespaceID,
+		BusinessID:  scheduleID,
+	})
+	_, err := scheduler.NewTestHandler(logger).CreateSchedule(engineCtx, &schedulerpb.CreateScheduleRequest{
+		NamespaceId: namespaceID,
+		FrontendRequest: &workflowservice.CreateScheduleRequest{
+			Namespace:  namespace,
+			ScheduleId: scheduleID,
+			Schedule:   schedule,
+			RequestId:  "create-request",
+		},
+	})
+	require.NoError(t, err)
+	return &schedulerTestEngine{
+		engine:     engine,
+		engineCtx:  engineCtx,
+		rootRef:    rootRef,
+		logger:     logger,
+		timeSource: config.timeSource,
+	}
+}
+
+// updateScheduler runs update against the Scheduler root component through
+// the engine's UpdateComponent path.
+func (e *schedulerTestEngine) updateScheduler(
+	update func(*scheduler.Scheduler, chasm.MutableContext) error,
+) error {
+	_, _, err := chasm.UpdateComponent(
+		e.engineCtx,
+		e.rootRef,
+		func(s *scheduler.Scheduler, ctx chasm.MutableContext, _ struct{}) (struct{}, error) {
+			return struct{}{}, update(s, ctx)
+		},
+		struct{}{},
+	)
+	return err
+}
+
+// readScheduler runs read against the Scheduler root component through the
+// engine's read-only ReadComponent path.
+func (e *schedulerTestEngine) readScheduler(
+	read func(*scheduler.Scheduler, chasm.Context) error,
+) error {
+	_, err := chasm.ReadComponent(
+		e.engineCtx,
+		e.rootRef,
+		func(s *scheduler.Scheduler, ctx chasm.Context, _ struct{}) (struct{}, error) {
+			return struct{}{}, read(s, ctx)
+		},
+		struct{}{},
+	)
+	return err
 }
 
 // newTestEnv creates a new test environment with the given options.


### PR DESCRIPTION
## Summary
- Generator execution clamps its processed time range to `LastProcessedTime`, but `computeFutureActionTimes` (used by both `Describe` and `UpdateFutureActionTimes`) only floored its starting time at `max(now, UpdateTime)`, ignoring the watermark.
- This let Describe/`FutureActionTimes` advertise occurrences at or before `LastProcessedTime` that the generator had already processed or silently skipped.
- Floors the starting time at `LastProcessedTime` as well, so every advertised future action is guaranteed to be strictly after the generator's high water mark.
- Reuses `common/util.MaxTime` for this floor and for the existing `UpdateTime`-vs-`LastProcessedTime` clamp in `GeneratorTaskHandler.Execute`, instead of hand-rolled `if X.After(Y) { Y = X }` checks.

## Test plan
- Added `TestGeneratorTask_FutureActionTimesRespectLastProcessedTimeWatermark` in `chasm/lib/scheduler/generator_tasks_test.go`, which pushes `LastProcessedTime` ahead of "now" and asserts all advertised future times are strictly after it. Verified it fails without the fix and passes with it.
- Built on a new scheduler-specific `chasmtest` helper (`newSchedulerTestEngine` + `updateScheduler`/`readScheduler` in `helper_test.go`), adapted from PR 0 of the `sch-readable` stack, rather than the `newTestEnv` rapid harness, so the watermark mutation and task execution cross the same transaction/read boundaries as production. Left out the parts of that PR not applicable here (frontend-client plumbing, the generic side-effect-task firing helper), since `GeneratorTaskHandler` is a pure task handler that doesn't touch the frontend client.
- `go test -tags test_dep ./chasm/lib/scheduler/...` passes.