### PR TITLE
Fix invoker action limit across phases

### DIFF
--- a/chasm/lib/scheduler/invoker_execute_task_test.go
+++ b/chasm/lib/scheduler/invoker_execute_task_test.go
@@ -668,6 +668,47 @@ func TestExecuteTask_ExceedsMaxActionsPerExecution(t *testing.T) {
 	})
 }
 
+func TestExecuteTask_MaxActionsPerExecutionAcrossPhases(t *testing.T) {
+	const maxActions = 2
+	env := newInvokerExecuteTestEnv(t, func(config *scheduler.Config) {
+		tweakables := scheduler.DefaultTweakables
+		tweakables.MaxActionsPerExecution = maxActions
+		config.Tweakables = func(string) scheduler.Tweakables { return tweakables }
+	})
+	startTime := timestamppb.New(env.TimeSource.Now())
+
+	env.mockHistoryClient.EXPECT().TerminateWorkflowExecution(gomock.Any(), gomock.Any()).Times(1).
+		Return(nil, nil)
+	env.mockHistoryClient.EXPECT().RequestCancelWorkflowExecution(gomock.Any(), gomock.Any()).Times(1).
+		Return(nil, nil)
+
+	runExecuteTestCase(t, env, &executeTestCase{
+		InitialBufferedStarts: []*schedulespb.BufferedStart{{
+			NominalTime:   startTime,
+			ActualTime:    startTime,
+			DesiredTime:   startTime,
+			RequestId:     "retry",
+			WorkflowId:    "retry-workflow",
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+			Attempt:       2,
+			BackoffTime:   startTime,
+		}},
+		InitialCancelWorkflows: []*commonpb.WorkflowExecution{{
+			WorkflowId: "cancel-workflow",
+			RunId:      "cancel-run",
+		}},
+		InitialTerminateWorkflows: []*commonpb.WorkflowExecution{{
+			WorkflowId: "terminate-workflow",
+			RunId:      "terminate-run",
+		}},
+		ExpectedBufferedStarts:     1,
+		ExpectedRunningWorkflows:   0,
+		ExpectedActionCount:        0,
+		ExpectedCancelWorkflows:    0,
+		ExpectedTerminateWorkflows: 0,
+	})
+}
+
 // Two concurrent ExecuteTasks can both clone the invoker before either
 // commits, both fire StartWorkflow for the same RequestId, and both observe
 // success (server dedupes by RequestId). The losing commit must not

--- a/chasm/lib/scheduler/invoker_tasks.go
+++ b/chasm/lib/scheduler/invoker_tasks.go
@@ -63,12 +63,21 @@ type (
 		frontendClient workflowservice.WorkflowServiceClient
 	}
 
