### PR TITLE
removed blanket timestamp wrapping (time-skipping fix)

### DIFF
--- a/service/history/api/create_workflow_util.go
+++ b/service/history/api/create_workflow_util.go
@@ -49,13 +49,18 @@ func NewWorkflowWithSignal(
 	startRequest *historyservice.StartWorkflowExecutionRequest,
 	signalWithStartRequest *workflowservice.SignalWithStartWorkflowExecutionRequest,
 ) (historyi.MutableState, error) {
-	newMutableState, err := CreateMutableState(
+	startTime := workflow.AdjustNowWithTimeSkipping(
+		shard.GetTimeSource().Now(),
+		startRequest.GetTimeSkippingStatePropagation(),
+	)
+	newMutableState, err := createMutableState(
 		shard,
 		namespaceEntry,
 		startRequest.StartRequest.WorkflowExecutionTimeout,
 		startRequest.StartRequest.WorkflowRunTimeout,
 		workflowID,
 		runID,
+		startTime,
 	)
 	if err != nil {
 		return nil, err
@@ -154,13 +159,14 @@ func NewWorkflowLeaseAndContext(
 	), nil
 }
 
-func CreateMutableState(
+func createMutableState(
 	shard historyi.ShardContext,
 	namespaceEntry *namespace.Namespace,
 	executionTimeout *durationpb.Duration,
 	runTimeout *durationpb.Duration,
 	workflowID string,
 	runID string,
+	startTime time.Time,
 ) (historyi.MutableState, error) {
 	newMutableState := workflow.NewMutableState(
 		shard,
@@ -169,7 +175,7 @@ func CreateMutableState(
 		namespaceEntry,
 		workflowID,
 		runID,
-		shard.GetTimeSource().Now(),
+		startTime,
 	)
 	if err := newMutableState.SetHistoryTree(executionTimeout, runTimeout, runID); err != nil {
 		return nil, err

--- a/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
+++ b/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
@@ -1456,7 +1456,7 @@ func (handler *workflowTaskCompletedHandler) handleRetry(
 		handler.mutableState.GetNamespaceEntry(),
 		handler.mutableState.GetWorkflowKey().WorkflowID,
 		newRunID,
-		handler.shard.GetTimeSource().Now(),
+		handler.mutableState.Now(),
 		handler.mutableState,
 	)
 	if err != nil {
@@ -1516,7 +1516,7 @@ func (handler *workflowTaskCompletedHandler) handleCron(
 		handler.mutableState.GetNamespaceEntry(),
 		handler.mutableState.GetWorkflowKey().WorkflowID,
 		newRunID,
-		handler.shard.GetTimeSource().Now(),
+		handler.mutableState.Now(),
 		handler.mutableState,
 	)
 	if err != nil {

--- a/service/history/transfer_queue_active_task_executor.go
+++ b/service/history/transfer_queue_active_task_executor.go
@@ -1092,7 +1092,7 @@ func (t *transferQueueActiveTaskExecutor) processStartChildExecution(
 		},
 	}
 
-	childRunID, childClock, err := t.startWorkflow(
+	childRunID, childClock, err := t.startChildWorkflow(
 		ctx,
 		task,
 		parentNamespaceName,
@@ -1671,7 +1671,7 @@ func (t *transferQueueActiveTaskExecutor) signalExternalExecution(
 	return err
 }
 
-func (t *transferQueueActiveTaskExecutor) startWorkflow(
+func (t *transferQueueActiveTaskExecutor) startChildWorkflow(
 	ctx context.Context,
 	task *tasks.StartChildExecutionTask,
 	namespace namespace.Name,
@@ -1719,6 +1719,12 @@ func (t *transferQueueActiveTaskExecutor) startWorkflow(
 		TimeSkippingConfig:       attributes.GetTimeSkippingConfig(),
 	}
 
+	statePropagation := attributes.GetTimeSkippingStatePropagation()
+	nowForExpirationAndBackoff := workflow.AdjustNowWithTimeSkipping(
+		t.shardContext.GetTimeSource().Now(),
+		statePropagation,
+	)
+
 	request := common.CreateHistoryStartWorkflowRequest(
 		targetNamespaceID.String(),
 		startRequest,
@@ -1734,13 +1740,13 @@ func (t *transferQueueActiveTaskExecutor) startWorkflow(
 			Clock:            vclock.NewVectorClock(t.shardContext.GetClusterMetadata().GetClusterID(), t.shardContext.GetShardID(), task.TaskID),
 		},
 		rootExecutionInfo,
-		t.shardContext.GetTimeSource().Now(),
+		nowForExpirationAndBackoff,
 	)
 
 	request.SourceVersionStamp = sourceVersionStamp
 	request.InheritedBuildId = inheritedBuildId
 	request.InheritedPinnedVersion = inheritedPinnedVersion
-	request.TimeSkippingStatePropagation = attributes.GetTimeSkippingStatePropagation()
+	request.TimeSkippingStatePropagation = statePropagation
 
 	// Only set the AutoUpgrade info if the Pinned version is not set.
 	if request.InheritedPinnedVersion == nil {

--- a/service/history/workflow/timeskipping.go
+++ b/service/history/workflow/timeskipping.go
@@ -37,7 +37,6 @@ func (ms *MutableStateImpl) initTimeSkippingInfo(
 		SessionSkipCount:           timeSkippingStatePropagation.GetInitialSkipCount(),
 	}
 	ms.wrapTimeSourceWithTimeSkipping()
-	ms.wrapExecutionTimes(initialSkip)
 	ms.applyFastForward(timeSkippingStatePropagation.GetFastForwardTargetTime())
 	ms.timeSkippingInfoUpdated = true
 }
@@ -103,28 +102,6 @@ func (ms *MutableStateImpl) setAndStampFastForwardInfo(
 		TransitionCount:          ms.NextTransitionCount(),
 	}
 	return tsi.FastForwardInfoLastUpdateVersionedTransition
-}
-
-func (ms *MutableStateImpl) wrapExecutionTimes(initialSkippedDuration *durationpb.Duration) {
-	if initialSkippedDuration == nil || initialSkippedDuration.AsDuration() == 0 {
-		return
-	}
-	accum := initialSkippedDuration.AsDuration()
-	if !timeNotSet(ms.executionState.StartTime) {
-		ms.executionState.StartTime = timestamppb.New(ms.executionState.StartTime.AsTime().Add(accum))
-	}
-	if !timeNotSet(ms.executionInfo.StartTime) {
-		ms.executionInfo.StartTime = timestamppb.New(ms.executionInfo.StartTime.AsTime().Add(accum))
-	}
-	if !timeNotSet(ms.executionInfo.ExecutionTime) {
-		ms.executionInfo.ExecutionTime = timestamppb.New(ms.executionInfo.ExecutionTime.AsTime().Add(accum))
-	}
-	if !timeNotSet(ms.executionInfo.WorkflowRunExpirationTime) {
-		ms.executionInfo.WorkflowRunExpirationTime = timestamppb.New(ms.executionInfo.WorkflowRunExpirationTime.AsTime().Add(accum))
-	}
-	if !timeNotSet(ms.executionInfo.WorkflowExecutionExpirationTime) {
-		ms.executionInfo.WorkflowExecutionExpirationTime = timestamppb.New(ms.executionInfo.WorkflowExecutionExpirationTime.AsTime().Add(accum))
-	}
 }
 
 // -- Propagation Methods of Time Skipping
@@ -283,6 +260,15 @@ func (t *timeSkippingTransition) GateByFastForward(ff *persistencespb.FastForwar
 // =============================================================================
 // Time Skipping Utility Functions
 // =============================================================================
+
+// AdjustNowWithTimeSkipping converts a real clock reading to the virtual clock frame inherited
+// through time-skipping state propagation.
+func AdjustNowWithTimeSkipping(
+	now time.Time,
+	statePropagation *commonpb.TimeSkippingStatePropagation,
+) time.Time {
+	return now.Add(statePropagation.GetInitialSkippedDuration().AsDuration())
+}
 
 func NewTimeSkippingInfoUtil(tsi *persistencespb.TimeSkippingInfo) *TimeSkippingInfoUtil {
 	return &TimeSkippingInfoUtil{tsi: tsi}

--- a/service/history/workflow/timeskipping_test.go
+++ b/service/history/workflow/timeskipping_test.go
@@ -653,38 +653,6 @@ func (s *mutableStateSuite) TestUpdateTimeSkippingInfo() {
 	})
 }
 
-// TestWrapExecutionTimes covers the three invariants of wrapExecutionTimes:
-// a nil/zero skipped duration is a no-op; a non-zero duration shifts every *set*
-// execution timestamp forward by exactly that duration; unset timestamps stay unset.
-func (s *mutableStateSuite) TestWrapExecutionTimes() {
-	base := time.Date(2026, 7, 1, 8, 0, 0, 0, time.UTC)
-
-	s.Run("NilOrZeroDurationIsNoOp", func() {
-		s.mutableState.executionInfo.StartTime = timestamppb.New(base)
-		s.mutableState.wrapExecutionTimes(nil)
-		s.Equal(base, s.mutableState.executionInfo.StartTime.AsTime())
-		s.mutableState.wrapExecutionTimes(durationpb.New(0))
-		s.Equal(base, s.mutableState.executionInfo.StartTime.AsTime())
-	})
-
-	s.Run("ShiftsSetTimestampsAndLeavesUnsetUntouched", func() {
-		accum := 2 * time.Hour
-		s.mutableState.executionState.StartTime = timestamppb.New(base)
-		s.mutableState.executionInfo.StartTime = timestamppb.New(base)
-		s.mutableState.executionInfo.ExecutionTime = timestamppb.New(base.Add(time.Minute))
-		s.mutableState.executionInfo.WorkflowRunExpirationTime = timestamppb.New(base.Add(time.Hour))
-		s.mutableState.executionInfo.WorkflowExecutionExpirationTime = nil // unset must stay unset
-
-		s.mutableState.wrapExecutionTimes(durationpb.New(accum))
-
-		s.Equal(base.Add(accum), s.mutableState.executionState.StartTime.AsTime())
-		s.Equal(base.Add(accum), s.mutableState.executionInfo.StartTime.AsTime())
-		s.Equal(base.Add(time.Minute).Add(accum), s.mutableState.executionInfo.ExecutionTime.AsTime())
-		s.Equal(base.Add(time.Hour).Add(accum), s.mutableState.executionInfo.WorkflowRunExpirationTime.AsTime())
-		s.Nil(s.mutableState.executionInfo.WorkflowExecutionExpirationTime, "unset timestamp must remain unset")
-	})
-}
-
 // TestApplyFastForward covers the full branch table of applyFastForward:
 // FastForward set / nil duration / nil config / Enabled=false.
 // The first-init virtual-time path is covered separately in TestInitTimeSkippingInfo.
@@ -1680,4 +1648,44 @@ func (s *mutableStateSuite) TestTimeSkippingInfoUtil() {
 		s.Equal(msNow, info.GetCurrentTime().AsTime())
 	})
 
+}
+
+func TestAdjustNowWithTimeSkipping(t *testing.T) {
+	now := time.Date(2026, 8, 19, 9, 0, 0, 0, time.UTC)
+
+	testCases := []struct {
+		name             string
+		statePropagation *commonpb.TimeSkippingStatePropagation
+		want             time.Time
+	}{
+		{
+			name: "nil propagation",
+			want: now,
+		},
+		{
+			name:             "nil initial skipped duration",
+			statePropagation: &commonpb.TimeSkippingStatePropagation{},
+			want:             now,
+		},
+		{
+			name: "zero initial skipped duration",
+			statePropagation: &commonpb.TimeSkippingStatePropagation{
+				InitialSkippedDuration: durationpb.New(0),
+			},
+			want: now,
+		},
+		{
+			name: "positive initial skipped duration",
+			statePropagation: &commonpb.TimeSkippingStatePropagation{
+				InitialSkippedDuration: durationpb.New(2 * time.Hour),
+			},
+			want: now.Add(2 * time.Hour),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, AdjustNowWithTimeSkipping(now, tc.statePropagation))
+		})
+	}
 }

--- a/tests/timeskipping_propagation_test.go
+++ b/tests/timeskipping_propagation_test.go
@@ -625,27 +625,26 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInChildWf_ThreeGenerations() {
 		"P's initiated event for C carries P's full accumulated at command time (3h = G's 1h + P's pt1 2h)")
 }
 
-// TestTSPInChildWf_AdmissionTimestampsShifted verifies the time-shift block inside
-// initTimeSkippingInfo (mutable_state_impl.go): when a child workflow boots with a
-// non-zero PropagatedSkippedDuration, the boot-time admission timestamps on the
-// child's MS are shifted forward by accum so they live in the virtual frame, while
-// the WorkflowRunTimeoutTask's VisibilityTimestamp stays in the wall frame.
+// TestTSPInChildWf_AdmissionTimestampsShifted verifies that a child workflow with a
+// non-zero PropagatedSkippedDuration is admitted directly in the parent's virtual
+// clock frame, while the WorkflowRunTimeoutTask's VisibilityTimestamp stays in the
+// wall frame.
 //
 // Scenario:
 //   - Parent TSC enabled. Parent runs StartTimer(t1, 1h) → idle → server skips 1h.
 //     Parent's AccumulatedSkippedDuration ≈ 1h.
-//   - Parent issues StartChildWorkflow with WorkflowRunTimeout=2h. The child's
-//     initiated event carries InitialSkippedDuration=1h. On the child MS,
-//     applyTimeSkippingConfig seeds AccumulatedSkippedDuration=1h, and
-//     initTimeSkippingInfo shifts admission timestamps forward by accum=1h.
+//   - Parent issues StartChildWorkflow with WorkflowRunTimeout=2h and
+//     WorkflowExecutionTimeout=4h. The child's initiated event carries
+//     InitialSkippedDuration=1h. On the child MS,
+//     applyTimeSkippingConfig seeds AccumulatedSkippedDuration=1h, and the child
+//     start request uses wallChildBoot+1h as its admission time.
 //
 // Boot-time assertions (virtual frame):
 //   - executionState.StartTime ≈ wallChildBoot + 1h
 //   - executionInfo.StartTime ≈ wallChildBoot + 1h
 //   - executionInfo.ExecutionTime ≈ wallChildBoot + 1h (no first-WT delay)
 //   - executionInfo.WorkflowRunExpirationTime ≈ wallChildBoot + 1h + 2h
-//   - executionInfo.WorkflowExecutionExpirationTime: zero when ExecutionTimeout is
-//     unset on the child; otherwise shifted by the same formula.
+//   - executionInfo.WorkflowExecutionExpirationTime ≈ wallChildBoot + 1h + 4h
 //
 // Wall-clock assertion (the load-bearing one): the child's WorkflowRunTimeoutTask
 // must fire at wallChildBoot + 2h — i.e., virtual_expiration − accum — so a
@@ -700,13 +699,14 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInChildWf_AdmissionTimestampsS
 				CommandType: enumspb.COMMAND_TYPE_START_CHILD_WORKFLOW_EXECUTION,
 				Attributes: &commandpb.Command_StartChildWorkflowExecutionCommandAttributes{
 					StartChildWorkflowExecutionCommandAttributes: &commandpb.StartChildWorkflowExecutionCommandAttributes{
-						Namespace:           ns,
-						WorkflowId:          childWFID,
-						WorkflowType:        childWFType,
-						TaskQueue:           tq,
-						WorkflowRunTimeout:  durationpb.New(2 * time.Hour),
-						WorkflowTaskTimeout: durationpb.New(10 * time.Second),
-						ParentClosePolicy:   enumspb.PARENT_CLOSE_POLICY_ABANDON,
+						Namespace:                ns,
+						WorkflowId:               childWFID,
+						WorkflowType:             childWFType,
+						TaskQueue:                tq,
+						WorkflowExecutionTimeout: durationpb.New(4 * time.Hour),
+						WorkflowRunTimeout:       durationpb.New(2 * time.Hour),
+						WorkflowTaskTimeout:      durationpb.New(10 * time.Second),
+						ParentClosePolicy:        enumspb.PARENT_CLOSE_POLICY_ABANDON,
 					},
 				},
 			}
@@ -756,6 +756,7 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInChildWf_AdmissionTimestampsS
 
 	const accum = time.Hour
 	const runTimeout = 2 * time.Hour
+	const executionTimeout = 4 * time.Hour
 	const tol = time.Minute
 
 	expectedStart := wallChildBoot.Add(accum)
@@ -772,15 +773,11 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInChildWf_AdmissionTimestampsS
 	s.WithinDuration(expectedRunExpiration, childMS.State.ExecutionInfo.WorkflowRunExpirationTime.AsTime(), tol,
 		"WorkflowRunExpirationTime = StartTime + RunTimeout in the virtual frame")
 
-	// WorkflowExecutionExpirationTime: the parent didn't set ExecutionTimeout, so the
-	// child's WorkflowExecutionTimeout is unset and the ExpirationTime is zero. The
-	// shift block in initTimeSkippingInfo only shifts non-nil values, so both branches
-	// are valid: zero is preserved as zero; non-zero is shifted by accum.
 	weExpiration := childMS.State.ExecutionInfo.WorkflowExecutionExpirationTime
-	if weExpiration != nil && !weExpiration.AsTime().IsZero() {
-		s.WithinDuration(expectedRunExpiration, weExpiration.AsTime(), tol,
-			"WorkflowExecutionExpirationTime, when set, lives in the virtual frame and is shifted by accum")
-	}
+	s.NotNil(weExpiration)
+	expectedExecutionExpiration := wallChildBoot.Add(accum + executionTimeout)
+	s.WithinDuration(expectedExecutionExpiration, weExpiration.AsTime(), tol,
+		"transfer request must derive WorkflowExecutionExpirationTime from the virtual child start")
 
 	recorder := env.GetTestCluster().GetHistoryTaskRecorder()
 	s.NotNil(recorder)
@@ -1185,6 +1182,9 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInReset() {
 	s.Equal(1, optionsUpdatedCount,
 		"reset run should contain exactly one reapplied OPTIONS_UPDATED event")
 	s.NotNil(startedEvent)
+	s.WithinDuration(startedEvent.GetEventTime().AsTime(), resetMS.State.ExecutionState.GetStartTime().AsTime(), 10*time.Second,
+		"reset/rebuild must preserve the already-materialized history start time")
+	s.WithinDuration(startedEvent.GetEventTime().AsTime(), resetMS.State.ExecutionInfo.GetStartTime().AsTime(), 10*time.Second)
 	startedTSC := startedEvent.GetWorkflowExecutionStartedEventAttributes().GetTimeSkippingConfig()
 	s.NotNil(startedTSC, "WorkflowExecutionStarted should carry the original TimeSkippingConfig")
 	s.False(startedTSC.GetEnabled(),
@@ -1303,6 +1303,11 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInCaN() {
 	})
 	s.NoError(err)
 	s.NotEmpty(hist2.History.Events)
+	startedEventTime := hist2.History.Events[0].GetEventTime().AsTime()
+	s.WithinDuration(startedEventTime, run2MS.State.ExecutionState.GetStartTime().AsTime(), 10*time.Second,
+		"continue-as-new constructor time is already virtual and must not be shifted again")
+	s.WithinDuration(startedEventTime, run2MS.State.ExecutionInfo.GetStartTime().AsTime(), 10*time.Second)
+	s.WithinDuration(startedEventTime, run2MS.State.ExecutionInfo.GetExecutionTime().AsTime(), 10*time.Second)
 	startedAttr := hist2.History.Events[0].GetWorkflowExecutionStartedEventAttributes()
 	s.NotNil(startedAttr)
 	s.Equal(run1ID, startedAttr.GetContinuedExecutionRunId(),
@@ -1402,6 +1407,95 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInCaN_SkipSessionPropagated() 
 		"started event TSC carries the propagated budget")
 	s.Equal(int32(1), startedAttr.GetTimeSkippingStatePropagation().GetInitialSkipCount(),
 		"started event carries run 1's SessionSkipCount as InitialSkipCount")
+}
+
+// TestTSPInCaN_ExecutionExpirationRemainsAbsolute verifies that time-skipping state
+// propagation does not extend the workflow execution timeout across runs. The expiration
+// timestamp is already expressed in virtual time and must remain unchanged when the next
+// run inherits the accumulated skipped duration.
+func (s *TimeSkippingPropagationTestSuite) TestTSPInCaN_ExecutionExpirationRemainsAbsolute() {
+	env := testcore.NewEnv(s.T())
+	env.OverrideDynamicConfig(dynamicconfig.WorkflowTimeSkippingEnabled, true)
+	tv := testvars.New(s.T())
+	ctx := s.Context()
+
+	const executionTimeout = 3 * time.Hour
+	wfType := tv.WorkflowType()
+	wfID := tv.WorkflowID()
+	tq := tv.TaskQueue()
+
+	start, err := env.FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:                uuid.NewString(),
+		Namespace:                env.Namespace().String(),
+		WorkflowId:               wfID,
+		WorkflowType:             wfType,
+		TaskQueue:                tq,
+		WorkflowExecutionTimeout: durationpb.New(executionTimeout),
+		WorkflowRunTimeout:       durationpb.New(24 * time.Hour),
+		WorkflowTaskTimeout:      durationpb.New(10 * time.Second),
+		TimeSkippingConfig:       &commonpb.TimeSkippingConfig{Enabled: true},
+	})
+	s.NoError(err)
+	run1ID := start.RunId
+
+	state := 0
+	handler := func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		fired := firedTimers(task)
+		switch {
+		case state == 0:
+			state = 1
+			return cmdsResponse(timerCmd("t1", time.Hour)), nil
+		case state == 1 && fired["t1"]:
+			state = 2
+			return cmdsResponse(continueAsNewCmd(wfType, tq)), nil
+		case state == 2:
+			state = 3
+			return cmdsResponse(), nil
+		}
+		return cmdsResponse(), nil
+	}
+
+	for i := range 3 {
+		_, pollErr := env.TaskPoller().PollAndHandleWorkflowTask(tv, handler)
+		if pollErr != nil {
+			s.T().Logf("iter %d: poll error: %v", i, pollErr)
+		}
+	}
+
+	var status enumspb.WorkflowExecutionStatus
+	s.AwaitTrue(func() bool {
+		desc, describeErr := env.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: env.Namespace().String(),
+			Execution: &commonpb.WorkflowExecution{WorkflowId: wfID},
+		})
+		if describeErr != nil {
+			return false
+		}
+		status = desc.WorkflowExecutionInfo.Status
+		return status != enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
+	}, 15*time.Second, 100*time.Millisecond)
+	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_TIMED_OUT, status)
+
+	run1MS := s.getMutableState(env, wfID, run1ID)
+	originalExpiration := run1MS.State.ExecutionInfo.GetWorkflowExecutionExpirationTime().AsTime()
+	s.False(originalExpiration.IsZero())
+
+	run2MS := s.getMutableStateByID(ctx, env, wfID)
+	run2ID := run2MS.State.ExecutionState.RunId
+	s.NotEqual(run1ID, run2ID)
+	s.Equal(originalExpiration, run2MS.State.ExecutionInfo.GetWorkflowExecutionExpirationTime().AsTime(),
+		"continue-as-new must preserve the chain's absolute virtual execution-expiration deadline")
+
+	hist2, err := env.FrontendClient().GetWorkflowExecutionHistory(ctx, &workflowservice.GetWorkflowExecutionHistoryRequest{
+		Namespace: env.Namespace().String(),
+		Execution: &commonpb.WorkflowExecution{WorkflowId: wfID, RunId: run2ID},
+	})
+	s.NoError(err)
+	s.NotEmpty(hist2.History.Events)
+	terminalEvent := hist2.History.Events[len(hist2.History.Events)-1]
+	s.Equal(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TIMED_OUT, terminalEvent.GetEventType())
+	s.WithinDuration(originalExpiration, terminalEvent.GetEventTime().AsTime(), 10*time.Second,
+		"workflow must time out at the original absolute virtual deadline")
 }
 
 // TestTSPInRetry verifies that a retried run is a same-lineage continuation: it inherits
