### PR TITLE
Make Worker Deployment Version deletion idempotent

### DIFF
--- a/service/worker/workerdeployment/activities.go
+++ b/service/worker/workerdeployment/activities.go
@@ -174,6 +174,11 @@ func (a *Activities) DeleteWorkerDeploymentVersion(ctx context.Context, args *de
 		},
 	)
 	if err != nil {
+		var notFound *serviceerror.NotFound
+		if errors.As(err, &notFound) {
+			// The version is already gone or being deleted, so deletion is idempotently successful.
+			return nil
+		}
 		return err
 	}
 

--- a/service/worker/workerdeployment/activities_test.go
+++ b/service/worker/workerdeployment/activities_test.go
@@ -1,0 +1,92 @@
+package workerdeployment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/sdk/testsuite"
+	deploymentspb "go.temporal.io/server/api/deployment/v1"
+	"go.temporal.io/server/api/historyservicemock/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/worker_versioning"
+	"go.temporal.io/server/service/history/consts"
+	"go.uber.org/mock/gomock"
+)
+
+// TestDeleteWorkerDeploymentVersionActivity covers how the activity treats the outcome of the
+// delete-version update it sends to the Worker Deployment Version workflow. A version workflow
+// that is no longer running answers that update with a NotFound, which the activity must treat
+// as "the version is already gone" so the deployment workflow can drop its version summary.
+// Errors that do not mean the version is gone must still surface.
+func TestDeleteWorkerDeploymentVersionActivity(t *testing.T) {
+	t.Parallel()
+	version := worker_versioning.WorkerDeploymentVersionToStringV31(&deploymentspb.WorkerDeploymentVersion{
+		DeploymentName: testDeployment,
+		BuildId:        testBuildID,
+	})
+
+	testCases := []struct {
+		name        string
+		updateErr   error
+		expectError bool
+	}{
+		{
+			name:        "version workflow already completed",
+			updateErr:   consts.ErrWorkflowCompleted,
+			expectError: false,
+		},
+		{
+			name:        "version workflow not found",
+			updateErr:   consts.ErrWorkflowExecutionNotFound,
+			expectError: false,
+		},
+		{
+			name:        "unrelated error is not swallowed",
+			updateErr:   serviceerror.NewUnavailable("history service is unavailable"),
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			mockHistoryClient := historyservicemock.NewMockHistoryServiceClient(ctrl)
+			mockHistoryClient.EXPECT().
+				UpdateWorkflowExecution(gomock.Any(), gomock.Any()).
+				Return(nil, tc.updateErr).
+				Times(1)
+
+			a := &Activities{
+				activityDeps: activityDeps{
+					Logger:        log.NewNoopLogger(),
+					HistoryClient: mockHistoryClient,
+				},
+				namespace: namespace.NewLocalNamespaceForTest(
+					&persistencespb.NamespaceInfo{Name: testNamespace},
+					nil,
+					"",
+				),
+			}
+
+			testSuite := &testsuite.WorkflowTestSuite{}
+			env := testSuite.NewTestActivityEnvironment()
+			env.RegisterActivity(a.DeleteWorkerDeploymentVersion)
+
+			_, err := env.ExecuteActivity(a.DeleteWorkerDeploymentVersion, &deploymentspb.DeleteVersionActivityArgs{
+				DeploymentName: testDeployment,
+				Version:        version,
+				RequestId:      "delete-version-request-id",
+			})
+
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/tests/worker_deployment_version_test.go
+++ b/tests/worker_deployment_version_test.go
@@ -1023,6 +1023,67 @@ func (s *DeploymentVersionSuite) TestDeleteVersion_ConcurrentDeleteVersion() {
 	}, time.Second*10, time.Millisecond*200)
 }
 
+// TestDeleteVersion_VersionWorkflowAlreadyClosed verifies that a version whose version workflow
+// is no longer running can still be deleted: the delete converges and the version summary is
+// removed from the Worker Deployment.
+func (s *DeploymentVersionSuite) TestDeleteVersion_VersionWorkflowAlreadyClosed() {
+	env := s.newTestEnv()
+	tv := env.Tv().WithBuildIDNumber(1)
+
+	s.createDeploymentAndVersion(env, tv, tv.ClientIdentity(), nil)
+
+	// The Worker Deployment knows about the version.
+	resp, err := env.FrontendClient().DescribeWorkerDeployment(s.Context(), &workflowservice.DescribeWorkerDeploymentRequest{
+		Namespace:      env.Namespace().String(),
+		DeploymentName: tv.DeploymentSeries(),
+	})
+	s.NoError(err)
+	var buildIDs []string
+	for _, vs := range resp.GetWorkerDeploymentInfo().GetVersionSummaries() {
+		buildIDs = append(buildIDs, vs.GetDeploymentVersion().GetBuildId())
+	}
+	s.Contains(buildIDs, tv.ExternalDeploymentVersion().GetBuildId())
+
+	// Close the version workflow without telling the Worker Deployment, leaving the version
+	// summary behind.
+	versionWorkflowID := workerdeployment.GenerateVersionWorkflowID(tv.DeploymentSeries(), tv.BuildID())
+	_, err = env.FrontendClient().TerminateWorkflowExecution(s.Context(), &workflowservice.TerminateWorkflowExecutionRequest{
+		Namespace: env.Namespace().String(),
+		WorkflowExecution: &commonpb.WorkflowExecution{
+			WorkflowId: versionWorkflowID,
+		},
+		Reason:   "test",
+		Identity: tv.ClientIdentity(),
+	})
+	s.NoError(err)
+
+	s.EventuallyWithT(func(t *assert.CollectT) {
+		a := require.New(t)
+		descResp, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: env.Namespace().String(),
+			Execution: &commonpb.WorkflowExecution{WorkflowId: versionWorkflowID},
+		})
+		a.NoError(err)
+		a.NotEqual(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, descResp.GetWorkflowExecutionInfo().GetStatus())
+	}, time.Second*10, time.Millisecond*200)
+
+	// Deleting the version converges even though its version workflow is gone.
+	s.tryDeleteVersion(env, tv, "", false)
+
+	// The version summary is removed from the Worker Deployment.
+	s.EventuallyWithT(func(t *assert.CollectT) {
+		a := require.New(t)
+		resp, err := env.FrontendClient().DescribeWorkerDeployment(s.Context(), &workflowservice.DescribeWorkerDeploymentRequest{
+			Namespace:      env.Namespace().String(),
+			DeploymentName: tv.DeploymentSeries(),
+		})
+		a.NoError(err)
+		for _, vs := range resp.GetWorkerDeploymentInfo().GetVersionSummaries() {
+			a.NotEqual(tv.ExternalDeploymentVersion().GetBuildId(), vs.GetDeploymentVersion().GetBuildId())
+		}
+	}, time.Second*10, time.Millisecond*200)
+}
+
 // VersionMissingTaskQueues
 func (s *DeploymentVersionSuite) TestVersionMissingTaskQueues_InvalidSetCurrentVersion() {
 	// Override the dynamic config to verify we don't get any unexpected masked errors.


### PR DESCRIPTION
## What changed?

Make `DeleteWorkerDeploymentVersion` idempotent when the corresponding version workflow is already completed, absent, or being deleted.

`NotFound` from the version workflow's `delete-version` update is now treated as success so the deployment workflow can remove the stale version summary.

## Why?

If the version workflow is gone while its summary remains in the parent deployment, deletion previously failed permanently and the stale version continued counting against the deployment's version limit.

Fixes #11539

## How did you test it?

- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)

Added coverage for completed and missing version workflows, unrelated error propagation, and end-to-end cleanup of the stale version summary.

## Potential risks

`NotFound` from the version workflow delete update is now treated as successful deletion. Other errors continue to propagate.