### PR TITLE
Make standalone activity completion callback attachment idempotent after closure

### DIFF
--- a/chasm/chasmtest/test_engine.go
+++ b/chasm/chasmtest/test_engine.go
@@ -240,8 +240,7 @@ func (e *Engine) UpdateComponent(
 	options := constructTransitionOptions(opts...)
 	if options.RequestID != "" {
 		if _, ok := execution.requestIDs[options.RequestID]; ok {
-			return nil, serviceerror.NewFailedPreconditionf(
-				"request ID %s has already been used for this execution", options.RequestID)
+			return nil, chasm.ErrRequestIDAlreadyUsed
 		}
 	}
 

--- a/chasm/chasmtest/test_engine_test.go
+++ b/chasm/chasmtest/test_engine_test.go
@@ -60,6 +60,7 @@ func TestUpdateComponentDeduplicatesRequestID(t *testing.T) {
 	updatedRef, err = update()
 	var failedPrecondition *serviceerror.FailedPrecondition
 	require.ErrorAs(t, err, &failedPrecondition)
+	require.ErrorIs(t, err, chasm.ErrRequestIDAlreadyUsed)
 	require.Nil(t, updatedRef)
 	require.Equal(t, 1, updateCount)
 }

--- a/chasm/errors.go
+++ b/chasm/errors.go
@@ -1,5 +1,11 @@
 package chasm
 
+import "go.temporal.io/api/serviceerror"
+
+// ErrRequestIDAlreadyUsed is returned by UpdateComponent when the request ID supplied via
+// WithRequestID has already been recorded on the execution.
+var ErrRequestIDAlreadyUsed = serviceerror.NewFailedPrecondition("request ID has already been used for this execution")
+
 type ExecutionAlreadyStartedError struct {
 	Message          string
 	CurrentRequestID string

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -434,6 +434,11 @@ func (a *Activity) addCompletionCallbacks(
 	if len(completionCallbacks) == 0 {
 		return nil
 	}
+	for _, callbackField := range a.Callbacks {
+		if callbackField.Get(ctx).GetRequestId() == requestID {
+			return nil
+		}
+	}
 	if a.LifecycleState(ctx).IsClosed() {
 		return serviceerror.NewFailedPrecondition("cannot attach callbacks to a closed activity")
 	}

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -434,11 +434,6 @@ func (a *Activity) addCompletionCallbacks(
 	if len(completionCallbacks) == 0 {
 		return nil
 	}
-	for _, callbackField := range a.Callbacks {
-		if callbackField.Get(ctx).GetRequestId() == requestID {
-			return nil
-		}
-	}
 	if a.LifecycleState(ctx).IsClosed() {
 		return serviceerror.NewFailedPrecondition("cannot attach callbacks to a closed activity")
 	}

--- a/chasm/lib/activity/handler.go
+++ b/chasm/lib/activity/handler.go
@@ -157,8 +157,9 @@ func (h *handler) StartActivityExecution(ctx context.Context, req *activitypb.St
 				return nil, nil
 			},
 			nil,
+			chasm.WithRequestID(requestID),
 		)
-		if err != nil {
+		if err != nil && !errors.Is(err, chasm.ErrRequestIDAlreadyUsed) {
 			return nil, err
 		}
 	}

--- a/service/history/chasm_engine.go
+++ b/service/history/chasm_engine.go
@@ -566,8 +566,7 @@ func (e *ChasmEngine) updateComponent(
 	// reject it as non-retryable (FailedPrecondition) without running updateFn or persisting.
 	if requestID != "" && executionLease.GetMutableState().HasRequestID(requestID) {
 		executionLease.GetReleaseFn()(nil)
-		return nil, serviceerror.NewFailedPreconditionf(
-			"request ID %s has already been used for this execution", requestID)
+		return nil, chasm.ErrRequestIDAlreadyUsed
 	}
 
 	defer func() {

--- a/service/history/chasm_engine_test.go
+++ b/service/history/chasm_engine_test.go
@@ -981,6 +981,7 @@ func (s *chasmEngineSuite) TestUpdateComponent_RequestIDIdempotency() {
 	dupRef, err := update()
 	var failedPrecondition *serviceerror.FailedPrecondition
 	s.ErrorAs(err, &failedPrecondition)
+	s.ErrorIs(err, chasm.ErrRequestIDAlreadyUsed)
 	s.Nil(dupRef)
 	s.Equal(1, updateCount, "updateFn must not run again for a duplicate request ID")
 }

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -282,6 +282,23 @@ func (s *standaloneActivityTestSuite) TestIDConflictPolicy() {
 				AttachCompletionCallbacks: true,
 				AttachLinks:               true,
 			}
+			workflowEventLink := func(workflowID string) *commonpb.Link {
+				return &commonpb.Link{
+					Variant: &commonpb.Link_WorkflowEvent_{
+						WorkflowEvent: &commonpb.Link_WorkflowEvent{
+							Namespace:  env.Namespace().String(),
+							WorkflowId: workflowID,
+							RunId:      "run-id",
+							Reference: &commonpb.Link_WorkflowEvent_EventRef{
+								EventRef: &commonpb.Link_WorkflowEvent_EventReference{
+									EventId:   1,
+									EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+								},
+							},
+						},
+					},
+				}
+			}
 
 			t.Run("AttachesToNewActivity", func(t *testing.T) {
 				newActivityID := testcore.RandomizeStr(t.Name())
@@ -354,23 +371,7 @@ func (s *standaloneActivityTestSuite) TestIDConflictPolicy() {
 				bothTaskQueue := testcore.RandomizeStr(t.Name())
 				bothStartResp := env.startAndValidateActivity(ctx, t, bothActivityID, bothTaskQueue)
 
-				attachedLinks := []*commonpb.Link{
-					{
-						Variant: &commonpb.Link_WorkflowEvent_{
-							WorkflowEvent: &commonpb.Link_WorkflowEvent{
-								Namespace:  env.Namespace().String(),
-								WorkflowId: "both-wf",
-								RunId:      "both-run",
-								Reference: &commonpb.Link_WorkflowEvent_EventRef{
-									EventRef: &commonpb.Link_WorkflowEvent_EventReference{
-										EventId:   1,
-										EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
-									},
-								},
-							},
-						},
-					},
-				}
+				attachedLinks := []*commonpb.Link{workflowEventLink("both-wf")}
 
 				resp, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
 					Namespace:    env.Namespace().String(),
@@ -411,6 +412,7 @@ func (s *standaloneActivityTestSuite) TestIDConflictPolicy() {
 				idempotentStartResp := env.startAndValidateActivity(s.Context(), t, idempotentActivityID, idempotentTaskQueue)
 
 				requestID := env.Tv().Any().String()
+				originalLinks := []*commonpb.Link{workflowEventLink("idempotent-original")}
 				startReq := &workflowservice.StartActivityExecutionRequest{
 					Namespace:    env.Namespace().String(),
 					ActivityId:   idempotentActivityID,
@@ -426,15 +428,20 @@ func (s *standaloneActivityTestSuite) TestIDConflictPolicy() {
 					CompletionCallbacks: []*commonpb.Callback{
 						{Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: "http://localhost/idempotent-cb"}}},
 					},
+					Links:             originalLinks,
 					OnConflictOptions: onConflictOpts,
 				}
 
-				// First call attaches the callback.
+				// First call attaches both values.
 				resp1, err := env.FrontendClient().StartActivityExecution(s.Context(), startReq)
 				require.NoError(t, err)
 				require.False(t, resp1.GetStarted())
 
-				// Second call with the same request ID should not duplicate the callback.
+				// A retry with the same request ID is ignored even if its payload changed.
+				startReq.CompletionCallbacks = []*commonpb.Callback{
+					{Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: "http://localhost/retry-cb"}}},
+				}
+				startReq.Links = []*commonpb.Link{workflowEventLink("idempotent-retry")}
 				resp2, err := env.FrontendClient().StartActivityExecution(s.Context(), startReq)
 				require.NoError(t, err)
 				require.False(t, resp2.GetStarted())
@@ -445,9 +452,9 @@ func (s *standaloneActivityTestSuite) TestIDConflictPolicy() {
 					RunId:      idempotentStartResp.RunId,
 				})
 				require.NoError(t, err)
-				// Only 1 callback: the second call with the same request ID should not add another.
 				require.Len(t, descResp.Callbacks, 1)
 				require.Equal(t, "http://localhost/idempotent-cb", descResp.Callbacks[0].GetInfo().GetCallback().GetNexus().GetUrl())
+				protorequire.ProtoSliceEqual(t, originalLinks, descResp.GetInfo().GetLinks())
 			})
 
 			t.Run("IdempotentWithSameRequestIdAfterClose", func(t *testing.T) {
@@ -503,6 +510,71 @@ func (s *standaloneActivityTestSuite) TestIDConflictPolicy() {
 				})
 				require.NoError(t, err)
 				require.Len(t, descResp.GetCallbacks(), 1)
+			})
+
+			t.Run("ConflictUpdateIdempotentAfterClose", func(t *testing.T) {
+				activityID := testcore.RandomizeStr(t.Name())
+				taskQueue := testcore.RandomizeStr(t.Name())
+				startResp := env.startAndValidateActivity(ctx, t, activityID, taskQueue)
+				requestID := env.Tv().Any().String()
+				ch, callbackAddress := newNexusCompletionHandler(t)
+				originalLinks := []*commonpb.Link{workflowEventLink("after-close-original")}
+				conflictReq := &workflowservice.StartActivityExecutionRequest{
+					Namespace:           env.Namespace().String(),
+					ActivityId:          activityID,
+					ActivityType:        env.Tv().ActivityType(),
+					Identity:            env.Tv().WorkerIdentity(),
+					Input:               defaultInput,
+					TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
+					StartToCloseTimeout: durationpb.New(time.Minute),
+					IdConflictPolicy:    enumspb.ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING,
+					RequestId:           requestID,
+					CompletionCallbacks: []*commonpb.Callback{{
+						Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: callbackAddress}},
+					}},
+					Links:             originalLinks,
+					OnConflictOptions: onConflictOpts,
+				}
+
+				conflictResp, err := env.FrontendClient().StartActivityExecution(ctx, conflictReq)
+				require.NoError(t, err)
+				require.False(t, conflictResp.GetStarted())
+				require.Equal(t, startResp.GetRunId(), conflictResp.GetRunId())
+
+				pollResp := env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, startResp.GetRunId())
+				_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+					Namespace: env.Namespace().String(),
+					TaskToken: pollResp.GetTaskToken(),
+					Result:    defaultResult,
+					Identity:  defaultIdentity,
+				})
+				require.NoError(t, err)
+
+				select {
+				case <-ch.requestCh:
+				case <-ctx.Done():
+					require.Fail(t, "timed out waiting for completion callback")
+				}
+
+				conflictReq.CompletionCallbacks = []*commonpb.Callback{{
+					Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: "http://localhost/retry-cb"}},
+				}}
+				conflictReq.Links = []*commonpb.Link{workflowEventLink("after-close-retry")}
+				retryResp, err := env.FrontendClient().StartActivityExecution(ctx, conflictReq)
+				require.NoError(t, err)
+				require.False(t, retryResp.GetStarted())
+				require.Equal(t, startResp.GetRunId(), retryResp.GetRunId())
+				ch.requestCompleteCh <- nil
+
+				descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+					Namespace:  env.Namespace().String(),
+					ActivityId: activityID,
+					RunId:      startResp.GetRunId(),
+				})
+				require.NoError(t, err)
+				require.Len(t, descResp.GetCallbacks(), 1)
+				require.Equal(t, callbackAddress, descResp.GetCallbacks()[0].GetInfo().GetCallback().GetNexus().GetUrl())
+				protorequire.ProtoSliceEqual(t, originalLinks, descResp.GetInfo().GetLinks())
 			})
 		})
 

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -449,6 +449,61 @@ func (s *standaloneActivityTestSuite) TestIDConflictPolicy() {
 				require.Len(t, descResp.Callbacks, 1)
 				require.Equal(t, "http://localhost/idempotent-cb", descResp.Callbacks[0].GetInfo().GetCallback().GetNexus().GetUrl())
 			})
