### PR TITLE
Configurable limit on activity info failure size

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -486,6 +486,20 @@ If exceeded, failure will be truncated before being stored in mutable state.`,
 		2*1024,
 		`MutableStateActivityFailureSizeLimitWarn is the per activity failure size warning limit for workflow mutable state`,
 	)
+	MutableStateActivityFailureTotalSizeLimitError = NewNamespaceIntSetting(
+		"limit.mutableStateActivityFailureTotalSize.error",
+		4*1024*1024,
+		`MutableStateActivityFailureTotalSizeLimitError is the limit on the total size of the last failures
+retained across all of a workflow's pending activities. Once the total is exceeded, newly recorded activity
+failures will be truncated. Set to 0 for no limit.`,
+	)
+	MutableStateActivityFailureTotalSizeLimitWarn = NewNamespaceIntSetting(
+		"limit.mutableStateActivityFailureTotalSize.warn",
+		2*1024*1024,
+		`MutableStateActivityFailureTotalSizeLimitWarn is the warning limit on the total size of the last
+failures retained across all of a workflow's pending activities. Controls what is logged without changing what is stored.
+Set to 0 for no limit.`,
+	)
 	MutableStateSizeLimitError = NewGlobalIntSetting(
 		"limit.mutableStateSize.error",
 		8*1024*1024,

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1077,9 +1077,13 @@ var (
 		"persisted_mutable_state_size",
 		WithDescription("Size of the persisted Workflow Execution's state in DB, emitted each time a workflow execution is updated."),
 	)
-	ExecutionInfoSize                    = NewBytesHistogramDef("execution_info_size")
-	ExecutionStateSize                   = NewBytesHistogramDef("execution_state_size")
-	ActivityInfoSize                     = NewBytesHistogramDef("activity_info_size")
+	ExecutionInfoSize        = NewBytesHistogramDef("execution_info_size")
+	ExecutionStateSize       = NewBytesHistogramDef("execution_state_size")
+	ActivityInfoSize         = NewBytesHistogramDef("activity_info_size")
+	ActivityFailureTotalSize = NewBytesHistogramDef(
+		"activity_failure_total_size",
+		WithDescription("Total size of the last failures retained across a Workflow Execution's pending activities, emitted each time an activity failure is recorded."),
+	)
 	TimerInfoSize                        = NewBytesHistogramDef("timer_info_size")
 	ChildInfoSize                        = NewBytesHistogramDef("child_info_size")
 	RequestCancelInfoSize                = NewBytesHistogramDef("request_cancel_info_size")

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -244,26 +244,28 @@ type Config struct {
 	NumParentClosePolicySystemWorkflows dynamicconfig.IntPropertyFn
 
 	// Size limit related settings
-	BlobSizeLimitError                        dynamicconfig.IntPropertyFnWithNamespaceFilter
-	BlobSizeLimitWarn                         dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MemoSizeLimitError                        dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MemoSizeLimitWarn                         dynamicconfig.IntPropertyFnWithNamespaceFilter
-	HistorySizeLimitError                     dynamicconfig.IntPropertyFnWithNamespaceFilter
-	HistorySizeLimitWarn                      dynamicconfig.IntPropertyFnWithNamespaceFilter
-	HistorySizeSuggestContinueAsNew           dynamicconfig.IntPropertyFnWithNamespaceFilter
-	HistoryCountLimitError                    dynamicconfig.IntPropertyFnWithNamespaceFilter
-	HistoryCountLimitWarn                     dynamicconfig.IntPropertyFnWithNamespaceFilter
-	HistoryCountSuggestContinueAsNew          dynamicconfig.IntPropertyFnWithNamespaceFilter
-	HistoryMaxPageSize                        dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MutableStateActivityFailureSizeLimitError dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MutableStateActivityFailureSizeLimitWarn  dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MutableStateSizeLimitError                dynamicconfig.IntPropertyFn
-	MutableStateSizeLimitWarn                 dynamicconfig.IntPropertyFn
-	MutableStateTombstoneCountLimit           dynamicconfig.IntPropertyFn
-	NumPendingChildExecutionsLimit            dynamicconfig.IntPropertyFnWithNamespaceFilter
-	NumPendingActivitiesLimit                 dynamicconfig.IntPropertyFnWithNamespaceFilter
-	NumPendingSignalsLimit                    dynamicconfig.IntPropertyFnWithNamespaceFilter
-	NumPendingCancelsRequestLimit             dynamicconfig.IntPropertyFnWithNamespaceFilter
+	BlobSizeLimitError                             dynamicconfig.IntPropertyFnWithNamespaceFilter
+	BlobSizeLimitWarn                              dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MemoSizeLimitError                             dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MemoSizeLimitWarn                              dynamicconfig.IntPropertyFnWithNamespaceFilter
+	HistorySizeLimitError                          dynamicconfig.IntPropertyFnWithNamespaceFilter
+	HistorySizeLimitWarn                           dynamicconfig.IntPropertyFnWithNamespaceFilter
+	HistorySizeSuggestContinueAsNew                dynamicconfig.IntPropertyFnWithNamespaceFilter
+	HistoryCountLimitError                         dynamicconfig.IntPropertyFnWithNamespaceFilter
+	HistoryCountLimitWarn                          dynamicconfig.IntPropertyFnWithNamespaceFilter
+	HistoryCountSuggestContinueAsNew               dynamicconfig.IntPropertyFnWithNamespaceFilter
+	HistoryMaxPageSize                             dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MutableStateActivityFailureSizeLimitError      dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MutableStateActivityFailureSizeLimitWarn       dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MutableStateActivityFailureTotalSizeLimitError dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MutableStateActivityFailureTotalSizeLimitWarn  dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MutableStateSizeLimitError                     dynamicconfig.IntPropertyFn
+	MutableStateSizeLimitWarn                      dynamicconfig.IntPropertyFn
+	MutableStateTombstoneCountLimit                dynamicconfig.IntPropertyFn
+	NumPendingChildExecutionsLimit                 dynamicconfig.IntPropertyFnWithNamespaceFilter
+	NumPendingActivitiesLimit                      dynamicconfig.IntPropertyFnWithNamespaceFilter
+	NumPendingSignalsLimit                         dynamicconfig.IntPropertyFnWithNamespaceFilter
+	NumPendingCancelsRequestLimit                  dynamicconfig.IntPropertyFnWithNamespaceFilter
 
 	// DefaultActivityRetryOptions specifies the out-of-box retry policy if
 	// none is configured on the Activity by the user.
@@ -702,26 +704,28 @@ func NewConfig(
 		EnableParentClosePolicyWorker:       dynamicconfig.EnableParentClosePolicyWorker.Get(dc),
 		ParentClosePolicyThreshold:          dynamicconfig.ParentClosePolicyThreshold.Get(dc),
 
-		BlobSizeLimitError:                        dynamicconfig.BlobSizeLimitError.Get(dc),
-		BlobSizeLimitWarn:                         dynamicconfig.BlobSizeLimitWarn.Get(dc),
-		MemoSizeLimitError:                        dynamicconfig.MemoSizeLimitError.Get(dc),
-		MemoSizeLimitWarn:                         dynamicconfig.MemoSizeLimitWarn.Get(dc),
-		NumPendingChildExecutionsLimit:            dynamicconfig.NumPendingChildExecutionsLimitError.Get(dc),
-		NumPendingActivitiesLimit:                 dynamicconfig.NumPendingActivitiesLimitError.Get(dc),
-		NumPendingSignalsLimit:                    dynamicconfig.NumPendingSignalsLimitError.Get(dc),
-		NumPendingCancelsRequestLimit:             dynamicconfig.NumPendingCancelRequestsLimitError.Get(dc),
-		HistorySizeLimitError:                     dynamicconfig.HistorySizeLimitError.Get(dc),
-		HistorySizeLimitWarn:                      dynamicconfig.HistorySizeLimitWarn.Get(dc),
-		HistorySizeSuggestContinueAsNew:           dynamicconfig.HistorySizeSuggestContinueAsNew.Get(dc),
-		HistoryCountLimitError:                    dynamicconfig.HistoryCountLimitError.Get(dc),
-		HistoryCountLimitWarn:                     dynamicconfig.HistoryCountLimitWarn.Get(dc),
-		HistoryCountSuggestContinueAsNew:          dynamicconfig.HistoryCountSuggestContinueAsNew.Get(dc),
-		HistoryMaxPageSize:                        dynamicconfig.HistoryMaxPageSize.Get(dc),
-		MutableStateActivityFailureSizeLimitError: dynamicconfig.MutableStateActivityFailureSizeLimitError.Get(dc),
-		MutableStateActivityFailureSizeLimitWarn:  dynamicconfig.MutableStateActivityFailureSizeLimitWarn.Get(dc),
-		MutableStateSizeLimitError:                dynamicconfig.MutableStateSizeLimitError.Get(dc),
-		MutableStateSizeLimitWarn:                 dynamicconfig.MutableStateSizeLimitWarn.Get(dc),
-		MutableStateTombstoneCountLimit:           dynamicconfig.MutableStateTombstoneCountLimit.Get(dc),
+		BlobSizeLimitError:                             dynamicconfig.BlobSizeLimitError.Get(dc),
+		BlobSizeLimitWarn:                              dynamicconfig.BlobSizeLimitWarn.Get(dc),
+		MemoSizeLimitError:                             dynamicconfig.MemoSizeLimitError.Get(dc),
+		MemoSizeLimitWarn:                              dynamicconfig.MemoSizeLimitWarn.Get(dc),
+		NumPendingChildExecutionsLimit:                 dynamicconfig.NumPendingChildExecutionsLimitError.Get(dc),
+		NumPendingActivitiesLimit:                      dynamicconfig.NumPendingActivitiesLimitError.Get(dc),
+		NumPendingSignalsLimit:                         dynamicconfig.NumPendingSignalsLimitError.Get(dc),
+		NumPendingCancelsRequestLimit:                  dynamicconfig.NumPendingCancelRequestsLimitError.Get(dc),
+		HistorySizeLimitError:                          dynamicconfig.HistorySizeLimitError.Get(dc),
+		HistorySizeLimitWarn:                           dynamicconfig.HistorySizeLimitWarn.Get(dc),
+		HistorySizeSuggestContinueAsNew:                dynamicconfig.HistorySizeSuggestContinueAsNew.Get(dc),
+		HistoryCountLimitError:                         dynamicconfig.HistoryCountLimitError.Get(dc),
+		HistoryCountLimitWarn:                          dynamicconfig.HistoryCountLimitWarn.Get(dc),
+		HistoryCountSuggestContinueAsNew:               dynamicconfig.HistoryCountSuggestContinueAsNew.Get(dc),
+		HistoryMaxPageSize:                             dynamicconfig.HistoryMaxPageSize.Get(dc),
+		MutableStateActivityFailureSizeLimitError:      dynamicconfig.MutableStateActivityFailureSizeLimitError.Get(dc),
+		MutableStateActivityFailureSizeLimitWarn:       dynamicconfig.MutableStateActivityFailureSizeLimitWarn.Get(dc),
+		MutableStateActivityFailureTotalSizeLimitError: dynamicconfig.MutableStateActivityFailureTotalSizeLimitError.Get(dc),
+		MutableStateActivityFailureTotalSizeLimitWarn:  dynamicconfig.MutableStateActivityFailureTotalSizeLimitWarn.Get(dc),
+		MutableStateSizeLimitError:                     dynamicconfig.MutableStateSizeLimitError.Get(dc),
+		MutableStateSizeLimitWarn:                      dynamicconfig.MutableStateSizeLimitWarn.Get(dc),
+		MutableStateTombstoneCountLimit:                dynamicconfig.MutableStateTombstoneCountLimit.Get(dc),
 
 		ThrottledLogRPS:   dynamicconfig.HistoryThrottledLogRPS.Get(dc),
 		EnableStickyQuery: dynamicconfig.EnableStickyQuery.Get(dc),

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -86,6 +86,9 @@ const (
 	mutableStateInvalidHistoryActionMsgTemplate = mutableStateInvalidHistoryActionMsg + ": %v, %v"
 
 	int64SizeBytes = 8
+
+	// Retained size for one activity failure once the limit MutableStateActivityFailureTotalSizeLimitError is exceeded.
+	minRetainedActivityFailureSize = 128
 )
 
 // Scheduled tasks with timestamp after this will not be created.
@@ -166,7 +169,9 @@ type (
 		// Running approximate total size of mutable state fields (except buffered events) when written to DB in bytes.
 		// Buffered events are added to this value when calling GetApproximatePersistedSize.
 		approximateSize int
-		chasmNodeSizes  map[string]int // chasm node path -> key + node size in bytes
+		// Running total of RetryLastFailure.Size() over pendingActivityInfoIDs.
+		activityFailureSize int
+		chasmNodeSizes      map[string]int // chasm node path -> key + node size in bytes
 		// Total number of tomestones tracked in mutable state
 		totalTombstones int
 		// Buffer events from DB
@@ -347,6 +352,7 @@ func NewMutableState(
 		chasmTree: &noopChasmTree{},
 
 		approximateSize:              0,
+		activityFailureSize:          0,
 		chasmNodeSizes:               make(map[string]int),
 		totalTombstones:              0,
 		currentVersion:               namespaceEntry.FailoverVersion(workflowID),
@@ -471,6 +477,7 @@ func NewMutableStateFromDB(
 	for _, activityInfo := range dbRecord.ActivityInfos {
 		mutableState.pendingActivityIDToEventID[activityInfo.ActivityId] = activityInfo.ScheduledEventId
 		mutableState.approximateSize += activityInfo.Size()
+		mutableState.activityFailureSize += activityInfo.GetRetryLastFailure().Size()
 		if (activityInfo.TimerTaskStatus & TimerTaskStatusCreatedHeartbeat) > 0 {
 			// Sets last pending timer heartbeat to year 2000.
 			// This ensures at least one heartbeat task will be processed for the pending activity.
@@ -2165,6 +2172,7 @@ func (ms *MutableStateImpl) UpdateActivityInfo(
 	ai.LastHeartbeatDetails = incomingActivityInfo.GetDetails()
 	ai.Attempt = incomingActivityInfo.GetAttempt()
 	ai.RetryLastWorkerIdentity = incomingActivityInfo.GetLastWorkerIdentity()
+	ms.activityFailureSize += incomingActivityInfo.LastFailure.Size() - ai.GetRetryLastFailure().Size()
 	ai.RetryLastFailure = incomingActivityInfo.LastFailure
 
 	if resetActivityTimerTaskStatus {
@@ -2227,6 +2235,7 @@ func (ms *MutableStateImpl) DeleteActivity(
 		delete(ms.pendingActivityInfoIDs, scheduledEventID)
 		delete(ms.pendingActivityTimerHeartbeats, scheduledEventID)
 		ms.approximateSize -= activityInfo.Size() + int64SizeBytes
+		ms.activityFailureSize -= activityInfo.GetRetryLastFailure().Size()
 
 		if _, ok = ms.pendingActivityIDToEventID[activityInfo.ActivityId]; ok {
 			delete(ms.pendingActivityIDToEventID, activityInfo.ActivityId)
@@ -6919,7 +6928,9 @@ func (ms *MutableStateImpl) RetryActivity(
 		// need to update activity
 		if err := ms.UpdateActivity(ai.ScheduledEventId, func(activityInfo *persistencespb.ActivityInfo, _ historyi.MutableState) error {
 			ClearActivityStartedState(activityInfo)
-			activityInfo.RetryLastFailure = ms.truncateRetryableActivityFailure(activityFailure)
+			truncated := ms.truncateRetryableActivityFailure(activityInfo, activityFailure)
+			ms.activityFailureSize += truncated.Size() - activityInfo.GetRetryLastFailure().Size()
+			activityInfo.RetryLastFailure = truncated
 			activityInfo.Attempt++
 			if ms.config.EnableActivityRetryStampIncrement() {
 				activityInfo.Stamp++
@@ -7001,11 +7012,15 @@ func (ms *MutableStateImpl) updateActivityInfoForRetries(
 	activityFailure *failurepb.Failure,
 ) error {
 	return ms.UpdateActivity(ai.ScheduledEventId, func(activityInfo *persistencespb.ActivityInfo, _ historyi.MutableState) error {
+		// The truncation and the size accounting both read the failure being replaced, so they run
+		// before UpdateActivityInfoForRetries overwrites RetryLastFailure.
+		truncated := ms.truncateRetryableActivityFailure(activityInfo, activityFailure)
+		ms.activityFailureSize += truncated.Size() - activityInfo.GetRetryLastFailure().Size()
 		UpdateActivityInfoForRetries(
 			activityInfo,
 			ms.GetCurrentVersion(),
 			nextAttempt,
-			ms.truncateRetryableActivityFailure(activityFailure),
+			truncated,
 			timestamppb.New(nextScheduledTime),
 			ms.config.EnableActivityRetryStampIncrement(),
 		)
@@ -7221,11 +7236,43 @@ func (ms *MutableStateImpl) decodeReportedProblems(p *commonpb.Payload) []string
 	return problems
 }
 
+// truncateRetryableActivityFailure decides whether activityFailure needs to be fully preserved or truncated using
+// two limits: per failure limit and total limit.
 func (ms *MutableStateImpl) truncateRetryableActivityFailure(
+	activityInfo *persistencespb.ActivityInfo,
 	activityFailure *failurepb.Failure,
 ) *failurepb.Failure {
+	if activityFailure == nil {
+		return nil
+	}
+
 	namespaceName := ms.namespaceEntry.Name().String()
 	failureSize := activityFailure.Size()
+
+	// What every other pending activity holds. activityInfo's own failure is being replaced, so excluding it here.
+	totalWithout := ms.activityFailureSize - activityInfo.GetRetryLastFailure().Size()
+	metrics.ActivityFailureTotalSize.With(ms.metricsHandler).Record(int64(totalWithout + failureSize))
+
+	totalLimitError := ms.config.MutableStateActivityFailureTotalSizeLimitError(namespaceName)
+	if totalLimitError > 0 && failureSize+totalWithout > totalLimitError {
+		ms.shard.GetThrottledLogger().Warn("total activity failure size exceeds error limit.",
+			tag.WorkflowNamespaceID(ms.executionInfo.NamespaceId),
+			tag.WorkflowID(ms.executionInfo.WorkflowId),
+			tag.WorkflowRunID(ms.executionState.RunId),
+			tag.NewInt("activity-failure-total-size", totalWithout+failureSize),
+		)
+		return failure.TruncateWithDepth(activityFailure, minRetainedActivityFailureSize, 0)
+	}
+
+	totalLimitWarn := ms.config.MutableStateActivityFailureTotalSizeLimitWarn(namespaceName)
+	if totalLimitWarn > 0 && totalWithout+failureSize > totalLimitWarn {
+		ms.shard.GetThrottledLogger().Warn("total activity failure size exceeds warn limit.",
+			tag.WorkflowNamespaceID(ms.executionInfo.NamespaceId),
+			tag.WorkflowID(ms.executionInfo.WorkflowId),
+			tag.WorkflowRunID(ms.executionState.RunId),
+			tag.NewInt("activity-failure-total-size", totalWithout+failureSize),
+		)
+	}
 
 	if failureSize <= ms.config.MutableStateActivityFailureSizeLimitWarn(namespaceName) {
 		return activityFailure
@@ -9359,6 +9406,7 @@ func (ms *MutableStateImpl) applyUpdatesToSubStateMachines(
 ) error {
 	err := applyUpdatesToSubStateMachine(ms, ms.pendingActivityInfoIDs, ms.updateActivityInfos, updatedActivityInfos, isSnapshot, ms.DeleteActivity, func(current, incoming *persistencespb.ActivityInfo) {
 		incoming.TimerTaskStatus = ms.getActivityTimerTaskStatus(current, incoming)
+		ms.activityFailureSize += incoming.RetryLastFailure.Size() - current.GetRetryLastFailure().Size()
 	}, func(ai *persistencespb.ActivityInfo) {
 		ms.pendingActivityIDToEventID[ai.ActivityId] = ai.ScheduledEventId
 		ms.activityInfosUserDataUpdated[ai.ScheduledEventId] = struct{}{}

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -3260,6 +3260,341 @@ func (s *mutableStateSuite) TestRetryActivity_TruncateRetryableFailure() {
 	s.Equal(activityFailure.GetMessage(), activityInfo.RetryLastFailure.Cause.GetMessage())
 }
 
+// scheduleAndStartActivity schedules and starts one retryable activity
+func (s *mutableStateSuite) scheduleAndStartActivity(activityID string) *persistencespb.ActivityInfo {
+	_, ai, err := s.mutableState.AddActivityTaskScheduledEvent(
+		int64(4),
+		&commandpb.ScheduleActivityTaskCommandAttributes{
+			ActivityId:             activityID,
+			ActivityType:           &commonpb.ActivityType{Name: "activity-type"},
+			TaskQueue:              &taskqueuepb.TaskQueue{Name: "task-queue"},
+			ScheduleToCloseTimeout: timestamp.DurationFromSeconds(3600),
+			RetryPolicy: &commonpb.RetryPolicy{
+				InitialInterval:    timestamp.DurationFromSeconds(1),
+				BackoffCoefficient: 1,
+			},
+		},
+		false,
+	)
+	s.NoError(err)
+
+	_, err = s.mutableState.AddActivityTaskStartedEvent(
+		ai, ai.ScheduledEventId, uuid.NewString(), "worker-identity", nil, nil, nil, "", nil,
+	)
+	s.NoError(err)
+	return ai
+}
+
+// stackHeavyActivityFailure builds the shape that motivates the aggregate limit: a small message with a
+// large stack trace, sized to land between the per-failure warn and error limits so per-failure
+// truncation does not fire and only the aggregate limit can bound it.
+func stackHeavyActivityFailure(stackBytes int) *failurepb.Failure {
+	return &failurepb.Failure{
+		Message:    "unsupported interval syntax",
+		Source:     "PythonSDK",
+		StackTrace: strings.Repeat("s", stackBytes),
+		FailureInfo: &failurepb.Failure_ApplicationFailureInfo{ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
+			Type:         "ValueError",
+			NonRetryable: false,
+		}},
+	}
+}
+
+// assertActivityFailureSizeConsistent recomputes the aggregate from the pending activities and compares
+// it against the incrementally maintained counter
+func (s *mutableStateSuite) assertActivityFailureSizeConsistent() {
+	expected := 0
+	for _, ai := range s.mutableState.pendingActivityInfoIDs {
+		expected += ai.GetRetryLastFailure().Size()
+	}
+	s.Equal(expected, s.mutableState.activityFailureSize)
+}
+
+func (s *mutableStateSuite) TestRetryActivity_AggregateFailureSizeLimit() {
+	s.mockEventsCache.EXPECT().PutEvent(gomock.Any(), gomock.Any()).AnyTimes()
+
+	const totalLimit = 4 * 1024
+	s.mockConfig.MutableStateActivityFailureTotalSizeLimitError = func(string) int { return totalLimit }
+	s.mockConfig.MutableStateActivityFailureTotalSizeLimitWarn = func(string) int { return totalLimit / 2 }
+
+	namespaceName := s.mutableState.namespaceEntry.Name().String()
+	activityFailure := stackHeavyActivityFailure(1500)
+	s.LessOrEqual(activityFailure.Size(), s.mockConfig.MutableStateActivityFailureSizeLimitError(namespaceName))
+
+	var full, cut int
+	for i := range 20 {
+		ai := s.scheduleAndStartActivity(fmt.Sprintf("activity-%d", i))
+		retryState, err := s.mutableState.RetryActivity(ai, activityFailure)
+		s.NoError(err)
+		s.Equal(enumspb.RETRY_STATE_IN_PROGRESS, retryState)
+
+		stored := ai.RetryLastFailure
+		s.NotNil(stored)
+		if stored.StackTrace == activityFailure.StackTrace {
+			full++
+		} else {
+			s.Equal(activityFailure.Message, stored.Message)
+			s.Equal("ValueError", stored.GetApplicationFailureInfo().GetType())
+			s.Less(len(stored.StackTrace), len(activityFailure.StackTrace))
+			s.Nil(stored.Cause)
+			s.LessOrEqual(stored.Size(), minRetainedActivityFailureSize)
+			cut++
+		}
+		s.assertActivityFailureSizeConsistent()
+	}
+
+	s.Positive(full)
+	s.Positive(cut)
+
+	s.LessOrEqual(s.mutableState.activityFailureSize, totalLimit+cut*minRetainedActivityFailureSize)
+}
+
+func (s *mutableStateSuite) TestRetryActivity_AggregateFailureSizeLimitDisabled() {
+	s.mockEventsCache.EXPECT().PutEvent(gomock.Any(), gomock.Any()).AnyTimes()
+
+	s.mockConfig.MutableStateActivityFailureTotalSizeLimitError = func(string) int { return 0 }
+	s.mockConfig.MutableStateActivityFailureTotalSizeLimitWarn = func(string) int { return 0 }
+
+	activityFailure := stackHeavyActivityFailure(1500)
+	for i := range 10 {
+		ai := s.scheduleAndStartActivity(fmt.Sprintf("activity-%d", i))
+		_, err := s.mutableState.RetryActivity(ai, activityFailure)
+		s.NoError(err)
+		s.Equal(activityFailure.StackTrace, ai.RetryLastFailure.StackTrace)
+	}
+	s.Greater(s.mutableState.activityFailureSize, 10*1500)
+	s.assertActivityFailureSizeConsistent()
+}
+
+// ResetActivity reaches RegenerateActivityRetryTask from inside an UpdateActivity updater, so
+// UpdateActivity re-enters itself while the stored failure is being cleared.
+func (s *mutableStateSuite) TestRetryActivity_AggregateFailureSizeAfterReset() {
+	s.mockEventsCache.EXPECT().PutEvent(gomock.Any(), gomock.Any()).AnyTimes()
+	s.mockConfig.MutableStateActivityFailureTotalSizeLimitError = func(string) int { return 0 }
+
+	ai := s.scheduleAndStartActivity("activity-0")
+	_, err := s.mutableState.RetryActivity(ai, stackHeavyActivityFailure(1500))
+	s.NoError(err)
+	s.Greater(s.mutableState.activityFailureSize, 1500)
+	s.assertActivityFailureSizeConsistent()
+
+	s.NoError(ResetActivity(context.Background(), s.mockShard, s.mutableState, "activity-0", false, false, false, 0))
+	s.Nil(ai.RetryLastFailure)
+	s.Zero(s.mutableState.activityFailureSize)
+	s.assertActivityFailureSizeConsistent()
+}
+
+// TestRetryActivity_AggregateFailureSizePausedPath covers the paused branch of RetryActivity, which
+// records the failure at its own assignment rather than through updateActivityInfoForRetries. Retrying
+// more than once is what exercises replacing a failure the activity already held.
+func (s *mutableStateSuite) TestRetryActivity_AggregateFailureSizePausedPath() {
+	s.mockEventsCache.EXPECT().PutEvent(gomock.Any(), gomock.Any()).AnyTimes()
+	s.mockConfig.MutableStateActivityFailureTotalSizeLimitError = func(string) int { return 0 }
+	s.mockConfig.MutableStateActivityFailureTotalSizeLimitWarn = func(string) int { return 0 }
+
+	ai := s.scheduleAndStartActivity("activity-0")
+	ai.Paused = true
+
+	// Sizes grow then shrink, so the subtraction is exercised in both directions
+	prevStored := 0
+	for i, stackBytes := range []int{200, 900, 300} {
+		retryState, err := s.mutableState.RetryActivity(ai, stackHeavyActivityFailure(stackBytes))
+		s.NoError(err)
+		s.Equal(enumspb.RETRY_STATE_IN_PROGRESS, retryState)
+
+		stored := ai.RetryLastFailure.Size()
+		// Each failure replaces the last rather than adding to it.
+		s.Equal(stored, s.mutableState.activityFailureSize)
+		s.assertActivityFailureSizeConsistent()
+
+		if i > 0 {
+			s.NotEqual(prevStored, stored)
+		}
+		prevStored = stored
+	}
+}
+
+// TestActivityFailureSizeAccounting covers the counter across the paths that add, replace, wipe and
+// delete a stored failure. A drifting counter degrades the cap with no visible symptom.
+func (s *mutableStateSuite) TestActivityFailureSizeAccounting() {
+	s.mockEventsCache.EXPECT().PutEvent(gomock.Any(), gomock.Any()).AnyTimes()
+	s.mockConfig.MutableStateActivityFailureTotalSizeLimitError = func(string) int { return 0 }
+
+	s.Zero(s.mutableState.activityFailureSize)
+
+	// Scheduled and started, no failure yet.
+	ai := s.scheduleAndStartActivity("activity-0")
+	s.Zero(s.mutableState.activityFailureSize)
+	s.assertActivityFailureSizeConsistent()
+
+	// First failure.
+	_, err := s.mutableState.RetryActivity(ai, stackHeavyActivityFailure(1500))
+	s.NoError(err)
+	afterFirst := s.mutableState.activityFailureSize
+	s.Greater(afterFirst, 1500)
+	s.assertActivityFailureSizeConsistent()
+
+	// A second, larger failure on the same activity replaces the first rather than adding to it.
+	_, err = s.mutableState.AddActivityTaskStartedEvent(
+		ai, ai.ScheduledEventId, uuid.NewString(), "worker-identity", nil, nil, nil, "", nil,
+	)
+	s.NoError(err)
+	retryState, err := s.mutableState.RetryActivity(ai, stackHeavyActivityFailure(2500))
+	s.NoError(err)
+	s.Equal(enumspb.RETRY_STATE_IN_PROGRESS, retryState)
+	s.Greater(s.mutableState.activityFailureSize, afterFirst)
+	s.Less(s.mutableState.activityFailureSize, afterFirst+2500)
+	s.assertActivityFailureSizeConsistent()
+
+	// RegenerateActivityRetryTask passes a nil failure, which wipes the field.
+	err = s.mutableState.RegenerateActivityRetryTask(ai, time.Now().UTC().Add(time.Minute))
+	s.NoError(err)
+	s.Nil(ai.RetryLastFailure)
+	s.Zero(s.mutableState.activityFailureSize)
+	s.assertActivityFailureSizeConsistent()
+
+	// A second activity's failure, then deleting it.
+	other := s.scheduleAndStartActivity("activity-1")
+	_, err = s.mutableState.RetryActivity(other, stackHeavyActivityFailure(1500))
+	s.NoError(err)
+	s.Greater(s.mutableState.activityFailureSize, 1500)
+	s.assertActivityFailureSizeConsistent()
+
+	s.NoError(s.mutableState.DeleteActivity(other.ScheduledEventId))
+	s.Zero(s.mutableState.activityFailureSize)
+	s.assertActivityFailureSizeConsistent()
+}
+
+// TestActivityFailureSizeFreshLoad checks the counter is re-derived from the DB record.
+func (s *mutableStateSuite) TestActivityFailureSizeFreshLoad() {
+	s.mockEventsCache.EXPECT().PutEvent(gomock.Any(), gomock.Any()).AnyTimes()
+	s.mockConfig.MutableStateActivityFailureTotalSizeLimitError = func(string) int { return 0 }
+
+	for i := range 3 {
+		ai := s.scheduleAndStartActivity(fmt.Sprintf("activity-%d", i))
+		_, err := s.mutableState.RetryActivity(ai, stackHeavyActivityFailure(1500))
+		s.NoError(err)
+	}
+	expected := s.mutableState.activityFailureSize
+	s.Greater(expected, 3*1500)
+
+	reloaded, err := NewMutableStateFromDB(
+		s.mockShard,
+		s.mockEventsCache,
+		s.logger,
+		tests.LocalNamespaceEntry,
+		s.mutableState.CloneToProto(),
+		123,
+	)
+	s.NoError(err)
+	s.Equal(expected, reloaded.activityFailureSize)
+}
+
+// TestActivityFailureSizeStateReplicationApply covers the counter on the state-based replication path,
+// which swaps whole ActivityInfos rather than mutating them in place.
+func (s *mutableStateSuite) TestActivityFailureSizeStateReplicationApply() {
+	s.mockEventsCache.EXPECT().PutEvent(gomock.Any(), gomock.Any()).AnyTimes()
+	s.mockShard.Resource.ClusterMetadata.EXPECT().IsVersionFromSameCluster(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+	s.mockConfig.MutableStateActivityFailureTotalSizeLimitError = func(string) int { return 0 }
+
+	ai := s.scheduleAndStartActivity("activity-0")
+	_, err := s.mutableState.RetryActivity(ai, stackHeavyActivityFailure(1500))
+	s.NoError(err)
+	before := s.mutableState.activityFailureSize
+	s.Greater(before, 1500)
+
+	// A replicated copy of the same activity, carrying a larger failure, replaces it.
+	incoming := common.CloneProto(ai)
+	incoming.RetryLastFailure = stackHeavyActivityFailure(2500)
+	incoming.LastUpdateVersionedTransition = &persistencespb.VersionedTransition{
+		NamespaceFailoverVersion: 1,
+		TransitionCount:          99,
+	}
+	s.NoError(s.mutableState.applyUpdatesToSubStateMachines(
+		map[int64]*persistencespb.ActivityInfo{ai.ScheduledEventId: incoming},
+		nil, nil, nil, nil, false,
+	))
+
+	s.Greater(s.mutableState.activityFailureSize, before)
+	s.assertActivityFailureSizeConsistent()
+
+	// And the same activity going away takes its failure with it.
+	s.NoError(s.mutableState.applyUpdatesToSubStateMachines(
+		map[int64]*persistencespb.ActivityInfo{}, nil, nil, nil, nil, true,
+	))
+	s.Zero(s.mutableState.activityFailureSize)
+	s.assertActivityFailureSizeConsistent()
+}
+
+// TestActivityFailureSizeReplicationNotLimited checks the deliberate asymmetry: the aggregate limit is applied
+// only on the active path.
+func (s *mutableStateSuite) TestActivityFailureSizeReplicationNotLimited() {
+	s.mockEventsCache.EXPECT().PutEvent(gomock.Any(), gomock.Any()).AnyTimes()
+	s.mockConfig.MutableStateActivityFailureTotalSizeLimitError = func(string) int { return 64 }
+
+	ai := s.scheduleAndStartActivity("activity-0")
+	incomingFailure := stackHeavyActivityFailure(1500)
+	err := s.mutableState.UpdateActivityInfo(&historyservice.ActivitySyncInfo{
+		ScheduledEventId: ai.ScheduledEventId,
+		Version:          ai.Version,
+		Attempt:          2,
+		LastFailure:      incomingFailure,
+	}, false)
+	s.NoError(err)
+
+	// Stored whole, even though it is far past the limit set above.
+	s.Equal(incomingFailure.Size(), ai.RetryLastFailure.Size())
+}
+
+// TestActivityFailureSizeReplicationReplacesFailure covers the event-based replication path replacing
+// and then clearing a failure the activity already held, which is what exercises the subtraction in
+// UpdateActivityInfo. Installing a first failure only ever subtracts zero.
+func (s *mutableStateSuite) TestActivityFailureSizeReplicationReplacesFailure() {
+	s.mockEventsCache.EXPECT().PutEvent(gomock.Any(), gomock.Any()).AnyTimes()
+	s.mockConfig.MutableStateActivityFailureTotalSizeLimitError = func(string) int { return 0 }
+
+	ai := s.scheduleAndStartActivity("activity-0")
+
+	syncFailure := func(f *failurepb.Failure, attempt int32) {
+		s.NoError(s.mutableState.UpdateActivityInfo(&historyservice.ActivitySyncInfo{
+			ScheduledEventId: ai.ScheduledEventId,
+			Version:          ai.Version,
+			Attempt:          attempt,
+			LastFailure:      f,
+		}, false))
+	}
+
+	// A second activity holds a failure throughout, so the total is never just the activity under test
+	// and a counter that resets rather than adjusts would show up.
+	other := s.scheduleAndStartActivity("activity-1")
+	_, err := s.mutableState.RetryActivity(other, stackHeavyActivityFailure(500))
+	s.NoError(err)
+	otherSize := other.RetryLastFailure.Size()
+
+	first := stackHeavyActivityFailure(1500)
+	syncFailure(first, 2)
+	s.Equal(otherSize+first.Size(), s.mutableState.activityFailureSize)
+	s.assertActivityFailureSizeConsistent()
+
+	// Replaced by a larger one: the old size has to come off, not accumulate.
+	second := stackHeavyActivityFailure(3000)
+	syncFailure(second, 3)
+	s.Equal(otherSize+second.Size(), s.mutableState.activityFailureSize)
+	s.assertActivityFailureSizeConsistent()
+
+	// Replaced by a smaller one.
+	third := stackHeavyActivityFailure(200)
+	syncFailure(third, 4)
+	s.Equal(otherSize+third.Size(), s.mutableState.activityFailureSize)
+	s.assertActivityFailureSizeConsistent()
+
+	// Cleared: a nil LastFailure frees the bytes rather than leaving them charged.
+	syncFailure(nil, 5)
+	s.Nil(ai.RetryLastFailure)
+	s.Equal(otherSize, s.mutableState.activityFailureSize)
+	s.assertActivityFailureSizeConsistent()
+}
+
 func (s *mutableStateSuite) TestRetryActivity_PausedIncrementsStamp() {
 	s.mockEventsCache.EXPECT().PutEvent(gomock.Any(), gomock.Any()).AnyTimes()
 	s.mockConfig.EnableActivityRetryStampIncrement = dynamicconfig.GetBoolPropertyFn(true)
@@ -5852,6 +6187,7 @@ func (s *mutableStateSuite) buildSnapshot(state *MutableStateImpl) *persistences
 }
 
 func (s *mutableStateSuite) TestApplySnapshot() {
+	s.mockShard.Resource.ClusterMetadata.EXPECT().IsVersionFromSameCluster(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 	testCases := []struct {
 		name                        string
 		updateWorkflowTask          bool
@@ -6003,6 +6339,7 @@ func (s *mutableStateSuite) buildMutation(
 }
 
 func (s *mutableStateSuite) TestApplyMutation() {
+	s.mockShard.Resource.ClusterMetadata.EXPECT().IsVersionFromSameCluster(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 	testCases := []struct {
 		name                        string
 		updateWorkflowTask          bool


### PR DESCRIPTION
## What changed?
Bound the total size of `RetryLastFailure` in the mutable state retained across a workflow's pending activities, not just each failure individually. New dynamic config `limit.mutableStateActivityFailureTotalSize.error` control this, set by default at 6MB (8MB is the mutable state size limit) 

## Why?
The existing per-failure limit lets a workflow with many pending activities accumulate an unbounded aggregate of retained failures in mutable state. The limit is applied only on the active path; replication applies whatever the active cluster decided, so both clusters retain the same bytes.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
`activityFailureSize` is a running counter updated at each mutation site, so a missed site drifts the total. Drift only shifts when truncation starts, it does not corrupt state.