-	// Per-task context.
-	invokerTaskHandlerContext struct {
-		context.Context
+	// invokerTaskRun holds state shared by one ExecuteTask.
+	invokerTaskRun struct {
+		h              *InvokerExecuteTaskHandler
+		logger         log.Logger
+		metricsHandler metrics.Handler
+		scheduler      *Scheduler
 
-		actionsTaken int
-		maxActions   int
+		budget actionBudget
+	}
+
+	// actionBudget caps the total number of actions a single ExecuteTask may
+	// perform across all phases.
+	actionBudget struct {
+		taken int
+		max   int
 	}
 
 	rateLimitedError struct {
@@ -228,10 +237,10 @@ func (h *InvokerExecuteTaskHandler) Execute(
 	//
 	// Run the phases serially so they consume the same per-task action budget.
 	// Each phase still executes its individual requests concurrently.
-	ictx := h.newInvokerTaskHandlerContext(ctx, scheduler)
-	result = result.Append(h.terminateWorkflows(&ictx, logger, metricsHandler, scheduler, invoker.GetTerminateWorkflows()))
-	result = result.Append(h.cancelWorkflows(&ictx, logger, metricsHandler, scheduler, invoker.GetCancelWorkflows()))
-	result = result.Append(h.startWorkflows(&ictx, logger, metricsHandler, scheduler, invoker, lastCompletionState, schedulerRef, now))
+	run := h.newTaskRun(logger, metricsHandler, scheduler)
+	result = result.Append(run.terminateWorkflows(ctx, invoker.GetTerminateWorkflows()))
+	result = result.Append(run.cancelWorkflows(ctx, invoker.GetCancelWorkflows()))
+	result = result.Append(run.startWorkflows(ctx, invoker, lastCompletionState, schedulerRef, now))
 
 	// Record action results on the Invoker (internal state), as well as the
 	// Scheduler (user-facing metrics).
@@ -258,43 +267,39 @@ func (h *InvokerExecuteTaskHandler) Execute(
 	return nil
 }
 
-// takeNextAction increments the context's actionTaken counter, returning true if
-// the action should be executed, and false if the task should instead yield.
-func (i *invokerTaskHandlerContext) takeNextAction() bool {
-	allowed := i.actionsTaken < i.maxActions
+// tryTake consumes one unit of the budget, returning true if the action should
+// be executed, and false if the task has exhausted its budget and should yield.
+func (b *actionBudget) tryTake() bool {
+	allowed := b.taken < b.max
 	if allowed {
-		i.actionsTaken++
+		b.taken++
 	}
 	return allowed
 }
 
 // cancelWorkflows does a best-effort attempt to cancel all workflow executions provided in targets.
-func (h *InvokerExecuteTaskHandler) cancelWorkflows(
-	ctx *invokerTaskHandlerContext,
-	logger log.Logger,
-	metricsHandler metrics.Handler,
-	scheduler *Scheduler,
+func (r *invokerTaskRun) cancelWorkflows(
+	ctx context.Context,
 	targets []*commonpb.WorkflowExecution,
 ) (result executeResult) {
 	var wg sync.WaitGroup
 	var resultMutex sync.Mutex
 
 	for _, wf := range targets {
-		if !ctx.takeNextAction() {
+		if !r.budget.tryTake() {
 			break
 		}
 
 		// Run all cancels concurrently.
-		newCtx := ctx.Clone()
 		wg.Go(func() {
-			err := h.cancelWorkflow(newCtx, scheduler, wf)
+			err := r.h.cancelWorkflow(ctx, r.scheduler, wf)
 
 			resultMutex.Lock()
 			defer resultMutex.Unlock()
 
 			if err != nil {
-				logger.Info("failed to cancel workflow", tag.Error(err), tag.WorkflowID(wf.WorkflowId))
-				metricsHandler.Counter(metrics.ScheduleCancelWorkflowErrors.Name()).Record(1)
+				r.logger.Info("failed to cancel workflow", tag.Error(err), tag.WorkflowID(wf.WorkflowId))
+				r.metricsHandler.Counter(metrics.ScheduleCancelWorkflowErrors.Name()).Record(1)
 			}
 
 			// Cancels are only attempted once here: transient failures are
@@ -311,32 +316,28 @@ func (h *InvokerExecuteTaskHandler) cancelWorkflows(
 }
 
 // terminateWorkflows does a best-effort attempt to terminate all workflow executions provided in targets.
-func (h *InvokerExecuteTaskHandler) terminateWorkflows(
-	ctx *invokerTaskHandlerContext,
-	logger log.Logger,
-	metricsHandler metrics.Handler,
-	scheduler *Scheduler,
+func (r *invokerTaskRun) terminateWorkflows(
+	ctx context.Context,
 	targets []*commonpb.WorkflowExecution,
 ) (result executeResult) {
 	var wg sync.WaitGroup
 	var resultMutex sync.Mutex
 
 	for _, wf := range targets {
-		if !ctx.takeNextAction() {
+		if !r.budget.tryTake() {
 			break
 		}
 
 		// Run all terminates concurrently.
-		newCtx := ctx.Clone()
 		wg.Go(func() {
-			err := h.terminateWorkflow(newCtx, scheduler, wf)
+			err := r.h.terminateWorkflow(ctx, r.scheduler, wf)
 
 			resultMutex.Lock()
 			defer resultMutex.Unlock()
 
 			if err != nil {
-				logger.Info("failed to terminate workflow", tag.Error(err), tag.WorkflowID(wf.WorkflowId))
-				metricsHandler.Counter(metrics.ScheduleTerminateWorkflowErrors.Name()).Record(1)
+				r.logger.Info("failed to terminate workflow", tag.Error(err), tag.WorkflowID(wf.WorkflowId))
+				r.metricsHandler.Counter(metrics.ScheduleTerminateWorkflowErrors.Name()).Record(1)
 			}
 
 			// Terminates are only attempted once here: transient failures are
@@ -353,17 +354,14 @@ func (h *InvokerExecuteTaskHandler) terminateWorkflows(
 }
 
 // startWorkflows executes the provided list of starts, returning a result with their outcomes.
-func (h *InvokerExecuteTaskHandler) startWorkflows(
-	ctx *invokerTaskHandlerContext,
-	logger log.Logger,
-	metricsHandler metrics.Handler,
-	scheduler *Scheduler,
+func (r *invokerTaskRun) startWorkflows(
+	ctx context.Context,
 	invoker *Invoker,
 	lastCompletionState *schedulerpb.LastCompletionResult,
 	schedulerRef []byte,
 	now time.Time,
 ) (result executeResult) {
-	metricsWithTag := metricsHandler.WithTags(
+	metricsWithTag := r.metricsHandler.WithTags(
 		metrics.StringTag(metrics.ScheduleActionTypeTag, metrics.ScheduleActionStartWorkflow))
 
 	var wg sync.WaitGroup
@@ -373,7 +371,7 @@ func (h *InvokerExecuteTaskHandler) startWorkflows(
 		// Starts that haven't been executed yet will remain in `BufferedStarts`,
 		// without change, so another ExecuteTask will be immediately created to continue
 		// processing in a new task.
-		if !ctx.takeNextAction() {
+		if !r.budget.tryTake() {
 			break
 		}
 
@@ -382,15 +380,14 @@ func (h *InvokerExecuteTaskHandler) startWorkflows(
 		start = common.CloneProto(start)
 
 		// Run all starts concurrently.
-		newCtx := ctx.Clone()
 		wg.Go(func() {
-			err := h.startWorkflow(newCtx, metricsHandler, scheduler, start, lastCompletionState, schedulerRef)
+			err := r.h.startWorkflow(ctx, r.metricsHandler, r.scheduler, start, lastCompletionState, schedulerRef)
 
 			resultMutex.Lock()
 			defer resultMutex.Unlock()
 
 			if err != nil {
-				logger.Info("failed to start workflow", tag.Error(err))
+				r.logger.Info("failed to start workflow", tag.Error(err))
 
 				// Don't count "already started" for the error metric or retry, as it is most likely
 				// due to misconfiguration.
@@ -399,7 +396,7 @@ func (h *InvokerExecuteTaskHandler) startWorkflows(
 				}
 
 				if isRetryableError(err) {
-					h.applyBackoff(start, err, now)
+					r.h.applyBackoff(start, err, now)
 					result.RetryableStarts = append(result.RetryableStarts, start)
 				} else {
 					// Drop the start from the buffer.
@@ -801,27 +798,22 @@ func (r *rateLimitedError) Error() string {
 	return fmt.Sprintf("rate limited for %s", r.delay)
 }
 
-func (h *InvokerExecuteTaskHandler) newInvokerTaskHandlerContext(
-	ctx context.Context,
+func (h *InvokerExecuteTaskHandler) newTaskRun(
+	logger log.Logger,
+	metricsHandler metrics.Handler,
 	scheduler *Scheduler,
-) invokerTaskHandlerContext {
+) *invokerTaskRun {
 	tweakables := h.config.Tweakables(scheduler.Namespace)
 	maxActions := tweakables.MaxActionsPerExecution
 	if maxActions <= 0 {
 		maxActions = DefaultTweakables.MaxActionsPerExecution
 	}
 
-	return invokerTaskHandlerContext{
-		Context:      ctx,
-		actionsTaken: 0,
-		maxActions:   maxActions,
-	}
-}
-
-func (i invokerTaskHandlerContext) Clone() invokerTaskHandlerContext {
-	return invokerTaskHandlerContext{
-		Context:      i.Context,
-		actionsTaken: i.actionsTaken,
-		maxActions:   i.maxActions,
+	return &invokerTaskRun{
+		h:              h,
+		logger:         logger,
+		metricsHandler: metricsHandler,
+		scheduler:      scheduler,
+		budget:         actionBudget{max: maxActions},
 	}
 }

--- a/chasm/lib/scheduler/invoker_tasks.go
+++ b/chasm/lib/scheduler/invoker_tasks.go
@@ -226,13 +226,12 @@ func (h *InvokerExecuteTaskHandler) Execute(
 	// Terminate, cancel, and start workflows. The result struct contains the
 	// complete outcome of all requests executed in a single batch.
 	//
-	// Invoker will never have work pending for more than one of these calls (terminate,
-	// cancel, start) at a time, so it isn't sensible to run them in parallel. The
-	// structure below is simply for code simplicity.
+	// Run the phases serially so they consume the same per-task action budget.
+	// Each phase still executes its individual requests concurrently.
 	ictx := h.newInvokerTaskHandlerContext(ctx, scheduler)
-	result = result.Append(h.terminateWorkflows(ictx, logger, metricsHandler, scheduler, invoker.GetTerminateWorkflows()))
-	result = result.Append(h.cancelWorkflows(ictx, logger, metricsHandler, scheduler, invoker.GetCancelWorkflows()))
-	result = result.Append(h.startWorkflows(ictx, logger, metricsHandler, scheduler, invoker, lastCompletionState, schedulerRef, now))
+	result = result.Append(h.terminateWorkflows(&ictx, logger, metricsHandler, scheduler, invoker.GetTerminateWorkflows()))
+	result = result.Append(h.cancelWorkflows(&ictx, logger, metricsHandler, scheduler, invoker.GetCancelWorkflows()))
+	result = result.Append(h.startWorkflows(&ictx, logger, metricsHandler, scheduler, invoker, lastCompletionState, schedulerRef, now))
 
 	// Record action results on the Invoker (internal state), as well as the
 	// Scheduler (user-facing metrics).
@@ -271,7 +270,7 @@ func (i *invokerTaskHandlerContext) takeNextAction() bool {
 
 // cancelWorkflows does a best-effort attempt to cancel all workflow executions provided in targets.
 func (h *InvokerExecuteTaskHandler) cancelWorkflows(
-	ctx invokerTaskHandlerContext,
+	ctx *invokerTaskHandlerContext,
 	logger log.Logger,
 	metricsHandler metrics.Handler,
 	scheduler *Scheduler,
@@ -313,7 +312,7 @@ func (h *InvokerExecuteTaskHandler) cancelWorkflows(
 
 // terminateWorkflows does a best-effort attempt to terminate all workflow executions provided in targets.
 func (h *InvokerExecuteTaskHandler) terminateWorkflows(
-	ctx invokerTaskHandlerContext,
+	ctx *invokerTaskHandlerContext,
 	logger log.Logger,
 	metricsHandler metrics.Handler,
 	scheduler *Scheduler,
@@ -355,7 +354,7 @@ func (h *InvokerExecuteTaskHandler) terminateWorkflows(
 
 // startWorkflows executes the provided list of starts, returning a result with their outcomes.
 func (h *InvokerExecuteTaskHandler) startWorkflows(
-	ctx invokerTaskHandlerContext,
+	ctx *invokerTaskHandlerContext,
 	logger log.Logger,
 	metricsHandler metrics.Handler,
 	scheduler *Scheduler,


### PR DESCRIPTION
## What changed?
Use a per-`ExecuteTask` action budget shared by the terminate, cancel, and start phases.

## Why?
Each phase previously received a value copy, allowing every non-empty phase to consume `MaxActionsPerExecution` independently.


## Potential risks
Deferred work remains queued for the next ExecuteTask once the shared action budget is exhausted.