### PR TITLE
Log outbound queue circuit breaker state changes

### DIFF
--- a/chasm/lib/callback/invocable_outbound.go
+++ b/chasm/lib/callback/invocable_outbound.go
@@ -46,7 +46,7 @@ func (n invocableOutbound) Invoke(
 		traceLogger := log.With(h.logger,
 			tag.WorkflowNamespace(ns.Name().String()),
 			tag.Operation("CompleteNexusOperation"),
-			tag.String("destination", taskAttr.Destination),
+			tag.Destination(taskAttr.Destination),
 			tag.WorkflowID(n.workflowID),
 			tag.WorkflowRunID(n.runID),
 			tag.AttemptStart(time.Now().UTC()),

--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -989,6 +989,12 @@ func Endpoint(endpoint string) ZapTag {
 	return NewStringTag("endpoint", endpoint)
 }
 
+// Destination returns a tag for an outbound task's destination, matching the key used by
+// metrics.DestinationTag.
+func Destination(destination string) ZapTag {
+	return NewStringTag("destination", destination)
+}
+
 func BuildId(buildId string) ZapTag {
 	return NewStringTag("build-id", buildId)
 }

--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -989,8 +989,7 @@ func Endpoint(endpoint string) ZapTag {
 	return NewStringTag("endpoint", endpoint)
 }
 
-// Destination returns a tag for an outbound task's destination, matching the key used by
-// metrics.DestinationTag.
+// Destination returns a tag for an outbound task's destination.
 func Destination(destination string) ZapTag {
 	return NewStringTag("destination", destination)
 }

--- a/components/callbacks/nexus_invocation.go
+++ b/components/callbacks/nexus_invocation.go
@@ -47,7 +47,7 @@ func (n nexusInvocation) Invoke(ctx context.Context, ns *namespace.Namespace, e 
 		traceLogger := log.With(e.Logger,
 			tag.WorkflowNamespace(ns.Name().String()),
 			tag.Operation("CompleteNexusOperation"),
-			tag.String("destination", task.destination),
+			tag.Destination(task.destination),
 			tag.WorkflowID(n.workflowID),
 			tag.WorkflowRunID(n.runID),
 			tag.AttemptStart(time.Now().UTC()),

--- a/service/history/circuitbreakerpool/fx.go
+++ b/service/history/circuitbreakerpool/fx.go
@@ -56,18 +56,10 @@ func OutboundQueueCircuitBreakerPoolProvider(
 	}
 }
 
-// onStateChange returns the gobreaker state-change hook that logs the transition. Without it an
-// opening breaker is invisible: the blocked tasks are counted by circuit_breaker_executable_blocked,
-// but nothing says when the breaker opened, for which destination, or when it recovered.
-//
-// This logs rather than emitting a metric because destination is unbounded for callback targets
-// (customer-controlled URLs), so a metric keyed on it would be a high-cardinality addition.
-//
-// gobreaker invokes this hook while holding its internal mutex, so it must stay cheap. Transitions
-// are bounded by the breaker's own Interval/Timeout settings, not by request volume.
-//
-// Note that TwoStepCircuitBreakerWithDynamicSettings replaces the underlying gobreaker instance when
-// its dynamic config changes, which resets state without a transition being observed here.
+// onStateChange logs breaker transitions, which are otherwise invisible: blocked tasks are counted
+// by circuit_breaker_executable_blocked, but nothing records when a breaker opened or recovered.
+// Logged rather than emitted as a metric because destination is unbounded for callback targets.
+// gobreaker calls this under its own mutex, so it must stay cheap.
 func onStateChange(
 	key tasks.TaskGroupNamespaceIDAndDestination,
 	nsName string,

--- a/service/history/circuitbreakerpool/fx.go
+++ b/service/history/circuitbreakerpool/fx.go
@@ -3,7 +3,10 @@ package circuitbreakerpool
 import (
 	"fmt"
 
+	"github.com/sony/gobreaker"
 	"go.temporal.io/server/common/circuitbreaker"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/tasks"
@@ -21,6 +24,7 @@ type OutboundQueueCircuitBreakerPool struct {
 func OutboundQueueCircuitBreakerPoolProvider(
 	namespaceRegistry namespace.Registry,
 	config *configs.Config,
+	logger log.Logger,
 ) *OutboundQueueCircuitBreakerPool {
 	return &OutboundQueueCircuitBreakerPool{
 		CircuitBreakerPool: NewCircuitBreakerPool(
@@ -37,6 +41,7 @@ func OutboundQueueCircuitBreakerPoolProvider(
 						key.NamespaceID,
 						key.Destination,
 					),
+					OnStateChange: onStateChange(key, nsName.String(), logger),
 				})
 				initial, cancel := config.OutboundQueueCircuitBreakerSettings(
 					nsName.String(),
@@ -48,5 +53,35 @@ func OutboundQueueCircuitBreakerPoolProvider(
 				return cb
 			},
 		),
+	}
+}
+
+// onStateChange returns the gobreaker state-change hook that logs the transition. Without it an
+// opening breaker is invisible: the blocked tasks are counted by circuit_breaker_executable_blocked,
+// but nothing says when the breaker opened, for which destination, or when it recovered.
+//
+// This logs rather than emitting a metric because destination is unbounded for callback targets
+// (customer-controlled URLs), so a metric keyed on it would be a high-cardinality addition.
+//
+// gobreaker invokes this hook while holding its internal mutex, so it must stay cheap. Transitions
+// are bounded by the breaker's own Interval/Timeout settings, not by request volume.
+//
+// Note that TwoStepCircuitBreakerWithDynamicSettings replaces the underlying gobreaker instance when
+// its dynamic config changes, which resets state without a transition being observed here.
+func onStateChange(
+	key tasks.TaskGroupNamespaceIDAndDestination,
+	nsName string,
+	logger log.Logger,
+) func(name string, from gobreaker.State, to gobreaker.State) {
+	return func(_ string, from gobreaker.State, to gobreaker.State) {
+		logger.Warn(
+			"outbound queue circuit breaker state change",
+			tag.WorkflowNamespace(nsName),
+			tag.WorkflowNamespaceID(key.NamespaceID),
+			tag.NewStringTag("destination", key.Destination),
+			tag.NewStringTag("task-group", key.TaskGroup),
+			tag.NewStringTag("from-state", from.String()),
+			tag.NewStringTag("to-state", to.String()),
+		)
 	}
 }

--- a/service/history/circuitbreakerpool/fx.go
+++ b/service/history/circuitbreakerpool/fx.go
@@ -56,8 +56,7 @@ func OutboundQueueCircuitBreakerPoolProvider(
 	}
 }
 
-// onStateChange logs breaker transitions. Logged rather than emitted as a metric because
-// destination is unbounded for callback targets. gobreaker calls this under its own mutex.
+// onStateChange logs breaker transitions.
 func onStateChange(
 	key tasks.TaskGroupNamespaceIDAndDestination,
 	nsName string,

--- a/service/history/circuitbreakerpool/fx.go
+++ b/service/history/circuitbreakerpool/fx.go
@@ -67,7 +67,7 @@ func onStateChange(
 			"outbound queue circuit breaker state change",
 			tag.WorkflowNamespace(nsName),
 			tag.WorkflowNamespaceID(key.NamespaceID),
-			tag.NewStringTag("destination", key.Destination),
+			tag.Destination(key.Destination),
 			tag.NewStringTag("task-group", key.TaskGroup),
 			tag.NewStringTag("from-state", from.String()),
 			tag.NewStringTag("to-state", to.String()),

--- a/service/history/circuitbreakerpool/fx.go
+++ b/service/history/circuitbreakerpool/fx.go
@@ -24,7 +24,7 @@ type OutboundQueueCircuitBreakerPool struct {
 func OutboundQueueCircuitBreakerPoolProvider(
 	namespaceRegistry namespace.Registry,
 	config *configs.Config,
-	logger log.Logger,
+	logger log.SnTaggedLogger,
 ) *OutboundQueueCircuitBreakerPool {
 	return &OutboundQueueCircuitBreakerPool{
 		CircuitBreakerPool: NewCircuitBreakerPool(
@@ -60,7 +60,7 @@ func OutboundQueueCircuitBreakerPoolProvider(
 func onStateChange(
 	key tasks.TaskGroupNamespaceIDAndDestination,
 	nsName string,
-	logger log.Logger,
+	logger log.SnTaggedLogger,
 ) func(name string, from gobreaker.State, to gobreaker.State) {
 	return func(_ string, from gobreaker.State, to gobreaker.State) {
 		logger.Warn(

--- a/service/history/circuitbreakerpool/fx.go
+++ b/service/history/circuitbreakerpool/fx.go
@@ -56,10 +56,8 @@ func OutboundQueueCircuitBreakerPoolProvider(
 	}
 }
 
-// onStateChange logs breaker transitions, which are otherwise invisible: blocked tasks are counted
-// by circuit_breaker_executable_blocked, but nothing records when a breaker opened or recovered.
-// Logged rather than emitted as a metric because destination is unbounded for callback targets.
-// gobreaker calls this under its own mutex, so it must stay cheap.
+// onStateChange logs breaker transitions. Logged rather than emitted as a metric because
+// destination is unbounded for callback targets. gobreaker calls this under its own mutex.
 func onStateChange(
 	key tasks.TaskGroupNamespaceIDAndDestination,
 	nsName string,


### PR DESCRIPTION
### What changed
Sets gobreaker's OnStateChange hook on the outbound queue circuit breaker pool, logging every transition.

### Why
Obtain more details for debugging curcuit breaker in production.

