### PR TITLE
tdbg: add per-schedule V1/V2/sentinel status check to schedule migrate status

### DIFF
--- a/tools/tdbg/commands.go
+++ b/tools/tdbg/commands.go
@@ -1100,11 +1100,11 @@ func describeScheduleMigrationStatus(c *cli.Context, clientFactory ClientFactory
 			"true at the same time. This needs manual investigation.\n", scheduleID)
 	}
 
-	_, _ = fmt.Fprintf(w, "\nDetails:\n")
+	_, _ = fmt.Fprint(w, "\nDetails:\n")
 	_, _ = fmt.Fprintf(w, "  %-22s[workflow ID %s]: %s\n", "V1 (workflow-backed)", v1ID, v1.describe())
 	_, _ = fmt.Fprintf(w, "  %-22s[business ID %s]: %s\n", "V2 (CHASM)", rawID, v2.describe())
 
-	_, _ = fmt.Fprintf(w, "\nInspect further:\n")
+	_, _ = fmt.Fprint(w, "\nInspect further:\n")
 	_, _ = fmt.Fprintf(w, "  V1: tdbg execution describe --workflow-id %s -n %s\n", v1ID, ns)
 	_, _ = fmt.Fprintf(w, "  V2: tdbg execution describe --workflow-id %s --archetype %s -n %s\n", rawID, chasm.SchedulerArchetype, ns)
 

