### PR TITLE
Removed time-skipping blanket timestamp wrapping

### DIFF
--- a/service/history/api/create_workflow_util.go
+++ b/service/history/api/create_workflow_util.go
@@ -49,6 +49,11 @@ func NewWorkflowWithSignal(
 	startRequest *historyservice.StartWorkflowExecutionRequest,
 	signalWithStartRequest *workflowservice.SignalWithStartWorkflowExecutionRequest,
 ) (historyi.MutableState, error) {
+	startTime := shard.GetTimeSource().Now()
+	initialSkip := startRequest.GetTimeSkippingStatePropagation().GetInitialSkippedDuration().AsDuration()
+	if startRequest.GetParentExecutionInfo() != nil && initialSkip > 0 {
+		startTime = startTime.Add(initialSkip)
+	}
 	newMutableState, err := CreateMutableState(
 		shard,
 		namespaceEntry,
@@ -56,6 +61,7 @@ func NewWorkflowWithSignal(
 		startRequest.StartRequest.WorkflowRunTimeout,
 		workflowID,
 		runID,
+		startTime,
 	)
 	if err != nil {
 		return nil, err
@@ -161,6 +167,7 @@ func CreateMutableState(
 	runTimeout *durationpb.Duration,
 	workflowID string,
 	runID string,
+	startTime time.Time,
 ) (historyi.MutableState, error) {
 	newMutableState := workflow.NewMutableState(
 		shard,
@@ -169,7 +176,7 @@ func CreateMutableState(
 		namespaceEntry,
 		workflowID,
 		runID,
-		shard.GetTimeSource().Now(),
+		startTime,
 	)
 	if err := newMutableState.SetHistoryTree(executionTimeout, runTimeout, runID); err != nil {
 		return nil, err

--- a/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
+++ b/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
@@ -1456,7 +1456,7 @@ func (handler *workflowTaskCompletedHandler) handleRetry(
 		handler.mutableState.GetNamespaceEntry(),
 		handler.mutableState.GetWorkflowKey().WorkflowID,
 		newRunID,
-		handler.shard.GetTimeSource().Now(),
+		handler.retryOrCronStartTime(),
 		handler.mutableState,
 	)
 	if err != nil {
@@ -1516,7 +1516,7 @@ func (handler *workflowTaskCompletedHandler) handleCron(
 		handler.mutableState.GetNamespaceEntry(),
 		handler.mutableState.GetWorkflowKey().WorkflowID,
 		newRunID,
-		handler.shard.GetTimeSource().Now(),
+		handler.retryOrCronStartTime(),
 		handler.mutableState,
 	)
 	if err != nil {
@@ -1550,6 +1550,16 @@ func (handler *workflowTaskCompletedHandler) handleCron(
 
 	handler.newMutableState = newMutableState
 	return nil
+}
+
+func (handler *workflowTaskCompletedHandler) retryOrCronStartTime() time.Time {
+	timeSkippingInfo := workflow.NewTimeSkippingInfoUtil(
+		handler.mutableState.GetExecutionInfo().GetTimeSkippingInfo(),
+	)
+	if timeSkippingInfo.GetAccumulatedSkippedDuration() > 0 {
+		return handler.mutableState.Now()
+	}
+	return handler.shard.GetTimeSource().Now()
 }
 
 func (handler *workflowTaskCompletedHandler) validateCommandAttr(

--- a/service/history/transfer_queue_active_task_executor.go
+++ b/service/history/transfer_queue_active_task_executor.go
@@ -1719,6 +1719,15 @@ func (t *transferQueueActiveTaskExecutor) startWorkflow(
 		TimeSkippingConfig:       attributes.GetTimeSkippingConfig(),
 	}
 
+	startTime := t.shardContext.GetTimeSource().Now()
+	statePropagation := attributes.GetTimeSkippingStatePropagation()
+	if statePropagation.GetInitialSkippedDuration().AsDuration() > 0 {
+		// The propagation state was captured while the parent was running in virtual time.
+		// The child config can be nil when propagation is disabled, but its admission time
+		// still has to remain in the parent's clock frame.
+		startTime = startTime.Add(statePropagation.GetInitialSkippedDuration().AsDuration())
+	}
+
 	request := common.CreateHistoryStartWorkflowRequest(
 		targetNamespaceID.String(),
 		startRequest,
@@ -1734,13 +1743,13 @@ func (t *transferQueueActiveTaskExecutor) startWorkflow(
 			Clock:            vclock.NewVectorClock(t.shardContext.GetClusterMetadata().GetClusterID(), t.shardContext.GetShardID(), task.TaskID),
 		},
 		rootExecutionInfo,
-		t.shardContext.GetTimeSource().Now(),
+		startTime,
 	)
 
 	request.SourceVersionStamp = sourceVersionStamp
 	request.InheritedBuildId = inheritedBuildId
 	request.InheritedPinnedVersion = inheritedPinnedVersion
-	request.TimeSkippingStatePropagation = attributes.GetTimeSkippingStatePropagation()
+	request.TimeSkippingStatePropagation = statePropagation
 
 	// Only set the AutoUpgrade info if the Pinned version is not set.
 	if request.InheritedPinnedVersion == nil {

--- a/service/history/workflow/timeskipping.go
+++ b/service/history/workflow/timeskipping.go
@@ -105,6 +105,16 @@ func (ms *MutableStateImpl) setAndStampFastForwardInfo(
 	return tsi.FastForwardInfoLastUpdateVersionedTransition
 }
 
+// New mutable states currently reach this function with timestamps in different clock frames:
+//   - workflow-task retry, cron, and child starts are constructed from the real shard clock; their
+//     inherited offset is discovered when the started event is applied, so their run-local times
+//     must be translated into the virtual frame;
+//   - a normal workflow start has no inherited offset, making the translation a no-op; and
+//   - continue-as-new, timer-triggered retry, and history reconstruction are constructed from an
+//     already-virtual event or mutable-state timestamp, so translating them again is incorrect.
+//
+// CONSIDER(time-skipping): initialize every new mutable state with an explicit clock frame so
+// timestamps are created directly in virtual time and this post-construction translation can go away.
 func (ms *MutableStateImpl) wrapExecutionTimes(initialSkippedDuration *durationpb.Duration) {
 	if initialSkippedDuration == nil || initialSkippedDuration.AsDuration() == 0 {
 		return

--- a/service/history/workflow/timeskipping.go
+++ b/service/history/workflow/timeskipping.go
@@ -22,6 +22,11 @@ import (
 // =============================================================================
 // Time Skipping Configuration Management
 // =============================================================================
+// Admission timestamps must already be in the correct clock frame before initialization:
+// child, workflow-task retry, and cron starts translate real shard time into inherited virtual
+// time; normal starts have no offset; and continue-as-new, timer retries, and history rebuilds
+// already supply virtual timestamps. Mutating them here would double-shift the latter paths and
+// move absolute execution-expiration deadlines.
 func (ms *MutableStateImpl) initTimeSkippingInfo(
 	config *commonpb.TimeSkippingConfig,
 	timeSkippingStatePropagation *commonpb.TimeSkippingStatePropagation,
@@ -37,7 +42,6 @@ func (ms *MutableStateImpl) initTimeSkippingInfo(
 		SessionSkipCount:           timeSkippingStatePropagation.GetInitialSkipCount(),
 	}
 	ms.wrapTimeSourceWithTimeSkipping()
-	ms.wrapExecutionTimes(initialSkip)
 	ms.applyFastForward(timeSkippingStatePropagation.GetFastForwardTargetTime())
 	ms.timeSkippingInfoUpdated = true
 }
@@ -103,38 +107,6 @@ func (ms *MutableStateImpl) setAndStampFastForwardInfo(
 		TransitionCount:          ms.NextTransitionCount(),
 	}
 	return tsi.FastForwardInfoLastUpdateVersionedTransition
-}
-
-// New mutable states currently reach this function with timestamps in different clock frames:
-//   - workflow-task retry, cron, and child starts are constructed from the real shard clock; their
-//     inherited offset is discovered when the started event is applied, so their run-local times
-//     must be translated into the virtual frame;
-//   - a normal workflow start has no inherited offset, making the translation a no-op; and
-//   - continue-as-new, timer-triggered retry, and history reconstruction are constructed from an
-//     already-virtual event or mutable-state timestamp, so translating them again is incorrect.
-//
-// CONSIDER(time-skipping): initialize every new mutable state with an explicit clock frame so
-// timestamps are created directly in virtual time and this post-construction translation can go away.
-func (ms *MutableStateImpl) wrapExecutionTimes(initialSkippedDuration *durationpb.Duration) {
-	if initialSkippedDuration == nil || initialSkippedDuration.AsDuration() == 0 {
-		return
-	}
-	accum := initialSkippedDuration.AsDuration()
-	if !timeNotSet(ms.executionState.StartTime) {
-		ms.executionState.StartTime = timestamppb.New(ms.executionState.StartTime.AsTime().Add(accum))
-	}
-	if !timeNotSet(ms.executionInfo.StartTime) {
-		ms.executionInfo.StartTime = timestamppb.New(ms.executionInfo.StartTime.AsTime().Add(accum))
-	}
-	if !timeNotSet(ms.executionInfo.ExecutionTime) {
-		ms.executionInfo.ExecutionTime = timestamppb.New(ms.executionInfo.ExecutionTime.AsTime().Add(accum))
-	}
-	if !timeNotSet(ms.executionInfo.WorkflowRunExpirationTime) {
-		ms.executionInfo.WorkflowRunExpirationTime = timestamppb.New(ms.executionInfo.WorkflowRunExpirationTime.AsTime().Add(accum))
-	}
-	if !timeNotSet(ms.executionInfo.WorkflowExecutionExpirationTime) {
-		ms.executionInfo.WorkflowExecutionExpirationTime = timestamppb.New(ms.executionInfo.WorkflowExecutionExpirationTime.AsTime().Add(accum))
-	}
 }
 
 // -- Propagation Methods of Time Skipping

--- a/service/history/workflow/timeskipping_test.go
+++ b/service/history/workflow/timeskipping_test.go
@@ -653,38 +653,6 @@ func (s *mutableStateSuite) TestUpdateTimeSkippingInfo() {
 	})
 }
 
-// TestWrapExecutionTimes covers the three invariants of wrapExecutionTimes:
-// a nil/zero skipped duration is a no-op; a non-zero duration shifts every *set*
-// execution timestamp forward by exactly that duration; unset timestamps stay unset.
-func (s *mutableStateSuite) TestWrapExecutionTimes() {
-	base := time.Date(2026, 7, 1, 8, 0, 0, 0, time.UTC)
-
-	s.Run("NilOrZeroDurationIsNoOp", func() {
-		s.mutableState.executionInfo.StartTime = timestamppb.New(base)
-		s.mutableState.wrapExecutionTimes(nil)
-		s.Equal(base, s.mutableState.executionInfo.StartTime.AsTime())
-		s.mutableState.wrapExecutionTimes(durationpb.New(0))
-		s.Equal(base, s.mutableState.executionInfo.StartTime.AsTime())
-	})
-
-	s.Run("ShiftsSetTimestampsAndLeavesUnsetUntouched", func() {
-		accum := 2 * time.Hour
-		s.mutableState.executionState.StartTime = timestamppb.New(base)
-		s.mutableState.executionInfo.StartTime = timestamppb.New(base)
-		s.mutableState.executionInfo.ExecutionTime = timestamppb.New(base.Add(time.Minute))
-		s.mutableState.executionInfo.WorkflowRunExpirationTime = timestamppb.New(base.Add(time.Hour))
-		s.mutableState.executionInfo.WorkflowExecutionExpirationTime = nil // unset must stay unset
-
-		s.mutableState.wrapExecutionTimes(durationpb.New(accum))
-
-		s.Equal(base.Add(accum), s.mutableState.executionState.StartTime.AsTime())
-		s.Equal(base.Add(accum), s.mutableState.executionInfo.StartTime.AsTime())
-		s.Equal(base.Add(time.Minute).Add(accum), s.mutableState.executionInfo.ExecutionTime.AsTime())
-		s.Equal(base.Add(time.Hour).Add(accum), s.mutableState.executionInfo.WorkflowRunExpirationTime.AsTime())
-		s.Nil(s.mutableState.executionInfo.WorkflowExecutionExpirationTime, "unset timestamp must remain unset")
-	})
-}
-
 // TestApplyFastForward covers the full branch table of applyFastForward:
 // FastForward set / nil duration / nil config / Enabled=false.
 // The first-init virtual-time path is covered separately in TestInitTimeSkippingInfo.

--- a/tests/timeskipping_propagation_test.go
+++ b/tests/timeskipping_propagation_test.go
@@ -1404,6 +1404,95 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInCaN_SkipSessionPropagated() 
 		"started event carries run 1's SessionSkipCount as InitialSkipCount")
 }
 
+// TestTSPInCaN_ExecutionExpirationRemainsAbsolute verifies that time-skipping state
+// propagation does not extend the workflow execution timeout across runs. The expiration
+// timestamp is already expressed in virtual time and must remain unchanged when the next
+// run inherits the accumulated skipped duration.
+func (s *TimeSkippingPropagationTestSuite) TestTSPInCaN_ExecutionExpirationRemainsAbsolute() {
+	env := testcore.NewEnv(s.T())
+	env.OverrideDynamicConfig(dynamicconfig.WorkflowTimeSkippingEnabled, true)
+	tv := testvars.New(s.T())
+	ctx := s.Context()
+
+	const executionTimeout = 3 * time.Hour
+	wfType := tv.WorkflowType()
+	wfID := tv.WorkflowID()
+	tq := tv.TaskQueue()
+
+	start, err := env.FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:                uuid.NewString(),
+		Namespace:                env.Namespace().String(),
+		WorkflowId:               wfID,
+		WorkflowType:             wfType,
+		TaskQueue:                tq,
+		WorkflowExecutionTimeout: durationpb.New(executionTimeout),
+		WorkflowRunTimeout:       durationpb.New(24 * time.Hour),
+		WorkflowTaskTimeout:      durationpb.New(10 * time.Second),
+		TimeSkippingConfig:       &commonpb.TimeSkippingConfig{Enabled: true},
+	})
+	s.NoError(err)
+	run1ID := start.RunId
+
+	state := 0
+	handler := func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		fired := firedTimers(task)
+		switch {
+		case state == 0:
+			state = 1
+			return cmdsResponse(timerCmd("t1", time.Hour)), nil
+		case state == 1 && fired["t1"]:
+			state = 2
+			return cmdsResponse(continueAsNewCmd(wfType, tq)), nil
+		case state == 2:
+			state = 3
+			return cmdsResponse(), nil
+		}
+		return cmdsResponse(), nil
+	}
+
+	for i := range 3 {
+		_, pollErr := env.TaskPoller().PollAndHandleWorkflowTask(tv, handler)
+		if pollErr != nil {
+			s.T().Logf("iter %d: poll error: %v", i, pollErr)
+		}
+	}
+
+	var status enumspb.WorkflowExecutionStatus
+	s.AwaitTrue(func() bool {
+		desc, describeErr := env.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: env.Namespace().String(),
+			Execution: &commonpb.WorkflowExecution{WorkflowId: wfID},
+		})
+		if describeErr != nil {
+			return false
+		}
+		status = desc.WorkflowExecutionInfo.Status
+		return status != enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
+	}, 15*time.Second, 100*time.Millisecond)
+	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_TIMED_OUT, status)
+
+	run1MS := s.getMutableState(env, wfID, run1ID)
+	originalExpiration := run1MS.State.ExecutionInfo.GetWorkflowExecutionExpirationTime().AsTime()
+	s.False(originalExpiration.IsZero())
+
+	run2MS := s.getMutableStateByID(ctx, env, wfID)
+	run2ID := run2MS.State.ExecutionState.RunId
+	s.NotEqual(run1ID, run2ID)
+	s.Equal(originalExpiration, run2MS.State.ExecutionInfo.GetWorkflowExecutionExpirationTime().AsTime(),
+		"continue-as-new must preserve the chain's absolute virtual execution-expiration deadline")
+
+	hist2, err := env.FrontendClient().GetWorkflowExecutionHistory(ctx, &workflowservice.GetWorkflowExecutionHistoryRequest{
+		Namespace: env.Namespace().String(),
+		Execution: &commonpb.WorkflowExecution{WorkflowId: wfID, RunId: run2ID},
+	})
+	s.NoError(err)
+	s.NotEmpty(hist2.History.Events)
+	terminalEvent := hist2.History.Events[len(hist2.History.Events)-1]
+	s.Equal(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TIMED_OUT, terminalEvent.GetEventType())
+	s.WithinDuration(originalExpiration, terminalEvent.GetEventTime().AsTime(), 10*time.Second,
+		"workflow must time out at the original absolute virtual deadline")
+}
+
 // TestTSPInRetry verifies that a retried run is a same-lineage continuation: it inherits
 // the previous attempt's current TimeSkippingConfig AND its in-flight accumulated skip.
 //

--- a/tests/timeskipping_propagation_test.go
+++ b/tests/timeskipping_propagation_test.go
@@ -1185,6 +1185,9 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInReset() {
 	s.Equal(1, optionsUpdatedCount,
 		"reset run should contain exactly one reapplied OPTIONS_UPDATED event")
 	s.NotNil(startedEvent)
+	s.WithinDuration(startedEvent.GetEventTime().AsTime(), resetMS.State.ExecutionState.GetStartTime().AsTime(), 10*time.Second,
+		"reset/rebuild must preserve the already-materialized history start time")
+	s.WithinDuration(startedEvent.GetEventTime().AsTime(), resetMS.State.ExecutionInfo.GetStartTime().AsTime(), 10*time.Second)
 	startedTSC := startedEvent.GetWorkflowExecutionStartedEventAttributes().GetTimeSkippingConfig()
 	s.NotNil(startedTSC, "WorkflowExecutionStarted should carry the original TimeSkippingConfig")
 	s.False(startedTSC.GetEnabled(),
@@ -1303,6 +1306,11 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInCaN() {
 	})
 	s.NoError(err)
 	s.NotEmpty(hist2.History.Events)
+	startedEventTime := hist2.History.Events[0].GetEventTime().AsTime()
+	s.WithinDuration(startedEventTime, run2MS.State.ExecutionState.GetStartTime().AsTime(), 10*time.Second,
+		"continue-as-new constructor time is already virtual and must not be shifted again")
+	s.WithinDuration(startedEventTime, run2MS.State.ExecutionInfo.GetStartTime().AsTime(), 10*time.Second)
+	s.WithinDuration(startedEventTime, run2MS.State.ExecutionInfo.GetExecutionTime().AsTime(), 10*time.Second)
 	startedAttr := hist2.History.Events[0].GetWorkflowExecutionStartedEventAttributes()
 	s.NotNil(startedAttr)
 	s.Equal(run1ID, startedAttr.GetContinuedExecutionRunId(),
@@ -1618,6 +1626,11 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInRetry() {
 	s.NotEmpty(hist2.History.Events)
 	startedAttr := hist2.History.Events[0].GetWorkflowExecutionStartedEventAttributes()
 	s.NotNil(startedAttr)
+	inheritedSkip := startedAttr.GetTimeSkippingStatePropagation().GetInitialSkippedDuration().AsDuration()
+	expectedAttempt2Start := hist2.History.Events[0].GetEventTime().AsTime().Add(inheritedSkip)
+	s.WithinDuration(expectedAttempt2Start, attempt2MS.State.ExecutionState.GetStartTime().AsTime(), 10*time.Second,
+		"WFT-completion retry starts from real shard time and must translate once into virtual time")
+	s.WithinDuration(expectedAttempt2Start, attempt2MS.State.ExecutionInfo.GetStartTime().AsTime(), 10*time.Second)
 	s.Equal(attempt1ID, startedAttr.GetContinuedExecutionRunId(),
 		"attempt 2 references attempt 1 as its predecessor via ContinuedExecutionRunId")
 	s.Equal(enumspb.CONTINUE_AS_NEW_INITIATOR_RETRY, startedAttr.GetInitiator(),
@@ -1760,6 +1773,11 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInCron() {
 	s.NotEmpty(hist2.History.Events)
 	startedAttr := hist2.History.Events[0].GetWorkflowExecutionStartedEventAttributes()
 	s.NotNil(startedAttr)
+	inheritedSkip := startedAttr.GetTimeSkippingStatePropagation().GetInitialSkippedDuration().AsDuration()
+	expectedRun2Start := hist2.History.Events[0].GetEventTime().AsTime().Add(inheritedSkip)
+	s.WithinDuration(expectedRun2Start, run2MS.State.ExecutionState.GetStartTime().AsTime(), 90*time.Second,
+		"cron starts from real shard time and must translate once into virtual time")
+	s.WithinDuration(expectedRun2Start, run2MS.State.ExecutionInfo.GetStartTime().AsTime(), 90*time.Second)
 	s.Equal(run1ID, startedAttr.GetContinuedExecutionRunId(),
 		"run 2 references run 1 as its predecessor via ContinuedExecutionRunId")
 	s.Equal(enumspb.CONTINUE_AS_NEW_INITIATOR_CRON_SCHEDULE, startedAttr.GetInitiator(),

--- a/tests/timeskipping_propagation_test.go
+++ b/tests/timeskipping_propagation_test.go
@@ -625,19 +625,18 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInChildWf_ThreeGenerations() {
 		"P's initiated event for C carries P's full accumulated at command time (3h = G's 1h + P's pt1 2h)")
 }
 
-// TestTSPInChildWf_AdmissionTimestampsShifted verifies the time-shift block inside
-// initTimeSkippingInfo (mutable_state_impl.go): when a child workflow boots with a
-// non-zero PropagatedSkippedDuration, the boot-time admission timestamps on the
-// child's MS are shifted forward by accum so they live in the virtual frame, while
-// the WorkflowRunTimeoutTask's VisibilityTimestamp stays in the wall frame.
+// TestTSPInChildWf_AdmissionTimestampsShifted verifies that a child workflow with a
+// non-zero PropagatedSkippedDuration is admitted directly in the parent's virtual
+// clock frame, while the WorkflowRunTimeoutTask's VisibilityTimestamp stays in the
+// wall frame.
 //
 // Scenario:
 //   - Parent TSC enabled. Parent runs StartTimer(t1, 1h) → idle → server skips 1h.
 //     Parent's AccumulatedSkippedDuration ≈ 1h.
 //   - Parent issues StartChildWorkflow with WorkflowRunTimeout=2h. The child's
 //     initiated event carries InitialSkippedDuration=1h. On the child MS,
-//     applyTimeSkippingConfig seeds AccumulatedSkippedDuration=1h, and
-//     initTimeSkippingInfo shifts admission timestamps forward by accum=1h.
+//     applyTimeSkippingConfig seeds AccumulatedSkippedDuration=1h, and the child
+//     start request uses wallChildBoot+1h as its admission time.
 //
 // Boot-time assertions (virtual frame):
 //   - executionState.StartTime ≈ wallChildBoot + 1h
@@ -774,8 +773,7 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInChildWf_AdmissionTimestampsS
 
 	// WorkflowExecutionExpirationTime: the parent didn't set ExecutionTimeout, so the
 	// child's WorkflowExecutionTimeout is unset and the ExpirationTime is zero. The
-	// shift block in initTimeSkippingInfo only shifts non-nil values, so both branches
-	// are valid: zero is preserved as zero; non-zero is shifted by accum.
+	// direct construction preserves zero; a non-zero value is derived from the virtual start.
 	weExpiration := childMS.State.ExecutionInfo.WorkflowExecutionExpirationTime
 	if weExpiration != nil && !weExpiration.AsTime().IsZero() {
 		s.WithinDuration(expectedRunExpiration, weExpiration.AsTime(), tol,
@@ -1626,10 +1624,9 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInRetry() {
 	s.NotEmpty(hist2.History.Events)
 	startedAttr := hist2.History.Events[0].GetWorkflowExecutionStartedEventAttributes()
 	s.NotNil(startedAttr)
-	inheritedSkip := startedAttr.GetTimeSkippingStatePropagation().GetInitialSkippedDuration().AsDuration()
-	expectedAttempt2Start := hist2.History.Events[0].GetEventTime().AsTime().Add(inheritedSkip)
+	expectedAttempt2Start := hist2.History.Events[0].GetEventTime().AsTime()
 	s.WithinDuration(expectedAttempt2Start, attempt2MS.State.ExecutionState.GetStartTime().AsTime(), 10*time.Second,
-		"WFT-completion retry starts from real shard time and must translate once into virtual time")
+		"WFT-completion retry event and mutable state must be constructed in the same virtual frame")
 	s.WithinDuration(expectedAttempt2Start, attempt2MS.State.ExecutionInfo.GetStartTime().AsTime(), 10*time.Second)
 	s.Equal(attempt1ID, startedAttr.GetContinuedExecutionRunId(),
 		"attempt 2 references attempt 1 as its predecessor via ContinuedExecutionRunId")
@@ -1773,10 +1770,9 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInCron() {
 	s.NotEmpty(hist2.History.Events)
 	startedAttr := hist2.History.Events[0].GetWorkflowExecutionStartedEventAttributes()
 	s.NotNil(startedAttr)
-	inheritedSkip := startedAttr.GetTimeSkippingStatePropagation().GetInitialSkippedDuration().AsDuration()
-	expectedRun2Start := hist2.History.Events[0].GetEventTime().AsTime().Add(inheritedSkip)
+	expectedRun2Start := hist2.History.Events[0].GetEventTime().AsTime()
 	s.WithinDuration(expectedRun2Start, run2MS.State.ExecutionState.GetStartTime().AsTime(), 90*time.Second,
-		"cron starts from real shard time and must translate once into virtual time")
+		"cron event and mutable state must be constructed in the same virtual frame")
 	s.WithinDuration(expectedRun2Start, run2MS.State.ExecutionInfo.GetStartTime().AsTime(), 90*time.Second)
 	s.Equal(run1ID, startedAttr.GetContinuedExecutionRunId(),
 		"run 2 references run 1 as its predecessor via ContinuedExecutionRunId")

--- a/tests/timeskipping_test.go
+++ b/tests/timeskipping_test.go
@@ -74,6 +74,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_StartWorkflow_DCEnabled() {
 	env := testcore.NewEnv(s.T())
 	env.OverrideDynamicConfig(dynamicconfig.WorkflowTimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
+	beforeStart := time.Now()
 
 	// Request leaves MaxSkipPerSession empty; the frontend populates it from dynamic config.
 	inputConfig := &commonpb.TimeSkippingConfig{
@@ -92,11 +93,17 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_StartWorkflow_DCEnabled() {
 		TimeSkippingConfig:  inputConfig,
 	})
 	s.NoError(err)
+	afterStart := time.Now()
 
 	ms := s.getMutableState(env, tv.WorkflowID(), resp.RunId)
 	s.True(ms.State.ExecutionInfo.GetTimeSkippingInfo().GetConfig().GetEnabled())
 	inputConfig.MaxSessionSkipCount = defaultMaxSkipPerSession // frontend populated this from dynamic config
 	s.True(proto.Equal(inputConfig, ms.State.ExecutionInfo.GetTimeSkippingInfo().GetConfig()))
+	startTime := ms.State.ExecutionState.GetStartTime().AsTime()
+	s.False(startTime.Before(beforeStart), "zero-offset start must not move before the admission window")
+	s.False(startTime.After(afterStart), "zero-offset start must not move after the admission window")
+	s.Equal(startTime, ms.State.ExecutionInfo.GetStartTime().AsTime())
+	s.Equal(startTime, ms.State.ExecutionInfo.GetExecutionTime().AsTime())
 }
 
 // TestTimeSkipping_SignalWithStart_DCEnabled verifies that SignalWithStartWorkflowExecution
@@ -237,6 +244,17 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_UpdateWorkflowOptions_DCEnabled
 	// No time-skipping config before any update.
 	ms := s.getMutableState(env, tv.WorkflowID(), runID)
 	s.Nil(ms.State.ExecutionInfo.GetTimeSkippingInfo().GetConfig())
+	initialStateStart := ms.State.ExecutionState.GetStartTime().AsTime()
+	initialInfoStart := ms.State.ExecutionInfo.GetStartTime().AsTime()
+	initialExecutionTime := ms.State.ExecutionInfo.GetExecutionTime().AsTime()
+	initialRunExpiration := ms.State.ExecutionInfo.GetWorkflowRunExpirationTime().AsTime()
+	assertAdmissionTimesUnchanged := func() {
+		current := s.getMutableState(env, tv.WorkflowID(), runID)
+		s.Equal(initialStateStart, current.State.ExecutionState.GetStartTime().AsTime())
+		s.Equal(initialInfoStart, current.State.ExecutionInfo.GetStartTime().AsTime())
+		s.Equal(initialExecutionTime, current.State.ExecutionInfo.GetExecutionTime().AsTime())
+		s.Equal(initialRunExpiration, current.State.ExecutionInfo.GetWorkflowRunExpirationTime().AsTime())
+	}
 
 	// First update: enable with a max_elapsed_duration. MaxSkipPerSession is left empty and
 	// populated by the frontend from dynamic config; the persisted config and event carry it.
@@ -249,6 +267,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_UpdateWorkflowOptions_DCEnabled
 
 	ms = s.getMutableState(env, tv.WorkflowID(), runID)
 	s.True(proto.Equal(config1, ms.State.ExecutionInfo.GetTimeSkippingInfo().GetConfig()))
+	assertAdmissionTimesUnchanged()
 	events := collectOptionsEvents()
 	s.Len(events, 1)
 	s.True(proto.Equal(config1, events[0].GetWorkflowExecutionOptionsUpdatedEventAttributes().GetTimeSkippingConfig()))
@@ -263,6 +282,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_UpdateWorkflowOptions_DCEnabled
 
 	ms = s.getMutableState(env, tv.WorkflowID(), runID)
 	s.True(proto.Equal(config2, ms.State.ExecutionInfo.GetTimeSkippingInfo().GetConfig()))
+	assertAdmissionTimesUnchanged()
 	events = collectOptionsEvents()
 	s.Len(events, 2)
 	s.True(proto.Equal(config2, events[1].GetWorkflowExecutionOptionsUpdatedEventAttributes().GetTimeSkippingConfig()))
@@ -275,6 +295,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_UpdateWorkflowOptions_DCEnabled
 
 	ms = s.getMutableState(env, tv.WorkflowID(), runID)
 	s.True(proto.Equal(config3, ms.State.ExecutionInfo.GetTimeSkippingInfo().GetConfig()))
+	assertAdmissionTimesUnchanged()
 	events = collectOptionsEvents()
 	s.Len(events, 3)
 	s.True(proto.Equal(config3, events[2].GetWorkflowExecutionOptionsUpdatedEventAttributes().GetTimeSkippingConfig()))

--- a/tests/xdc/timeskipping_replication_test.go
+++ b/tests/xdc/timeskipping_replication_test.go
@@ -178,8 +178,10 @@ func (s *timeSkippingReplicationSuite) TestBasicSkipReplicates() {
 
 	s.waitForTimeSkippingInfoSynced(ctx, nsID, wfID, runID)
 
-	active := s.getExecutionInfoFromCluster(ctx, 0, nsID, wfID, runID).GetTimeSkippingInfo()
-	standby := s.getExecutionInfoFromCluster(ctx, 1, nsID, wfID, runID).GetTimeSkippingInfo()
+	activeInfo := s.getExecutionInfoFromCluster(ctx, 0, nsID, wfID, runID)
+	standbyInfo := s.getExecutionInfoFromCluster(ctx, 1, nsID, wfID, runID)
+	active := activeInfo.GetTimeSkippingInfo()
+	standby := standbyInfo.GetTimeSkippingInfo()
 	s.True(proto.Equal(active.GetConfig(), standby.GetConfig()))
 	s.Equal(
 		active.GetAccumulatedSkippedDuration().AsDuration(),
@@ -187,6 +189,10 @@ func (s *timeSkippingReplicationSuite) TestBasicSkipReplicates() {
 	)
 	s.InDelta(float64(startDelay), float64(standby.GetAccumulatedSkippedDuration().AsDuration()), float64(accumTol),
 		"standby's accumulated skip should match the configured startDelay within tolerance")
+	s.Equal(activeInfo.GetStartTime().AsTime(), standbyInfo.GetStartTime().AsTime(),
+		"replication must preserve the already-virtual start timestamp without applying the offset again")
+	s.Equal(activeInfo.GetExecutionTime().AsTime(), standbyInfo.GetExecutionTime().AsTime())
+	s.Equal(activeInfo.GetWorkflowRunExpirationTime().AsTime(), standbyInfo.GetWorkflowRunExpirationTime().AsTime())
 }
 
 // TestFastForwardDisablePropagates verifies that completing a registered FastForward


### PR DESCRIPTION
## What changed?
Removed blanket timestamp wrapping and adjusted only child, retry, and cron start times.


## Why?
Prevents double-shifting already-virtual timestamps and absolute workflow expiration deadlines.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

