### PR TITLE
Tag Nexus pre-dispatch failure logs

### DIFF
--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -1023,8 +1023,7 @@ func NexusEndpointTargetNamespaceID(namespaceID string) ZapTag {
 	return NewStringTag("nexus-endpoint-target-namespace-id", namespaceID)
 }
 
-// NexusEndpointID returns a tag for a Nexus endpoint's ID, which is all that is known when the
-// endpoint lookup itself failed.
+// NexusEndpointID returns a tag for a Nexus endpoint's ID, all that is known if its lookup failed.
 func NexusEndpointID(endpointID string) ZapTag {
 	return NewStringTag("nexus-endpoint-id", endpointID)
 }

--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -1023,8 +1023,8 @@ func NexusEndpointTargetNamespaceID(namespaceID string) ZapTag {
 	return NewStringTag("nexus-endpoint-target-namespace-id", namespaceID)
 }
 
-// NexusEndpointID returns a tag for the ID of a Nexus endpoint. Requests dispatched by endpoint
-// carry the ID rather than the name, and the name is unresolvable if the lookup itself failed.
+// NexusEndpointID returns a tag for a Nexus endpoint's ID, which is all that is known when the
+// endpoint lookup itself failed.
 func NexusEndpointID(endpointID string) ZapTag {
 	return NewStringTag("nexus-endpoint-id", endpointID)
 }

--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -1023,6 +1023,12 @@ func NexusEndpointTargetNamespaceID(namespaceID string) ZapTag {
 	return NewStringTag("nexus-endpoint-target-namespace-id", namespaceID)
 }
 
