### PR TITLE
Reuse test context for namespace setup

### DIFF
--- a/tests/archival_test.go
+++ b/tests/archival_test.go
@@ -174,6 +174,7 @@ func (s *ArchivalSuite) newTestEnv() *archivalTestEnv {
 	// Register namespace using built-in filestore archiver
 	ae.archivalNamespace = namespace.Name(testcore.RandomizeStr("archival-enabled-namespace"))
 	ae.archivalNamespaceID, err = ae.RegisterNamespace(
+		s.Context(),
 		ae.archivalNamespace,
 		0, // Archive right away.
 		enumspb.ARCHIVAL_STATE_ENABLED,
@@ -187,6 +188,7 @@ func (s *ArchivalSuite) newTestEnv() *archivalTestEnv {
 	customHistoryURI := customArchiverScheme + "://custom-history-archiver"
 	customVisibilityURI := customArchiverScheme + "://custom-visibility-archiver"
 	ae.customArchiverNamespaceID, err = ae.RegisterNamespace(
+		s.Context(),
 		ae.customArchiverNamespace,
 		0, // Archive right away.
 		enumspb.ARCHIVAL_STATE_ENABLED,

--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -40,6 +40,7 @@ import (
 	"go.temporal.io/server/common/testing/historyrequire"
 	"go.temporal.io/server/common/testing/protorequire"
 	"go.temporal.io/server/common/testing/taskpoller"
+	"go.temporal.io/server/common/testing/testcontext"
 	"go.temporal.io/server/common/testing/testhooks"
 	"go.temporal.io/server/common/testing/testlogger"
 	"go.temporal.io/server/common/testing/testtelemetry"
@@ -342,12 +343,13 @@ func (s *FunctionalTestBase) setupCluster(options ...TestClusterOption) {
 	s.Require().NoError(err)
 
 	// Setup test cluster namespaces.
+	ctx := testcontext.For(s.T())
 	s.namespace = namespace.Name(RandomizeStr("namespace"))
-	s.namespaceID, err = s.RegisterNamespace(s.Namespace(), 1, enumspb.ARCHIVAL_STATE_DISABLED, "", "")
+	s.namespaceID, err = s.RegisterNamespace(ctx, s.Namespace(), 1, enumspb.ARCHIVAL_STATE_DISABLED, "", "")
 	s.Require().NoError(err)
 
 	s.externalNamespace = namespace.Name(RandomizeStr("external-namespace"))
-	_, err = s.RegisterNamespace(s.ExternalNamespace(), 1, enumspb.ARCHIVAL_STATE_DISABLED, "", "")
+	_, err = s.RegisterNamespace(ctx, s.ExternalNamespace(), 1, enumspb.ARCHIVAL_STATE_DISABLED, "", "")
 	s.Require().NoError(err)
 }
 
@@ -504,6 +506,7 @@ func (s *FunctionalTestBase) tearDownSdk() {
 //  2. Update search attributes would require an extra API call,
 //  3. One more extra API call would be necessary to get namespace.ID.
 func (s *FunctionalTestBase) RegisterNamespace(
+	ctx context.Context,
 	nsName namespace.Name,
 	retentionDays int32,
 	archivalState enumspb.ArchivalState,
@@ -540,7 +543,7 @@ func (s *FunctionalTestBase) RegisterNamespace(
 		},
 		IsGlobalNamespace: false,
 	}
-	_, err := s.testCluster.testBase.MetadataManager.CreateNamespace(context.Background(), namespaceRequest)
+	_, err := s.testCluster.testBase.MetadataManager.CreateNamespace(ctx, namespaceRequest)
 
 	if err != nil {
 		return namespace.EmptyID, err
@@ -550,7 +553,7 @@ func (s *FunctionalTestBase) RegisterNamespace(
 	ticker := time.NewTicker(NamespaceCacheRefreshInterval / 2)
 	defer ticker.Stop()
 	for {
-		_, describeErr := s.FrontendClient().DescribeNamespace(NewContext(), &workflowservice.DescribeNamespaceRequest{
+		_, describeErr := s.FrontendClient().DescribeNamespace(ctx, &workflowservice.DescribeNamespaceRequest{
 			Namespace: nsName.String(),
 		})
 		if describeErr == nil {
@@ -562,7 +565,7 @@ func (s *FunctionalTestBase) RegisterNamespace(
 		<-ticker.C
 	}
 
-	_, err = s.OperatorClient().AddSearchAttributes(NewContext(), &operatorservice.AddSearchAttributesRequest{
+	_, err = s.OperatorClient().AddSearchAttributes(ctx, &operatorservice.AddSearchAttributesRequest{
 		Namespace:        nsName.String(),
 		SearchAttributes: expectedSearchAttributes,
 	})
@@ -572,7 +575,7 @@ func (s *FunctionalTestBase) RegisterNamespace(
 
 	namespaceCacheDeadline = time.Now().Add(5 * NamespaceCacheRefreshInterval)
 	for {
-		listResp, listErr := s.OperatorClient().ListSearchAttributes(NewContext(), &operatorservice.ListSearchAttributesRequest{
+		listResp, listErr := s.OperatorClient().ListSearchAttributes(ctx, &operatorservice.ListSearchAttributesRequest{
 			Namespace: nsName.String(),
 		})
 		if listErr == nil {

--- a/tests/testcore/test_env.go
+++ b/tests/testcore/test_env.go
@@ -259,7 +259,7 @@ func NewEnv(t *testing.T, opts ...TestOption) *TestEnv {
 
 	// Create the test context before any expensive setup, so that the deadline
 	// extension below can compensate for the time setup takes.
-	testcontext.For(t)
+	ctx := testcontext.For(t)
 
 	var options testOptions
 	for _, opt := range opts {
@@ -296,6 +296,7 @@ func NewEnv(t *testing.T, opts ...TestOption) *TestEnv {
 	baseName := strings.ReplaceAll(t.Name(), "/", "-")
 	ns := namespace.Name(RandomizeStr(baseName))
 	nsID, err := base.RegisterNamespace(
+		ctx,
 		ns,
 		1, // 1 day retention
 		enumspb.ARCHIVAL_STATE_DISABLED,

--- a/tests/timeskipping_test.go
+++ b/tests/timeskipping_test.go
@@ -516,7 +516,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_RetentionClearsSkippedWorkflowI
 
 	// NewEnv's namespace has 1 day retention, which cannot be lowered through the frontend.
 	ns := namespace.Name(testcore.RandomizeStr("ts-retention"))
-	_, err := env.RegisterNamespace(ns, 0, enumspb.ARCHIVAL_STATE_DISABLED, "", "")
+	_, err := env.RegisterNamespace(s.Context(), ns, 0, enumspb.ARCHIVAL_STATE_DISABLED, "", "")
 	s.NoError(err)
 
 	tv := testvars.New(s.T())


### PR DESCRIPTION
## What changed?

Pass one test-owned context through namespace creation, namespace cache polling, and search attribute registration during functional test setup.

## Why?

Reusing the test context avoids creating independent timeout contexts for each setup RPC and ties their resources to the test lifecycle.