@@ -1529,6 +1623,10 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInRetry() {
 	s.NotEmpty(hist2.History.Events)
 	startedAttr := hist2.History.Events[0].GetWorkflowExecutionStartedEventAttributes()
 	s.NotNil(startedAttr)
+	expectedAttempt2Start := hist2.History.Events[0].GetEventTime().AsTime()
+	s.WithinDuration(expectedAttempt2Start, attempt2MS.State.ExecutionState.GetStartTime().AsTime(), 10*time.Second,
+		"WFT-completion retry event and mutable state must be constructed in the same virtual frame")
+	s.WithinDuration(expectedAttempt2Start, attempt2MS.State.ExecutionInfo.GetStartTime().AsTime(), 10*time.Second)
 	s.Equal(attempt1ID, startedAttr.GetContinuedExecutionRunId(),
 		"attempt 2 references attempt 1 as its predecessor via ContinuedExecutionRunId")
 	s.Equal(enumspb.CONTINUE_AS_NEW_INITIATOR_RETRY, startedAttr.GetInitiator(),
@@ -1671,6 +1769,10 @@ func (s *TimeSkippingPropagationTestSuite) TestTSPInCron() {
 	s.NotEmpty(hist2.History.Events)
 	startedAttr := hist2.History.Events[0].GetWorkflowExecutionStartedEventAttributes()
 	s.NotNil(startedAttr)
+	expectedRun2Start := hist2.History.Events[0].GetEventTime().AsTime()
+	s.WithinDuration(expectedRun2Start, run2MS.State.ExecutionState.GetStartTime().AsTime(), 90*time.Second,
+		"cron event and mutable state must be constructed in the same virtual frame")
+	s.WithinDuration(expectedRun2Start, run2MS.State.ExecutionInfo.GetStartTime().AsTime(), 90*time.Second)
 	s.Equal(run1ID, startedAttr.GetContinuedExecutionRunId(),
 		"run 2 references run 1 as its predecessor via ContinuedExecutionRunId")
 	s.Equal(enumspb.CONTINUE_AS_NEW_INITIATOR_CRON_SCHEDULE, startedAttr.GetInitiator(),

--- a/tests/timeskipping_test.go
+++ b/tests/timeskipping_test.go
@@ -74,6 +74,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_StartWorkflow_DCEnabled() {
 	env := testcore.NewEnv(s.T())
 	env.OverrideDynamicConfig(dynamicconfig.WorkflowTimeSkippingEnabled, true)
 	tv := testvars.New(s.T())
+	beforeStart := time.Now()
 
 	// Request leaves MaxSkipPerSession empty; the frontend populates it from dynamic config.
 	inputConfig := &commonpb.TimeSkippingConfig{
@@ -92,11 +93,17 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_StartWorkflow_DCEnabled() {
 		TimeSkippingConfig:  inputConfig,
 	})
 	s.NoError(err)
+	afterStart := time.Now()
 
 	ms := s.getMutableState(env, tv.WorkflowID(), resp.RunId)
 	s.True(ms.State.ExecutionInfo.GetTimeSkippingInfo().GetConfig().GetEnabled())
 	inputConfig.MaxSessionSkipCount = defaultMaxSkipPerSession // frontend populated this from dynamic config
 	s.True(proto.Equal(inputConfig, ms.State.ExecutionInfo.GetTimeSkippingInfo().GetConfig()))
+	startTime := ms.State.ExecutionState.GetStartTime().AsTime()
+	s.False(startTime.Before(beforeStart), "zero-offset start must not move before the admission window")
+	s.False(startTime.After(afterStart), "zero-offset start must not move after the admission window")
+	s.Equal(startTime, ms.State.ExecutionInfo.GetStartTime().AsTime())
+	s.Equal(startTime, ms.State.ExecutionInfo.GetExecutionTime().AsTime())
 }
 
 // TestTimeSkipping_SignalWithStart_DCEnabled verifies that SignalWithStartWorkflowExecution
@@ -237,6 +244,17 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_UpdateWorkflowOptions_DCEnabled
 	// No time-skipping config before any update.
 	ms := s.getMutableState(env, tv.WorkflowID(), runID)
 	s.Nil(ms.State.ExecutionInfo.GetTimeSkippingInfo().GetConfig())
+	initialStateStart := ms.State.ExecutionState.GetStartTime().AsTime()
+	initialInfoStart := ms.State.ExecutionInfo.GetStartTime().AsTime()
+	initialExecutionTime := ms.State.ExecutionInfo.GetExecutionTime().AsTime()
+	initialRunExpiration := ms.State.ExecutionInfo.GetWorkflowRunExpirationTime().AsTime()
+	assertAdmissionTimesUnchanged := func() {
+		current := s.getMutableState(env, tv.WorkflowID(), runID)
+		s.Equal(initialStateStart, current.State.ExecutionState.GetStartTime().AsTime())
+		s.Equal(initialInfoStart, current.State.ExecutionInfo.GetStartTime().AsTime())
+		s.Equal(initialExecutionTime, current.State.ExecutionInfo.GetExecutionTime().AsTime())
+		s.Equal(initialRunExpiration, current.State.ExecutionInfo.GetWorkflowRunExpirationTime().AsTime())
+	}
 
 	// First update: enable with a max_elapsed_duration. MaxSkipPerSession is left empty and
 	// populated by the frontend from dynamic config; the persisted config and event carry it.
@@ -249,6 +267,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_UpdateWorkflowOptions_DCEnabled
 
 	ms = s.getMutableState(env, tv.WorkflowID(), runID)
 	s.True(proto.Equal(config1, ms.State.ExecutionInfo.GetTimeSkippingInfo().GetConfig()))
+	assertAdmissionTimesUnchanged()
 	events := collectOptionsEvents()
 	s.Len(events, 1)
 	s.True(proto.Equal(config1, events[0].GetWorkflowExecutionOptionsUpdatedEventAttributes().GetTimeSkippingConfig()))
@@ -263,6 +282,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_UpdateWorkflowOptions_DCEnabled
 
 	ms = s.getMutableState(env, tv.WorkflowID(), runID)
 	s.True(proto.Equal(config2, ms.State.ExecutionInfo.GetTimeSkippingInfo().GetConfig()))
+	assertAdmissionTimesUnchanged()
 	events = collectOptionsEvents()
 	s.Len(events, 2)
 	s.True(proto.Equal(config2, events[1].GetWorkflowExecutionOptionsUpdatedEventAttributes().GetTimeSkippingConfig()))
@@ -275,6 +295,7 @@ func (s *TimeSkippingTestSuite) TestTimeSkipping_UpdateWorkflowOptions_DCEnabled
 
 	ms = s.getMutableState(env, tv.WorkflowID(), runID)
 	s.True(proto.Equal(config3, ms.State.ExecutionInfo.GetTimeSkippingInfo().GetConfig()))
+	assertAdmissionTimesUnchanged()
 	events = collectOptionsEvents()
 	s.Len(events, 3)
 	s.True(proto.Equal(config3, events[2].GetWorkflowExecutionOptionsUpdatedEventAttributes().GetTimeSkippingConfig()))

--- a/tests/xdc/timeskipping_replication_test.go
+++ b/tests/xdc/timeskipping_replication_test.go
@@ -178,8 +178,10 @@ func (s *timeSkippingReplicationSuite) TestBasicSkipReplicates() {
 
 	s.waitForTimeSkippingInfoSynced(ctx, nsID, wfID, runID)
 
-	active := s.getExecutionInfoFromCluster(ctx, 0, nsID, wfID, runID).GetTimeSkippingInfo()
-	standby := s.getExecutionInfoFromCluster(ctx, 1, nsID, wfID, runID).GetTimeSkippingInfo()
+	activeInfo := s.getExecutionInfoFromCluster(ctx, 0, nsID, wfID, runID)
+	standbyInfo := s.getExecutionInfoFromCluster(ctx, 1, nsID, wfID, runID)
+	active := activeInfo.GetTimeSkippingInfo()
+	standby := standbyInfo.GetTimeSkippingInfo()
 	s.True(proto.Equal(active.GetConfig(), standby.GetConfig()))
 	s.Equal(
 		active.GetAccumulatedSkippedDuration().AsDuration(),
@@ -187,6 +189,10 @@ func (s *timeSkippingReplicationSuite) TestBasicSkipReplicates() {
 	)
 	s.InDelta(float64(startDelay), float64(standby.GetAccumulatedSkippedDuration().AsDuration()), float64(accumTol),
 		"standby's accumulated skip should match the configured startDelay within tolerance")
+	s.Equal(activeInfo.GetStartTime().AsTime(), standbyInfo.GetStartTime().AsTime(),
+		"replication must preserve the already-virtual start timestamp without applying the offset again")
+	s.Equal(activeInfo.GetExecutionTime().AsTime(), standbyInfo.GetExecutionTime().AsTime())
+	s.Equal(activeInfo.GetWorkflowRunExpirationTime().AsTime(), standbyInfo.GetWorkflowRunExpirationTime().AsTime())
 }
 
 // TestFastForwardDisablePropagates verifies that completing a registered FastForward


### PR DESCRIPTION
## What changed?

- Removed blanket timestamp wrapping
- cron/retry/start child wf use virtual time directly

## Why?
there was a double-shifting for CaN but not for other cases
it shall be fixed unifying the clock used by all virtual time propagating cases, and this PR chooses to unify in a way that all cases propagate use virtual time

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)

