### PR TITLE
Emit namespace migration workflow lifecycle events

### DIFF
--- a/common/wideevents/namespace_lifecycle_events.go
+++ b/common/wideevents/namespace_lifecycle_events.go
@@ -19,6 +19,69 @@ const (
 	PhaseHandoverIncomplete       = "shard_handover_incomplete"
 )
 
+// Namespace migration system workflow lifecycle phases.
+const (
+	PhaseNamespaceHandoverStarted          = "namespace_handover_started"
+	PhaseNamespaceHandoverFinished         = "namespace_handover_finished"
+	PhaseNamespaceForceReplicationStarted  = "namespace_force_replication_started"
+	PhaseNamespaceForceReplicationFinished = "namespace_force_replication_finished"
+	PhaseNamespaceCatchupStarted           = "namespace_catchup_started"
+	PhaseNamespaceCatchupFinished          = "namespace_catchup_finished"
+)
+
+// Namespace migration system workflow terminal statuses.
+const (
+	NamespaceMigrationWorkflowSucceeded = "succeeded"
+	NamespaceMigrationWorkflowCanceled  = "canceled"
+	NamespaceMigrationWorkflowFailed    = "failed"
+)
+
+// NamespaceMigrationWorkflowLifecycleInput describes one namespace migration system workflow
+// starting or finishing. Input contains only the operation parameters useful for tracing.
+type NamespaceMigrationWorkflowLifecycleInput struct {
+	Phase                 string
+	Namespace             string
+	NamespaceID           string
+	WorkflowType          string
+	WorkflowID            string
+	RunID                 string
+	FirstRunID            string
+	Input                 map[string]any
+	Status                string
+	ErrorMessage          string
+	VerifiedWorkflowCount *int64
+}
+
+// EmitNamespaceMigrationWorkflowLifecycle emits a system workflow lifecycle event.
+func EmitNamespaceMigrationWorkflowLifecycle(
+	logger otellog.Logger,
+	in NamespaceMigrationWorkflowLifecycleInput,
+) {
+	details := map[string]any{
+		"workflow_type": in.WorkflowType,
+		"workflow_id":   in.WorkflowID,
+		"run_id":        in.RunID,
+		"first_run_id":  in.FirstRunID,
+		"input":         in.Input,
+	}
+	if in.Status != "" {
+		details["status"] = in.Status
+	}
+	if in.ErrorMessage != "" {
+		details["error_message"] = in.ErrorMessage
+	}
+	if in.VerifiedWorkflowCount != nil {
+		details["verified_workflow_count"] = *in.VerifiedWorkflowCount
+	}
+
+	Emit(logger, NamespaceLifecyclePayload{
+		Phase:       in.Phase,
+		Namespace:   in.Namespace,
+		NamespaceID: in.NamespaceID,
+		Details:     details,
+	})
+}
+
 // Why a shard took or advanced its watermark.
 const (
 	// WatermarkAdded: the namespace entered handover.

--- a/common/wideevents/namespace_lifecycle_events_test.go
+++ b/common/wideevents/namespace_lifecycle_events_test.go
@@ -145,6 +145,32 @@ func TestEmitHandoverWatermarkEvents(t *testing.T) {
 	require.Equal(t, true, lagDetails(t, lg.records[1])["deleted_from_db"])
 }
 
+func TestEmitNamespaceMigrationWorkflowLifecycle(t *testing.T) {
+	lg := &captureLogger{}
+	verifiedCount := int64(42)
+
+	EmitNamespaceMigrationWorkflowLifecycle(lg, NamespaceMigrationWorkflowLifecycleInput{
+		Phase:                 PhaseNamespaceForceReplicationFinished,
+		Namespace:             "ns",
+		NamespaceID:           "ns-id",
+		WorkflowType:          "force-replication-v2",
+		WorkflowID:            "workflow-id",
+		RunID:                 "run-id",
+		FirstRunID:            "first-run-id",
+		Input:                 map[string]any{"target_cluster": "target"},
+		Status:                NamespaceMigrationWorkflowSucceeded,
+		VerifiedWorkflowCount: &verifiedCount,
+	})
+
+	require.Len(t, lg.records, 1)
+	require.Equal(t, PhaseNamespaceForceReplicationFinished, attrValue(lg.records[0], "phase"))
+	require.Equal(t, "ns-id", attrValue(lg.records[0], "namespace_id"))
+	details := lagDetails(t, lg.records[0])
+	require.Equal(t, "force-replication-v2", details["workflow_type"])
+	require.Equal(t, NamespaceMigrationWorkflowSucceeded, details["status"])
+	require.EqualValues(t, verifiedCount, details["verified_workflow_count"])
+}
+
 func TestEmitNamespaceRegistered(t *testing.T) {
 	lg := &captureLogger{}
 

--- a/service/worker/migration/catchup_workflow.go
+++ b/service/worker/migration/catchup_workflow.go
@@ -5,6 +5,7 @@ import (
 
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
+	"go.temporal.io/server/common/wideevents"
 )
 
 const (
@@ -21,9 +22,23 @@ type (
 	CatchUpOutput struct{}
 )
 
-func CatchupWorkflow(ctx workflow.Context, params CatchUpParams) (CatchUpOutput, error) {
+func CatchupWorkflow(ctx workflow.Context, params CatchUpParams) (_ CatchUpOutput, retErr error) {
 	if err := validateCatchupParams(&params); err != nil {
 		return CatchUpOutput{}, err
+	}
+	if workflow.GetVersion(ctx, migrationWorkflowLifecycleVersion, workflow.DefaultVersion, 1) > workflow.DefaultVersion {
+		lifecycle := newMigrationWorkflowLifecycle(
+			ctx,
+			params.Namespace,
+			wideevents.PhaseNamespaceCatchupStarted,
+			wideevents.PhaseNamespaceCatchupFinished,
+			map[string]any{
+				"catchup_cluster": params.CatchupCluster,
+				"target_cluster":  params.TargetCluster,
+			},
+		)
+		defer func() { lifecycle.emitFinished(ctx, retErr, nil) }()
+		lifecycle.emitStarted(ctx)
 	}
 
 	retryPolicy := &temporal.RetryPolicy{
@@ -39,12 +54,12 @@ func CatchupWorkflow(ctx workflow.Context, params CatchUpParams) (CatchUpOutput,
 	ctx1 := workflow.WithActivityOptions(ctx, ao)
 
 	var a *activities
-	err := workflow.ExecuteActivity(ctx1, a.WaitCatchup, params).Get(ctx, nil)
-	if err != nil {
-		return CatchUpOutput{}, err
+	retErr = workflow.ExecuteActivity(ctx1, a.WaitCatchup, params).Get(ctx, nil)
+	if retErr != nil {
+		return CatchUpOutput{}, retErr
 	}
 
-	return CatchUpOutput{}, err
+	return CatchUpOutput{}, nil
 }
 
 func validateCatchupParams(params *CatchUpParams) error {

--- a/service/worker/migration/catchup_workflow_test.go
+++ b/service/worker/migration/catchup_workflow_test.go
@@ -6,12 +6,22 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+	"go.temporal.io/server/common/wideevents"
 )
 
 func TestCatchupWorkflow(t *testing.T) {
 	testSuite := &testsuite.WorkflowTestSuite{}
 	env := testSuite.NewTestWorkflowEnvironment()
 	var a *activities
+	var lifecycleEvents []wideevents.NamespaceMigrationWorkflowLifecycleInput
+	env.OnGetVersion(migrationWorkflowLifecycleVersion, workflow.DefaultVersion, 1).Return(workflow.Version(1))
+	env.OnActivity(a.EmitNamespaceMigrationWorkflowLifecycle, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			lifecycleEvents = append(lifecycleEvents, args.Get(1).(wideevents.NamespaceMigrationWorkflowLifecycleInput))
+		}).
+		Return(nil).
+		Twice()
 
 	env.OnActivity(a.WaitCatchup, mock.Anything, mock.Anything).Return(nil)
 
@@ -22,5 +32,9 @@ func TestCatchupWorkflow(t *testing.T) {
 
 	require.True(t, env.IsWorkflowCompleted())
 	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, []string{
+		wideevents.PhaseNamespaceCatchupStarted,
+		wideevents.PhaseNamespaceCatchupFinished,
+	}, []string{lifecycleEvents[0].Phase, lifecycleEvents[1].Phase})
 	env.AssertExpectations(t)
 }

--- a/service/worker/migration/force_replication_workflow.go
+++ b/service/worker/migration/force_replication_workflow.go
@@ -9,6 +9,7 @@ import (
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/wideevents"
 )
 
 type (
@@ -116,7 +117,7 @@ const (
 	defaultVerifyIntervalInSeconds                 = 5
 )
 
-func ForceReplicationWorkflow(ctx workflow.Context, params ForceReplicationParams) error {
+func ForceReplicationWorkflow(ctx workflow.Context, params ForceReplicationParams) (retErr error) {
 	// For now, we'll return the initial page token for simplicity.
 	// If we want this to be more precise, we could track processed pages.
 	startPageToken := params.NextPageToken
@@ -137,6 +138,8 @@ func ForceReplicationWorkflow(ctx workflow.Context, params ForceReplicationParam
 	if err := validateAndSetForceReplicationParams(ctx, &params); err != nil {
 		return err
 	}
+	finishLifecycle := startForceReplicationWorkflowLifecycle(ctx, params)
+	defer func() { finishLifecycle(retErr, verifiedWorkflowCountForEvent(params)) }()
 
 	if params.TotalForceReplicateWorkflowCount == 0 {
 		wfCount, err := countWorkflowForReplication(ctx, params)
@@ -199,7 +202,7 @@ func ForceReplicationWorkflow(ctx workflow.Context, params ForceReplicationParam
 	return workflow.NewContinueAsNewError(ctx, ForceReplicationWorkflow, params)
 }
 
-func ForceReplicationWorkflowV2(ctx workflow.Context, params ForceReplicationParams) error {
+func ForceReplicationWorkflowV2(ctx workflow.Context, params ForceReplicationParams) (retErr error) {
 	// For now, we'll return the initial page token for simplicity.
 	// If we want this to be more precise, we could track processed pages.
 	startPageToken := params.NextPageToken
@@ -220,6 +223,8 @@ func ForceReplicationWorkflowV2(ctx workflow.Context, params ForceReplicationPar
 	if err := validateAndSetForceReplicationParams(ctx, &params); err != nil {
 		return err
 	}
+	finishLifecycle := startForceReplicationWorkflowLifecycle(ctx, params)
+	defer func() { finishLifecycle(retErr, verifiedWorkflowCountForEvent(params)) }()
 
 	if params.TotalForceReplicateWorkflowCount == 0 {
 		wfCount, err := countWorkflowForReplication(ctx, params)
@@ -275,6 +280,48 @@ func ForceReplicationWorkflowV2(ctx workflow.Context, params ForceReplicationPar
 
 	params.ContinuedAsNewCount++
 	return workflow.NewContinueAsNewError(ctx, ForceReplicationWorkflowV2, params)
+}
+
+func newForceReplicationWorkflowLifecycle(
+	ctx workflow.Context,
+	params ForceReplicationParams,
+) migrationWorkflowLifecycle {
+	return newMigrationWorkflowLifecycle(
+		ctx,
+		params.Namespace,
+		wideevents.PhaseNamespaceForceReplicationStarted,
+		wideevents.PhaseNamespaceForceReplicationFinished,
+		map[string]any{
+			"query":                     params.Query,
+			"target_cluster":            params.TargetClusterName,
+			"verification_enabled":      params.EnableVerification,
+			"concurrent_activity_count": params.ConcurrentActivityCount,
+			"overall_rps":               params.OverallRps,
+		},
+	)
+}
+
+func startForceReplicationWorkflowLifecycle(
+	ctx workflow.Context,
+	params ForceReplicationParams,
+) func(error, *int64) {
+	if workflow.GetVersion(ctx, migrationWorkflowLifecycleVersion, workflow.DefaultVersion, 1) == workflow.DefaultVersion {
+		return func(error, *int64) {}
+	}
+	lifecycle := newForceReplicationWorkflowLifecycle(ctx, params)
+	if lifecycle.isFirstRun() {
+		lifecycle.emitStarted(ctx)
+	}
+	return func(err error, verifiedWorkflowCount *int64) {
+		lifecycle.emitFinished(ctx, err, verifiedWorkflowCount)
+	}
+}
+
+func verifiedWorkflowCountForEvent(params ForceReplicationParams) *int64 {
+	if !params.EnableVerification {
+		return nil
+	}
+	return &params.ReplicatedWorkflowCount
 }
 
 func maybeKickoffTaskQueueUserDataReplication(ctx workflow.Context, params ForceReplicationParams, onDone func(failureReason string)) error {

--- a/service/worker/migration/force_replication_workflow_test.go
+++ b/service/worker/migration/force_replication_workflow_test.go
@@ -26,6 +26,7 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/testing/mockapi/workflowservicemock/v1"
+	"go.temporal.io/server/common/wideevents"
 	"go.uber.org/mock/gomock"
 )
 
@@ -67,7 +68,15 @@ func (s *ForceReplicationWorkflowTestSuite) TestForceReplicationWorkflow() {
 	namespaceID := uuid.NewString()
 
 	var a *activities
-	env.OnActivity(a.CountWorkflow, mock.Anything, mock.Anything).Return(&countWorkflowResponse{WorkflowCount: 4}, nil)
+	var lifecycleEvents []wideevents.NamespaceMigrationWorkflowLifecycleInput
+	env.OnGetVersion(migrationWorkflowLifecycleVersion, workflow.DefaultVersion, 1).Return(workflow.Version(1))
+	env.OnActivity(a.EmitNamespaceMigrationWorkflowLifecycle, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			lifecycleEvents = append(lifecycleEvents, args.Get(1).(wideevents.NamespaceMigrationWorkflowLifecycleInput))
+		}).
+		Return(nil).
+		Twice()
+	env.OnActivity(a.CountWorkflow, mock.Anything, mock.Anything).Return(&countWorkflowResponse{WorkflowCount: 10}, nil)
 	env.OnActivity(a.GetMetadata, mock.Anything, MetadataRequest{Namespace: "test-ns"}).Return(&MetadataResponse{ShardCount: 4, NamespaceID: namespaceID}, nil)
 
 	totalPageCount := 4
@@ -109,6 +118,7 @@ func (s *ForceReplicationWorkflowTestSuite) TestForceReplicationWorkflow() {
 		PageCountPerExecution:   4,
 		EnableVerification:      true,
 		TargetClusterEndpoint:   "test-target",
+		ReplicatedWorkflowCount: 6,
 	})
 
 	s.True(env.IsWorkflowCompleted())
@@ -126,9 +136,14 @@ func (s *ForceReplicationWorkflowTestSuite) TestForceReplicationWorkflow() {
 	s.Equal(closeTime, status.LastCloseTime)
 	s.True(status.TaskQueueUserDataReplicationStatus.Done)
 	s.Equal("", status.TaskQueueUserDataReplicationStatus.FailureMessage)
-	s.Equal(int64(4), status.TotalWorkflowCount)
-	s.Equal(int64(4), status.ReplicatedWorkflowCount)
+	s.Equal(int64(10), status.TotalWorkflowCount)
+	s.Equal(int64(10), status.ReplicatedWorkflowCount)
 	s.Equal([]byte(nil), status.PageTokenForRestart)
+	s.Equal(wideevents.PhaseNamespaceForceReplicationStarted, lifecycleEvents[0].Phase)
+	s.Equal(wideevents.PhaseNamespaceForceReplicationFinished, lifecycleEvents[1].Phase)
+	s.Equal(wideevents.NamespaceMigrationWorkflowSucceeded, lifecycleEvents[1].Status)
+	s.Require().NotNil(lifecycleEvents[1].VerifiedWorkflowCount)
+	s.Equal(int64(10), *lifecycleEvents[1].VerifiedWorkflowCount)
 }
 
 func (s *ForceReplicationWorkflowTestSuite) TestContinueAsNew() {
@@ -184,7 +199,7 @@ func (s *ForceReplicationWorkflowTestSuite) TestContinueAsNew() {
 	expectContinueAsNew := true
 
 	// Run the workflow once. We should get a continue as new error.
-	continueAsNewInput, queryStatus := s.testRunForceReplicationForContinueAsNew(
+	continueAsNewInput, queryStatus, lifecycleEvents := s.testRunForceReplicationForContinueAsNew(
 		mockListWorkflows,
 		ForceReplicationParams{
 			Namespace:               "test-ns",
@@ -232,6 +247,8 @@ func (s *ForceReplicationWorkflowTestSuite) TestContinueAsNew() {
 	s.Equal(startTime, queryStatus.LastStartTime)
 	s.Equal(1, queryStatus.ContinuedAsNewCount)
 	s.Equal([]byte("fake-initial-page-token"), queryStatus.PageTokenForRestart)
+	s.Require().Len(lifecycleEvents, 1)
+	s.Equal(wideevents.PhaseNamespaceForceReplicationStarted, lifecycleEvents[0].Phase)
 }
 
 func (s *ForceReplicationWorkflowTestSuite) testRunForceReplicationForContinueAsNew(
@@ -239,13 +256,21 @@ func (s *ForceReplicationWorkflowTestSuite) testRunForceReplicationForContinueAs
 	input ForceReplicationParams,
 	expectContinueAsNew bool,
 	expMaxPageCountPerExecution int,
-) (*ForceReplicationParams, ForceReplicationStatus) {
+) (*ForceReplicationParams, ForceReplicationStatus, []wideevents.NamespaceMigrationWorkflowLifecycleInput) {
 	testSuite := &testsuite.WorkflowTestSuite{}
 	env := testSuite.NewTestWorkflowEnvironment()
 	env.RegisterWorkflowWithOptions(ForceTaskQueueUserDataReplicationWorkflow, workflow.RegisterOptions{Name: forceTaskQueueUserDataReplicationWorkflow})
 	namespaceID := uuid.NewString()
 
 	var a *activities
+	var lifecycleEvents []wideevents.NamespaceMigrationWorkflowLifecycleInput
+	env.OnGetVersion(migrationWorkflowLifecycleVersion, workflow.DefaultVersion, 1).Return(workflow.Version(1))
+	env.OnActivity(a.EmitNamespaceMigrationWorkflowLifecycle, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			lifecycleEvents = append(lifecycleEvents, args.Get(1).(wideevents.NamespaceMigrationWorkflowLifecycleInput))
+		}).
+		Return(nil).
+		Once()
 	if input.TotalForceReplicateWorkflowCount == 0 {
 		env.OnActivity(a.CountWorkflow, mock.Anything, mock.Anything).Return(&countWorkflowResponse{WorkflowCount: 10}, nil)
 	}
@@ -284,7 +309,7 @@ func (s *ForceReplicationWorkflowTestSuite) testRunForceReplicationForContinueAs
 	var status ForceReplicationStatus
 	s.NoError(envValue.Get(&status))
 
-	return continueAsNewParams, status
+	return continueAsNewParams, status, lifecycleEvents
 }
 
 func (s *ForceReplicationWorkflowTestSuite) TestInvalidInput() {

--- a/service/worker/migration/handover_workflow.go
+++ b/service/worker/migration/handover_workflow.go
@@ -6,6 +6,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
+	"go.temporal.io/server/common/wideevents"
 )
 
 const (
@@ -62,6 +63,22 @@ func NamespaceHandoverWorkflowV2(ctx workflow.Context, params NamespaceHandoverP
 func NamespaceHandoverWorkflow(ctx workflow.Context, params NamespaceHandoverParams) (retErr error) {
 	if err := validateAndSetNamespaceHandoverParams(&params); err != nil {
 		return err
+	}
+	if workflow.GetVersion(ctx, migrationWorkflowLifecycleVersion, workflow.DefaultVersion, 1) > workflow.DefaultVersion {
+		lifecycle := newMigrationWorkflowLifecycle(
+			ctx,
+			params.Namespace,
+			wideevents.PhaseNamespaceHandoverStarted,
+			wideevents.PhaseNamespaceHandoverFinished,
+			map[string]any{
+				"remote_cluster":           params.RemoteCluster,
+				"allowed_lagging_seconds":  params.AllowedLaggingSeconds,
+				"allowed_lagging_tasks":    params.AllowedLaggingTasks,
+				"handover_timeout_seconds": params.HandoverTimeoutSeconds,
+			},
+		)
+		defer func() { lifecycle.emitFinished(ctx, retErr, nil) }()
+		lifecycle.emitStarted(ctx)
 	}
 	retryPolicy := &temporal.RetryPolicy{
 		InitialInterval:    time.Second,

--- a/service/worker/migration/handover_workflow_test.go
+++ b/service/worker/migration/handover_workflow_test.go
@@ -11,12 +11,22 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+	"go.temporal.io/server/common/wideevents"
 )
 
 func TestHandoverWorkflow(t *testing.T) {
 	testSuite := &testsuite.WorkflowTestSuite{}
 	env := testSuite.NewTestWorkflowEnvironment()
 	var a *activities
+	var lifecycleEvents []wideevents.NamespaceMigrationWorkflowLifecycleInput
+	env.OnGetVersion(migrationWorkflowLifecycleVersion, workflow.DefaultVersion, 1).Return(workflow.Version(1))
+	env.OnActivity(a.EmitNamespaceMigrationWorkflowLifecycle, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			lifecycleEvents = append(lifecycleEvents, args.Get(1).(wideevents.NamespaceMigrationWorkflowLifecycleInput))
+		}).
+		Return(nil).
+		Twice()
 
 	namespaceID := uuid.NewString()
 
@@ -47,6 +57,11 @@ func TestHandoverWorkflow(t *testing.T) {
 
 	require.True(t, env.IsWorkflowCompleted())
 	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, []string{
+		wideevents.PhaseNamespaceHandoverStarted,
+		wideevents.PhaseNamespaceHandoverFinished,
+	}, []string{lifecycleEvents[0].Phase, lifecycleEvents[1].Phase})
+	require.Equal(t, wideevents.NamespaceMigrationWorkflowSucceeded, lifecycleEvents[1].Status)
 	env.AssertExpectations(t)
 }
 
@@ -56,6 +71,14 @@ func TestHandoverWorkflow_CancelAfterHandoverState_ResetsToNormal(t *testing.T) 
 	testSuite := &testsuite.WorkflowTestSuite{}
 	env := testSuite.NewTestWorkflowEnvironment()
 	var a *activities
+	var lifecycleEvents []wideevents.NamespaceMigrationWorkflowLifecycleInput
+	env.OnGetVersion(migrationWorkflowLifecycleVersion, workflow.DefaultVersion, 1).Return(workflow.Version(1))
+	env.OnActivity(a.EmitNamespaceMigrationWorkflowLifecycle, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			lifecycleEvents = append(lifecycleEvents, args.Get(1).(wideevents.NamespaceMigrationWorkflowLifecycleInput))
+		}).
+		Return(nil).
+		Twice()
 
 	namespaceID := uuid.NewString()
 
@@ -96,6 +119,7 @@ func TestHandoverWorkflow_CancelAfterHandoverState_ResetsToNormal(t *testing.T) 
 		stateUpdates,
 		"defer must reset state to NORMAL after cancel",
 	)
+	require.Equal(t, wideevents.NamespaceMigrationWorkflowCanceled, lifecycleEvents[1].Status)
 }
 
 func TestHandoverWorkflow_SetTimeout(t *testing.T) {

--- a/service/worker/migration/workflow_lifecycle_events.go
+++ b/service/worker/migration/workflow_lifecycle_events.go
@@ -1,0 +1,128 @@
+package migration
+
+import (
+	"context"
+	"time"
+
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+	"go.temporal.io/server/common/wideevents"
+)
+
+const (
+	migrationWorkflowLifecycleVersion = "migration-workflow-lifecycle-events-20260819"
+	maxWorkflowLifecycleErrorLength   = 2048
+)
+
+type migrationWorkflowLifecycle struct {
+	namespace     string
+	startedPhase  string
+	finishedPhase string
+	workflowType  string
+	workflowID    string
+	runID         string
+	firstRunID    string
+	input         map[string]any
+}
+
+func newMigrationWorkflowLifecycle(
+	ctx workflow.Context,
+	namespace string,
+	startedPhase string,
+	finishedPhase string,
+	input map[string]any,
+) migrationWorkflowLifecycle {
+	info := workflow.GetInfo(ctx)
+	firstRunID := info.FirstRunID
+	if firstRunID == "" {
+		firstRunID = info.WorkflowExecution.RunID
+	}
+	return migrationWorkflowLifecycle{
+		namespace:     namespace,
+		startedPhase:  startedPhase,
+		finishedPhase: finishedPhase,
+		workflowType:  info.WorkflowType.Name,
+		workflowID:    info.WorkflowExecution.ID,
+		runID:         info.WorkflowExecution.RunID,
+		firstRunID:    firstRunID,
+		input:         input,
+	}
+}
+
+func (l migrationWorkflowLifecycle) isFirstRun() bool {
+	return l.runID == l.firstRunID
+}
+
+func (l migrationWorkflowLifecycle) emitStarted(ctx workflow.Context) {
+	l.emit(ctx, l.startedPhase, "", "", nil)
+}
+
+func (l migrationWorkflowLifecycle) emitFinished(
+	ctx workflow.Context,
+	err error,
+	verifiedWorkflowCount *int64,
+) {
+	if workflow.IsContinueAsNewError(err) {
+		return
+	}
+
+	status := wideevents.NamespaceMigrationWorkflowSucceeded
+	errorMessage := ""
+	if err != nil {
+		status = wideevents.NamespaceMigrationWorkflowFailed
+		if temporal.IsCanceledError(err) {
+			status = wideevents.NamespaceMigrationWorkflowCanceled
+		}
+		errorMessage = err.Error()
+		if len(errorMessage) > maxWorkflowLifecycleErrorLength {
+			errorMessage = errorMessage[:maxWorkflowLifecycleErrorLength]
+		}
+	}
+
+	disconnectedCtx, cancel := workflow.NewDisconnectedContext(ctx)
+	defer cancel()
+	l.emit(disconnectedCtx, l.finishedPhase, status, errorMessage, verifiedWorkflowCount)
+}
+
+func (l migrationWorkflowLifecycle) emit(
+	ctx workflow.Context,
+	phase string,
+	status string,
+	errorMessage string,
+	verifiedWorkflowCount *int64,
+) {
+	activityCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: 10 * time.Second,
+		RetryPolicy:         &temporal.RetryPolicy{MaximumAttempts: 1},
+	})
+	var a *activities
+	err := workflow.ExecuteActivity(activityCtx, a.EmitNamespaceMigrationWorkflowLifecycle,
+		wideevents.NamespaceMigrationWorkflowLifecycleInput{
+			Phase:                 phase,
+			Namespace:             l.namespace,
+			WorkflowType:          l.workflowType,
+			WorkflowID:            l.workflowID,
+			RunID:                 l.runID,
+			FirstRunID:            l.firstRunID,
+			Input:                 l.input,
+			Status:                status,
+			ErrorMessage:          errorMessage,
+			VerifiedWorkflowCount: verifiedWorkflowCount,
+		},
+	).Get(ctx, nil)
+	if err != nil {
+		workflow.GetLogger(ctx).Warn("Failed to emit namespace migration workflow lifecycle event", "error", err)
+	}
+}
+
+func (a *activities) EmitNamespaceMigrationWorkflowLifecycle(
+	_ context.Context,
+	in wideevents.NamespaceMigrationWorkflowLifecycleInput,
+) error {
+	if a.emitNamespaceLifecycleEvents == nil || !a.emitNamespaceLifecycleEvents() {
+		return nil
+	}
+	in.NamespaceID = a.namespaceIDForEvent(in.Namespace)
+	wideevents.EmitNamespaceMigrationWorkflowLifecycle(a.EventLogger, in)
+	return nil
+}


### PR DESCRIPTION
## What changed?
Adds `namespace_lifecycle` start and finish events for the namespace handover, force replication, and catchup system workflows.

The events carry workflow identity and the core operation inputs. Finished events classify the result as succeeded, canceled, or failed. Force replication reports its cumulative verified workflow count and emits only one start and one finish across a continue-as-new chain.

Emission uses one shared activity, the existing `system.emitNamespaceLifecycleEvents` gate, disconnected cleanup for cancellation, and workflow versioning for replay compatibility. Existing shard handover events are unchanged.

## Why?
These system workflows currently have no consistent operation-level event pair, which makes it difficult to correlate a namespace migration request with its final outcome.

## How did you test it?
- [x] covered by existing tests
- [x] added new unit test(s)

`go test -tags test_dep ./common/wideevents ./service/worker/migration`

`make fmt-imports`

`make lint-code` reports no issues introduced by this change; the repository-wide target still reports existing findings on current `main`.

## Potential risks
The terminal event is best effort and cannot run after server-side workflow termination or workflow run timeout because those outcomes do not execute workflow cleanup.