### PR TITLE
Tag HSM outbound Nexus call failure logs

### DIFF
--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -274,6 +274,7 @@ func (e taskExecutor) executeInvocationTask(ctx context.Context, env hsm.Environ
 	logTags := outboundCallLogTags(
 		"StartOperation",
 		ns.Name().String(),
+		endpoint.GetEndpoint().GetSpec().GetTarget().GetWorker().GetNamespaceId(),
 		args.requestID,
 		args.operation,
 		args.endpointName,
@@ -733,6 +734,7 @@ func (e taskExecutor) executeCancelationTask(ctx context.Context, env hsm.Enviro
 	logTags := outboundCallLogTags(
 		"CancelOperation",
 		ns.Name().String(),
+		endpoint.GetEndpoint().GetSpec().GetTarget().GetWorker().GetNamespaceId(),
 		args.requestID,
 		args.operation,
 		args.endpointName,
@@ -957,7 +959,7 @@ func createNexusOperationFailure(operation Operation, scheduledEventID int64, ca
 
 func outboundCallLogTags(
 	method string,
-	namespaceName, requestID, operation, endpointName string,
+	namespaceName, targetNamespaceID, requestID, operation, endpointName string,
 	workflowKey definition.WorkflowKey,
 	attemptStart time.Time,
 	attempt int32,
@@ -965,6 +967,7 @@ func outboundCallLogTags(
 	return []tag.Tag{
 		tag.Operation(method),
 		tag.WorkflowNamespace(namespaceName),
+		tag.NexusEndpointTargetNamespaceID(targetNamespaceID),
 		tag.RequestID(requestID),
 		tag.NexusOperation(operation),
 		tag.Endpoint(endpointName),

--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -25,6 +25,7 @@ import (
 	"go.temporal.io/server/chasm"
 	chasmnexus "go.temporal.io/server/chasm/lib/nexusoperation"
 	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
@@ -270,6 +271,17 @@ func (e taskExecutor) executeInvocationTask(ctx context.Context, env hsm.Environ
 		Links: []nexus.Link{args.nexusLink},
 	}
 
+	logTags := outboundCallLogTags(
+		"StartOperation",
+		ns.Name().String(),
+		args.requestID,
+		args.operation,
+		args.endpointName,
+		ref.WorkflowKey,
+		time.Now().UTC(),
+		task.Attempt,
+	)
+
 	var result *nexusrpc.ClientStartOperationResponse[*commonpb.Payload]
 	var callErr error
 	var startTime time.Time
@@ -291,17 +303,7 @@ func (e taskExecutor) executeInvocationTask(ctx context.Context, env hsm.Environ
 		}
 
 		if e.HTTPTraceProvider != nil {
-			traceLogger := log.With(e.Logger,
-				tag.Operation("StartOperation"),
-				tag.WorkflowNamespace(ns.Name().String()),
-				tag.RequestID(args.requestID),
-				tag.NexusOperation(args.operation),
-				tag.Endpoint(args.endpointName),
-				tag.WorkflowID(ref.WorkflowKey.WorkflowID),
-				tag.WorkflowRunID(ref.WorkflowKey.RunID),
-				tag.AttemptStart(time.Now().UTC()),
-				tag.Attempt(task.Attempt),
-			)
+			traceLogger := log.With(e.Logger, logTags...)
 			if trace := e.HTTPTraceProvider.NewTrace(task.Attempt, traceLogger); trace != nil {
 				callCtx = httptrace.WithClientTrace(callCtx, trace)
 			}
@@ -333,13 +335,7 @@ func (e taskExecutor) executeInvocationTask(ctx context.Context, env hsm.Environ
 	chasmnexus.OutboundRequestCounter.With(e.MetricsHandler).Record(1, namespaceTag, destTag, methodTag, outcomeTag, failureSourceTag)
 	chasmnexus.OutboundRequestLatency.With(e.MetricsHandler).Record(time.Since(startTime), namespaceTag, destTag, methodTag, outcomeTag, failureSourceTag)
 
-	if callErr != nil {
-		if failureSource == commonnexus.FailureSourceWorker || errors.As(callErr, new(*operationTimeoutBelowMinError)) {
-			e.Logger.Debug("Nexus StartOperation request failed", tag.Error(callErr))
-		} else {
-			e.Logger.Error("Nexus StartOperation request failed", tag.Error(callErr))
-		}
-	}
+	e.logOutboundCallFailure("StartOperation", logTags, callErr, failureSource)
 
 	err = e.saveResult(ctx, env, ref, result, callErr)
 
@@ -734,6 +730,17 @@ func (e taskExecutor) executeCancelationTask(ctx context.Context, env hsm.Enviro
 	// Set this value on the parent context so that our custom HTTP caller can mutate it since we cannot access response headers directly.
 	callCtx = context.WithValue(callCtx, commonnexus.FailureSourceContextKey, &atomic.Value{})
 
+	logTags := outboundCallLogTags(
+		"CancelOperation",
+		ns.Name().String(),
+		args.requestID,
+		args.operation,
+		args.endpointName,
+		ref.WorkflowKey,
+		time.Now().UTC(),
+		task.Attempt,
+	)
+
 	var callErr error
 	var startTime time.Time
 	if callTimeout < e.Config.MinRequestTimeout(ns.Name().String()) {
@@ -758,17 +765,7 @@ func (e taskExecutor) executeCancelationTask(ctx context.Context, env hsm.Enviro
 		}
 
 		if e.HTTPTraceProvider != nil {
-			traceLogger := log.With(e.Logger,
-				tag.Operation("CancelOperation"),
-				tag.WorkflowNamespace(ns.Name().String()),
-				tag.RequestID(args.requestID),
-				tag.NexusOperation(args.operation),
-				tag.Endpoint(args.endpointName),
-				tag.WorkflowID(ref.WorkflowKey.WorkflowID),
-				tag.WorkflowRunID(ref.WorkflowKey.RunID),
-				tag.AttemptStart(time.Now().UTC()),
-				tag.Attempt(task.Attempt),
-			)
+			traceLogger := log.With(e.Logger, logTags...)
 			if trace := e.HTTPTraceProvider.NewTrace(task.Attempt, traceLogger); trace != nil {
 				callCtx = httptrace.WithClientTrace(callCtx, trace)
 			}
@@ -791,13 +788,7 @@ func (e taskExecutor) executeCancelationTask(ctx context.Context, env hsm.Enviro
 	chasmnexus.OutboundRequestCounter.With(e.MetricsHandler).Record(1, namespaceTag, destTag, methodTag, statusCodeTag, failureSourceTag)
 	chasmnexus.OutboundRequestLatency.With(e.MetricsHandler).Record(time.Since(startTime), namespaceTag, destTag, methodTag, statusCodeTag, failureSourceTag)
 
-	if callErr != nil {
-		if failureSource == commonnexus.FailureSourceWorker || errors.As(callErr, new(*operationTimeoutBelowMinError)) {
-			e.Logger.Debug("Nexus CancelOperation request failed", tag.Error(callErr))
-		} else {
-			e.Logger.Error("Nexus CancelOperation request failed", tag.Error(callErr))
-		}
-	}
+	e.logOutboundCallFailure("CancelOperation", logTags, callErr, failureSource)
 
 	err = e.saveCancelationResult(ctx, env, ref, callErr, args.scheduledEventID)
 
@@ -961,6 +952,46 @@ func createNexusOperationFailure(operation Operation, scheduledEventID int64, ca
 			},
 		},
 		Cause: cause,
+	}
+}
+
+// outboundCallLogTags returns the structured log tags describing an outbound Nexus call. It mirrors
+// chasm/lib/nexusoperation's invocationTraceContext.tags() so that HSM and CHASM operations are
+// searchable by the same fields during the HSM->CHASM migration; a query written against one
+// implementation's tags would otherwise silently return only that half of a namespace's traffic.
+func outboundCallLogTags(
+	method string,
+	namespaceName, requestID, operation, endpointName string,
+	workflowKey definition.WorkflowKey,
+	attemptStart time.Time,
+	attempt int32,
+) []tag.Tag {
+	return []tag.Tag{
+		tag.Operation(method),
+		tag.WorkflowNamespace(namespaceName),
+		tag.RequestID(requestID),
+		tag.NexusOperation(operation),
+		tag.Endpoint(endpointName),
+		tag.WorkflowID(workflowKey.WorkflowID),
+		tag.WorkflowRunID(workflowKey.RunID),
+		tag.AttemptStart(attemptStart),
+		tag.Attempt(attempt),
+	}
+}
+
+// logOutboundCallFailure logs a failed outbound Nexus call. Failures whose source is the customer's
+// worker are logged at debug: a Nexus operation failing is not a server error and should not clutter
+// server error logs.
+func (e taskExecutor) logOutboundCallFailure(method string, logTags []tag.Tag, callErr error, failureSource string) {
+	if callErr == nil {
+		return
+	}
+	tags := append(logTags, tag.Error(callErr)) //nolint:gocritic // intentionally does not write back to logTags
+	msg := fmt.Sprintf("Nexus %s request failed", method)
+	if failureSource == commonnexus.FailureSourceWorker || errors.As(callErr, new(*operationTimeoutBelowMinError)) {
+		e.Logger.Debug(msg, tags...)
+	} else {
+		e.Logger.Error(msg, tags...)
 	}
 }
 

--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -958,51 +958,6 @@ func createNexusOperationFailure(operation Operation, scheduledEventID int64, ca
 	}
 }
 
-// invocationTraceContext captures per-call contextual information used for HTTP tracing and failure logging.
-type invocationTraceContext struct {
-	operationTag      string // "StartOperation" or "CancelOperation"
-	namespaceName     string // source (caller) namespace
-	targetNamespaceID string
-	requestID         string
-	operation         string
-	endpointName      string
-	workflowID        string
-	runID             string
-	attemptStart      time.Time
-	attempt           int32
-}
-
-// tags returns the structured log tags describing the call.
-func (c invocationTraceContext) tags() []tag.Tag {
-	return []tag.Tag{
-		tag.Operation(c.operationTag),
-		tag.WorkflowNamespace(c.namespaceName),
-		tag.NexusEndpointTargetNamespaceID(c.targetNamespaceID),
-		tag.RequestID(c.requestID),
-		tag.NexusOperation(c.operation),
-		tag.Endpoint(c.endpointName),
-		tag.WorkflowID(c.workflowID),
-		tag.WorkflowRunID(c.runID),
-		tag.AttemptStart(c.attemptStart),
-		tag.Attempt(c.attempt),
-	}
-}
-
-// logCallFailure logs a failed outbound Nexus call.
-func (e taskExecutor) logCallFailure(traceCtx invocationTraceContext, callErr error, failureSource string) {
-	if callErr == nil {
-		return
-	}
-	tags := append(traceCtx.tags(), tag.Error(callErr))
-	msg := fmt.Sprintf("Nexus %s request failed", traceCtx.operationTag)
-	_, isTimeoutBelowMin := errors.AsType[*operationTimeoutBelowMinError](callErr)
-	if failureSource == commonnexus.FailureSourceWorker || isTimeoutBelowMin {
-		e.Logger.Debug(msg, tags...)
-	} else {
-		e.Logger.Error(msg, tags...)
-	}
-}
-
 func startCallOutcomeTag(callCtx context.Context, result *nexusrpc.ClientStartOperationResponse[*commonpb.Payload], callErr error) string {
 
 	if callErr != nil {
@@ -1062,6 +1017,51 @@ func cancelCallOutcomeTag(callCtx context.Context, callErr error) string {
 		return "unknown-error"
 	}
 	return "successful"
+}
+
+// invocationTraceContext captures per-call contextual information used for HTTP tracing and failure logging.
+type invocationTraceContext struct {
+	operationTag      string // "StartOperation" or "CancelOperation"
+	namespaceName     string // source (caller) namespace
+	targetNamespaceID string
+	requestID         string
+	operation         string
+	endpointName      string
+	workflowID        string
+	runID             string
+	attemptStart      time.Time
+	attempt           int32
+}
+
+// tags returns the structured log tags describing the call.
+func (c invocationTraceContext) tags() []tag.Tag {
+	return []tag.Tag{
+		tag.Operation(c.operationTag),
+		tag.WorkflowNamespace(c.namespaceName),
+		tag.NexusEndpointTargetNamespaceID(c.targetNamespaceID),
+		tag.RequestID(c.requestID),
+		tag.NexusOperation(c.operation),
+		tag.Endpoint(c.endpointName),
+		tag.WorkflowID(c.workflowID),
+		tag.WorkflowRunID(c.runID),
+		tag.AttemptStart(c.attemptStart),
+		tag.Attempt(c.attempt),
+	}
+}
+
+// logCallFailure logs a failed outbound Nexus call.
+func (e taskExecutor) logCallFailure(traceCtx invocationTraceContext, callErr error, failureSource string) {
+	if callErr == nil {
+		return
+	}
+	tags := append(traceCtx.tags(), tag.Error(callErr))
+	msg := fmt.Sprintf("Nexus %s request failed", traceCtx.operationTag)
+	_, isTimeoutBelowMin := errors.AsType[*operationTimeoutBelowMinError](callErr)
+	if failureSource == commonnexus.FailureSourceWorker || isTimeoutBelowMin {
+		e.Logger.Debug(msg, tags...)
+	} else {
+		e.Logger.Error(msg, tags...)
+	}
 }
 
 func isDestinationDown(err error) bool {

--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -955,8 +955,6 @@ func createNexusOperationFailure(operation Operation, scheduledEventID int64, ca
 	}
 }
 
-// outboundCallLogTags mirrors chasm/lib/nexusoperation's invocationTraceContext.tags() so one log
-// query matches both implementations during the HSM->CHASM migration.
 func outboundCallLogTags(
 	method string,
 	namespaceName, requestID, operation, endpointName string,

--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -955,10 +955,9 @@ func createNexusOperationFailure(operation Operation, scheduledEventID int64, ca
 	}
 }
 
-// outboundCallLogTags returns the structured log tags describing an outbound Nexus call. It mirrors
-// chasm/lib/nexusoperation's invocationTraceContext.tags() so that HSM and CHASM operations are
-// searchable by the same fields during the HSM->CHASM migration; a query written against one
-// implementation's tags would otherwise silently return only that half of a namespace's traffic.
+// outboundCallLogTags mirrors chasm/lib/nexusoperation's invocationTraceContext.tags() so HSM and
+// CHASM operations stay searchable by the same fields during the migration; a query written against
+// one implementation's tags would otherwise silently return only half a namespace's traffic.
 func outboundCallLogTags(
 	method string,
 	namespaceName, requestID, operation, endpointName string,
@@ -979,9 +978,8 @@ func outboundCallLogTags(
 	}
 }
 
-// logOutboundCallFailure logs a failed outbound Nexus call. Failures whose source is the customer's
-// worker are logged at debug: a Nexus operation failing is not a server error and should not clutter
-// server error logs.
+// logOutboundCallFailure logs a failed outbound Nexus call. Worker-sourced failures log at debug: a
+// Nexus operation failing is not a server error and should not clutter server error logs.
 func (e taskExecutor) logOutboundCallFailure(method string, logTags []tag.Tag, callErr error, failureSource string) {
 	if callErr == nil {
 		return

--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -25,7 +25,6 @@ import (
 	"go.temporal.io/server/chasm"
 	chasmnexus "go.temporal.io/server/chasm/lib/nexusoperation"
 	"go.temporal.io/server/common"
-	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
@@ -271,17 +270,18 @@ func (e taskExecutor) executeInvocationTask(ctx context.Context, env hsm.Environ
 		Links: []nexus.Link{args.nexusLink},
 	}
 
-	callLogger := e.outboundCallLogger(
-		"StartOperation",
-		ns.Name().String(),
-		endpoint.GetEndpoint().GetSpec().GetTarget().GetWorker().GetNamespaceId(),
-		args.requestID,
-		args.operation,
-		args.endpointName,
-		ref.WorkflowKey,
-		time.Now().UTC(),
-		task.Attempt,
-	)
+	traceCtx := invocationTraceContext{
+		operationTag:      "StartOperation",
+		namespaceName:     ns.Name().String(),
+		targetNamespaceID: endpoint.GetEndpoint().GetSpec().GetTarget().GetWorker().GetNamespaceId(),
+		requestID:         args.requestID,
+		operation:         args.operation,
+		endpointName:      args.endpointName,
+		workflowID:        ref.WorkflowKey.WorkflowID,
+		runID:             ref.WorkflowKey.RunID,
+		attemptStart:      time.Now().UTC(),
+		attempt:           task.Attempt,
+	}
 
 	var result *nexusrpc.ClientStartOperationResponse[*commonpb.Payload]
 	var callErr error
@@ -304,7 +304,8 @@ func (e taskExecutor) executeInvocationTask(ctx context.Context, env hsm.Environ
 		}
 
 		if e.HTTPTraceProvider != nil {
-			if trace := e.HTTPTraceProvider.NewTrace(task.Attempt, callLogger); trace != nil {
+			traceLogger := log.With(e.Logger, traceCtx.tags()...)
+			if trace := e.HTTPTraceProvider.NewTrace(traceCtx.attempt, traceLogger); trace != nil {
 				callCtx = httptrace.WithClientTrace(callCtx, trace)
 			}
 		}
@@ -335,7 +336,7 @@ func (e taskExecutor) executeInvocationTask(ctx context.Context, env hsm.Environ
 	chasmnexus.OutboundRequestCounter.With(e.MetricsHandler).Record(1, namespaceTag, destTag, methodTag, outcomeTag, failureSourceTag)
 	chasmnexus.OutboundRequestLatency.With(e.MetricsHandler).Record(time.Since(startTime), namespaceTag, destTag, methodTag, outcomeTag, failureSourceTag)
 
-	logOutboundCallFailure(callLogger, "StartOperation", callErr, failureSource)
+	e.logCallFailure(traceCtx, callErr, failureSource)
 
 	err = e.saveResult(ctx, env, ref, result, callErr)
 
@@ -730,17 +731,18 @@ func (e taskExecutor) executeCancelationTask(ctx context.Context, env hsm.Enviro
 	// Set this value on the parent context so that our custom HTTP caller can mutate it since we cannot access response headers directly.
 	callCtx = context.WithValue(callCtx, commonnexus.FailureSourceContextKey, &atomic.Value{})
 
-	callLogger := e.outboundCallLogger(
-		"CancelOperation",
-		ns.Name().String(),
-		endpoint.GetEndpoint().GetSpec().GetTarget().GetWorker().GetNamespaceId(),
-		args.requestID,
-		args.operation,
-		args.endpointName,
-		ref.WorkflowKey,
-		time.Now().UTC(),
-		task.Attempt,
-	)
+	traceCtx := invocationTraceContext{
+		operationTag:      "CancelOperation",
+		namespaceName:     ns.Name().String(),
+		targetNamespaceID: endpoint.GetEndpoint().GetSpec().GetTarget().GetWorker().GetNamespaceId(),
+		requestID:         args.requestID,
+		operation:         args.operation,
+		endpointName:      args.endpointName,
+		workflowID:        ref.WorkflowKey.WorkflowID,
+		runID:             ref.WorkflowKey.RunID,
+		attemptStart:      time.Now().UTC(),
+		attempt:           task.Attempt,
+	}
 
 	var callErr error
 	var startTime time.Time
@@ -766,7 +768,8 @@ func (e taskExecutor) executeCancelationTask(ctx context.Context, env hsm.Enviro
 		}
 
 		if e.HTTPTraceProvider != nil {
-			if trace := e.HTTPTraceProvider.NewTrace(task.Attempt, callLogger); trace != nil {
+			traceLogger := log.With(e.Logger, traceCtx.tags()...)
+			if trace := e.HTTPTraceProvider.NewTrace(traceCtx.attempt, traceLogger); trace != nil {
 				callCtx = httptrace.WithClientTrace(callCtx, trace)
 			}
 		}
@@ -788,7 +791,7 @@ func (e taskExecutor) executeCancelationTask(ctx context.Context, env hsm.Enviro
 	chasmnexus.OutboundRequestCounter.With(e.MetricsHandler).Record(1, namespaceTag, destTag, methodTag, statusCodeTag, failureSourceTag)
 	chasmnexus.OutboundRequestLatency.With(e.MetricsHandler).Record(time.Since(startTime), namespaceTag, destTag, methodTag, statusCodeTag, failureSourceTag)
 
-	logOutboundCallFailure(callLogger, "CancelOperation", callErr, failureSource)
+	e.logCallFailure(traceCtx, callErr, failureSource)
 
 	err = e.saveCancelationResult(ctx, env, ref, callErr, args.scheduledEventID)
 
@@ -955,39 +958,48 @@ func createNexusOperationFailure(operation Operation, scheduledEventID int64, ca
 	}
 }
 
-func (e taskExecutor) outboundCallLogger(
-	method string,
-	namespaceName, targetNamespaceID, requestID, operation, endpointName string,
-	workflowKey definition.WorkflowKey,
-	attemptStart time.Time,
-	attempt int32,
-) log.Logger {
-	return log.With(
-		e.Logger,
-		tag.Operation(method),
-		tag.WorkflowNamespace(namespaceName),
-		tag.NexusEndpointTargetNamespaceID(targetNamespaceID),
-		tag.RequestID(requestID),
-		tag.NexusOperation(operation),
-		tag.Endpoint(endpointName),
-		tag.WorkflowID(workflowKey.WorkflowID),
-		tag.WorkflowRunID(workflowKey.RunID),
-		tag.AttemptStart(attemptStart),
-		tag.Attempt(attempt),
-	)
+// invocationTraceContext captures per-call contextual information used for HTTP tracing and failure logging.
+type invocationTraceContext struct {
+	operationTag      string // "StartOperation" or "CancelOperation"
+	namespaceName     string // source (caller) namespace
+	targetNamespaceID string
+	requestID         string
+	operation         string
+	endpointName      string
+	workflowID        string
+	runID             string
+	attemptStart      time.Time
+	attempt           int32
 }
 
-// logOutboundCallFailure logs worker-sourced failures at debug: a Nexus operation failing is not a
-// server error.
-func logOutboundCallFailure(logger log.Logger, method string, callErr error, failureSource string) {
+// tags returns the structured log tags describing the call.
+func (c invocationTraceContext) tags() []tag.Tag {
+	return []tag.Tag{
+		tag.Operation(c.operationTag),
+		tag.WorkflowNamespace(c.namespaceName),
+		tag.NexusEndpointTargetNamespaceID(c.targetNamespaceID),
+		tag.RequestID(c.requestID),
+		tag.NexusOperation(c.operation),
+		tag.Endpoint(c.endpointName),
+		tag.WorkflowID(c.workflowID),
+		tag.WorkflowRunID(c.runID),
+		tag.AttemptStart(c.attemptStart),
+		tag.Attempt(c.attempt),
+	}
+}
+
+// logCallFailure logs a failed outbound Nexus call.
+func (e taskExecutor) logCallFailure(traceCtx invocationTraceContext, callErr error, failureSource string) {
 	if callErr == nil {
 		return
 	}
-	msg := fmt.Sprintf("Nexus %s request failed", method)
-	if failureSource == commonnexus.FailureSourceWorker || errors.As(callErr, new(*operationTimeoutBelowMinError)) {
-		logger.Debug(msg, tag.Error(callErr))
+	tags := append(traceCtx.tags(), tag.Error(callErr))
+	msg := fmt.Sprintf("Nexus %s request failed", traceCtx.operationTag)
+	_, isTimeoutBelowMin := errors.AsType[*operationTimeoutBelowMinError](callErr)
+	if failureSource == commonnexus.FailureSourceWorker || isTimeoutBelowMin {
+		e.Logger.Debug(msg, tags...)
 	} else {
-		logger.Error(msg, tag.Error(callErr))
+		e.Logger.Error(msg, tags...)
 	}
 }
 

--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -955,9 +955,8 @@ func createNexusOperationFailure(operation Operation, scheduledEventID int64, ca
 	}
 }
 
-// outboundCallLogTags mirrors chasm/lib/nexusoperation's invocationTraceContext.tags() so HSM and
-// CHASM operations stay searchable by the same fields during the migration; a query written against
-// one implementation's tags would otherwise silently return only half a namespace's traffic.
+// outboundCallLogTags mirrors chasm/lib/nexusoperation's invocationTraceContext.tags() so one log
+// query matches both implementations during the HSM->CHASM migration.
 func outboundCallLogTags(
 	method string,
 	namespaceName, requestID, operation, endpointName string,
@@ -978,8 +977,8 @@ func outboundCallLogTags(
 	}
 }
 
-// logOutboundCallFailure logs a failed outbound Nexus call. Worker-sourced failures log at debug: a
-// Nexus operation failing is not a server error and should not clutter server error logs.
+// logOutboundCallFailure logs worker-sourced failures at debug: a Nexus operation failing is not a
+// server error.
 func (e taskExecutor) logOutboundCallFailure(method string, logTags []tag.Tag, callErr error, failureSource string) {
 	if callErr == nil {
 		return

--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -271,7 +271,7 @@ func (e taskExecutor) executeInvocationTask(ctx context.Context, env hsm.Environ
 		Links: []nexus.Link{args.nexusLink},
 	}
 
-	logTags := outboundCallLogTags(
+	callLogger := e.outboundCallLogger(
 		"StartOperation",
 		ns.Name().String(),
 		endpoint.GetEndpoint().GetSpec().GetTarget().GetWorker().GetNamespaceId(),
@@ -304,8 +304,7 @@ func (e taskExecutor) executeInvocationTask(ctx context.Context, env hsm.Environ
 		}
 
 		if e.HTTPTraceProvider != nil {
-			traceLogger := log.With(e.Logger, logTags...)
-			if trace := e.HTTPTraceProvider.NewTrace(task.Attempt, traceLogger); trace != nil {
+			if trace := e.HTTPTraceProvider.NewTrace(task.Attempt, callLogger); trace != nil {
 				callCtx = httptrace.WithClientTrace(callCtx, trace)
 			}
 		}
@@ -336,7 +335,7 @@ func (e taskExecutor) executeInvocationTask(ctx context.Context, env hsm.Environ
 	chasmnexus.OutboundRequestCounter.With(e.MetricsHandler).Record(1, namespaceTag, destTag, methodTag, outcomeTag, failureSourceTag)
 	chasmnexus.OutboundRequestLatency.With(e.MetricsHandler).Record(time.Since(startTime), namespaceTag, destTag, methodTag, outcomeTag, failureSourceTag)
 
-	e.logOutboundCallFailure("StartOperation", logTags, callErr, failureSource)
+	logOutboundCallFailure(callLogger, "StartOperation", callErr, failureSource)
 
 	err = e.saveResult(ctx, env, ref, result, callErr)
 
@@ -731,7 +730,7 @@ func (e taskExecutor) executeCancelationTask(ctx context.Context, env hsm.Enviro
 	// Set this value on the parent context so that our custom HTTP caller can mutate it since we cannot access response headers directly.
 	callCtx = context.WithValue(callCtx, commonnexus.FailureSourceContextKey, &atomic.Value{})
 
-	logTags := outboundCallLogTags(
+	callLogger := e.outboundCallLogger(
 		"CancelOperation",
 		ns.Name().String(),
 		endpoint.GetEndpoint().GetSpec().GetTarget().GetWorker().GetNamespaceId(),
@@ -767,8 +766,7 @@ func (e taskExecutor) executeCancelationTask(ctx context.Context, env hsm.Enviro
 		}
 
 		if e.HTTPTraceProvider != nil {
-			traceLogger := log.With(e.Logger, logTags...)
-			if trace := e.HTTPTraceProvider.NewTrace(task.Attempt, traceLogger); trace != nil {
+			if trace := e.HTTPTraceProvider.NewTrace(task.Attempt, callLogger); trace != nil {
 				callCtx = httptrace.WithClientTrace(callCtx, trace)
 			}
 		}
@@ -790,7 +788,7 @@ func (e taskExecutor) executeCancelationTask(ctx context.Context, env hsm.Enviro
 	chasmnexus.OutboundRequestCounter.With(e.MetricsHandler).Record(1, namespaceTag, destTag, methodTag, statusCodeTag, failureSourceTag)
 	chasmnexus.OutboundRequestLatency.With(e.MetricsHandler).Record(time.Since(startTime), namespaceTag, destTag, methodTag, statusCodeTag, failureSourceTag)
 
-	e.logOutboundCallFailure("CancelOperation", logTags, callErr, failureSource)
+	logOutboundCallFailure(callLogger, "CancelOperation", callErr, failureSource)
 
 	err = e.saveCancelationResult(ctx, env, ref, callErr, args.scheduledEventID)
 
@@ -957,14 +955,15 @@ func createNexusOperationFailure(operation Operation, scheduledEventID int64, ca
 	}
 }
 
-func outboundCallLogTags(
+func (e taskExecutor) outboundCallLogger(
 	method string,
 	namespaceName, targetNamespaceID, requestID, operation, endpointName string,
 	workflowKey definition.WorkflowKey,
 	attemptStart time.Time,
 	attempt int32,
-) []tag.Tag {
-	return []tag.Tag{
+) log.Logger {
+	return log.With(
+		e.Logger,
 		tag.Operation(method),
 		tag.WorkflowNamespace(namespaceName),
 		tag.NexusEndpointTargetNamespaceID(targetNamespaceID),
@@ -975,21 +974,20 @@ func outboundCallLogTags(
 		tag.WorkflowRunID(workflowKey.RunID),
 		tag.AttemptStart(attemptStart),
 		tag.Attempt(attempt),
-	}
+	)
 }
 
 // logOutboundCallFailure logs worker-sourced failures at debug: a Nexus operation failing is not a
 // server error.
-func (e taskExecutor) logOutboundCallFailure(method string, logTags []tag.Tag, callErr error, failureSource string) {
+func logOutboundCallFailure(logger log.Logger, method string, callErr error, failureSource string) {
 	if callErr == nil {
 		return
 	}
-	tags := append(logTags, tag.Error(callErr)) //nolint:gocritic // intentionally does not write back to logTags
 	msg := fmt.Sprintf("Nexus %s request failed", method)
 	if failureSource == commonnexus.FailureSourceWorker || errors.As(callErr, new(*operationTimeoutBelowMinError)) {
-		e.Logger.Debug(msg, tags...)
+		logger.Debug(msg, tag.Error(callErr))
 	} else {
-		e.Logger.Error(msg, tags...)
+		logger.Error(msg, tag.Error(callErr))
 	}
 }
 


### PR DESCRIPTION
## What changed

The HSM Nexus executor logged outbound call failure logs were missing tags. 

## Why

`chasm/lib/nexusoperation` already logs exactly these fields via `invocationTraceContext.tags()`, 