--- a/tools/tdbg/commands.go
+++ b/tools/tdbg/commands.go
@@ -22,6 +22,7 @@ import (
 	historyspb "go.temporal.io/server/api/history/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/chasm"
+	schedulerpb "go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/codec"
 	"go.temporal.io/server/common/log"
@@ -31,6 +32,7 @@ import (
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/service/history/tasks"
+	"go.temporal.io/server/service/worker/dummy"
 	"go.temporal.io/server/service/worker/scheduler"
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -951,8 +953,13 @@ func v2ScheduleVisibilityQuery() string {
 
 // AdminScheduleStatus reports how many schedules in --namespace are currently V1
 // (workflow-backed) vs V2 (CHASM), using the same default visibility queries as
-// `schedule migrate --from-visibility`.
+// `schedule migrate --from-visibility`. With --schedule-id, it instead reports the migration
+// status of that one schedule.
 func AdminScheduleStatus(c *cli.Context, clientFactory ClientFactory) error {
+	if scheduleID := c.String(FlagScheduleID); scheduleID != "" {
+		return describeScheduleMigrationStatus(c, clientFactory, scheduleID)
+	}
+
 	ns, err := getRequiredOption(c, FlagNamespace)
 	if err != nil {
 		return err
@@ -987,6 +994,173 @@ func countScheduleVisibility(c *cli.Context, wfClient workflowservice.WorkflowSe
 		return 0, err
 	}
 	return resp.GetCount(), nil
+}
+
+// v2ScheduleStatus is what was found, if anything, on the CHASM (V2) side of a schedule ID.
+type v2ScheduleStatus struct {
+	found    bool
+	sentinel bool // only meaningful when found
+}
+
+// isGenuine reports whether this is a real V2 schedule, as opposed to a migration sentinel
+// reserving the ID.
+func (s v2ScheduleStatus) isGenuine() bool { return s.found && !s.sentinel }
+
+func (s v2ScheduleStatus) describe() string {
+	switch {
+	case !s.found:
+		return "not found"
+	case s.sentinel:
+		return "sentinel (V1→V2 migration placeholder)"
+	default:
+		return "genuine"
+	}
+}
+
+// v1ScheduleStatus is what was found, if anything, on the workflow (V1) side of a schedule ID.
+type v1ScheduleStatus struct {
+	found        bool
+	workflowType string // only meaningful when found
+}
+
+// isGenuine reports whether this is a real V1 scheduler workflow.
+func (s v1ScheduleStatus) isGenuine() bool {
+	return s.found && s.workflowType == scheduler.WorkflowType
+}
+
+// isSentinel reports whether this is a placeholder DummyWorkflow reserving the V1 workflow ID
+// during a V2->V1 rollback.
+func (s v1ScheduleStatus) isSentinel() bool {
+	return s.found && s.workflowType == dummy.DummyWFTypeName
+}
+
+func (s v1ScheduleStatus) describe() string {
+	switch {
+	case !s.found:
+		return "not found"
+	case s.isGenuine():
+		return "genuine"
+	case s.isSentinel():
+		return "sentinel (V2→V1 rollback placeholder)"
+	default:
+		return fmt.Sprintf("unexpected workflow type %q", s.workflowType)
+	}
+}
+
+// describeScheduleMigrationStatus reports whether a single schedule is currently V1
+// (workflow-backed), V2 (CHASM), or caught in a migration sentinel state, using the same
+// DescribeMutableState RPC as `execution describe`. It always probes both the V1 workflow ID and
+// the V2 (CHASM) business ID -- regardless of which form --schedule-id was given in -- so the
+// report reflects a confirmed lookup rather than an inference from the ID's shape alone.
+func describeScheduleMigrationStatus(c *cli.Context, clientFactory ClientFactory, scheduleID string) error {
+	ns, err := getRequiredOption(c, FlagNamespace)
+	if err != nil {
+		return err
+	}
+
+	rawID := strings.TrimPrefix(scheduleID, primitives.ScheduleWorkflowIDPrefix)
+	v1ID := scheduleID
+	if rawID == scheduleID {
+		v1ID = primitives.ScheduleWorkflowIDPrefix + scheduleID
+	}
+
+	adminClient := clientFactory.AdminClient(c)
+
+	v2, err := describeSchedulerChasmState(c, adminClient, ns, rawID)
+	if err != nil {
+		return fmt.Errorf("unable to describe schedule %q: %w", scheduleID, err)
+	}
+	v1, err := describeWorkflowTypeName(c, adminClient, ns, v1ID)
+	if err != nil {
+		return fmt.Errorf("unable to describe schedule %q: %w", scheduleID, err)
+	}
+
+	w := c.App.Writer
+	switch {
+	case v1.isGenuine() && !v2.found:
+		_, _ = fmt.Fprintf(w, "Schedule %q is a V1 (workflow-backed) schedule.\n", scheduleID)
+	case !v1.found && v2.isGenuine():
+		_, _ = fmt.Fprintf(w, "Schedule %q is a V2 (CHASM) schedule.\n", scheduleID)
+	case v1.isGenuine() && v2.sentinel:
+		_, _ = fmt.Fprintf(w, "Schedule %q is a V1 (workflow-backed) schedule.\n", scheduleID)
+		_, _ = fmt.Fprintf(w, "Additionally, a placeholder (\"sentinel\") V2 entity exists at business ID %q, "+
+			"reserving that ID while a V1→V2 migration is in progress. This is expected during migration and "+
+			"requires no action — the V1 schedule above remains authoritative until the migration completes.\n",
+			rawID)
+	case v1.isSentinel() && v2.isGenuine():
+		_, _ = fmt.Fprintf(w, "Schedule %q is a V2 (CHASM) schedule.\n", scheduleID)
+		_, _ = fmt.Fprintf(w, "Additionally, a placeholder (\"sentinel\") V1 workflow exists at workflow ID %q, "+
+			"reserving that ID while a V2→V1 rollback is in progress. This is expected during rollback and "+
+			"requires no action.\n", v1ID)
+	case !v1.found && !v2.found:
+		_, _ = fmt.Fprintf(w, "Schedule %q was not found as either a V1 (workflow-backed) or V2 (CHASM) schedule. "+
+			"It may not exist, may have been deleted, or the ID may be mistyped.\n", scheduleID)
+	default:
+		_, _ = fmt.Fprintf(w, "Schedule %q is in an unexpected state — both sides below should not normally be "+
+			"true at the same time. This needs manual investigation.\n", scheduleID)
+	}
+
+	_, _ = fmt.Fprintf(w, "\nDetails:\n")
+	_, _ = fmt.Fprintf(w, "  %-22s[workflow ID %s]: %s\n", "V1 (workflow-backed)", v1ID, v1.describe())
+	_, _ = fmt.Fprintf(w, "  %-22s[business ID %s]: %s\n", "V2 (CHASM)", rawID, v2.describe())
+
+	_, _ = fmt.Fprintf(w, "\nInspect further:\n")
+	_, _ = fmt.Fprintf(w, "  V1: tdbg execution describe --workflow-id %s -n %s\n", v1ID, ns)
+	_, _ = fmt.Fprintf(w, "  V2: tdbg execution describe --workflow-id %s --archetype %s -n %s\n", rawID, chasm.SchedulerArchetype, ns)
+
+	return nil
+}
+
+// describeSchedulerChasmState looks up the CHASM (V2) side of scheduleID and reports whether a
+// genuine schedule, a migration sentinel, or nothing exists there.
+func describeSchedulerChasmState(c *cli.Context, adminClient adminservice.AdminServiceClient, ns, scheduleID string) (v2ScheduleStatus, error) {
+	ctx, cancel := newContext(c)
+	defer cancel()
+	resp, err := adminClient.DescribeMutableState(ctx, &adminservice.DescribeMutableStateRequest{
+		Namespace: ns,
+		Execution: &commonpb.WorkflowExecution{WorkflowId: scheduleID},
+		Archetype: chasm.SchedulerArchetype,
+	})
+	if common.IsNotFoundError(err) {
+		return v2ScheduleStatus{}, nil
+	}
+	if err != nil {
+		return v2ScheduleStatus{}, err
+	}
+
+	// The CHASM tree's root node -- the Scheduler component itself -- always encodes to the
+	// empty path.
+	node, ok := resp.GetDatabaseMutableState().GetChasmNodes()[""]
+	if !ok {
+		return v2ScheduleStatus{}, nil
+	}
+	var state schedulerpb.SchedulerState
+	if err := serialization.Decode(node.GetData(), &state); err != nil {
+		return v2ScheduleStatus{}, fmt.Errorf("failed to decode scheduler state: %w", err)
+	}
+	return v2ScheduleStatus{found: true, sentinel: state.GetSentinel()}, nil
+}
+
+// describeWorkflowTypeName looks up the workflow (V1) side of workflowID and reports its
+// workflow type, if it exists.
+func describeWorkflowTypeName(c *cli.Context, adminClient adminservice.AdminServiceClient, ns, workflowID string) (v1ScheduleStatus, error) {
+	ctx, cancel := newContext(c)
+	defer cancel()
+	resp, err := adminClient.DescribeMutableState(ctx, &adminservice.DescribeMutableStateRequest{
+		Namespace: ns,
+		Execution: &commonpb.WorkflowExecution{WorkflowId: workflowID},
+		Archetype: chasm.WorkflowArchetype,
+	})
+	if common.IsNotFoundError(err) {
+		return v1ScheduleStatus{}, nil
+	}
+	if err != nil {
+		return v1ScheduleStatus{}, err
+	}
+	return v1ScheduleStatus{
+		found:        true,
+		workflowType: resp.GetDatabaseMutableState().GetExecutionInfo().GetWorkflowTypeName(),
+	}, nil
 }
 
 // migrateSingleSchedule migrates one schedule and performs the migration immediately.

--- a/tools/tdbg/schedule_status_test.go
+++ b/tools/tdbg/schedule_status_test.go
@@ -8,8 +8,15 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/api/adminservice/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/chasm"
+	schedulerpb "go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
+	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/common/primitives"
+	"go.temporal.io/server/service/worker/dummy"
 	"go.temporal.io/server/service/worker/scheduler"
 	"go.temporal.io/server/tools/tdbg"
 	"go.temporal.io/server/tools/tdbg/tdbgtest"
@@ -94,4 +101,159 @@ func TestScheduleStatus_CountError(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unable to count")
 	require.Contains(t, err.Error(), "boom")
+}
+
+// describeMutableStateAdminClient fakes AdminService.DescribeMutableState for the single-schedule
+// `status --schedule-id` path, keyed by the requested WorkflowId. Any WorkflowId with no fixture
+// registered returns NotFound, matching a real server's response for a nonexistent execution.
+type describeMutableStateAdminClient struct {
+	adminservice.AdminServiceClient
+	responses map[string]*adminservice.DescribeMutableStateResponse // workflowID -> response
+
+	requests []*adminservice.DescribeMutableStateRequest
+}
+
+func (c *describeMutableStateAdminClient) DescribeMutableState(
+	_ context.Context,
+	req *adminservice.DescribeMutableStateRequest,
+	_ ...grpc.CallOption,
+) (*adminservice.DescribeMutableStateResponse, error) {
+	c.requests = append(c.requests, req)
+	if resp, ok := c.responses[req.GetExecution().GetWorkflowId()]; ok {
+		return resp, nil
+	}
+	return nil, serviceerror.NewNotFound("not found")
+}
+
+// chasmSchedulerStateResponse builds a DescribeMutableState response for a CHASM Scheduler
+// component at the tree root, as produced by the real server for a V2 schedule or CHASM-side
+// sentinel.
+func chasmSchedulerStateResponse(t *testing.T, sentinel bool) *adminservice.DescribeMutableStateResponse {
+	t.Helper()
+	blob, err := serialization.Encode(&schedulerpb.SchedulerState{Sentinel: sentinel})
+	require.NoError(t, err)
+	return &adminservice.DescribeMutableStateResponse{
+		DatabaseMutableState: &persistencespb.WorkflowMutableState{
+			ChasmNodes: map[string]*persistencespb.ChasmNode{
+				"": {Data: blob},
+			},
+		},
+	}
+}
+
+// workflowTypeResponse builds a DescribeMutableState response for a plain workflow execution of
+// the given type, as produced by the real server for a V1 scheduler workflow or a V1-side
+// (dummy workflow) sentinel.
+func workflowTypeResponse(typeName string) *adminservice.DescribeMutableStateResponse {
+	return &adminservice.DescribeMutableStateResponse{
+		DatabaseMutableState: &persistencespb.WorkflowMutableState{
+			ExecutionInfo: &persistencespb.WorkflowExecutionInfo{WorkflowTypeName: typeName},
+		},
+	}
+}
+
+func runScheduleStatusForSchedule(t *testing.T, admin adminservice.AdminServiceClient, args ...string) (stdoutStr, stderrStr string, err error) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	factory := migrateClientFactory{admin: admin}
+	app := tdbgtest.NewCliApp(func(params *tdbg.Params) {
+		params.ClientFactory = factory
+		params.Writer = &stdout
+		params.ErrWriter = &stderr
+	})
+	runArgs := append([]string{"tdbg"}, args...)
+	err = app.Run(runArgs)
+	return stdout.String(), stderr.String(), err
+}
+
+func TestScheduleStatus_SingleSchedule_PrefixedInputStillDoesBothLookups(t *testing.T) {
+	v1ID := primitives.ScheduleWorkflowIDPrefix + "foo"
+	admin := &describeMutableStateAdminClient{responses: map[string]*adminservice.DescribeMutableStateResponse{
+		v1ID: workflowTypeResponse(scheduler.WorkflowType),
+	}}
+
+	stdout, _, err := runScheduleStatusForSchedule(t, admin, "-n", "my-ns", "schedule", "migrate", "status", "--schedule-id", v1ID)
+	require.NoError(t, err)
+
+	require.Len(t, admin.requests, 2)
+	gotIDs := []string{admin.requests[0].GetExecution().GetWorkflowId(), admin.requests[1].GetExecution().GetWorkflowId()}
+	require.ElementsMatch(t, []string{v1ID, "foo"}, gotIDs)
+
+	require.Contains(t, stdout, fmt.Sprintf("Schedule %q is a V1 (workflow-backed) schedule.\n", v1ID))
+	require.NotContains(t, stdout, "Additionally")
+}
+
+func TestScheduleStatus_SingleSchedule_GenuineV1(t *testing.T) {
+	admin := &describeMutableStateAdminClient{responses: map[string]*adminservice.DescribeMutableStateResponse{
+		primitives.ScheduleWorkflowIDPrefix + "foo": workflowTypeResponse(scheduler.WorkflowType),
+	}}
+
+	stdout, _, err := runScheduleStatusForSchedule(t, admin, "-n", "my-ns", "schedule", "migrate", "status", "--schedule-id", "foo")
+	require.NoError(t, err)
+
+	require.Contains(t, stdout, `Schedule "foo" is a V1 (workflow-backed) schedule.`+"\n")
+	require.NotContains(t, stdout, "Additionally")
+	require.Contains(t, stdout, "[workflow ID temporal-sys-scheduler:foo]: genuine")
+	require.Contains(t, stdout, "[business ID foo]: not found")
+}
+
+func TestScheduleStatus_SingleSchedule_GenuineV2(t *testing.T) {
+	admin := &describeMutableStateAdminClient{responses: map[string]*adminservice.DescribeMutableStateResponse{
+		"foo": chasmSchedulerStateResponse(t, false),
+	}}
+
+	stdout, _, err := runScheduleStatusForSchedule(t, admin, "-n", "my-ns", "schedule", "migrate", "status", "--schedule-id", "foo")
+	require.NoError(t, err)
+
+	require.Contains(t, stdout, `Schedule "foo" is a V2 (CHASM) schedule.`+"\n")
+	require.NotContains(t, stdout, "Additionally")
+}
+
+func TestScheduleStatus_SingleSchedule_V1GenuineWithV2Sentinel(t *testing.T) {
+	admin := &describeMutableStateAdminClient{responses: map[string]*adminservice.DescribeMutableStateResponse{
+		primitives.ScheduleWorkflowIDPrefix + "foo": workflowTypeResponse(scheduler.WorkflowType),
+		"foo": chasmSchedulerStateResponse(t, true),
+	}}
+
+	stdout, _, err := runScheduleStatusForSchedule(t, admin, "-n", "my-ns", "schedule", "migrate", "status", "--schedule-id", "foo")
+	require.NoError(t, err)
+
+	require.Contains(t, stdout, `Schedule "foo" is a V1 (workflow-backed) schedule.`+"\n")
+	require.Contains(t, stdout, "Additionally, a placeholder (\"sentinel\") V2 entity exists")
+	require.Contains(t, stdout, "V1→V2 migration is in progress")
+}
+
+func TestScheduleStatus_SingleSchedule_V1SentinelWithV2Genuine(t *testing.T) {
+	admin := &describeMutableStateAdminClient{responses: map[string]*adminservice.DescribeMutableStateResponse{
+		primitives.ScheduleWorkflowIDPrefix + "foo": workflowTypeResponse(dummy.DummyWFTypeName),
+		"foo": chasmSchedulerStateResponse(t, false),
+	}}
+
+	stdout, _, err := runScheduleStatusForSchedule(t, admin, "-n", "my-ns", "schedule", "migrate", "status", "--schedule-id", "foo")
+	require.NoError(t, err)
+
+	require.Contains(t, stdout, `Schedule "foo" is a V2 (CHASM) schedule.`+"\n")
+	require.Contains(t, stdout, "Additionally, a placeholder (\"sentinel\") V1 workflow exists")
+	require.Contains(t, stdout, "V2→V1 rollback is in progress")
+}
+
+func TestScheduleStatus_SingleSchedule_NotFoundBothSides(t *testing.T) {
+	admin := &describeMutableStateAdminClient{}
+
+	stdout, _, err := runScheduleStatusForSchedule(t, admin, "-n", "my-ns", "schedule", "migrate", "status", "--schedule-id", "foo")
+	require.NoError(t, err)
+
+	require.Contains(t, stdout, `Schedule "foo" was not found as either a V1 (workflow-backed) or V2 (CHASM) schedule.`)
+}
+
+func TestScheduleStatus_SingleSchedule_UnexpectedBothGenuine(t *testing.T) {
+	admin := &describeMutableStateAdminClient{responses: map[string]*adminservice.DescribeMutableStateResponse{
+		primitives.ScheduleWorkflowIDPrefix + "foo": workflowTypeResponse(scheduler.WorkflowType),
+		"foo": chasmSchedulerStateResponse(t, false),
+	}}
+
+	stdout, _, err := runScheduleStatusForSchedule(t, admin, "-n", "my-ns", "schedule", "migrate", "status", "--schedule-id", "foo")
+	require.NoError(t, err)
+
+	require.Contains(t, stdout, `Schedule "foo" is in an unexpected state`)
 }

--- a/tools/tdbg/tdbg_commands.go
+++ b/tools/tdbg/tdbg_commands.go
@@ -347,8 +347,16 @@ func newAdminScheduleCommands(clientFactory ClientFactory) []*cli.Command {
 			},
 			Subcommands: []*cli.Command{
 				{
-					Name:  "status",
-					Usage: "Show counts of V1 (workflow-backed) and V2 (CHASM) schedules in --namespace, from visibility",
+					Name: "status",
+					Usage: "Show counts of V1 (workflow-backed) and V2 (CHASM) schedules in --namespace, from visibility. " +
+						"With --schedule-id, instead reports the migration status of that one schedule (V1, V2, or sentinel).",
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:    FlagScheduleID,
+							Aliases: FlagScheduleIDAlias,
+							Usage:   "Schedule ID to check the migration status of a single schedule, instead of namespace-wide counts",
+						},
+					},
 					Action: func(c *cli.Context) error {
 						return AdminScheduleStatus(c, clientFactory)
 					},


### PR DESCRIPTION
## What

Adds a `--schedule-id` flag to `tdbg schedule migrate status`. When set, it looks up one specific schedule instead of the namespace-wide V1-vs-V2 counts, and reports whether that schedule is currently V1 (workflow-backed), V2 (CHASM), or caught in a migration sentinel state.

## Why

During schedule migration triage, an operator often needs to know the status of *one specific* schedule, not aggregate counts. There was no way to answer that without manually poking `execution describe` and reasoning about CHASM node internals by hand.

## How it works

It always probes **both** sides — the V1 workflow ID (`temporal-sys-scheduler:<id>`) and the V2/CHASM business ID (`<id>`) — via the same `DescribeMutableState` RPC that `tdbg execution describe` uses, regardless of which ID form was passed in. It deliberately does not short-circuit based on the input's shape (e.g. its prefix) without confirming against the server — an unconfirmed inference is confusing/untrustworthy in a diagnostic tool.

This lets it flag both kinds of migration sentinel:
- a **CHASM-side sentinel** `Scheduler` component reserving the ID during a V1→V2 migration
- a **V1-side `DummyWorkflow`** reserving the workflow ID during a V2→V1 rollback

Output leads with a plain-language headline describing the schedule's current, authoritative form (written for someone with no prior knowledge of the V1/V2 migration internals), followed by a note about any sentinel found on the other side, a details table of both sides' raw status, and the exact `execution describe` invocations to inspect each side further.

### Example output (V2→V1 rollback in flight)

```
Schedule "foo" is a V2 (CHASM) schedule.
Additionally, a placeholder ("sentinel") V1 workflow exists at workflow ID "temporal-sys-scheduler:foo",
reserving that ID while a V2→V1 rollback is in progress. This is expected during rollback and requires no action.

Details:
  V1 (workflow-backed)  [workflow ID temporal-sys-scheduler:foo]: sentinel (V2→V1 rollback placeholder)
  V2 (CHASM)            [business ID foo]: genuine

Inspect further:
  V1: tdbg execution describe --workflow-id temporal-sys-scheduler:foo -n <namespace>
  V2: tdbg execution describe --workflow-id foo --archetype scheduler.scheduler -n <namespace>
```

## Testing

- `go test ./tools/tdbg/... -run TestScheduleStatus -v` — new tests cover: prefixed input, genuine V1, genuine V2, V1 genuine + CHASM sentinel, V1 sentinel + genuine V2, not-found on both sides, and an unexpected/inconsistent-state fallback. Existing aggregate-count tests are unaffected.
- `go build ./tools/...`, `go vet ./tools/tdbg/...`
- Manually checked `tdbg schedule migrate status --help` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)