### PR TITLE
Fix batch operations targeting paused executions

### DIFF
--- a/service/worker/batcher/activities.go
+++ b/service/worker/batcher/activities.go
@@ -37,8 +37,8 @@ import (
 )
 
 const (
-	pageSize                 = 1000
-	statusRunningQueryFilter = "ExecutionStatus='Running'"
+	pageSize                         = 1000
+	statusRunningOrPausedQueryFilter = "ExecutionStatus='Running' OR ExecutionStatus='Paused'"
 
 	// defaultTaskTimeout bounds how long processing a single task may take so
 	// that one hung operation cannot block the task processor forever.
@@ -540,9 +540,10 @@ func (a *activities) adjustQueryBatchTypeEnum(query string, batchType enumspb.Ba
 		enumspb.BATCH_OPERATION_TYPE_SIGNAL, enumspb.BATCH_OPERATION_TYPE_SIGNAL_WORKFLOW,
 		enumspb.BATCH_OPERATION_TYPE_CANCEL, enumspb.BATCH_OPERATION_TYPE_CANCEL_WORKFLOW,
 		enumspb.BATCH_OPERATION_TYPE_UPDATE_EXECUTION_OPTIONS, enumspb.BATCH_OPERATION_TYPE_UPDATE_WORKFLOW_EXECUTION_OPTIONS,
-		enumspb.BATCH_OPERATION_TYPE_UNPAUSE_ACTIVITY, enumspb.BATCH_OPERATION_TYPE_UPDATE_ACTIVITY_OPTIONS, enumspb.BATCH_OPERATION_TYPE_RESET_ACTIVITY,
-		enumspb.BATCH_OPERATION_TYPE_TERMINATE_ACTIVITY, enumspb.BATCH_OPERATION_TYPE_CANCEL_ACTIVITY:
-		return fmt.Sprintf("(%s) AND (%s)", query, statusRunningQueryFilter)
+		enumspb.BATCH_OPERATION_TYPE_UNPAUSE_ACTIVITY, enumspb.BATCH_OPERATION_TYPE_UPDATE_ACTIVITY_OPTIONS,
+		enumspb.BATCH_OPERATION_TYPE_RESET_ACTIVITY, enumspb.BATCH_OPERATION_TYPE_TERMINATE_ACTIVITY,
+		enumspb.BATCH_OPERATION_TYPE_CANCEL_ACTIVITY:
+		return fmt.Sprintf("(%s) AND (%s)", query, statusRunningOrPausedQueryFilter)
 	default:
 		return query
 	}
@@ -867,8 +868,8 @@ func isNonRetryableError(err error, batchType enumspb.BatchOperationType) bool {
 		// spending every AttemptsOnRetryableError -- processTaskWithRetries
 		// retries in place with no backoff.
 		//
-		// Only these two are listed. UNPAUSE_ACTIVITY, UPDATE_ACTIVITY_OPTIONS
-		// and RESET_ACTIVITY get the same Running filter appended by
+		// Only these two are listed. UNPAUSE_ACTIVITY, UPDATE_ACTIVITY_OPTIONS,
+		// and RESET_ACTIVITY get the same open-status filter appended by
 		// adjustQueryBatchTypeEnum and so reach this path too, but their
 		// FailedPreconditions include states a retry does clear (pending reset,
 		// pending cancellation, deferred Reset(RestoreOriginalOptions)).

--- a/service/worker/batcher/activities_test.go
+++ b/service/worker/batcher/activities_test.go
@@ -371,31 +371,31 @@ func (s *activitiesSuite) TestAdjustQueryBatchTypeEnum() {
 		{
 			name:           "Acceptance",
 			query:          "A=B",
-			expectedResult: fmt.Sprintf("(A=B) AND (%s)", statusRunningQueryFilter),
+			expectedResult: fmt.Sprintf("(A=B) AND (%s)", statusRunningOrPausedQueryFilter),
 			batchType:      enumspb.BATCH_OPERATION_TYPE_TERMINATE_WORKFLOW,
 		},
 		{
 			name:           "Acceptance with parenthesis",
 			query:          "(A=B)",
-			expectedResult: fmt.Sprintf("((A=B)) AND (%s)", statusRunningQueryFilter),
+			expectedResult: fmt.Sprintf("((A=B)) AND (%s)", statusRunningOrPausedQueryFilter),
 			batchType:      enumspb.BATCH_OPERATION_TYPE_TERMINATE_WORKFLOW,
 		},
 		{
 			name:           "Acceptance with multiple conditions",
 			query:          "(A=B) OR C=D",
-			expectedResult: fmt.Sprintf("((A=B) OR C=D) AND (%s)", statusRunningQueryFilter),
+			expectedResult: fmt.Sprintf("((A=B) OR C=D) AND (%s)", statusRunningOrPausedQueryFilter),
 			batchType:      enumspb.BATCH_OPERATION_TYPE_TERMINATE_WORKFLOW,
 		},
 		{
 			name:           "Contains status - 1",
 			query:          "ExecutionStatus=Completed",
-			expectedResult: fmt.Sprintf("(ExecutionStatus=Completed) AND (%s)", statusRunningQueryFilter),
+			expectedResult: fmt.Sprintf("(ExecutionStatus=Completed) AND (%s)", statusRunningOrPausedQueryFilter),
 			batchType:      enumspb.BATCH_OPERATION_TYPE_TERMINATE_WORKFLOW,
 		},
 		{
 			name:           "Contains status - 2",
 			query:          "A=B OR ExecutionStatus='Completed'",
-			expectedResult: fmt.Sprintf("(A=B OR ExecutionStatus='Completed') AND (%s)", statusRunningQueryFilter),
+			expectedResult: fmt.Sprintf("(A=B OR ExecutionStatus='Completed') AND (%s)", statusRunningOrPausedQueryFilter),
 			batchType:      enumspb.BATCH_OPERATION_TYPE_TERMINATE_WORKFLOW,
 		},
 		{
@@ -407,53 +407,53 @@ func (s *activitiesSuite) TestAdjustQueryBatchTypeEnum() {
 		{
 			name:           "Terminate workflow variant",
 			query:          "A=B",
-			expectedResult: fmt.Sprintf("(A=B) AND (%s)", statusRunningQueryFilter),
+			expectedResult: fmt.Sprintf("(A=B) AND (%s)", statusRunningOrPausedQueryFilter),
 			batchType:      enumspb.BATCH_OPERATION_TYPE_TERMINATE_WORKFLOW,
 		},
 		//nolint:staticcheck // SA1019: verifies batches started before the enum split
 		{
 			name:           "Terminate legacy workflow variant",
 			query:          "A=B",
-			expectedResult: fmt.Sprintf("(A=B) AND (%s)", statusRunningQueryFilter),
+			expectedResult: fmt.Sprintf("(A=B) AND (%s)", statusRunningOrPausedQueryFilter),
 			batchType:      enumspb.BATCH_OPERATION_TYPE_TERMINATE,
 		},
 		{
 			name:           "Cancel workflow variant",
 			query:          "A=B",
-			expectedResult: fmt.Sprintf("(A=B) AND (%s)", statusRunningQueryFilter),
+			expectedResult: fmt.Sprintf("(A=B) AND (%s)", statusRunningOrPausedQueryFilter),
 			batchType:      enumspb.BATCH_OPERATION_TYPE_CANCEL_WORKFLOW,
 		},
 		//nolint:staticcheck // SA1019: verifies batches started before the enum split
 		{
 			name:           "Cancel legacy workflow variant",
 			query:          "A=B",
-			expectedResult: fmt.Sprintf("(A=B) AND (%s)", statusRunningQueryFilter),
+			expectedResult: fmt.Sprintf("(A=B) AND (%s)", statusRunningOrPausedQueryFilter),
 			batchType:      enumspb.BATCH_OPERATION_TYPE_CANCEL,
 		},
 		{
 			name:           "Signal workflow variant",
 			query:          "A=B",
-			expectedResult: fmt.Sprintf("(A=B) AND (%s)", statusRunningQueryFilter),
+			expectedResult: fmt.Sprintf("(A=B) AND (%s)", statusRunningOrPausedQueryFilter),
 			batchType:      enumspb.BATCH_OPERATION_TYPE_SIGNAL_WORKFLOW,
 		},
 		//nolint:staticcheck // SA1019: verifies batches started before the enum split
 		{
 			name:           "Signal legacy workflow variant",
 			query:          "A=B",
-			expectedResult: fmt.Sprintf("(A=B) AND (%s)", statusRunningQueryFilter),
+			expectedResult: fmt.Sprintf("(A=B) AND (%s)", statusRunningOrPausedQueryFilter),
 			batchType:      enumspb.BATCH_OPERATION_TYPE_SIGNAL,
 		},
 		{
 			name:           "Update workflow execution options variant",
 			query:          "A=B",
-			expectedResult: fmt.Sprintf("(A=B) AND (%s)", statusRunningQueryFilter),
+			expectedResult: fmt.Sprintf("(A=B) AND (%s)", statusRunningOrPausedQueryFilter),
 			batchType:      enumspb.BATCH_OPERATION_TYPE_UPDATE_WORKFLOW_EXECUTION_OPTIONS,
 		},
 		//nolint:staticcheck // SA1019: verifies batches started before the enum split
 		{
 			name:           "Update legacy workflow execution options variant",
 			query:          "A=B",
-			expectedResult: fmt.Sprintf("(A=B) AND (%s)", statusRunningQueryFilter),
+			expectedResult: fmt.Sprintf("(A=B) AND (%s)", statusRunningOrPausedQueryFilter),
 			batchType:      enumspb.BATCH_OPERATION_TYPE_UPDATE_EXECUTION_OPTIONS,
 		},
 		{
@@ -487,18 +487,36 @@ func (s *activitiesSuite) TestAdjustQueryBatchTypeEnum() {
 			batchType:      enumspb.BATCH_OPERATION_TYPE_DELETE,
 		},
 		{
-			// A caller must be able to terminate/cancel only running activities via
+			// A caller must be able to terminate/cancel non-terminal activities via
 			// query; the server adds the filter so the caller doesn't have to.
-			name:           "Terminate activity is filtered to running",
+			name:           "Terminate activity is filtered to running and paused",
 			query:          "ActivityType='foo'",
-			expectedResult: fmt.Sprintf("(ActivityType='foo') AND (%s)", statusRunningQueryFilter),
+			expectedResult: "(ActivityType='foo') AND (ExecutionStatus='Running' OR ExecutionStatus='Paused')",
 			batchType:      enumspb.BATCH_OPERATION_TYPE_TERMINATE_ACTIVITY,
 		},
 		{
-			name:           "Cancel activity is filtered to running",
+			name:           "Cancel activity is filtered to running and paused",
 			query:          "ActivityType='foo'",
-			expectedResult: fmt.Sprintf("(ActivityType='foo') AND (%s)", statusRunningQueryFilter),
+			expectedResult: "(ActivityType='foo') AND (ExecutionStatus='Running' OR ExecutionStatus='Paused')",
 			batchType:      enumspb.BATCH_OPERATION_TYPE_CANCEL_ACTIVITY,
+		},
+		{
+			name:           "Unpause workflow activity is filtered to running and paused workflows",
+			query:          "WorkflowType='foo'",
+			expectedResult: "(WorkflowType='foo') AND (ExecutionStatus='Running' OR ExecutionStatus='Paused')",
+			batchType:      enumspb.BATCH_OPERATION_TYPE_UNPAUSE_ACTIVITY,
+		},
+		{
+			name:           "Update workflow activity options is filtered to running and paused workflows",
+			query:          "WorkflowType='foo'",
+			expectedResult: "(WorkflowType='foo') AND (ExecutionStatus='Running' OR ExecutionStatus='Paused')",
+			batchType:      enumspb.BATCH_OPERATION_TYPE_UPDATE_ACTIVITY_OPTIONS,
+		},
+		{
+			name:           "Reset workflow activity is filtered to running and paused workflows",
+			query:          "WorkflowType='foo'",
+			expectedResult: "(WorkflowType='foo') AND (ExecutionStatus='Running' OR ExecutionStatus='Paused')",
+			batchType:      enumspb.BATCH_OPERATION_TYPE_RESET_ACTIVITY,
 		},
 		{
 			// Delete applies regardless of execution status, so no filter is added.

--- a/tests/activity_api_batch_cancel_test.go
+++ b/tests/activity_api_batch_cancel_test.go
@@ -84,11 +84,9 @@ func (s *ActivityAPIBatchCancelClientTestSuite) TestActivityBatchCancel_Success(
 	}
 }
 
-// TestActivityBatchCancel_ExcludesNonRunning verifies that a batch cancel query
-// omitting `ExecutionStatus = 'Running'` still only targets the running
-// activity: the server must add the filter automatically (adjustQueryBatchTypeEnum)
-// so an already-completed activity of the same type is excluded, not (re-)canceled.
-func (s *ActivityAPIBatchCancelClientTestSuite) TestActivityBatchCancel_ExcludesNonRunning() {
+// TestActivityBatchCancel_TargetsRunningAndPaused verifies that a batch cancel
+// query targets non-terminal activities while excluding completed activities.
+func (s *ActivityAPIBatchCancelClientTestSuite) TestActivityBatchCancel_TargetsRunningAndPaused() {
 	env := newStandaloneActivityBatchEnv(s.T())
 	t := s.T()
 	ctx := s.Context()
@@ -99,6 +97,16 @@ func (s *ActivityAPIBatchCancelClientTestSuite) TestActivityBatchCancel_Excludes
 	// task can't race and pick up the running activity's task instead.
 	runningID := testcore.RandomizeStr(fmt.Sprintf("%s-running", t.Name()))
 	runningResp := env.startAndValidateActivity(ctx, t, runningID, testcore.RandomizeStr(fmt.Sprintf("%s-running-tq", t.Name())))
+	pausedID := testcore.RandomizeStr(fmt.Sprintf("%s-paused", t.Name()))
+	pausedResp := env.startAndValidateActivity(ctx, t, pausedID, testcore.RandomizeStr(fmt.Sprintf("%s-paused-tq", t.Name())))
+	_, err := env.FrontendClient().PauseActivityExecution(ctx, &workflowservice.PauseActivityExecutionRequest{
+		Namespace:  env.Namespace().String(),
+		ActivityId: pausedID,
+		RunId:      pausedResp.RunId,
+		Identity:   "test-identity",
+		Reason:     "test-pause",
+	})
+	require.NoError(t, err)
 
 	// This activity completes normally before the batch runs, so it must be
 	// excluded from a batch operation scoped only by ActivityType.
@@ -106,7 +114,7 @@ func (s *ActivityAPIBatchCancelClientTestSuite) TestActivityBatchCancel_Excludes
 	completedID := testcore.RandomizeStr(fmt.Sprintf("%s-completed", t.Name()))
 	completedResp := env.startAndValidateActivity(ctx, t, completedID, completedTaskQueue)
 	pollResp := env.pollActivityTaskAndValidate(ctx, t, completedID, completedTaskQueue, completedResp.RunId)
-	_, err := env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+	_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
 		Namespace: env.Namespace().String(),
 		TaskToken: pollResp.TaskToken,
 		Result:    defaultResult,
@@ -116,9 +124,13 @@ func (s *ActivityAPIBatchCancelClientTestSuite) TestActivityBatchCancel_Excludes
 	// Query intentionally omits ExecutionStatus = 'Running'.
 	query := fmt.Sprintf("ActivityType = '%s'", activityType)
 
-	// Wait for both activities to be indexed *and* for the completed one to no
-	// longer be indexed as Running, so the batch sees exactly one target.
-	waitForRunningFilterToSettle(ctx, t, env, query, 2, 1)
+	// Wait for all activities to be indexed and the batch filter to see the
+	// running and paused activities, but not the completed activity.
+	waitForActivityBatchFilterToSettle(ctx, t, env, query, map[string]enumspb.ActivityExecutionStatus{
+		runningID:   enumspb.ACTIVITY_EXECUTION_STATUS_RUNNING,
+		pausedID:    enumspb.ACTIVITY_EXECUTION_STATUS_PAUSED,
+		completedID: enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED,
+	})
 
 	jobID := uuid.NewString()
 	_, err = env.SdkClient().WorkflowService().StartBatchOperation(ctx, &workflowservice.StartBatchOperationRequest{
@@ -135,8 +147,8 @@ func (s *ActivityAPIBatchCancelClientTestSuite) TestActivityBatchCancel_Excludes
 	})
 	s.NoError(err)
 
-	// The server-added ExecutionStatus = 'Running' filter must exclude the
-	// already-completed activity: only 1 execution is ever targeted, not 2.
+	// The server-added open-status filter must include the paused activity and
+	// exclude the completed activity.
 	//nolint:forbidigo // tests with waits
 	s.EventuallyWithT(func(c *assert.CollectT) {
 		desc, err := env.FrontendClient().DescribeBatchOperation(ctx, &workflowservice.DescribeBatchOperationRequest{
@@ -144,10 +156,11 @@ func (s *ActivityAPIBatchCancelClientTestSuite) TestActivityBatchCancel_Excludes
 			JobId:     jobID,
 		})
 		require.NoError(c, err)
-		require.EqualValues(c, 1, desc.GetTotalOperationCount())
+		require.EqualValues(c, 2, desc.GetTotalOperationCount())
 	}, 10*time.Second, 200*time.Millisecond)
 
 	env.eventuallyCanceled(ctx, t, runningID, runningResp.RunId)
+	env.eventuallyCanceled(ctx, t, pausedID, pausedResp.RunId)
 
 	// The already-completed activity must remain untouched by the batch.
 	descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{

--- a/tests/activity_api_batch_terminate_test.go
+++ b/tests/activity_api_batch_terminate_test.go
@@ -59,6 +59,7 @@ func newStandaloneActivityBatchEnvWithBatchOperations(t *testing.T, enabled bool
 	cluster.OverrideDynamicConfig(t, dynamicconfig.EnableChasm, nsValues(true))
 	cluster.OverrideDynamicConfig(t, activity.Enabled, nsValues(true))
 	cluster.OverrideDynamicConfig(t, activity.EnableCallbacks, nsValues(true))
+	cluster.OverrideDynamicConfig(t, activity.EnableStandaloneActivityOperatorCommands, nsValues(true))
 	cluster.OverrideDynamicConfig(t, dynamicconfig.FrontendEnableBatchOperationsForStandaloneActivities, nsValues(enabled))
 	return env
 }
@@ -113,20 +114,23 @@ func assertBatchOperationType(
 	}, 10*time.Second, 200*time.Millisecond)
 }
 
-// waitForRunningFilterToSettle waits until visibility has settled on the target
-// set that a terminate/cancel batch over `query` will actually see: `wantTotal`
-// executions match `query`, and `wantRunning` of those also match the
-// `ExecutionStatus='Running'` filter the batcher appends
-// (adjustQueryBatchTypeEnum).
-func waitForRunningFilterToSettle(
+// waitForActivityBatchFilterToSettle waits until visibility has settled on the
+// exact target set that a terminate/cancel batch over `query` will see.
+func waitForActivityBatchFilterToSettle(
 	ctx context.Context,
 	t *testing.T,
 	env *standaloneActivityEnv,
 	query string,
-	wantTotal int,
-	wantRunning int,
+	expectedStatuses map[string]enumspb.ActivityExecutionStatus,
 ) {
 	t.Helper()
+
+	wantOpen := 0
+	for _, status := range expectedStatuses {
+		if status == enumspb.ACTIVITY_EXECUTION_STATUS_RUNNING || status == enumspb.ACTIVITY_EXECUTION_STATUS_PAUSED {
+			wantOpen++
+		}
+	}
 
 	//nolint:forbidigo // for tests with waits
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -136,16 +140,22 @@ func waitForRunningFilterToSettle(
 			Query:     query,
 		})
 		require.NoError(c, err)
-		require.Len(c, listResp.GetExecutions(), wantTotal)
+		require.Len(c, listResp.GetExecutions(), len(expectedStatuses))
+
+		actualStatuses := make(map[string]enumspb.ActivityExecutionStatus, len(listResp.GetExecutions()))
+		for _, execution := range listResp.GetExecutions() {
+			actualStatuses[execution.GetActivityId()] = execution.GetStatus()
+		}
+		require.Equal(c, expectedStatuses, actualStatuses)
 
 		// Mirrors the query the batcher itself counts with, so this waits on
 		// exactly the value that drives TotalOperationCount.
 		countResp, err := env.FrontendClient().CountActivityExecutions(ctx, &workflowservice.CountActivityExecutionsRequest{
 			Namespace: env.Namespace().String(),
-			Query:     fmt.Sprintf("(%s) AND (ExecutionStatus='Running')", query),
+			Query:     fmt.Sprintf("(%s) AND (ExecutionStatus='Running' OR ExecutionStatus='Paused')", query),
 		})
 		require.NoError(c, err)
-		require.EqualValues(c, wantRunning, countResp.GetCount())
+		require.EqualValues(c, wantOpen, countResp.GetCount())
 	}, 20*time.Second, 100*time.Millisecond)
 }
 
@@ -386,11 +396,9 @@ func (s *ActivityAPIBatchTerminateClientTestSuite) TestActivityBatchTerminate_No
 	}, 10*time.Second, 200*time.Millisecond)
 }
 
-// TestActivityBatchTerminate_ExcludesNonRunning verifies that a batch terminate
-// query omitting `ExecutionStatus = 'Running'` still only targets the running
-// activity: the server must add the filter automatically (adjustQueryBatchTypeEnum)
-// so an already-completed activity of the same type is excluded, not (re-)terminated.
-func (s *ActivityAPIBatchTerminateClientTestSuite) TestActivityBatchTerminate_ExcludesNonRunning() {
+// TestActivityBatchTerminate_TargetsRunningAndPaused verifies that a batch terminate
+// query targets non-terminal activities while excluding completed activities.
+func (s *ActivityAPIBatchTerminateClientTestSuite) TestActivityBatchTerminate_TargetsRunningAndPaused() {
 	env := newStandaloneActivityBatchEnv(s.T())
 	t := s.T()
 	ctx := s.Context()
@@ -401,6 +409,16 @@ func (s *ActivityAPIBatchTerminateClientTestSuite) TestActivityBatchTerminate_Ex
 	// task can't race and pick up the running activity's task instead.
 	runningID := testcore.RandomizeStr(fmt.Sprintf("%s-running", t.Name()))
 	runningResp := env.startAndValidateActivity(ctx, t, runningID, testcore.RandomizeStr(fmt.Sprintf("%s-running-tq", t.Name())))
+	pausedID := testcore.RandomizeStr(fmt.Sprintf("%s-paused", t.Name()))
+	pausedResp := env.startAndValidateActivity(ctx, t, pausedID, testcore.RandomizeStr(fmt.Sprintf("%s-paused-tq", t.Name())))
+	_, err := env.FrontendClient().PauseActivityExecution(ctx, &workflowservice.PauseActivityExecutionRequest{
+		Namespace:  env.Namespace().String(),
+		ActivityId: pausedID,
+		RunId:      pausedResp.RunId,
+		Identity:   "test-identity",
+		Reason:     "test-pause",
+	})
+	require.NoError(t, err)
 
 	// This activity completes normally before the batch runs, so it must be
 	// excluded from a batch operation scoped only by ActivityType.
@@ -408,7 +426,7 @@ func (s *ActivityAPIBatchTerminateClientTestSuite) TestActivityBatchTerminate_Ex
 	completedID := testcore.RandomizeStr(fmt.Sprintf("%s-completed", t.Name()))
 	completedResp := env.startAndValidateActivity(ctx, t, completedID, completedTaskQueue)
 	pollResp := env.pollActivityTaskAndValidate(ctx, t, completedID, completedTaskQueue, completedResp.RunId)
-	_, err := env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+	_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
 		Namespace: env.Namespace().String(),
 		TaskToken: pollResp.TaskToken,
 		Result:    defaultResult,
@@ -418,9 +436,13 @@ func (s *ActivityAPIBatchTerminateClientTestSuite) TestActivityBatchTerminate_Ex
 	// Query intentionally omits ExecutionStatus = 'Running'.
 	query := fmt.Sprintf("ActivityType = '%s'", activityType)
 
-	// Wait for both activities to be indexed *and* for the completed one to no
-	// longer be indexed as Running, so the batch sees exactly one target.
-	waitForRunningFilterToSettle(ctx, t, env, query, 2, 1)
+	// Wait for all activities to be indexed and the batch filter to see the
+	// running and paused activities, but not the completed activity.
+	waitForActivityBatchFilterToSettle(ctx, t, env, query, map[string]enumspb.ActivityExecutionStatus{
+		runningID:   enumspb.ACTIVITY_EXECUTION_STATUS_RUNNING,
+		pausedID:    enumspb.ACTIVITY_EXECUTION_STATUS_PAUSED,
+		completedID: enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED,
+	})
 
 	jobID := uuid.NewString()
 	_, err = env.SdkClient().WorkflowService().StartBatchOperation(ctx, &workflowservice.StartBatchOperationRequest{
@@ -437,8 +459,8 @@ func (s *ActivityAPIBatchTerminateClientTestSuite) TestActivityBatchTerminate_Ex
 	})
 	s.NoError(err)
 
-	// The server-added ExecutionStatus = 'Running' filter must exclude the
-	// already-completed activity: only 1 execution is ever targeted, not 2.
+	// The server-added open-status filter must include the paused activity and
+	// exclude the completed activity.
 	//nolint:forbidigo // for tests with waits
 	s.EventuallyWithT(func(c *assert.CollectT) {
 		desc, err := env.FrontendClient().DescribeBatchOperation(ctx, &workflowservice.DescribeBatchOperationRequest{
@@ -446,10 +468,11 @@ func (s *ActivityAPIBatchTerminateClientTestSuite) TestActivityBatchTerminate_Ex
 			JobId:     jobID,
 		})
 		require.NoError(c, err)
-		require.EqualValues(c, 1, desc.GetTotalOperationCount())
+		require.EqualValues(c, 2, desc.GetTotalOperationCount())
 	}, 10*time.Second, 200*time.Millisecond)
 
 	env.eventuallyTerminated(ctx, t, runningID, runningResp.RunId)
+	env.eventuallyTerminated(ctx, t, pausedID, pausedResp.RunId)
 
 	// The already-completed activity must remain untouched by the batch.
 	descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{

--- a/tests/workflow_api_batch_signal_test.go
+++ b/tests/workflow_api_batch_signal_test.go
@@ -84,6 +84,80 @@ func (s *WorkflowAPIBatchSignalClientTestSuite) TestWorkflowBatchSignal_Separate
 	s.Equal("first-signal-data,second-signal-data", result)
 }
 
+func (s *WorkflowAPIBatchSignalClientTestSuite) TestWorkflowBatchSignal_PausedWorkflow() {
+	env := newWorkflowBatchEnv(s.T())
+	t := s.T()
+	ctx := s.Context()
+
+	workflowType := testcore.RandomizeStr(t.Name())
+	env.SdkWorker().RegisterWorkflowWithOptions(signalReceivingWorkflow, workflow.RegisterOptions{Name: workflowType})
+
+	run, err := env.SdkClient().ExecuteWorkflow(ctx, sdkclient.StartWorkflowOptions{
+		ID:        testcore.RandomizeStr(t.Name()),
+		TaskQueue: env.WorkerTaskQueue(),
+	}, workflowType)
+	require.NoError(t, err)
+
+	_, err = env.FrontendClient().PauseWorkflowExecution(ctx, &workflowservice.PauseWorkflowExecutionRequest{
+		Namespace:  env.Namespace().String(),
+		WorkflowId: run.GetID(),
+		RunId:      run.GetRunID(),
+		Identity:   "batch-signal-test",
+		Reason:     "test",
+		RequestId:  uuid.NewString(),
+	})
+	require.NoError(t, err)
+
+	query := fmt.Sprintf("WorkflowId = '%s'", run.GetID())
+	//nolint:forbidigo // for tests with waits
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		resp, err := env.FrontendClient().ListWorkflowExecutions(ctx, &workflowservice.ListWorkflowExecutionsRequest{
+			Namespace: env.Namespace().String(),
+			PageSize:  1,
+			Query:     fmt.Sprintf("%s AND ExecutionStatus = 'Paused'", query),
+		})
+		require.NoError(c, err)
+		require.Len(c, resp.GetExecutions(), 1)
+	}, 10*time.Second, 100*time.Millisecond)
+
+	inputPayloads, err := converter.GetDefaultDataConverter().ToPayloads("signal-while-paused")
+	require.NoError(t, err)
+	jobID := uuid.NewString()
+	_, err = env.SdkClient().WorkflowService().StartBatchOperation(ctx, &workflowservice.StartBatchOperationRequest{
+		Namespace: env.Namespace().String(),
+		Operation: &workflowservice.StartBatchOperationRequest_SignalOperation{
+			SignalOperation: &batchpb.BatchOperationSignal{
+				Signal:   batchSignalTestSignalName,
+				Input:    inputPayloads,
+				Identity: "batch-signaler",
+			},
+		},
+		VisibilityQuery: query,
+		JobId:           jobID,
+		Reason:          "test",
+	})
+	require.NoError(t, err)
+	assertWorkflowBatchOperationSucceeded(ctx, t, env, jobID)
+
+	desc, err := env.SdkClient().DescribeWorkflowExecution(ctx, run.GetID(), run.GetRunID())
+	require.NoError(t, err)
+	require.Equal(t, enumspb.WORKFLOW_EXECUTION_STATUS_PAUSED, desc.GetWorkflowExecutionInfo().GetStatus())
+
+	_, err = env.FrontendClient().UnpauseWorkflowExecution(ctx, &workflowservice.UnpauseWorkflowExecutionRequest{
+		Namespace:  env.Namespace().String(),
+		WorkflowId: run.GetID(),
+		RunId:      run.GetRunID(),
+		Identity:   "batch-signal-test",
+		Reason:     "test",
+		RequestId:  uuid.NewString(),
+	})
+	require.NoError(t, err)
+
+	var result string
+	require.NoError(t, run.Get(ctx, &result))
+	require.Equal(t, "signal-while-paused", result)
+}
+
 // signalWorkflowViaBatch starts a batch signal operation targeting a single
 // workflow execution and returns the batch job ID.
 func (s *WorkflowAPIBatchSignalClientTestSuite) signalWorkflowViaBatch(

--- a/tests/workflow_api_batch_terminate_test.go
+++ b/tests/workflow_api_batch_terminate_test.go
@@ -39,6 +39,7 @@ func newWorkflowBatchEnv(t *testing.T) *testcore.TestEnv {
 		t,
 		testcore.WithWorkerService("batch operations"),
 		testcore.WithDynamicConfig(dynamicconfig.FrontendMaxConcurrentBatchOperationPerNamespace, testcore.ClientSuiteLimit),
+		testcore.WithDynamicConfig(dynamicconfig.WorkflowPauseEnabled, true),
 	)
 }
 


### PR DESCRIPTION
## What changed?
Batch operations now target Paused executions in addition to Running ones. The filter auto-appended by adjustQueryBatchTypeEnum changed from  ExecutionStatus='Running' to ExecutionStatus='Running' OR ExecutionStatus='Paused', affecting all workflow batch types (terminate/signal/cancel/update-options) and activity batch types (unpause/update-options/reset/terminate/cancel).

## Why?
A paused execution is still non-terminal. Users issuing a batch terminate/signal/cancel reasonably expect it to apply to paused targets, but the old  Running-only filter silently skipped them. 

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [X] added new functional test(s)

## Potential risks
- The filter now references ExecutionStatus='Paused' on every batch operation.  This is ok as it's an additive clause to the visibilty query
- This would be changing behavior for batch callers as paused activities are now affected.
