### PR TITLE
Improve replication applied lifecycle events

### DIFF
--- a/common/wideevents/replication_events.go
+++ b/common/wideevents/replication_events.go
@@ -362,6 +362,9 @@ func (p ReplicationLifecyclePayload) appendApplied(attrs []log.KeyValue) []log.K
 	if p.Error != "" {
 		attrs = append(attrs, log.String("error", p.Error))
 	}
+	if p.NewRunID != "" {
+		attrs = append(attrs, log.String("new_run_id", p.NewRunID))
+	}
 	if p.State == "" {
 		return attrs
 	}

--- a/common/wideevents/replication_events_test.go
+++ b/common/wideevents/replication_events_test.go
@@ -103,6 +103,7 @@ func TestReplicationLifecycleEncodeApplied(t *testing.T) {
 		LastEventID:        9,
 		LastEventVersion:   5,
 		Outcome:            "applied",
+		NewRunID:           "continued-run",
 		NewExecutionRunID:  "new-run",
 		SignalCount:        6,
 		UpdateCount:        2,
@@ -110,6 +111,7 @@ func TestReplicationLifecycleEncodeApplied(t *testing.T) {
 	f := attrMap(p.Attributes())
 
 	require.Equal(t, "applied", f["phase"].AsString())
+	require.Equal(t, "continued-run", f["new_run_id"].AsString())
 	require.Equal(t, "new-run", f["new_execution_run_id"].AsString())
 	require.Equal(t, int64(6), f["signal_count"].AsInt64())
 	require.Equal(t, int64(2), f["update_count"].AsInt64())
@@ -243,6 +245,7 @@ func TestReplicationLifecycleFieldSetLocked(t *testing.T) {
 			"phase":                 "applied",
 			"outcome":               "applied",
 			"error":                 "boom",
+			"new_run_id":            "new-run",
 			"state":                 "Running",
 			"status":                "Unspecified",
 			"applied_next_event_id": int64(10),

--- a/service/history/ndc/workflow_state_replicator.go
+++ b/service/history/ndc/workflow_state_replicator.go
@@ -224,6 +224,7 @@ func (r *WorkflowStateReplicatorImpl) SyncWorkflowState(
 		nil,
 		false,
 		skipCloseTransferTask,
+		nil,
 	)
 }
 
@@ -255,6 +256,7 @@ func (r *WorkflowStateReplicatorImpl) ReplicateVersionedTransition(
 	// live ms after the lock is released would race with the next writer.
 	var ms historyi.MutableState
 	var appliedMS *persistencespb.WorkflowMutableState
+	captureMutableState := func(createdMS historyi.MutableState) { ms = createdMS }
 	origin := wideevents.ReplicationTaskOriginFromContext(ctx)
 	defer func() {
 		if emitLifecycle && retError == nil {
@@ -302,7 +304,7 @@ func (r *WorkflowStateReplicatorImpl) ReplicateVersionedTransition(
 	if versionedTransitionArtifact.IsFirstSync {
 		// this is the first replication task for this workflow
 		// TODO: Handle reset case to reduce the amount of history events write
-		continueProcess, err := r.handleFirstReplicationTask(ctx, archetypeID, wfCtx, versionedTransitionArtifact, sourceClusterName)
+		continueProcess, err := r.handleFirstReplicationTask(ctx, archetypeID, wfCtx, versionedTransitionArtifact, sourceClusterName, captureMutableState)
 		if err != nil || !continueProcess {
 			return err
 		}
@@ -311,7 +313,7 @@ func (r *WorkflowStateReplicatorImpl) ReplicateVersionedTransition(
 	ms, err = wfCtx.LoadMutableState(ctx, r.shardContext)
 	switch err.(type) {
 	case *serviceerror.NotFound:
-		return r.applySnapshot(ctx, namespaceID, wid, rid, archetypeID, wfCtx, releaseFn, nil, versionedTransitionArtifact, sourceClusterName)
+		return r.applySnapshot(ctx, namespaceID, wid, rid, archetypeID, wfCtx, releaseFn, nil, versionedTransitionArtifact, sourceClusterName, captureMutableState)
 	case nil:
 		localTransitionHistory := ms.GetExecutionInfo().TransitionHistory
 		if len(localTransitionHistory) == 0 {
@@ -358,7 +360,7 @@ func (r *WorkflowStateReplicatorImpl) ReplicateVersionedTransition(
 			}
 			if localLastWriteVersion < sourceLastWriteVersion ||
 				localLastHistoryItem.GetEventId() <= sourceLastHistoryItem.EventId {
-				return r.applySnapshot(ctx, namespaceID, wid, rid, archetypeID, wfCtx, releaseFn, ms, versionedTransitionArtifact, sourceClusterName)
+				return r.applySnapshot(ctx, namespaceID, wid, rid, archetypeID, wfCtx, releaseFn, ms, versionedTransitionArtifact, sourceClusterName, nil)
 			}
 			return consts.ErrDuplicate
 		}
@@ -371,7 +373,7 @@ func (r *WorkflowStateReplicatorImpl) ReplicateVersionedTransition(
 		case errors.Is(err, consts.ErrStaleState):
 			// local is stale, try to apply mutable state update
 			if snapshot != nil {
-				return r.applySnapshot(ctx, namespaceID, wid, rid, archetypeID, wfCtx, releaseFn, ms, versionedTransitionArtifact, sourceClusterName)
+				return r.applySnapshot(ctx, namespaceID, wid, rid, archetypeID, wfCtx, releaseFn, ms, versionedTransitionArtifact, sourceClusterName, nil)
 			}
 			return r.applyMutation(ctx, namespaceID, wid, rid, archetypeID, wfCtx, ms, releaseFn, versionedTransitionArtifact, sourceClusterName)
 		case errors.Is(err, consts.ErrStaleReference):
@@ -584,6 +586,7 @@ func (r *WorkflowStateReplicatorImpl) handleFirstReplicationTask(
 	wfCtx historyi.WorkflowContext,
 	versionedTransition *replicationspb.VersionedTransitionArtifact,
 	sourceClusterName string,
+	captureMutableState func(historyi.MutableState),
 ) (continueProcess bool, retErr error) {
 	mutation, snapshot, executionState, executionInfo, err := parseVersionedTransitionAttributes(versionedTransition)
 	if err != nil {
@@ -602,6 +605,7 @@ func (r *WorkflowStateReplicatorImpl) handleFirstReplicationTask(
 			snapshot,
 			versionedTransition,
 			sourceClusterName,
+			captureMutableState,
 		)
 	}
 
@@ -626,6 +630,7 @@ func (r *WorkflowStateReplicatorImpl) handleFirstReplicationTaskWithoutNewRun(
 	snapshot *replicationspb.SyncWorkflowStateSnapshotAttributes,
 	versionedTransition *replicationspb.VersionedTransitionArtifact,
 	sourceClusterName string,
+	captureMutableState func(historyi.MutableState),
 ) (continueProcess bool, retErr error) {
 	nsEntry, err := r.namespaceRegistry.GetNamespaceByID(namespace.ID(executionInfo.NamespaceId))
 	if err != nil {
@@ -694,6 +699,9 @@ func (r *WorkflowStateReplicatorImpl) handleFirstReplicationTaskWithoutNewRun(
 	)
 	if errors.Is(err, consts.ErrDuplicate) {
 		return true, nil
+	}
+	if err == nil && captureMutableState != nil {
+		captureMutableState(localMutableState)
 	}
 
 	return false, err
@@ -994,6 +1002,7 @@ func (r *WorkflowStateReplicatorImpl) applySnapshot(
 	localMutableState historyi.MutableState,
 	versionedTransition *replicationspb.VersionedTransitionArtifact,
 	sourceClusterName string,
+	captureMutableState func(historyi.MutableState),
 ) error {
 	attribute := versionedTransition.GetSyncWorkflowStateSnapshotAttributes()
 	if attribute == nil || attribute.State == nil {
@@ -1026,6 +1035,7 @@ func (r *WorkflowStateReplicatorImpl) applySnapshot(
 			versionedTransition.NewRunInfo,
 			true,
 			versionedTransition.IsCloseTransferTaskAcked && versionedTransition.IsForceReplication,
+			captureMutableState,
 		)
 	}
 	return r.applySnapshotWhenWorkflowExist(
@@ -1678,6 +1688,7 @@ func (r *WorkflowStateReplicatorImpl) applySnapshotWhenWorkflowNotExist(
 	newRunInfo *replicationspb.NewRunInfo,
 	isStateBased bool,
 	skipGenerateCloseTransferTask bool,
+	captureMutableState func(historyi.MutableState),
 ) error {
 	var lastWriteVersion int64
 	executionInfo := sourceMutableState.ExecutionInfo
@@ -1744,6 +1755,9 @@ func (r *WorkflowStateReplicatorImpl) applySnapshotWhenWorkflowNotExist(
 	err = taskRefresher.Refresh(ctx, mutableState, skipGenerateCloseTransferTask)
 	if err != nil {
 		return err
+	}
+	if captureMutableState != nil {
+		captureMutableState(mutableState)
 	}
 	return r.transactionMgr.CreateWorkflow(
 		ctx,

--- a/service/history/ndc/workflow_state_replicator_test.go
+++ b/service/history/ndc/workflow_state_replicator_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	otellog "go.opentelemetry.io/otel/log"
+	"go.opentelemetry.io/otel/log/embedded"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
@@ -33,6 +35,7 @@ import (
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/quotas"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
+	"go.temporal.io/server/common/wideevents"
 	"go.temporal.io/server/service/history/events"
 	"go.temporal.io/server/service/history/hsm"
 	historyi "go.temporal.io/server/service/history/interfaces"
@@ -45,6 +48,11 @@ import (
 )
 
 type (
+	replicationEventCapture struct {
+		embedded.Logger
+		records []otellog.Record
+	}
+
 	workflowReplicatorSuite struct {
 		suite.Suite
 		*require.Assertions
@@ -66,6 +74,14 @@ type (
 		workflowStateReplicator *WorkflowStateReplicatorImpl
 	}
 )
+
+func (c *replicationEventCapture) Emit(_ context.Context, record otellog.Record) {
+	c.records = append(c.records, record)
+}
+
+func (*replicationEventCapture) Enabled(context.Context, otellog.EnabledParameters) bool {
+	return true
+}
 
 func TestWorkflowReplicatorSuite(t *testing.T) {
 	s := new(workflowReplicatorSuite)
@@ -604,6 +620,100 @@ func EqVersionedTransition(expected *persistencespb.VersionedTransition) gomock.
 	return &VersionedTransitionMatcher{expected: expected}
 }
 
+func (s *workflowReplicatorSuite) Test_ReplicateVersionedTransition_NotFound_CapturesCreatedState() {
+	s.mockShard.GetConfig().EmitReplicationLifecycleEvents = dynamicconfig.GetBoolPropertyFn(true)
+	eventCapture := &replicationEventCapture{}
+	workflowStateReplicator := s.workflowStateReplicator
+	workflowStateReplicator.eventLogger = eventCapture
+	mockTransactionManager := NewMockTransactionManager(s.controller)
+	workflowStateReplicator.transactionMgr = mockTransactionManager
+
+	namespaceID := uuid.NewString()
+	versionedTransitionArtifact := &replicationspb.VersionedTransitionArtifact{
+		StateAttributes: &replicationspb.VersionedTransitionArtifact_SyncWorkflowStateSnapshotAttributes{
+			SyncWorkflowStateSnapshotAttributes: &replicationspb.SyncWorkflowStateSnapshotAttributes{
+				State: &persistencespb.WorkflowMutableState{
+					ExecutionInfo: &persistencespb.WorkflowExecutionInfo{
+						WorkflowId:  s.workflowID,
+						NamespaceId: namespaceID,
+						TransitionHistory: []*persistencespb.VersionedTransition{
+							{NamespaceFailoverVersion: 2, TransitionCount: 10},
+						},
+						VersionHistories:         versionhistory.NewVersionHistories(&historyspb.VersionHistory{}),
+						WorkflowExecutionTimeout: timestamp.DurationPtr(time.Hour),
+						WorkflowRunTimeout:       timestamp.DurationPtr(time.Hour),
+					},
+					ExecutionState: &persistencespb.WorkflowExecutionState{
+						RunId:  s.runID,
+						State:  enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING,
+						Status: enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+					},
+					NextEventId: 42,
+				},
+			},
+		},
+	}
+
+	mockWeCtx := historyi.NewMockWorkflowContext(s.controller)
+	s.mockWorkflowCache.EXPECT().GetOrCreateChasmExecution(
+		gomock.Any(),
+		s.mockShard,
+		namespace.ID(namespaceID),
+		&commonpb.WorkflowExecution{WorkflowId: s.workflowID, RunId: s.runID},
+		chasm.WorkflowArchetypeID,
+		locks.PriorityHigh,
+	).Return(mockWeCtx, wcache.NoopReleaseFn, nil)
+	mockWeCtx.EXPECT().LoadMutableState(gomock.Any(), s.mockShard).
+		Return(nil, serviceerror.NewNotFound("mutable state not found"))
+	s.mockNamespaceCache.EXPECT().GetNamespaceByID(namespace.ID(namespaceID)).Return(
+		namespace.NewNamespaceForTest(
+			&persistencespb.NamespaceInfo{Name: "test-namespace"},
+			nil,
+			false,
+			nil,
+			int64(100),
+		),
+		nil,
+	)
+	s.mockNamespaceCache.EXPECT().GetNamespaceName(namespace.ID(namespaceID)).
+		Return(namespace.Name("test-namespace"), nil)
+	s.mockEventCache.EXPECT().GetEvent(gomock.Any(), gomock.Any(), gomock.Any(), common.FirstEventID, gomock.Any()).
+		Return(&historypb.HistoryEvent{
+			Attributes: &historypb.HistoryEvent_WorkflowExecutionStartedEventAttributes{
+				WorkflowExecutionStartedEventAttributes: &historypb.WorkflowExecutionStartedEventAttributes{},
+			},
+		}, nil).AnyTimes()
+	mockTransactionManager.EXPECT().CreateWorkflow(
+		gomock.Any(),
+		chasm.WorkflowArchetypeID,
+		gomock.AssignableToTypeOf(&WorkflowImpl{}),
+	).DoAndReturn(func(_ context.Context, _ chasm.ArchetypeID, wf Workflow) error {
+		wf.GetMutableState().GetExecutionState().State = enumsspb.WORKFLOW_EXECUTION_STATE_ZOMBIE
+		wf.GetReleaseFn()(nil)
+		return nil
+	})
+
+	err := workflowStateReplicator.ReplicateVersionedTransition(
+		context.Background(),
+		chasm.WorkflowArchetypeID,
+		versionedTransitionArtifact,
+		"source-cluster",
+	)
+	s.NoError(err)
+	s.Require().Len(eventCapture.records, 1)
+	record := eventCapture.records[0]
+	s.Equal(wideevents.ReplicationLifecycleEventName, record.EventName())
+	fields := make(map[string]otellog.Value)
+	record.WalkAttributes(func(kv otellog.KeyValue) bool {
+		fields[kv.Key] = kv.Value
+		return true
+	})
+	s.Equal(string(wideevents.ReplicationApplied), fields["phase"].AsString())
+	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_ZOMBIE.String(), fields["state"].AsString())
+	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING.String(), fields["status"].AsString())
+	s.Equal(int64(42), fields["applied_next_event_id"].AsInt64())
+}
+
 func (s *workflowReplicatorSuite) Test_ReplicateVersionedTransition_SameBranch_SyncSnapshot() {
 	workflowStateReplicator := NewWorkflowStateReplicator(
 		s.mockShard,
@@ -880,7 +990,9 @@ func (s *workflowReplicatorSuite) Test_ReplicateVersionedTransition_SameBranch_S
 	s.NoError(err)
 }
 
-func (s *workflowReplicatorSuite) Test_ReplicateVersionedTransition_FirstTask_SyncMutation() {
+func (s *workflowReplicatorSuite) Test_ReplicateVersionedTransition_FirstTask_CapturesCreatedState() {
+	s.mockShard.GetConfig().EmitReplicationLifecycleEvents = dynamicconfig.GetBoolPropertyFn(true)
+	eventCapture := &replicationEventCapture{}
 	workflowStateReplicator := NewWorkflowStateReplicator(
 		s.mockShard,
 		s.mockWorkflowCache,
@@ -888,7 +1000,7 @@ func (s *workflowReplicatorSuite) Test_ReplicateVersionedTransition_FirstTask_Sy
 		s.serializer,
 		quotas.NoopRequestRateLimiter,
 		s.logger,
-		nil,
+		eventCapture,
 	)
 	mockTransactionManager := NewMockTransactionManager(s.controller)
 	mockTaskRefresher := workflow.NewMockTaskRefresher(s.controller)
@@ -936,30 +1048,35 @@ func (s *workflowReplicatorSuite) Test_ReplicateVersionedTransition_FirstTask_Sy
 		locks.PriorityHigh,
 	).Return(mockWeCtx, wcache.NoopReleaseFn, nil)
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(namespace.ID(namespaceID)).Return(namespace.NewNamespaceForTest(
-		&persistencespb.NamespaceInfo{},
+		&persistencespb.NamespaceInfo{Name: "test-namespace"},
 		nil,
 		false,
 		nil,
 		int64(100),
 	), nil).AnyTimes()
+	s.mockNamespaceCache.EXPECT().GetNamespaceName(namespace.ID(namespaceID)).
+		Return(namespace.Name("test-namespace"), nil)
 	mockTaskRefresher.EXPECT().Refresh(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
 	mockTransactionManager.EXPECT().CreateWorkflow(
 		gomock.Any(),
 		chasm.WorkflowArchetypeID,
 		gomock.AssignableToTypeOf(&WorkflowImpl{}),
-	).DoAndReturn(func(ctx context.Context, _ chasm.ArchetypeID, wf Workflow) error {
-		// Capture localMutableState from the workflow
+	).DoAndReturn(func(_ context.Context, _ chasm.ArchetypeID, wf Workflow) error {
 		localMutableState := wf.GetMutableState()
-
-		// Perform your comparisons here
 		s.Equal(localMutableState.GetExecutionInfo().TransitionHistory, transitionHistory)
-
+		localMutableState.GetExecutionState().State = enumsspb.WORKFLOW_EXECUTION_STATE_ZOMBIE
 		return nil
 	}).Times(1)
 	err := workflowStateReplicator.ReplicateVersionedTransition(context.Background(), chasm.WorkflowArchetypeID, versionedTransitionArtifact, "test")
 	s.NoError(err)
-
+	s.Require().Len(eventCapture.records, 1)
+	fields := make(map[string]otellog.Value)
+	eventCapture.records[0].WalkAttributes(func(kv otellog.KeyValue) bool {
+		fields[kv.Key] = kv.Value
+		return true
+	})
+	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_ZOMBIE.String(), fields["state"].AsString())
 }
 
 func (s *workflowReplicatorSuite) Test_ReplicateVersionedTransition_MutationProvidedWithGap_ReturnSyncStateError() {
@@ -1668,6 +1785,7 @@ func (s *workflowReplicatorSuite) Test_handleFirstReplicationTask_WithSnapshot_S
 		mockWeCtx,
 		versionedTransitionArtifact,
 		"test-cluster",
+		nil,
 	)
 	s.NoError(err)
 	s.False(continueProcess)
@@ -1742,6 +1860,7 @@ func (s *workflowReplicatorSuite) Test_handleFirstReplicationTask_WithMutation_S
 		mockWeCtx,
 		versionedTransitionArtifact,
 		"test-cluster",
+		nil,
 	)
 	s.NoError(err)
 	s.False(continueProcess)
@@ -1767,6 +1886,7 @@ func (s *workflowReplicatorSuite) Test_handleFirstReplicationTask_InvalidArtifac
 		mockWeCtx,
 		versionedTransitionArtifact,
 		"test-cluster",
+		nil,
 	)
 	s.Error(err)
 	s.Contains(err.Error(), "unknown artifact type")
@@ -1843,6 +1963,7 @@ func (s *workflowReplicatorSuite) Test_handleFirstReplicationTask_CreateWorkflow
 		mockWeCtx,
 		versionedTransitionArtifact,
 		"test-cluster",
+		nil,
 	)
 	s.Error(err)
 	s.Equal(expectedErr, err)

--- a/service/history/replication/executable_verify_versioned_transition_task.go
+++ b/service/history/replication/executable_verify_versioned_transition_task.go
@@ -90,9 +90,10 @@ func (e *ExecutableVerifyVersionedTransitionTask) Execute() (retErr error) {
 	// inspectedMS is the mutable-state snapshot examined during verification, captured for the
 	// best-effort "applied" lifecycle event emitted below.
 	var inspectedMS *persistencespb.WorkflowMutableState
+	var backfillDetails map[string]any
 	defer func() {
 		if emitLifecycle {
-			e.emitReplicationVerifyApplied(inspectedMS, retErr)
+			e.emitReplicationVerifyApplied(inspectedMS, retErr, backfillDetails)
 		}
 	}()
 
@@ -206,6 +207,13 @@ func (e *ExecutableVerifyVersionedTransitionTask) Execute() (retErr error) {
 	startEventVersion, err := versionhistory.GetVersionHistoryEventVersion(targetHistory, lcaItem.EventId+1)
 	if err != nil {
 		return err
+	}
+	backfillDetails = map[string]any{
+		"recovery_action":     wideevents.ReplRecoveryActionResendHistory,
+		"first_event_id":      lcaItem.EventId + 1,
+		"first_event_version": startEventVersion,
+		"last_event_id":       lastItem.EventId,
+		"last_event_version":  lastItem.Version,
 	}
 	return e.BackFillEvents(
 		ctx,

--- a/service/history/replication/executable_verify_versioned_transition_task_test.go
+++ b/service/history/replication/executable_verify_versioned_transition_task_test.go
@@ -1,6 +1,7 @@
 package replication
 
 import (
+	"encoding/json"
 	"errors"
 	"math/rand"
 	"testing"
@@ -9,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	otellog "go.opentelemetry.io/otel/log"
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
 	enumsspb "go.temporal.io/server/api/enums/v1"
@@ -273,9 +275,9 @@ func (s *executableVerifyVersionedTransitionTaskSuite) mockGetMutableState(
 	runId string,
 	mutableState historyi.MutableState,
 	err error,
-) {
+) *gomock.Call {
 	shardContext := historyi.NewMockShardContext(s.controller)
-	s.shardController.EXPECT().GetShardByNamespaceWorkflow(
+	shardCall := s.shardController.EXPECT().GetShardByNamespaceWorkflow(
 		namespace.ID(s.task.NamespaceID),
 		s.task.WorkflowID,
 	).Return(shardContext, nil)
@@ -294,6 +296,7 @@ func (s *executableVerifyVersionedTransitionTaskSuite) mockGetMutableState(
 		chasm.WorkflowArchetypeID,
 		locks.PriorityHigh,
 	).Return(wfCtx, func(err error) {}, err)
+	return shardCall
 }
 
 func (s *executableVerifyVersionedTransitionTaskSuite) TestExecute_CurrentBranch_NotUpToDate() {
@@ -596,6 +599,16 @@ func (s *executableVerifyVersionedTransitionTaskSuite) TestExecute_NonCurrentBra
 }
 
 func (s *executableVerifyVersionedTransitionTaskSuite) TestExecute_NonCurrentBranch_NotUpToDate() {
+	s.config.EmitReplicationLifecycleEvents = func() bool { return true }
+	eventCapture := &eventCaptureLogger{}
+	eventShard := historyi.NewMockShardContext(s.controller)
+	eventShard.EXPECT().GetEventLogger().Return(eventCapture).Times(2)
+	eventShard.EXPECT().GetShardID().Return(int32(1)).Times(2)
+	s.namespaceCache.EXPECT().GetNamespaceName(namespace.ID(s.namespaceID)).
+		Return(namespace.Name("test-namespace"), nil).Times(2)
+	s.executableTask.EXPECT().Attempt().Return(1)
+	s.executableTask.EXPECT().SourceShardKey().Return(s.sourceShardKey).AnyTimes()
+
 	taskNextEvent := int64(10)
 	replicationTask := &replicationspb.ReplicationTask{
 		TaskType:     enumsspb.REPLICATION_TASK_TYPE_VERIFY_VERSIONED_TRANSITION_TASK,
@@ -654,7 +667,14 @@ func (s *executableVerifyVersionedTransitionTaskSuite) TestExecute_NonCurrentBra
 		},
 	).AnyTimes()
 
-	s.mockGetMutableState(s.namespaceID, s.workflowID, s.runID, mu, nil)
+	executingCall := s.shardController.EXPECT().GetShardByNamespaceWorkflow(
+		namespace.ID(s.namespaceID), s.workflowID,
+	).Return(eventShard, nil)
+	loadCall := s.mockGetMutableState(s.namespaceID, s.workflowID, s.runID, mu, nil)
+	appliedCall := s.shardController.EXPECT().GetShardByNamespaceWorkflow(
+		namespace.ID(s.namespaceID), s.workflowID,
+	).Return(eventShard, nil)
+	gomock.InOrder(executingCall, loadCall, appliedCall)
 
 	task := NewExecutableVerifyVersionedTransitionTask(
 		s.toolBox,
@@ -678,6 +698,27 @@ func (s *executableVerifyVersionedTransitionTaskSuite) TestExecute_NonCurrentBra
 
 	err := task.Execute()
 	s.NoError(err)
+	s.Require().Len(eventCapture.records, 2)
+	attrs := make(map[string]otellog.Value)
+	eventCapture.records[1].WalkAttributes(func(kv otellog.KeyValue) bool {
+		attrs[kv.Key] = kv.Value
+		return true
+	})
+	s.Equal("backfilled", attrs["outcome"].AsString())
+	s.Equal(s.newRunID, attrs["new_run_id"].AsString())
+	var details struct {
+		RecoveryAction    string `json:"recovery_action"`
+		FirstEventID      int64  `json:"first_event_id"`
+		FirstEventVersion int64  `json:"first_event_version"`
+		LastEventID       int64  `json:"last_event_id"`
+		LastEventVersion  int64  `json:"last_event_version"`
+	}
+	s.NoError(json.Unmarshal([]byte(attrs["details"].AsString()), &details))
+	s.Equal("resend_history", details.RecoveryAction)
+	s.Equal(int64(9), details.FirstEventID)
+	s.Equal(int64(1), details.FirstEventVersion)
+	s.Equal(int64(9), details.LastEventID)
+	s.Equal(int64(1), details.LastEventVersion)
 }
 
 func (s *executableVerifyVersionedTransitionTaskSuite) TestExecute_Skip_TerminalState() {

--- a/service/history/replication/replication_events.go
+++ b/service/history/replication/replication_events.go
@@ -522,12 +522,13 @@ func shippedEventRange(
 }
 
 // emitReplicationVerifyApplied emits a best-effort "applied" ReplicationLifecycle event for a
-// verify task. Outcome is "verified" when verification passed (no error) and "resend_needed" when
-// the task requested a state resend; any other error is reported with its message. ms may be nil
+// verify task. Outcome is "verified" for a no-op success, "backfilled" after repairing history,
+// "resend_needed" when requesting state resend, or "error". ms may be nil
 // (e.g. the workflow was not found) in which case only identity fields are populated.
 func (e *ExecutableVerifyVersionedTransitionTask) emitReplicationVerifyApplied(
 	ms *persistencespb.WorkflowMutableState,
 	retErr error,
+	backfillDetails map[string]any,
 ) {
 	shardContext, err := e.ShardController.GetShardByNamespaceWorkflow(namespace.ID(e.NamespaceID), e.WorkflowID)
 	if err != nil {
@@ -548,6 +549,8 @@ func (e *ExecutableVerifyVersionedTransitionTask) emitReplicationVerifyApplied(
 			outcome = "error"
 			errStr = retErr.Error()
 		}
+	} else if backfillDetails != nil {
+		outcome = "backfilled"
 	}
 
 	var nsName string
@@ -568,6 +571,7 @@ func (e *ExecutableVerifyVersionedTransitionTask) emitReplicationVerifyApplied(
 		SourceCluster: e.SourceClusterName(),
 		SourceShard:   e.SourceShardKey().ShardID,
 		SourceTaskID:  e.TaskID(),
+		NewRunID:      e.taskAttr.GetNewRunId(),
 	}
 	if vt := e.ReplicationTask().GetVersionedTransition(); vt != nil {
 		payload.FailoverVersion = vt.GetNamespaceFailoverVersion()
@@ -582,6 +586,7 @@ func (e *ExecutableVerifyVersionedTransitionTask) emitReplicationVerifyApplied(
 	if ms != nil {
 		details["actual"] = actualState(ms)
 	}
+	maps.Copy(details, backfillDetails)
 	payload.Details = details
 
 	wideevents.Emit(logger, payload)


### PR DESCRIPTION
## Summary

- capture post-transaction mutable state for fresh `NotFound` snapshots and `IsFirstSync` creation
- report successful verify history repairs as `outcome=backfilled`
- include the repaired event range and `new_run_id` in the verify applied event
- add regression coverage for fresh zombie applies and non-current-branch backfills

## Testing

- `go test ./service/history/ndc ./service/history/replication ./common/wideevents -count=1`