### PR TITLE
Add Nexus operation context to handler-side logs

### DIFF
--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -1013,6 +1013,10 @@ func NexusOperation(operation string) ZapTag {
 	return NewStringTag("nexus-operation", operation)
 }
 
+func NexusService(service string) ZapTag {
+	return NewStringTag("nexus-service", service)
+}
+
 // NexusTaskQueueName returns tag for NexusTaskQueueName
 func NexusTaskQueueName(taskQueueName string) ZapTag {
 	return NewStringTag("nexus-task-queue-name", taskQueueName)

--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -308,6 +308,25 @@ func (c *operationContext) enrichNexusOperationMetrics(service, operation string
 	}
 }
 
+// enrichNexusOperationLogger adds the Nexus operation context to the handler-side logger. The
+// request ID is the only identifier shared with the caller: it is generated caller-side, recorded on
+// the NexusOperationScheduled/Started/TimedOut history events, and sent on the wire, so logging it
+// here is what makes a caller-side failure and its handler-side counterpart greppable as one unit.
+//
+// Unlike enrichNexusOperationMetrics these are unconditional, since log fields carry no cardinality
+// cost. Cancel requests have no request ID, in which case the tag is omitted.
+func (c *operationContext) enrichNexusOperationLogger(service, operation, requestID string) {
+	tags := []tag.Tag{
+		tag.NexusService(service),
+		tag.NexusOperation(operation),
+		tag.Endpoint(c.endpointName),
+	}
+	if requestID != "" {
+		tags = append(tags, tag.RequestID(requestID))
+	}
+	c.logger = log.With(c.logger, tags...)
+}
+
 // Key to extract a nexusContext object from a context.Context.
 type nexusContextKey struct{}
 
@@ -397,6 +416,7 @@ func (h *nexusHandler) StartOperation(
 	}
 	ctx = oc.augmentContext(ctx, options.Header)
 	oc.enrichNexusOperationMetrics(service, operation, options.Header)
+	oc.enrichNexusOperationLogger(service, operation, options.RequestID)
 	defer oc.capturePanicAndRecordMetrics(&ctx, &retErr)
 
 	var links []*nexuspb.Link
@@ -637,6 +657,7 @@ func (h *nexusHandler) CancelOperation(ctx context.Context, service, operation, 
 	}
 	ctx = oc.augmentContext(ctx, options.Header)
 	oc.enrichNexusOperationMetrics(service, operation, options.Header)
+	oc.enrichNexusOperationLogger(service, operation, "")
 	defer oc.capturePanicAndRecordMetrics(&ctx, &retErr)
 
 	request := oc.matchingRequest(&nexuspb.Request{

--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -309,9 +309,8 @@ func (c *operationContext) enrichNexusOperationMetrics(service, operation string
 }
 
 // enrichNexusOperationLogger adds Nexus operation context to the handler-side logger. The request ID
-// is the only identifier also recorded caller-side (on the NexusOperationScheduled/Started/TimedOut
-// events), so logging it is what makes both sides of a call greppable as one unit. Unconditional
-// unlike enrichNexusOperationMetrics, since log fields carry no cardinality cost.
+// is the only identifier also recorded caller-side, making both sides of a call greppable together.
+// Unconditional unlike the metrics variant, since log fields carry no cardinality cost.
 func (c *operationContext) enrichNexusOperationLogger(service, operation, requestID string) {
 	tags := []tag.Tag{
 		tag.NexusService(service),

--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -308,9 +308,8 @@ func (c *operationContext) enrichNexusOperationMetrics(service, operation string
 	}
 }
 
-// enrichNexusOperationLogger adds Nexus operation context to the handler-side logger. The request ID
-// is the only identifier also recorded caller-side, making both sides of a call greppable together.
-// Unconditional unlike the metrics variant, since log fields carry no cardinality cost.
+// enrichNexusOperationLogger adds Nexus operation context. The request ID is also recorded
+// caller-side, making both sides greppable; unconditional since logs have no cardinality cost.
 func (c *operationContext) enrichNexusOperationLogger(service, operation, requestID string) {
 	tags := []tag.Tag{
 		tag.NexusService(service),

--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -308,13 +308,10 @@ func (c *operationContext) enrichNexusOperationMetrics(service, operation string
 	}
 }
 
-// enrichNexusOperationLogger adds the Nexus operation context to the handler-side logger. The
-// request ID is the only identifier shared with the caller: it is generated caller-side, recorded on
-// the NexusOperationScheduled/Started/TimedOut history events, and sent on the wire, so logging it
-// here is what makes a caller-side failure and its handler-side counterpart greppable as one unit.
-//
-// Unlike enrichNexusOperationMetrics these are unconditional, since log fields carry no cardinality
-// cost. Cancel requests have no request ID, in which case the tag is omitted.
+// enrichNexusOperationLogger adds Nexus operation context to the handler-side logger. The request ID
+// is the only identifier also recorded caller-side (on the NexusOperationScheduled/Started/TimedOut
+// events), so logging it is what makes both sides of a call greppable as one unit. Unconditional
+// unlike enrichNexusOperationMetrics, since log fields carry no cardinality cost.
 func (c *operationContext) enrichNexusOperationLogger(service, operation, requestID string) {
 	tags := []tag.Tag{
 		tag.NexusService(service),

--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -308,9 +308,8 @@ func (c *operationContext) enrichNexusOperationMetrics(service, operation string
 	}
 }
 
-// enrichNexusOperationLogger adds Nexus operation context. The request ID is also recorded
-// caller-side, making both sides greppable; unconditional since logs have no cardinality cost.
-func (c *operationContext) enrichNexusOperationLogger(service, operation, requestID string) {
+// enrichNexusOperationLogs adds Nexus operation context to the handler-side logger.
+func (c *operationContext) enrichNexusOperationLogs(service, operation, requestID string) {
 	tags := []tag.Tag{
 		tag.NexusService(service),
 		tag.NexusOperation(operation),
@@ -411,7 +410,7 @@ func (h *nexusHandler) StartOperation(
 	}
 	ctx = oc.augmentContext(ctx, options.Header)
 	oc.enrichNexusOperationMetrics(service, operation, options.Header)
-	oc.enrichNexusOperationLogger(service, operation, options.RequestID)
+	oc.enrichNexusOperationLogs(service, operation, options.RequestID)
 	defer oc.capturePanicAndRecordMetrics(&ctx, &retErr)
 
 	var links []*nexuspb.Link
@@ -652,7 +651,7 @@ func (h *nexusHandler) CancelOperation(ctx context.Context, service, operation, 
 	}
 	ctx = oc.augmentContext(ctx, options.Header)
 	oc.enrichNexusOperationMetrics(service, operation, options.Header)
-	oc.enrichNexusOperationLogger(service, operation, "")
+	oc.enrichNexusOperationLogs(service, operation, "")
 	defer oc.capturePanicAndRecordMetrics(&ctx, &retErr)
 
 	request := oc.matchingRequest(&nexuspb.Request{


### PR DESCRIPTION
## What changed

Adds a few Nexus-specific log tags to the handler-side frontend logger.

## Why

Mainly for the request ID to debug Nexus calls across namespaces better.