### PR TITLE
Release functional test cleanup references

### DIFF
--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -750,15 +750,18 @@ func (s *FunctionalTestBase) RegisterTest(t testlogger.CleanupCapableT) {
 		s.t.addTest(t)
 	}
 
+	base := s
 	t.Cleanup(func() {
-		if tl, ok := s.Logger.(*testlogger.TestLogger); ok {
+		// testing.T retains executed cleanup slots, so release the captured base explicitly.
+		defer func() { base = nil }()
+		if tl, ok := base.Logger.(*testlogger.TestLogger); ok {
 			if f := tl.Failure(); f != nil {
 				t.Errorf("cluster poisoned by %s log: %s", f.Level, f.Msg)
 			}
 		}
-		wasLast := s.t != nil && s.t.removeTest(t)
-		if wasLast && s.Poisoned() {
-			if err := s.tearDownTestCluster(); err != nil {
+		wasLast := base.t != nil && base.t.removeTest(t)
+		if wasLast && base.Poisoned() {
+			if err := base.tearDownTestCluster(); err != nil {
 				t.Logf("Failed to tear down poisoned cluster: %v", err)
 			}
 		}

--- a/tests/testcore/test_cluster_pool.go
+++ b/tests/testcore/test_cluster_pool.go
@@ -344,6 +344,7 @@ func (p *clusterRouter) getDedicated(t *testing.T, req clusterRequest) *Function
 
 		// Register cleanup to tear down the cluster when the test completes.
 		t.Cleanup(func() {
+			defer func() { cluster = nil }()
 			if err := cluster.tearDownTestCluster(); err != nil {
 				t.Logf("Failed to tear down cluster: %v", err)
 			}


### PR DESCRIPTION
## What changed?

Release the `FunctionalTestBase` captured by registered-test and dedicated-cluster cleanup callbacks after those callbacks run.

## Why?

Go retains executed cleanup slots in the cleanup slice backing array. Those callbacks otherwise keep the functional test base and its logger reachable after cleanup, causing the object leak test to fail.