+
+			t.Run("IdempotentWithSameRequestIdAfterClose", func(t *testing.T) {
+				activityID := testcore.RandomizeStr(t.Name())
+				taskQueue := testcore.RandomizeStr(t.Name())
+				requestID := env.Tv().Any().String()
+				ch, callbackAddress := newNexusCompletionHandler(t)
+				startReq := &workflowservice.StartActivityExecutionRequest{
+					Namespace:           env.Namespace().String(),
+					ActivityId:          activityID,
+					ActivityType:        env.Tv().ActivityType(),
+					Identity:            env.Tv().WorkerIdentity(),
+					Input:               defaultInput,
+					TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
+					StartToCloseTimeout: durationpb.New(time.Minute),
+					IdConflictPolicy:    enumspb.ACTIVITY_ID_CONFLICT_POLICY_USE_EXISTING,
+					RequestId:           requestID,
+					CompletionCallbacks: []*commonpb.Callback{{
+						Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: callbackAddress}},
+					}},
+					OnConflictOptions: onConflictOpts,
+				}
+
+				startResp, err := env.FrontendClient().StartActivityExecution(ctx, startReq)
+				require.NoError(t, err)
+				require.True(t, startResp.GetStarted())
+
+				pollResp := env.pollActivityTaskAndValidate(ctx, t, activityID, taskQueue, startResp.GetRunId())
+				_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+					Namespace: env.Namespace().String(),
+					TaskToken: pollResp.GetTaskToken(),
+					Result:    defaultResult,
+					Identity:  defaultIdentity,
+				})
+				require.NoError(t, err)
+
+				select {
+				case <-ch.requestCh:
+				case <-ctx.Done():
+					require.Fail(t, "timed out waiting for completion callback")
+				}
+
+				retryResp, err := env.FrontendClient().StartActivityExecution(ctx, startReq)
+				require.NoError(t, err)
+				require.False(t, retryResp.GetStarted())
+				require.Equal(t, startResp.GetRunId(), retryResp.GetRunId())
+				ch.requestCompleteCh <- nil
+
+				descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+					Namespace:  env.Namespace().String(),
+					ActivityId: activityID,
+					RunId:      startResp.GetRunId(),
+				})
+				require.NoError(t, err)
+				require.Len(t, descResp.GetCallbacks(), 1)
+			})
 		})
 
 		t.Run("DoesNotApplyToCompletedActivity", func(t *testing.T) {


### PR DESCRIPTION
## What changed?

Makes Standalone Activity conflict updates idempotent by recording the `requestID` when attaching callbacks or links and recognizing duplicate request IDs. I needed to add a dedicated CHASM error for

## Why?
This prevents a successful attachment whose response was lost from failing on retry or duplicating/replacing callbacks and links.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0e834082e0304841cb3d13147c6efe368953fa3c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->