+// NexusEndpointID returns a tag for the ID of a Nexus endpoint. Requests dispatched by endpoint
+// carry the ID rather than the name, and the name is unresolvable if the lookup itself failed.
+func NexusEndpointID(endpointID string) ZapTag {
+	return NewStringTag("nexus-endpoint-id", endpointID)
+}
+
 // WorkflowRuleID returns tag for WorkflowRuleID
 func WorkflowRuleID(ruleID string) ZapTag {
 	return NewStringTag("wf-rule-id", ruleID)

--- a/service/frontend/nexus_operation_http_handler.go
+++ b/service/frontend/nexus_operation_http_handler.go
@@ -260,7 +260,12 @@ func (h *NexusOperationHTTPHandler) baseNexusContext(apiName string, header http
 // endpoint is valid for dispatching.
 // For security reasons, at the moment only worker target endpoints are considered valid, in the future external
 // endpoints may also be supported.
-func (h *NexusOperationHTTPHandler) nexusContextFromEndpoint(entry *persistencespb.NexusEndpointEntry, w http.ResponseWriter, r *http.Request, logger log.Logger) (*nexusContext, bool) {
+func (h *NexusOperationHTTPHandler) nexusContextFromEndpoint(
+	entry *persistencespb.NexusEndpointEntry,
+	w http.ResponseWriter,
+	r *http.Request,
+	logger log.Logger,
+) (*nexusContext, bool) {
 	switch v := entry.Endpoint.Spec.GetTarget().GetVariant().(type) {
 	case *persistencespb.NexusEndpointTarget_Worker_:
 		nsName, err := h.namespaceRegistry.GetNamespaceName(namespace.ID(v.Worker.GetNamespaceId()))

--- a/service/frontend/nexus_operation_http_handler.go
+++ b/service/frontend/nexus_operation_http_handler.go
@@ -142,24 +142,40 @@ func (h *NexusOperationHTTPHandler) dispatchNexusTaskByNamespaceAndTaskQueue(w h
 	params := prepareRequest(commonnexus.RouteDispatchNexusTaskByNamespaceAndTaskQueue, w, r)
 
 	if nc.taskQueue, err = url.PathUnescape(params.TaskQueue); err != nil {
-		h.logger.Error("invalid URL", tag.Error(err), tag.NexusTaskQueueName(params.TaskQueue))
+		h.logger.Error(
+			"invalid URL",
+			tag.Error(err),
+			tag.NexusTaskQueueName(params.TaskQueue),
+		)
 		h.writeFailure(w, r, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid URL"))
 		return
 	}
 	if nc.namespaceName, err = url.PathUnescape(params.Namespace); err != nil {
-		h.logger.Error("invalid URL", tag.Error(err), tag.WorkflowNamespace(params.Namespace))
+		h.logger.Error(
+			"invalid URL",
+			tag.Error(err),
+			tag.WorkflowNamespace(params.Namespace),
+		)
 		h.writeFailure(w, r, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid URL"))
 		return
 	}
 	if err = h.namespaceValidationInterceptor.ValidateName(nc.namespaceName); err != nil {
-		h.logger.Error("invalid namespace name", tag.Error(err), tag.WorkflowNamespace(nc.namespaceName))
+		h.logger.Error(
+			"invalid namespace name",
+			tag.Error(err),
+			tag.WorkflowNamespace(nc.namespaceName),
+		)
 		h.writeFailure(w, r, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "%v", err.Error()))
 		return
 	}
 
 	rWithAuthCtx, err := h.parseTLSAndAuthInfo(r, nc)
 	if err != nil {
-		h.logger.Error("failed to get claims", tag.Error(err), tag.WorkflowNamespace(nc.namespaceName))
+		h.logger.Error(
+			"failed to get claims",
+			tag.Error(err),
+			tag.WorkflowNamespace(nc.namespaceName),
+		)
 		h.writeFailure(w, r, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeUnauthenticated, "unauthorized"))
 		return
 	}
@@ -167,7 +183,12 @@ func (h *NexusOperationHTTPHandler) dispatchNexusTaskByNamespaceAndTaskQueue(w h
 
 	u, err := mux.CurrentRoute(r).URL("namespace", params.Namespace, "task_queue", params.TaskQueue)
 	if err != nil {
-		h.logger.Error("invalid URL", tag.Error(err), tag.WorkflowNamespace(nc.namespaceName), tag.NexusTaskQueueName(nc.taskQueue))
+		h.logger.Error(
+			"invalid URL",
+			tag.Error(err),
+			tag.WorkflowNamespace(nc.namespaceName),
+			tag.NexusTaskQueueName(nc.taskQueue),
+		)
 		h.writeFailure(w, r, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error"))
 		return
 	}
@@ -181,13 +202,21 @@ func (h *NexusOperationHTTPHandler) dispatchNexusTaskByEndpoint(w http.ResponseW
 
 	endpointID, err := url.PathUnescape(endpointIDEscaped)
 	if err != nil {
-		h.logger.Error("invalid URL", tag.Error(err), tag.NexusEndpointID(endpointIDEscaped))
+		h.logger.Error(
+			"invalid URL",
+			tag.Error(err),
+			tag.NexusEndpointID(endpointIDEscaped),
+		)
 		h.writeFailure(w, r, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid URL"))
 		return
 	}
 	endpointEntry, err := h.enpointRegistry.GetByID(r.Context(), endpointID)
 	if err != nil {
-		h.logger.Error("invalid Nexus endpoint ID", tag.Error(err), tag.NexusEndpointID(endpointID))
+		h.logger.Error(
+			"invalid Nexus endpoint ID",
+			tag.Error(err),
+			tag.NexusEndpointID(endpointID),
+		)
 		s, ok := status.FromError(err)
 		if !ok {
 			s = serviceerror.ToStatus(err)
@@ -219,7 +248,12 @@ func (h *NexusOperationHTTPHandler) dispatchNexusTaskByEndpoint(w http.ResponseW
 
 	rWithAuthCtx, err := h.parseTLSAndAuthInfo(r, nc)
 	if err != nil {
-		h.logger.Error("failed to get claims", tag.Error(err), tag.NexusEndpointID(endpointID), tag.Endpoint(nc.endpointName))
+		h.logger.Error(
+			"failed to get claims",
+			tag.Error(err),
+			tag.NexusEndpointID(endpointID),
+			tag.Endpoint(nc.endpointName),
+		)
 		h.writeFailure(w, r, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeUnauthenticated, "unauthorized"))
 		return
 	}
@@ -227,7 +261,12 @@ func (h *NexusOperationHTTPHandler) dispatchNexusTaskByEndpoint(w http.ResponseW
 
 	u, err := mux.CurrentRoute(r).URL("endpoint", endpointIDEscaped)
 	if err != nil {
-		h.logger.Error("invalid URL", tag.Error(err), tag.NexusEndpointID(endpointID), tag.Endpoint(nc.endpointName))
+		h.logger.Error(
+			"invalid URL",
+			tag.Error(err),
+			tag.NexusEndpointID(endpointID),
+			tag.Endpoint(nc.endpointName),
+		)
 		h.writeFailure(w, r, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error"))
 		return
 	}

--- a/service/frontend/nexus_operation_http_handler.go
+++ b/service/frontend/nexus_operation_http_handler.go
@@ -140,8 +140,6 @@ func (h *NexusOperationHTTPHandler) dispatchNexusTaskByNamespaceAndTaskQueue(w h
 	var err error
 	nc := h.baseNexusContext(configs.DispatchNexusTaskByNamespaceAndTaskQueueAPIName, r.Header)
 	params := prepareRequest(commonnexus.RouteDispatchNexusTaskByNamespaceAndTaskQueue, w, r)
-	// Bound from the raw route params, since the failures below happen before those params are
-	// parsed and would otherwise name neither the namespace nor the task queue they were for.
 	logger := log.With(
 		h.logger,
 		tag.WorkflowNamespace(params.Namespace),

--- a/service/frontend/nexus_operation_http_handler.go
+++ b/service/frontend/nexus_operation_http_handler.go
@@ -140,42 +140,33 @@ func (h *NexusOperationHTTPHandler) dispatchNexusTaskByNamespaceAndTaskQueue(w h
 	var err error
 	nc := h.baseNexusContext(configs.DispatchNexusTaskByNamespaceAndTaskQueueAPIName, r.Header)
 	params := prepareRequest(commonnexus.RouteDispatchNexusTaskByNamespaceAndTaskQueue, w, r)
+	// Bound from the raw route params, since the failures below happen before those params are
+	// parsed and would otherwise name neither the namespace nor the task queue they were for.
+	logger := log.With(
+		h.logger,
+		tag.WorkflowNamespace(params.Namespace),
+		tag.NexusTaskQueueName(params.TaskQueue),
+	)
 
 	if nc.taskQueue, err = url.PathUnescape(params.TaskQueue); err != nil {
-		h.logger.Error(
-			"invalid URL",
-			tag.Error(err),
-			tag.NexusTaskQueueName(params.TaskQueue),
-		)
+		logger.Error("invalid URL", tag.Error(err))
 		h.writeFailure(w, r, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid URL"))
 		return
 	}
 	if nc.namespaceName, err = url.PathUnescape(params.Namespace); err != nil {
-		h.logger.Error(
-			"invalid URL",
-			tag.Error(err),
-			tag.WorkflowNamespace(params.Namespace),
-		)
+		logger.Error("invalid URL", tag.Error(err))
 		h.writeFailure(w, r, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid URL"))
 		return
 	}
 	if err = h.namespaceValidationInterceptor.ValidateName(nc.namespaceName); err != nil {
-		h.logger.Error(
-			"invalid namespace name",
-			tag.Error(err),
-			tag.WorkflowNamespace(nc.namespaceName),
-		)
+		logger.Error("invalid namespace name", tag.Error(err))
 		h.writeFailure(w, r, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "%v", err.Error()))
 		return
 	}
 
 	rWithAuthCtx, err := h.parseTLSAndAuthInfo(r, nc)
 	if err != nil {
-		h.logger.Error(
-			"failed to get claims",
-			tag.Error(err),
-			tag.WorkflowNamespace(nc.namespaceName),
-		)
+		logger.Error("failed to get claims", tag.Error(err))
 		h.writeFailure(w, r, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeUnauthenticated, "unauthorized"))
 		return
 	}
@@ -183,12 +174,7 @@ func (h *NexusOperationHTTPHandler) dispatchNexusTaskByNamespaceAndTaskQueue(w h
 
 	u, err := mux.CurrentRoute(r).URL("namespace", params.Namespace, "task_queue", params.TaskQueue)
 	if err != nil {
-		h.logger.Error(
-			"invalid URL",
-			tag.Error(err),
-			tag.WorkflowNamespace(nc.namespaceName),
-			tag.NexusTaskQueueName(nc.taskQueue),
-		)
+		logger.Error("invalid URL", tag.Error(err))
 		h.writeFailure(w, r, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error"))
 		return
 	}
@@ -199,24 +185,17 @@ func (h *NexusOperationHTTPHandler) dispatchNexusTaskByNamespaceAndTaskQueue(w h
 // Handler for [nexushttp.RouteSet.DispatchNexusTaskByEndpoint].
 func (h *NexusOperationHTTPHandler) dispatchNexusTaskByEndpoint(w http.ResponseWriter, r *http.Request) {
 	endpointIDEscaped := prepareRequest(commonnexus.RouteDispatchNexusTaskByEndpoint, w, r)
+	logger := log.With(h.logger, tag.NexusEndpointID(endpointIDEscaped))
 
 	endpointID, err := url.PathUnescape(endpointIDEscaped)
 	if err != nil {
-		h.logger.Error(
-			"invalid URL",
-			tag.Error(err),
-			tag.NexusEndpointID(endpointIDEscaped),
-		)
+		logger.Error("invalid URL", tag.Error(err))
 		h.writeFailure(w, r, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid URL"))
 		return
 	}
 	endpointEntry, err := h.enpointRegistry.GetByID(r.Context(), endpointID)
 	if err != nil {
-		h.logger.Error(
-			"invalid Nexus endpoint ID",
-			tag.Error(err),
-			tag.NexusEndpointID(endpointID),
-		)
+		logger.Error("invalid Nexus endpoint ID", tag.Error(err))
 		s, ok := status.FromError(err)
 		if !ok {
 			s = serviceerror.ToStatus(err)
@@ -240,7 +219,9 @@ func (h *NexusOperationHTTPHandler) dispatchNexusTaskByEndpoint(w http.ResponseW
 		return
 	}
 
-	nc, ok := h.nexusContextFromEndpoint(endpointEntry, w, r)
+	logger = log.With(logger, tag.Endpoint(endpointEntry.Endpoint.GetSpec().GetName()))
+
+	nc, ok := h.nexusContextFromEndpoint(endpointEntry, w, r, logger)
 	if !ok {
 		// nexusContextFromEndpoint already writes the failure response.
 		return
@@ -248,12 +229,7 @@ func (h *NexusOperationHTTPHandler) dispatchNexusTaskByEndpoint(w http.ResponseW
 
 	rWithAuthCtx, err := h.parseTLSAndAuthInfo(r, nc)
 	if err != nil {
-		h.logger.Error(
-			"failed to get claims",
-			tag.Error(err),
-			tag.NexusEndpointID(endpointID),
-			tag.Endpoint(nc.endpointName),
-		)
+		logger.Error("failed to get claims", tag.Error(err))
 		h.writeFailure(w, r, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeUnauthenticated, "unauthorized"))
 		return
 	}
@@ -261,12 +237,7 @@ func (h *NexusOperationHTTPHandler) dispatchNexusTaskByEndpoint(w http.ResponseW
 
 	u, err := mux.CurrentRoute(r).URL("endpoint", endpointIDEscaped)
 	if err != nil {
-		h.logger.Error(
-			"invalid URL",
-			tag.Error(err),
-			tag.NexusEndpointID(endpointID),
-			tag.Endpoint(nc.endpointName),
-		)
+		logger.Error("invalid URL", tag.Error(err))
 		h.writeFailure(w, r, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error"))
 		return
 	}
@@ -291,16 +262,14 @@ func (h *NexusOperationHTTPHandler) baseNexusContext(apiName string, header http
 // endpoint is valid for dispatching.
 // For security reasons, at the moment only worker target endpoints are considered valid, in the future external
 // endpoints may also be supported.
-func (h *NexusOperationHTTPHandler) nexusContextFromEndpoint(entry *persistencespb.NexusEndpointEntry, w http.ResponseWriter, r *http.Request) (*nexusContext, bool) {
+func (h *NexusOperationHTTPHandler) nexusContextFromEndpoint(entry *persistencespb.NexusEndpointEntry, w http.ResponseWriter, r *http.Request, logger log.Logger) (*nexusContext, bool) {
 	switch v := entry.Endpoint.Spec.GetTarget().GetVariant().(type) {
 	case *persistencespb.NexusEndpointTarget_Worker_:
 		nsName, err := h.namespaceRegistry.GetNamespaceName(namespace.ID(v.Worker.GetNamespaceId()))
 		if err != nil {
-			h.logger.Error(
+			logger.Error(
 				"failed to get namespace name by ID",
 				tag.Error(err),
-				tag.NexusEndpointID(entry.Id),
-				tag.Endpoint(entry.Endpoint.GetSpec().GetName()),
 				tag.NexusEndpointTargetNamespaceID(v.Worker.GetNamespaceId()),
 			)
 			var notFoundErr *serviceerror.NamespaceNotFound
@@ -322,12 +291,7 @@ func (h *NexusOperationHTTPHandler) nexusContextFromEndpoint(entry *persistences
 		nc.endpointID = entry.Id
 		return nc, true
 	default:
-		h.logger.Error(
-			"unsupported Nexus endpoint target type",
-			tag.NexusEndpointID(entry.Id),
-			tag.Endpoint(entry.Endpoint.GetSpec().GetName()),
-			tag.NewStringTag("target-type", fmt.Sprintf("%T", v)),
-		)
+		logger.Error("unsupported Nexus endpoint target type", tag.NewStringTag("target-type", fmt.Sprintf("%T", v)))
 		h.writeFailure(w, r, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid endpoint target"))
 		return nil, false
 	}

--- a/service/frontend/nexus_operation_http_handler.go
+++ b/service/frontend/nexus_operation_http_handler.go
@@ -3,6 +3,7 @@ package frontend
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"path"
@@ -141,24 +142,24 @@ func (h *NexusOperationHTTPHandler) dispatchNexusTaskByNamespaceAndTaskQueue(w h
 	params := prepareRequest(commonnexus.RouteDispatchNexusTaskByNamespaceAndTaskQueue, w, r)
 
 	if nc.taskQueue, err = url.PathUnescape(params.TaskQueue); err != nil {
-		h.logger.Error("invalid URL", tag.Error(err))
+		h.logger.Error("invalid URL", tag.Error(err), tag.NexusTaskQueueName(params.TaskQueue))
 		h.writeFailure(w, r, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid URL"))
 		return
 	}
 	if nc.namespaceName, err = url.PathUnescape(params.Namespace); err != nil {
-		h.logger.Error("invalid URL", tag.Error(err))
+		h.logger.Error("invalid URL", tag.Error(err), tag.WorkflowNamespace(params.Namespace))
 		h.writeFailure(w, r, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid URL"))
 		return
 	}
 	if err = h.namespaceValidationInterceptor.ValidateName(nc.namespaceName); err != nil {
-		h.logger.Error("invalid namespace name", tag.Error(err))
+		h.logger.Error("invalid namespace name", tag.Error(err), tag.WorkflowNamespace(nc.namespaceName))
 		h.writeFailure(w, r, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "%v", err.Error()))
 		return
 	}
 
 	rWithAuthCtx, err := h.parseTLSAndAuthInfo(r, nc)
 	if err != nil {
-		h.logger.Error("failed to get claims", tag.Error(err))
+		h.logger.Error("failed to get claims", tag.Error(err), tag.WorkflowNamespace(nc.namespaceName))
 		h.writeFailure(w, r, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeUnauthenticated, "unauthorized"))
 		return
 	}
@@ -166,7 +167,7 @@ func (h *NexusOperationHTTPHandler) dispatchNexusTaskByNamespaceAndTaskQueue(w h
 
 	u, err := mux.CurrentRoute(r).URL("namespace", params.Namespace, "task_queue", params.TaskQueue)
 	if err != nil {
-		h.logger.Error("invalid URL", tag.Error(err))
+		h.logger.Error("invalid URL", tag.Error(err), tag.WorkflowNamespace(nc.namespaceName), tag.NexusTaskQueueName(nc.taskQueue))
 		h.writeFailure(w, r, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error"))
 		return
 	}
@@ -180,13 +181,13 @@ func (h *NexusOperationHTTPHandler) dispatchNexusTaskByEndpoint(w http.ResponseW
 
 	endpointID, err := url.PathUnescape(endpointIDEscaped)
 	if err != nil {
-		h.logger.Error("invalid URL", tag.Error(err))
+		h.logger.Error("invalid URL", tag.Error(err), tag.NexusEndpointID(endpointIDEscaped))
 		h.writeFailure(w, r, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid URL"))
 		return
 	}
 	endpointEntry, err := h.enpointRegistry.GetByID(r.Context(), endpointID)
 	if err != nil {
-		h.logger.Error("invalid Nexus endpoint ID", tag.Error(err))
+		h.logger.Error("invalid Nexus endpoint ID", tag.Error(err), tag.NexusEndpointID(endpointID))
 		s, ok := status.FromError(err)
 		if !ok {
 			s = serviceerror.ToStatus(err)
@@ -218,7 +219,7 @@ func (h *NexusOperationHTTPHandler) dispatchNexusTaskByEndpoint(w http.ResponseW
 
 	rWithAuthCtx, err := h.parseTLSAndAuthInfo(r, nc)
 	if err != nil {
-		h.logger.Error("failed to get claims", tag.Error(err))
+		h.logger.Error("failed to get claims", tag.Error(err), tag.NexusEndpointID(endpointID), tag.Endpoint(nc.endpointName))
 		h.writeFailure(w, r, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeUnauthenticated, "unauthorized"))
 		return
 	}
@@ -226,7 +227,7 @@ func (h *NexusOperationHTTPHandler) dispatchNexusTaskByEndpoint(w http.ResponseW
 
 	u, err := mux.CurrentRoute(r).URL("endpoint", endpointIDEscaped)
 	if err != nil {
-		h.logger.Error("invalid URL", tag.Error(err))
+		h.logger.Error("invalid URL", tag.Error(err), tag.NexusEndpointID(endpointID), tag.Endpoint(nc.endpointName))
 		h.writeFailure(w, r, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error"))
 		return
 	}
@@ -256,7 +257,13 @@ func (h *NexusOperationHTTPHandler) nexusContextFromEndpoint(entry *persistences
 	case *persistencespb.NexusEndpointTarget_Worker_:
 		nsName, err := h.namespaceRegistry.GetNamespaceName(namespace.ID(v.Worker.GetNamespaceId()))
 		if err != nil {
-			h.logger.Error("failed to get namespace name by ID", tag.Error(err))
+			h.logger.Error(
+				"failed to get namespace name by ID",
+				tag.Error(err),
+				tag.NexusEndpointID(entry.Id),
+				tag.Endpoint(entry.Endpoint.GetSpec().GetName()),
+				tag.NexusEndpointTargetNamespaceID(v.Worker.GetNamespaceId()),
+			)
 			var notFoundErr *serviceerror.NamespaceNotFound
 			if errors.As(err, &notFoundErr) {
 				h.writeFailure(w, r, &nexus.HandlerError{
@@ -276,6 +283,12 @@ func (h *NexusOperationHTTPHandler) nexusContextFromEndpoint(entry *persistences
 		nc.endpointID = entry.Id
 		return nc, true
 	default:
+		h.logger.Error(
+			"unsupported Nexus endpoint target type",
+			tag.NexusEndpointID(entry.Id),
+			tag.Endpoint(entry.Endpoint.GetSpec().GetName()),
+			tag.NewStringTag("target-type", fmt.Sprintf("%T", v)),
+		)
 		h.writeFailure(w, r, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid endpoint target"))
 		return nil, false
 	}


### PR DESCRIPTION
## What changed

Adds logs tags for failures on the Nexus frontend path.

## Why

Have more details to correlate issues with requests.

