### PR TITLE
Preserve the original workflow start time on RebuildMutableState

### DIFF
--- a/api/persistence/v1/executions.pb.go
+++ b/api/persistence/v1/executions.pb.go
@@ -375,8 +375,11 @@ type WorkflowExecutionInfo struct {
 	DeclinedTargetVersionUpgrade *v17.DeclinedTargetVersionUpgrade `protobuf:"bytes,114,opt,name=declined_target_version_upgrade,json=declinedTargetVersionUpgrade,proto3" json:"declined_target_version_upgrade,omitempty"`
 	// Time skipping info that contains the config and runtime history of the time skipping for the workflow.
 	TimeSkippingInfo *TimeSkippingInfo `protobuf:"bytes,115,opt,name=time_skipping_info,json=timeSkippingInfo,proto3" json:"time_skipping_info,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// Time of the most recent AdminRebuildMutableState call for this run, unset if the run
+	// was never rebuilt.
+	MutableStateRebuildTime *timestamppb.Timestamp `protobuf:"bytes,116,opt,name=mutable_state_rebuild_time,json=mutableStateRebuildTime,proto3" json:"mutable_state_rebuild_time,omitempty"`
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
 }
 
 func (x *WorkflowExecutionInfo) Reset() {
@@ -1144,6 +1147,13 @@ func (x *WorkflowExecutionInfo) GetDeclinedTargetVersionUpgrade() *v17.DeclinedT
 func (x *WorkflowExecutionInfo) GetTimeSkippingInfo() *TimeSkippingInfo {
 	if x != nil {
 		return x.TimeSkippingInfo
+	}
+	return nil
+}
+
+func (x *WorkflowExecutionInfo) GetMutableStateRebuildTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.MutableStateRebuildTime
 	}
 	return nil
 }
@@ -4972,7 +4982,7 @@ const file_temporal_server_api_persistence_v1_executions_proto_rawDesc = "" +
 	"\x03key\x18\x01 \x01(\x05R\x03key\x12D\n" +
 	"\x05value\x18\x02 \x01(\v2..temporal.server.api.persistence.v1.QueueStateR\x05value:\x028\x01J\x04\b\x04\x10\x05J\x04\b\x05\x10\x06J\x04\b\b\x10\tJ\x04\b\t\x10\n" +
 	"J\x04\b\n" +
-	"\x10\vJ\x04\b\v\x10\fJ\x04\b\f\x10\rJ\x04\b\x0e\x10\x0fJ\x04\b\x0f\x10\x10J\x04\b\x10\x10\x11\"\xd3B\n" +
+	"\x10\vJ\x04\b\v\x10\fJ\x04\b\f\x10\rJ\x04\b\x0e\x10\x0fJ\x04\b\x0f\x10\x10J\x04\b\x10\x10\x11\"\xacC\n" +
 	"\x15WorkflowExecutionInfo\x12!\n" +
 	"\fnamespace_id\x18\x01 \x01(\tR\vnamespaceId\x12\x1f\n" +
 	"\vworkflow_id\x18\x02 \x01(\tR\n" +
@@ -5084,7 +5094,8 @@ const file_temporal_server_api_persistence_v1_executions_proto_rawDesc = "" +
 	"!last_workflow_task_timed_out_type\x18l \x01(\x0e2\".temporal.api.enums.v1.TimeoutTypeH\x00R\x1clastWorkflowTaskTimedOutType\x12~\n" +
 	"\x1clast_notified_target_version\x18q \x01(\v2=.temporal.server.api.persistence.v1.LastNotifiedTargetVersionR\x19lastNotifiedTargetVersion\x12|\n" +
 	"\x1fdeclined_target_version_upgrade\x18r \x01(\v25.temporal.api.history.v1.DeclinedTargetVersionUpgradeR\x1cdeclinedTargetVersionUpgrade\x12b\n" +
-	"\x12time_skipping_info\x18s \x01(\v24.temporal.server.api.persistence.v1.TimeSkippingInfoR\x10timeSkippingInfo\x1ad\n" +
+	"\x12time_skipping_info\x18s \x01(\v24.temporal.server.api.persistence.v1.TimeSkippingInfoR\x10timeSkippingInfo\x12W\n" +
+	"\x1amutable_state_rebuild_time\x18t \x01(\v2\x1a.google.protobuf.TimestampR\x17mutableStateRebuildTime\x1ad\n" +
 	"\x15SearchAttributesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x125\n" +
 	"\x05value\x18\x02 \x01(\v2\x1f.temporal.api.common.v1.PayloadR\x05value:\x028\x01\x1aX\n" +
@@ -5609,124 +5620,125 @@ var file_temporal_server_api_persistence_v1_executions_proto_depIdxs = []int32{
 	4,   // 45: temporal.server.api.persistence.v1.WorkflowExecutionInfo.last_notified_target_version:type_name -> temporal.server.api.persistence.v1.LastNotifiedTargetVersion
 	63,  // 46: temporal.server.api.persistence.v1.WorkflowExecutionInfo.declined_target_version_upgrade:type_name -> temporal.api.history.v1.DeclinedTargetVersionUpgrade
 	2,   // 47: temporal.server.api.persistence.v1.WorkflowExecutionInfo.time_skipping_info:type_name -> temporal.server.api.persistence.v1.TimeSkippingInfo
-	64,  // 48: temporal.server.api.persistence.v1.TimeSkippingInfo.config:type_name -> temporal.api.common.v1.TimeSkippingConfig
-	48,  // 49: temporal.server.api.persistence.v1.TimeSkippingInfo.accumulated_skipped_duration:type_name -> google.protobuf.Duration
-	3,   // 50: temporal.server.api.persistence.v1.TimeSkippingInfo.fast_forward_info:type_name -> temporal.server.api.persistence.v1.FastForwardInfo
-	56,  // 51: temporal.server.api.persistence.v1.TimeSkippingInfo.fast_forward_info_last_update_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
-	56,  // 52: temporal.server.api.persistence.v1.TimeSkippingInfo.last_update_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
-	47,  // 53: temporal.server.api.persistence.v1.FastForwardInfo.target_time:type_name -> google.protobuf.Timestamp
-	65,  // 54: temporal.server.api.persistence.v1.LastNotifiedTargetVersion.deployment_version:type_name -> temporal.api.deployment.v1.WorkerDeploymentVersion
-	66,  // 55: temporal.server.api.persistence.v1.WorkflowExecutionState.state:type_name -> temporal.server.api.enums.v1.WorkflowExecutionState
-	67,  // 56: temporal.server.api.persistence.v1.WorkflowExecutionState.status:type_name -> temporal.api.enums.v1.WorkflowExecutionStatus
-	56,  // 57: temporal.server.api.persistence.v1.WorkflowExecutionState.last_update_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
-	47,  // 58: temporal.server.api.persistence.v1.WorkflowExecutionState.start_time:type_name -> google.protobuf.Timestamp
-	37,  // 59: temporal.server.api.persistence.v1.WorkflowExecutionState.request_ids:type_name -> temporal.server.api.persistence.v1.WorkflowExecutionState.RequestIdsEntry
-	68,  // 60: temporal.server.api.persistence.v1.RequestIDInfo.event_type:type_name -> temporal.api.enums.v1.EventType
-	47,  // 61: temporal.server.api.persistence.v1.RequestIDInfo.attach_time:type_name -> google.protobuf.Timestamp
-	69,  // 62: temporal.server.api.persistence.v1.TransferTaskInfo.task_type:type_name -> temporal.server.api.enums.v1.TaskType
-	47,  // 63: temporal.server.api.persistence.v1.TransferTaskInfo.visibility_time:type_name -> google.protobuf.Timestamp
-	38,  // 64: temporal.server.api.persistence.v1.TransferTaskInfo.close_execution_task_details:type_name -> temporal.server.api.persistence.v1.TransferTaskInfo.CloseExecutionTaskDetails
-	70,  // 65: temporal.server.api.persistence.v1.TransferTaskInfo.chasm_task_info:type_name -> temporal.server.api.persistence.v1.ChasmTaskInfo
-	69,  // 66: temporal.server.api.persistence.v1.ReplicationTaskInfo.task_type:type_name -> temporal.server.api.enums.v1.TaskType
-	47,  // 67: temporal.server.api.persistence.v1.ReplicationTaskInfo.visibility_time:type_name -> google.protobuf.Timestamp
-	71,  // 68: temporal.server.api.persistence.v1.ReplicationTaskInfo.priority:type_name -> temporal.server.api.enums.v1.TaskPriority
-	56,  // 69: temporal.server.api.persistence.v1.ReplicationTaskInfo.versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
-	9,   // 70: temporal.server.api.persistence.v1.ReplicationTaskInfo.task_equivalents:type_name -> temporal.server.api.persistence.v1.ReplicationTaskInfo
-	72,  // 71: temporal.server.api.persistence.v1.ReplicationTaskInfo.last_version_history_item:type_name -> temporal.server.api.history.v1.VersionHistoryItem
-	69,  // 72: temporal.server.api.persistence.v1.VisibilityTaskInfo.task_type:type_name -> temporal.server.api.enums.v1.TaskType
-	47,  // 73: temporal.server.api.persistence.v1.VisibilityTaskInfo.visibility_time:type_name -> google.protobuf.Timestamp
-	47,  // 74: temporal.server.api.persistence.v1.VisibilityTaskInfo.close_time:type_name -> google.protobuf.Timestamp
-	47,  // 75: temporal.server.api.persistence.v1.VisibilityTaskInfo.start_time:type_name -> google.protobuf.Timestamp
-	70,  // 76: temporal.server.api.persistence.v1.VisibilityTaskInfo.chasm_task_info:type_name -> temporal.server.api.persistence.v1.ChasmTaskInfo
-	69,  // 77: temporal.server.api.persistence.v1.TimerTaskInfo.task_type:type_name -> temporal.server.api.enums.v1.TaskType
-	62,  // 78: temporal.server.api.persistence.v1.TimerTaskInfo.timeout_type:type_name -> temporal.api.enums.v1.TimeoutType
-	73,  // 79: temporal.server.api.persistence.v1.TimerTaskInfo.workflow_backoff_type:type_name -> temporal.server.api.enums.v1.WorkflowBackoffType
-	47,  // 80: temporal.server.api.persistence.v1.TimerTaskInfo.visibility_time:type_name -> google.protobuf.Timestamp
-	70,  // 81: temporal.server.api.persistence.v1.TimerTaskInfo.chasm_task_info:type_name -> temporal.server.api.persistence.v1.ChasmTaskInfo
-	56,  // 82: temporal.server.api.persistence.v1.TimerTaskInfo.versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
-	69,  // 83: temporal.server.api.persistence.v1.ArchivalTaskInfo.task_type:type_name -> temporal.server.api.enums.v1.TaskType
-	47,  // 84: temporal.server.api.persistence.v1.ArchivalTaskInfo.visibility_time:type_name -> google.protobuf.Timestamp
-	69,  // 85: temporal.server.api.persistence.v1.OutboundTaskInfo.task_type:type_name -> temporal.server.api.enums.v1.TaskType
-	47,  // 86: temporal.server.api.persistence.v1.OutboundTaskInfo.visibility_time:type_name -> google.protobuf.Timestamp
-	74,  // 87: temporal.server.api.persistence.v1.OutboundTaskInfo.state_machine_info:type_name -> temporal.server.api.persistence.v1.StateMachineTaskInfo
-	70,  // 88: temporal.server.api.persistence.v1.OutboundTaskInfo.chasm_task_info:type_name -> temporal.server.api.persistence.v1.ChasmTaskInfo
-	14,  // 89: temporal.server.api.persistence.v1.OutboundTaskInfo.worker_commands_task:type_name -> temporal.server.api.persistence.v1.WorkerCommandsTask
-	75,  // 90: temporal.server.api.persistence.v1.WorkerCommandsTask.commands:type_name -> temporal.api.worker.v1.WorkerCommand
-	47,  // 91: temporal.server.api.persistence.v1.ActivityInfo.scheduled_time:type_name -> google.protobuf.Timestamp
-	47,  // 92: temporal.server.api.persistence.v1.ActivityInfo.started_time:type_name -> google.protobuf.Timestamp
-	48,  // 93: temporal.server.api.persistence.v1.ActivityInfo.schedule_to_start_timeout:type_name -> google.protobuf.Duration
-	48,  // 94: temporal.server.api.persistence.v1.ActivityInfo.schedule_to_close_timeout:type_name -> google.protobuf.Duration
-	48,  // 95: temporal.server.api.persistence.v1.ActivityInfo.start_to_close_timeout:type_name -> google.protobuf.Duration
-	48,  // 96: temporal.server.api.persistence.v1.ActivityInfo.heartbeat_timeout:type_name -> google.protobuf.Duration
-	48,  // 97: temporal.server.api.persistence.v1.ActivityInfo.retry_initial_interval:type_name -> google.protobuf.Duration
-	48,  // 98: temporal.server.api.persistence.v1.ActivityInfo.retry_maximum_interval:type_name -> google.protobuf.Duration
-	47,  // 99: temporal.server.api.persistence.v1.ActivityInfo.retry_expiration_time:type_name -> google.protobuf.Timestamp
-	76,  // 100: temporal.server.api.persistence.v1.ActivityInfo.retry_last_failure:type_name -> temporal.api.failure.v1.Failure
-	77,  // 101: temporal.server.api.persistence.v1.ActivityInfo.last_heartbeat_details:type_name -> temporal.api.common.v1.Payloads
-	47,  // 102: temporal.server.api.persistence.v1.ActivityInfo.last_heartbeat_update_time:type_name -> google.protobuf.Timestamp
-	78,  // 103: temporal.server.api.persistence.v1.ActivityInfo.activity_type:type_name -> temporal.api.common.v1.ActivityType
-	39,  // 104: temporal.server.api.persistence.v1.ActivityInfo.use_workflow_build_id_info:type_name -> temporal.server.api.persistence.v1.ActivityInfo.UseWorkflowBuildIdInfo
-	55,  // 105: temporal.server.api.persistence.v1.ActivityInfo.last_worker_version_stamp:type_name -> temporal.api.common.v1.WorkerVersionStamp
-	56,  // 106: temporal.server.api.persistence.v1.ActivityInfo.last_update_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
-	47,  // 107: temporal.server.api.persistence.v1.ActivityInfo.first_scheduled_time:type_name -> google.protobuf.Timestamp
-	47,  // 108: temporal.server.api.persistence.v1.ActivityInfo.last_attempt_complete_time:type_name -> google.protobuf.Timestamp
-	79,  // 109: temporal.server.api.persistence.v1.ActivityInfo.last_started_deployment:type_name -> temporal.api.deployment.v1.Deployment
-	65,  // 110: temporal.server.api.persistence.v1.ActivityInfo.last_deployment_version:type_name -> temporal.api.deployment.v1.WorkerDeploymentVersion
-	60,  // 111: temporal.server.api.persistence.v1.ActivityInfo.priority:type_name -> temporal.api.common.v1.Priority
-	40,  // 112: temporal.server.api.persistence.v1.ActivityInfo.pause_info:type_name -> temporal.server.api.persistence.v1.ActivityInfo.PauseInfo
-	53,  // 113: temporal.server.api.persistence.v1.ActivityInfo.started_clock:type_name -> temporal.server.api.clock.v1.VectorClock
-	47,  // 114: temporal.server.api.persistence.v1.TimerInfo.expiry_time:type_name -> google.protobuf.Timestamp
-	56,  // 115: temporal.server.api.persistence.v1.TimerInfo.last_update_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
-	80,  // 116: temporal.server.api.persistence.v1.ChildExecutionInfo.parent_close_policy:type_name -> temporal.api.enums.v1.ParentClosePolicy
-	53,  // 117: temporal.server.api.persistence.v1.ChildExecutionInfo.clock:type_name -> temporal.server.api.clock.v1.VectorClock
-	56,  // 118: temporal.server.api.persistence.v1.ChildExecutionInfo.last_update_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
-	60,  // 119: temporal.server.api.persistence.v1.ChildExecutionInfo.priority:type_name -> temporal.api.common.v1.Priority
-	56,  // 120: temporal.server.api.persistence.v1.RequestCancelInfo.last_update_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
-	56,  // 121: temporal.server.api.persistence.v1.SignalInfo.last_update_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
-	81,  // 122: temporal.server.api.persistence.v1.Checksum.flavor:type_name -> temporal.server.api.enums.v1.ChecksumFlavor
-	42,  // 123: temporal.server.api.persistence.v1.Callback.nexus:type_name -> temporal.server.api.persistence.v1.Callback.Nexus
-	43,  // 124: temporal.server.api.persistence.v1.Callback.hsm:type_name -> temporal.server.api.persistence.v1.Callback.HSM
-	82,  // 125: temporal.server.api.persistence.v1.Callback.links:type_name -> temporal.api.common.v1.Link
-	83,  // 126: temporal.server.api.persistence.v1.HSMCompletionCallbackArg.last_event:type_name -> temporal.api.history.v1.HistoryEvent
-	23,  // 127: temporal.server.api.persistence.v1.CallbackInfo.callback:type_name -> temporal.server.api.persistence.v1.Callback
-	46,  // 128: temporal.server.api.persistence.v1.CallbackInfo.trigger:type_name -> temporal.server.api.persistence.v1.CallbackInfo.Trigger
-	47,  // 129: temporal.server.api.persistence.v1.CallbackInfo.registration_time:type_name -> google.protobuf.Timestamp
-	84,  // 130: temporal.server.api.persistence.v1.CallbackInfo.state:type_name -> temporal.server.api.enums.v1.CallbackState
-	47,  // 131: temporal.server.api.persistence.v1.CallbackInfo.last_attempt_complete_time:type_name -> google.protobuf.Timestamp
-	76,  // 132: temporal.server.api.persistence.v1.CallbackInfo.last_attempt_failure:type_name -> temporal.api.failure.v1.Failure
-	47,  // 133: temporal.server.api.persistence.v1.CallbackInfo.next_attempt_schedule_time:type_name -> google.protobuf.Timestamp
-	48,  // 134: temporal.server.api.persistence.v1.NexusOperationInfo.schedule_to_close_timeout:type_name -> google.protobuf.Duration
-	47,  // 135: temporal.server.api.persistence.v1.NexusOperationInfo.scheduled_time:type_name -> google.protobuf.Timestamp
-	85,  // 136: temporal.server.api.persistence.v1.NexusOperationInfo.state:type_name -> temporal.server.api.enums.v1.NexusOperationState
-	47,  // 137: temporal.server.api.persistence.v1.NexusOperationInfo.last_attempt_complete_time:type_name -> google.protobuf.Timestamp
-	76,  // 138: temporal.server.api.persistence.v1.NexusOperationInfo.last_attempt_failure:type_name -> temporal.api.failure.v1.Failure
-	47,  // 139: temporal.server.api.persistence.v1.NexusOperationInfo.next_attempt_schedule_time:type_name -> google.protobuf.Timestamp
-	48,  // 140: temporal.server.api.persistence.v1.NexusOperationInfo.schedule_to_start_timeout:type_name -> google.protobuf.Duration
-	48,  // 141: temporal.server.api.persistence.v1.NexusOperationInfo.start_to_close_timeout:type_name -> google.protobuf.Duration
-	47,  // 142: temporal.server.api.persistence.v1.NexusOperationInfo.started_time:type_name -> google.protobuf.Timestamp
-	47,  // 143: temporal.server.api.persistence.v1.NexusOperationCancellationInfo.requested_time:type_name -> google.protobuf.Timestamp
-	86,  // 144: temporal.server.api.persistence.v1.NexusOperationCancellationInfo.state:type_name -> temporal.api.enums.v1.NexusOperationCancellationState
-	47,  // 145: temporal.server.api.persistence.v1.NexusOperationCancellationInfo.last_attempt_complete_time:type_name -> google.protobuf.Timestamp
-	76,  // 146: temporal.server.api.persistence.v1.NexusOperationCancellationInfo.last_attempt_failure:type_name -> temporal.api.failure.v1.Failure
-	47,  // 147: temporal.server.api.persistence.v1.NexusOperationCancellationInfo.next_attempt_schedule_time:type_name -> google.protobuf.Timestamp
-	47,  // 148: temporal.server.api.persistence.v1.WorkflowPauseInfo.pause_time:type_name -> google.protobuf.Timestamp
-	87,  // 149: temporal.server.api.persistence.v1.ShardInfo.QueueStatesEntry.value:type_name -> temporal.server.api.persistence.v1.QueueState
-	88,  // 150: temporal.server.api.persistence.v1.WorkflowExecutionInfo.SearchAttributesEntry.value:type_name -> temporal.api.common.v1.Payload
-	88,  // 151: temporal.server.api.persistence.v1.WorkflowExecutionInfo.MemoEntry.value:type_name -> temporal.api.common.v1.Payload
-	89,  // 152: temporal.server.api.persistence.v1.WorkflowExecutionInfo.UpdateInfosEntry.value:type_name -> temporal.server.api.persistence.v1.UpdateInfo
-	90,  // 153: temporal.server.api.persistence.v1.WorkflowExecutionInfo.SubStateMachinesByTypeEntry.value:type_name -> temporal.server.api.persistence.v1.StateMachineMap
-	28,  // 154: temporal.server.api.persistence.v1.WorkflowExecutionInfo.ChildrenInitializedPostResetPointEntry.value:type_name -> temporal.server.api.persistence.v1.ResetChildInfo
-	7,   // 155: temporal.server.api.persistence.v1.WorkflowExecutionState.RequestIdsEntry.value:type_name -> temporal.server.api.persistence.v1.RequestIDInfo
-	47,  // 156: temporal.server.api.persistence.v1.ActivityInfo.PauseInfo.pause_time:type_name -> google.protobuf.Timestamp
-	41,  // 157: temporal.server.api.persistence.v1.ActivityInfo.PauseInfo.manual:type_name -> temporal.server.api.persistence.v1.ActivityInfo.PauseInfo.Manual
-	44,  // 158: temporal.server.api.persistence.v1.Callback.Nexus.header:type_name -> temporal.server.api.persistence.v1.Callback.Nexus.HeaderEntry
-	91,  // 159: temporal.server.api.persistence.v1.Callback.HSM.ref:type_name -> temporal.server.api.persistence.v1.StateMachineRef
-	45,  // 160: temporal.server.api.persistence.v1.CallbackInfo.Trigger.workflow_closed:type_name -> temporal.server.api.persistence.v1.CallbackInfo.WorkflowClosed
-	161, // [161:161] is the sub-list for method output_type
-	161, // [161:161] is the sub-list for method input_type
-	161, // [161:161] is the sub-list for extension type_name
-	161, // [161:161] is the sub-list for extension extendee
-	0,   // [0:161] is the sub-list for field type_name
+	47,  // 48: temporal.server.api.persistence.v1.WorkflowExecutionInfo.mutable_state_rebuild_time:type_name -> google.protobuf.Timestamp
+	64,  // 49: temporal.server.api.persistence.v1.TimeSkippingInfo.config:type_name -> temporal.api.common.v1.TimeSkippingConfig
+	48,  // 50: temporal.server.api.persistence.v1.TimeSkippingInfo.accumulated_skipped_duration:type_name -> google.protobuf.Duration
+	3,   // 51: temporal.server.api.persistence.v1.TimeSkippingInfo.fast_forward_info:type_name -> temporal.server.api.persistence.v1.FastForwardInfo
+	56,  // 52: temporal.server.api.persistence.v1.TimeSkippingInfo.fast_forward_info_last_update_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
+	56,  // 53: temporal.server.api.persistence.v1.TimeSkippingInfo.last_update_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
+	47,  // 54: temporal.server.api.persistence.v1.FastForwardInfo.target_time:type_name -> google.protobuf.Timestamp
+	65,  // 55: temporal.server.api.persistence.v1.LastNotifiedTargetVersion.deployment_version:type_name -> temporal.api.deployment.v1.WorkerDeploymentVersion
+	66,  // 56: temporal.server.api.persistence.v1.WorkflowExecutionState.state:type_name -> temporal.server.api.enums.v1.WorkflowExecutionState
+	67,  // 57: temporal.server.api.persistence.v1.WorkflowExecutionState.status:type_name -> temporal.api.enums.v1.WorkflowExecutionStatus
+	56,  // 58: temporal.server.api.persistence.v1.WorkflowExecutionState.last_update_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
+	47,  // 59: temporal.server.api.persistence.v1.WorkflowExecutionState.start_time:type_name -> google.protobuf.Timestamp
+	37,  // 60: temporal.server.api.persistence.v1.WorkflowExecutionState.request_ids:type_name -> temporal.server.api.persistence.v1.WorkflowExecutionState.RequestIdsEntry
+	68,  // 61: temporal.server.api.persistence.v1.RequestIDInfo.event_type:type_name -> temporal.api.enums.v1.EventType
+	47,  // 62: temporal.server.api.persistence.v1.RequestIDInfo.attach_time:type_name -> google.protobuf.Timestamp
+	69,  // 63: temporal.server.api.persistence.v1.TransferTaskInfo.task_type:type_name -> temporal.server.api.enums.v1.TaskType
+	47,  // 64: temporal.server.api.persistence.v1.TransferTaskInfo.visibility_time:type_name -> google.protobuf.Timestamp
+	38,  // 65: temporal.server.api.persistence.v1.TransferTaskInfo.close_execution_task_details:type_name -> temporal.server.api.persistence.v1.TransferTaskInfo.CloseExecutionTaskDetails
+	70,  // 66: temporal.server.api.persistence.v1.TransferTaskInfo.chasm_task_info:type_name -> temporal.server.api.persistence.v1.ChasmTaskInfo
+	69,  // 67: temporal.server.api.persistence.v1.ReplicationTaskInfo.task_type:type_name -> temporal.server.api.enums.v1.TaskType
+	47,  // 68: temporal.server.api.persistence.v1.ReplicationTaskInfo.visibility_time:type_name -> google.protobuf.Timestamp
+	71,  // 69: temporal.server.api.persistence.v1.ReplicationTaskInfo.priority:type_name -> temporal.server.api.enums.v1.TaskPriority
+	56,  // 70: temporal.server.api.persistence.v1.ReplicationTaskInfo.versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
+	9,   // 71: temporal.server.api.persistence.v1.ReplicationTaskInfo.task_equivalents:type_name -> temporal.server.api.persistence.v1.ReplicationTaskInfo
+	72,  // 72: temporal.server.api.persistence.v1.ReplicationTaskInfo.last_version_history_item:type_name -> temporal.server.api.history.v1.VersionHistoryItem
+	69,  // 73: temporal.server.api.persistence.v1.VisibilityTaskInfo.task_type:type_name -> temporal.server.api.enums.v1.TaskType
+	47,  // 74: temporal.server.api.persistence.v1.VisibilityTaskInfo.visibility_time:type_name -> google.protobuf.Timestamp
+	47,  // 75: temporal.server.api.persistence.v1.VisibilityTaskInfo.close_time:type_name -> google.protobuf.Timestamp
+	47,  // 76: temporal.server.api.persistence.v1.VisibilityTaskInfo.start_time:type_name -> google.protobuf.Timestamp
+	70,  // 77: temporal.server.api.persistence.v1.VisibilityTaskInfo.chasm_task_info:type_name -> temporal.server.api.persistence.v1.ChasmTaskInfo
+	69,  // 78: temporal.server.api.persistence.v1.TimerTaskInfo.task_type:type_name -> temporal.server.api.enums.v1.TaskType
+	62,  // 79: temporal.server.api.persistence.v1.TimerTaskInfo.timeout_type:type_name -> temporal.api.enums.v1.TimeoutType
+	73,  // 80: temporal.server.api.persistence.v1.TimerTaskInfo.workflow_backoff_type:type_name -> temporal.server.api.enums.v1.WorkflowBackoffType
+	47,  // 81: temporal.server.api.persistence.v1.TimerTaskInfo.visibility_time:type_name -> google.protobuf.Timestamp
+	70,  // 82: temporal.server.api.persistence.v1.TimerTaskInfo.chasm_task_info:type_name -> temporal.server.api.persistence.v1.ChasmTaskInfo
+	56,  // 83: temporal.server.api.persistence.v1.TimerTaskInfo.versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
+	69,  // 84: temporal.server.api.persistence.v1.ArchivalTaskInfo.task_type:type_name -> temporal.server.api.enums.v1.TaskType
+	47,  // 85: temporal.server.api.persistence.v1.ArchivalTaskInfo.visibility_time:type_name -> google.protobuf.Timestamp
+	69,  // 86: temporal.server.api.persistence.v1.OutboundTaskInfo.task_type:type_name -> temporal.server.api.enums.v1.TaskType
+	47,  // 87: temporal.server.api.persistence.v1.OutboundTaskInfo.visibility_time:type_name -> google.protobuf.Timestamp
+	74,  // 88: temporal.server.api.persistence.v1.OutboundTaskInfo.state_machine_info:type_name -> temporal.server.api.persistence.v1.StateMachineTaskInfo
+	70,  // 89: temporal.server.api.persistence.v1.OutboundTaskInfo.chasm_task_info:type_name -> temporal.server.api.persistence.v1.ChasmTaskInfo
+	14,  // 90: temporal.server.api.persistence.v1.OutboundTaskInfo.worker_commands_task:type_name -> temporal.server.api.persistence.v1.WorkerCommandsTask
+	75,  // 91: temporal.server.api.persistence.v1.WorkerCommandsTask.commands:type_name -> temporal.api.worker.v1.WorkerCommand
+	47,  // 92: temporal.server.api.persistence.v1.ActivityInfo.scheduled_time:type_name -> google.protobuf.Timestamp
+	47,  // 93: temporal.server.api.persistence.v1.ActivityInfo.started_time:type_name -> google.protobuf.Timestamp
+	48,  // 94: temporal.server.api.persistence.v1.ActivityInfo.schedule_to_start_timeout:type_name -> google.protobuf.Duration
+	48,  // 95: temporal.server.api.persistence.v1.ActivityInfo.schedule_to_close_timeout:type_name -> google.protobuf.Duration
+	48,  // 96: temporal.server.api.persistence.v1.ActivityInfo.start_to_close_timeout:type_name -> google.protobuf.Duration
+	48,  // 97: temporal.server.api.persistence.v1.ActivityInfo.heartbeat_timeout:type_name -> google.protobuf.Duration
+	48,  // 98: temporal.server.api.persistence.v1.ActivityInfo.retry_initial_interval:type_name -> google.protobuf.Duration
+	48,  // 99: temporal.server.api.persistence.v1.ActivityInfo.retry_maximum_interval:type_name -> google.protobuf.Duration
+	47,  // 100: temporal.server.api.persistence.v1.ActivityInfo.retry_expiration_time:type_name -> google.protobuf.Timestamp
+	76,  // 101: temporal.server.api.persistence.v1.ActivityInfo.retry_last_failure:type_name -> temporal.api.failure.v1.Failure
+	77,  // 102: temporal.server.api.persistence.v1.ActivityInfo.last_heartbeat_details:type_name -> temporal.api.common.v1.Payloads
+	47,  // 103: temporal.server.api.persistence.v1.ActivityInfo.last_heartbeat_update_time:type_name -> google.protobuf.Timestamp
+	78,  // 104: temporal.server.api.persistence.v1.ActivityInfo.activity_type:type_name -> temporal.api.common.v1.ActivityType
+	39,  // 105: temporal.server.api.persistence.v1.ActivityInfo.use_workflow_build_id_info:type_name -> temporal.server.api.persistence.v1.ActivityInfo.UseWorkflowBuildIdInfo
+	55,  // 106: temporal.server.api.persistence.v1.ActivityInfo.last_worker_version_stamp:type_name -> temporal.api.common.v1.WorkerVersionStamp
+	56,  // 107: temporal.server.api.persistence.v1.ActivityInfo.last_update_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
+	47,  // 108: temporal.server.api.persistence.v1.ActivityInfo.first_scheduled_time:type_name -> google.protobuf.Timestamp
+	47,  // 109: temporal.server.api.persistence.v1.ActivityInfo.last_attempt_complete_time:type_name -> google.protobuf.Timestamp
+	79,  // 110: temporal.server.api.persistence.v1.ActivityInfo.last_started_deployment:type_name -> temporal.api.deployment.v1.Deployment
+	65,  // 111: temporal.server.api.persistence.v1.ActivityInfo.last_deployment_version:type_name -> temporal.api.deployment.v1.WorkerDeploymentVersion
+	60,  // 112: temporal.server.api.persistence.v1.ActivityInfo.priority:type_name -> temporal.api.common.v1.Priority
+	40,  // 113: temporal.server.api.persistence.v1.ActivityInfo.pause_info:type_name -> temporal.server.api.persistence.v1.ActivityInfo.PauseInfo
+	53,  // 114: temporal.server.api.persistence.v1.ActivityInfo.started_clock:type_name -> temporal.server.api.clock.v1.VectorClock
+	47,  // 115: temporal.server.api.persistence.v1.TimerInfo.expiry_time:type_name -> google.protobuf.Timestamp
+	56,  // 116: temporal.server.api.persistence.v1.TimerInfo.last_update_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
+	80,  // 117: temporal.server.api.persistence.v1.ChildExecutionInfo.parent_close_policy:type_name -> temporal.api.enums.v1.ParentClosePolicy
+	53,  // 118: temporal.server.api.persistence.v1.ChildExecutionInfo.clock:type_name -> temporal.server.api.clock.v1.VectorClock
+	56,  // 119: temporal.server.api.persistence.v1.ChildExecutionInfo.last_update_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
+	60,  // 120: temporal.server.api.persistence.v1.ChildExecutionInfo.priority:type_name -> temporal.api.common.v1.Priority
+	56,  // 121: temporal.server.api.persistence.v1.RequestCancelInfo.last_update_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
+	56,  // 122: temporal.server.api.persistence.v1.SignalInfo.last_update_versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
+	81,  // 123: temporal.server.api.persistence.v1.Checksum.flavor:type_name -> temporal.server.api.enums.v1.ChecksumFlavor
+	42,  // 124: temporal.server.api.persistence.v1.Callback.nexus:type_name -> temporal.server.api.persistence.v1.Callback.Nexus
+	43,  // 125: temporal.server.api.persistence.v1.Callback.hsm:type_name -> temporal.server.api.persistence.v1.Callback.HSM
+	82,  // 126: temporal.server.api.persistence.v1.Callback.links:type_name -> temporal.api.common.v1.Link
+	83,  // 127: temporal.server.api.persistence.v1.HSMCompletionCallbackArg.last_event:type_name -> temporal.api.history.v1.HistoryEvent
+	23,  // 128: temporal.server.api.persistence.v1.CallbackInfo.callback:type_name -> temporal.server.api.persistence.v1.Callback
+	46,  // 129: temporal.server.api.persistence.v1.CallbackInfo.trigger:type_name -> temporal.server.api.persistence.v1.CallbackInfo.Trigger
+	47,  // 130: temporal.server.api.persistence.v1.CallbackInfo.registration_time:type_name -> google.protobuf.Timestamp
+	84,  // 131: temporal.server.api.persistence.v1.CallbackInfo.state:type_name -> temporal.server.api.enums.v1.CallbackState
+	47,  // 132: temporal.server.api.persistence.v1.CallbackInfo.last_attempt_complete_time:type_name -> google.protobuf.Timestamp
+	76,  // 133: temporal.server.api.persistence.v1.CallbackInfo.last_attempt_failure:type_name -> temporal.api.failure.v1.Failure
+	47,  // 134: temporal.server.api.persistence.v1.CallbackInfo.next_attempt_schedule_time:type_name -> google.protobuf.Timestamp
+	48,  // 135: temporal.server.api.persistence.v1.NexusOperationInfo.schedule_to_close_timeout:type_name -> google.protobuf.Duration
+	47,  // 136: temporal.server.api.persistence.v1.NexusOperationInfo.scheduled_time:type_name -> google.protobuf.Timestamp
+	85,  // 137: temporal.server.api.persistence.v1.NexusOperationInfo.state:type_name -> temporal.server.api.enums.v1.NexusOperationState
+	47,  // 138: temporal.server.api.persistence.v1.NexusOperationInfo.last_attempt_complete_time:type_name -> google.protobuf.Timestamp
+	76,  // 139: temporal.server.api.persistence.v1.NexusOperationInfo.last_attempt_failure:type_name -> temporal.api.failure.v1.Failure
+	47,  // 140: temporal.server.api.persistence.v1.NexusOperationInfo.next_attempt_schedule_time:type_name -> google.protobuf.Timestamp
+	48,  // 141: temporal.server.api.persistence.v1.NexusOperationInfo.schedule_to_start_timeout:type_name -> google.protobuf.Duration
+	48,  // 142: temporal.server.api.persistence.v1.NexusOperationInfo.start_to_close_timeout:type_name -> google.protobuf.Duration
+	47,  // 143: temporal.server.api.persistence.v1.NexusOperationInfo.started_time:type_name -> google.protobuf.Timestamp
+	47,  // 144: temporal.server.api.persistence.v1.NexusOperationCancellationInfo.requested_time:type_name -> google.protobuf.Timestamp
+	86,  // 145: temporal.server.api.persistence.v1.NexusOperationCancellationInfo.state:type_name -> temporal.api.enums.v1.NexusOperationCancellationState
+	47,  // 146: temporal.server.api.persistence.v1.NexusOperationCancellationInfo.last_attempt_complete_time:type_name -> google.protobuf.Timestamp
+	76,  // 147: temporal.server.api.persistence.v1.NexusOperationCancellationInfo.last_attempt_failure:type_name -> temporal.api.failure.v1.Failure
+	47,  // 148: temporal.server.api.persistence.v1.NexusOperationCancellationInfo.next_attempt_schedule_time:type_name -> google.protobuf.Timestamp
+	47,  // 149: temporal.server.api.persistence.v1.WorkflowPauseInfo.pause_time:type_name -> google.protobuf.Timestamp
+	87,  // 150: temporal.server.api.persistence.v1.ShardInfo.QueueStatesEntry.value:type_name -> temporal.server.api.persistence.v1.QueueState
+	88,  // 151: temporal.server.api.persistence.v1.WorkflowExecutionInfo.SearchAttributesEntry.value:type_name -> temporal.api.common.v1.Payload
+	88,  // 152: temporal.server.api.persistence.v1.WorkflowExecutionInfo.MemoEntry.value:type_name -> temporal.api.common.v1.Payload
+	89,  // 153: temporal.server.api.persistence.v1.WorkflowExecutionInfo.UpdateInfosEntry.value:type_name -> temporal.server.api.persistence.v1.UpdateInfo
+	90,  // 154: temporal.server.api.persistence.v1.WorkflowExecutionInfo.SubStateMachinesByTypeEntry.value:type_name -> temporal.server.api.persistence.v1.StateMachineMap
+	28,  // 155: temporal.server.api.persistence.v1.WorkflowExecutionInfo.ChildrenInitializedPostResetPointEntry.value:type_name -> temporal.server.api.persistence.v1.ResetChildInfo
+	7,   // 156: temporal.server.api.persistence.v1.WorkflowExecutionState.RequestIdsEntry.value:type_name -> temporal.server.api.persistence.v1.RequestIDInfo
+	47,  // 157: temporal.server.api.persistence.v1.ActivityInfo.PauseInfo.pause_time:type_name -> google.protobuf.Timestamp
+	41,  // 158: temporal.server.api.persistence.v1.ActivityInfo.PauseInfo.manual:type_name -> temporal.server.api.persistence.v1.ActivityInfo.PauseInfo.Manual
+	44,  // 159: temporal.server.api.persistence.v1.Callback.Nexus.header:type_name -> temporal.server.api.persistence.v1.Callback.Nexus.HeaderEntry
+	91,  // 160: temporal.server.api.persistence.v1.Callback.HSM.ref:type_name -> temporal.server.api.persistence.v1.StateMachineRef
+	45,  // 161: temporal.server.api.persistence.v1.CallbackInfo.Trigger.workflow_closed:type_name -> temporal.server.api.persistence.v1.CallbackInfo.WorkflowClosed
+	162, // [162:162] is the sub-list for method output_type
+	162, // [162:162] is the sub-list for method input_type
+	162, // [162:162] is the sub-list for extension type_name
+	162, // [162:162] is the sub-list for extension extendee
+	0,   // [0:162] is the sub-list for field type_name
 }
 
 func init() { file_temporal_server_api_persistence_v1_executions_proto_init() }

--- a/proto/internal/temporal/server/api/persistence/v1/executions.proto
+++ b/proto/internal/temporal/server/api/persistence/v1/executions.proto
@@ -319,6 +319,10 @@ message WorkflowExecutionInfo {
 
   // Time skipping info that contains the config and runtime history of the time skipping for the workflow.
   TimeSkippingInfo time_skipping_info = 115;
+
+  // Time of the most recent AdminRebuildMutableState call for this run, unset if the run
+  // was never rebuilt.
+  google.protobuf.Timestamp mutable_state_rebuild_time = 116;
 }
 
 message TimeSkippingInfo {

--- a/service/history/ndc/conflict_resolver.go
+++ b/service/history/ndc/conflict_resolver.go
@@ -158,6 +158,7 @@ func (r *ConflictResolverImpl) rebuild(
 	rebuildVersionHistory, err := versionhistory.GetCurrentVersionHistory(rebuildVersionHistories)
 	rebuildMutableState.GetExecutionInfo().PreviousTransitionHistory = r.mutableState.GetExecutionInfo().PreviousTransitionHistory
 	rebuildMutableState.GetExecutionInfo().LastTransitionHistoryBreakPoint = r.mutableState.GetExecutionInfo().LastTransitionHistoryBreakPoint
+	rebuildMutableState.GetExecutionInfo().MutableStateRebuildTime = r.mutableState.GetExecutionInfo().MutableStateRebuildTime
 	if err != nil {
 		return nil, err
 	}

--- a/service/history/ndc/state_rebuilder.go
+++ b/service/history/ndc/state_rebuilder.go
@@ -31,7 +31,7 @@ type (
 	StateRebuilder interface {
 		Rebuild(
 			ctx context.Context,
-			now time.Time,
+			startTime time.Time,
 			baseWorkflowIdentifier definition.WorkflowKey,
 			baseBranchToken []byte,
 			baseLastEventID int64,
@@ -42,7 +42,7 @@ type (
 		) (historyi.MutableState, RebuildStats, error)
 		RebuildWithCurrentMutableState(
 			ctx context.Context,
-			now time.Time,
+			startTime time.Time,
 			baseWorkflowIdentifier definition.WorkflowKey,
 			baseBranchToken []byte,
 			baseLastEventID int64,
@@ -102,7 +102,7 @@ func NewStateRebuilder(
 
 func (r *StateRebuilderImpl) Rebuild(
 	ctx context.Context,
-	now time.Time,
+	startTime time.Time,
 	baseWorkflowIdentifier definition.WorkflowKey,
 	baseBranchToken []byte,
 	baseLastEventID int64,
@@ -113,7 +113,7 @@ func (r *StateRebuilderImpl) Rebuild(
 ) (historyi.MutableState, RebuildStats, error) {
 	rebuiltMutableState, lastTxnId, err := r.buildMutableStateFromEvent(
 		ctx,
-		now,
+		startTime,
 		baseWorkflowIdentifier,
 		baseBranchToken,
 		baseLastEventID,
@@ -151,7 +151,7 @@ func (r *StateRebuilderImpl) Rebuild(
 
 func (r *StateRebuilderImpl) RebuildWithCurrentMutableState(
 	ctx context.Context,
-	now time.Time,
+	startTime time.Time,
 	baseWorkflowIdentifier definition.WorkflowKey,
 	baseBranchToken []byte,
 	baseLastEventID int64,
@@ -163,7 +163,7 @@ func (r *StateRebuilderImpl) RebuildWithCurrentMutableState(
 	// Use the original start request ID handlers can still correlate rebuilt callbacks to the correct BufferedStart entry.
 	rebuiltMutableState, lastTxnId, err := r.buildMutableStateFromEvent(
 		ctx,
-		now,
+		startTime,
 		baseWorkflowIdentifier,
 		baseBranchToken,
 		baseLastEventID,
@@ -223,7 +223,7 @@ func copyToRebuildMutableState(
 
 func (r *StateRebuilderImpl) buildMutableStateFromEvent(
 	ctx context.Context,
-	now time.Time,
+	startTime time.Time,
 	baseWorkflowIdentifier definition.WorkflowKey,
 	baseBranchToken []byte,
 	baseLastEventID int64,
@@ -248,7 +248,7 @@ func (r *StateRebuilderImpl) buildMutableStateFromEvent(
 	rebuiltMutableState, stateBuilder := r.initializeBuilders(
 		namespaceEntry,
 		targetWorkflowIdentifier,
-		now,
+		startTime,
 	)
 
 	var lastTxnId int64
@@ -307,7 +307,7 @@ func (r *StateRebuilderImpl) buildMutableStateFromEvent(
 func (r *StateRebuilderImpl) initializeBuilders(
 	namespaceEntry *namespace.Namespace,
 	workflowIdentifier definition.WorkflowKey,
-	now time.Time,
+	startTime time.Time,
 ) (historyi.MutableState, workflow.MutableStateRebuilder) {
 	resetMutableState := workflow.NewMutableState(
 		r.shard,
@@ -316,7 +316,7 @@ func (r *StateRebuilderImpl) initializeBuilders(
 		namespaceEntry,
 		workflowIdentifier.GetWorkflowID(),
 		workflowIdentifier.GetRunID(),
-		now,
+		startTime,
 	)
 	stateBuilder := workflow.NewMutableStateRebuilder(
 		r.shard,

--- a/service/history/ndc/state_rebuilder_mock.go
+++ b/service/history/ndc/state_rebuilder_mock.go
@@ -45,9 +45,9 @@ func (m *MockStateRebuilder) EXPECT() *MockStateRebuilderMockRecorder {
 }
 
 // Rebuild mocks base method.
-func (m *MockStateRebuilder) Rebuild(ctx context.Context, now time.Time, baseWorkflowIdentifier definition.WorkflowKey, baseBranchToken []byte, baseLastEventID int64, baseLastEventVersion *int64, targetWorkflowIdentifier definition.WorkflowKey, targetBranchToken []byte, requestID string) (interfaces.MutableState, RebuildStats, error) {
+func (m *MockStateRebuilder) Rebuild(ctx context.Context, startTime time.Time, baseWorkflowIdentifier definition.WorkflowKey, baseBranchToken []byte, baseLastEventID int64, baseLastEventVersion *int64, targetWorkflowIdentifier definition.WorkflowKey, targetBranchToken []byte, requestID string) (interfaces.MutableState, RebuildStats, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Rebuild", ctx, now, baseWorkflowIdentifier, baseBranchToken, baseLastEventID, baseLastEventVersion, targetWorkflowIdentifier, targetBranchToken, requestID)
+	ret := m.ctrl.Call(m, "Rebuild", ctx, startTime, baseWorkflowIdentifier, baseBranchToken, baseLastEventID, baseLastEventVersion, targetWorkflowIdentifier, targetBranchToken, requestID)
 	ret0, _ := ret[0].(interfaces.MutableState)
 	ret1, _ := ret[1].(RebuildStats)
 	ret2, _ := ret[2].(error)
@@ -55,15 +55,15 @@ func (m *MockStateRebuilder) Rebuild(ctx context.Context, now time.Time, baseWor
 }
 
 // Rebuild indicates an expected call of Rebuild.
-func (mr *MockStateRebuilderMockRecorder) Rebuild(ctx, now, baseWorkflowIdentifier, baseBranchToken, baseLastEventID, baseLastEventVersion, targetWorkflowIdentifier, targetBranchToken, requestID any) *gomock.Call {
+func (mr *MockStateRebuilderMockRecorder) Rebuild(ctx, startTime, baseWorkflowIdentifier, baseBranchToken, baseLastEventID, baseLastEventVersion, targetWorkflowIdentifier, targetBranchToken, requestID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rebuild", reflect.TypeOf((*MockStateRebuilder)(nil).Rebuild), ctx, now, baseWorkflowIdentifier, baseBranchToken, baseLastEventID, baseLastEventVersion, targetWorkflowIdentifier, targetBranchToken, requestID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rebuild", reflect.TypeOf((*MockStateRebuilder)(nil).Rebuild), ctx, startTime, baseWorkflowIdentifier, baseBranchToken, baseLastEventID, baseLastEventVersion, targetWorkflowIdentifier, targetBranchToken, requestID)
 }
 
 // RebuildWithCurrentMutableState mocks base method.
-func (m *MockStateRebuilder) RebuildWithCurrentMutableState(ctx context.Context, now time.Time, baseWorkflowIdentifier definition.WorkflowKey, baseBranchToken []byte, baseLastEventID int64, baseLastEventVersion *int64, targetWorkflowIdentifier definition.WorkflowKey, targetBranchToken []byte, currentMutableState *persistence.WorkflowMutableState) (interfaces.MutableState, RebuildStats, error) {
+func (m *MockStateRebuilder) RebuildWithCurrentMutableState(ctx context.Context, startTime time.Time, baseWorkflowIdentifier definition.WorkflowKey, baseBranchToken []byte, baseLastEventID int64, baseLastEventVersion *int64, targetWorkflowIdentifier definition.WorkflowKey, targetBranchToken []byte, currentMutableState *persistence.WorkflowMutableState) (interfaces.MutableState, RebuildStats, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RebuildWithCurrentMutableState", ctx, now, baseWorkflowIdentifier, baseBranchToken, baseLastEventID, baseLastEventVersion, targetWorkflowIdentifier, targetBranchToken, currentMutableState)
+	ret := m.ctrl.Call(m, "RebuildWithCurrentMutableState", ctx, startTime, baseWorkflowIdentifier, baseBranchToken, baseLastEventID, baseLastEventVersion, targetWorkflowIdentifier, targetBranchToken, currentMutableState)
 	ret0, _ := ret[0].(interfaces.MutableState)
 	ret1, _ := ret[1].(RebuildStats)
 	ret2, _ := ret[2].(error)
@@ -71,7 +71,7 @@ func (m *MockStateRebuilder) RebuildWithCurrentMutableState(ctx context.Context,
 }
 
 // RebuildWithCurrentMutableState indicates an expected call of RebuildWithCurrentMutableState.
-func (mr *MockStateRebuilderMockRecorder) RebuildWithCurrentMutableState(ctx, now, baseWorkflowIdentifier, baseBranchToken, baseLastEventID, baseLastEventVersion, targetWorkflowIdentifier, targetBranchToken, currentMutableState any) *gomock.Call {
+func (mr *MockStateRebuilderMockRecorder) RebuildWithCurrentMutableState(ctx, startTime, baseWorkflowIdentifier, baseBranchToken, baseLastEventID, baseLastEventVersion, targetWorkflowIdentifier, targetBranchToken, currentMutableState any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RebuildWithCurrentMutableState", reflect.TypeOf((*MockStateRebuilder)(nil).RebuildWithCurrentMutableState), ctx, now, baseWorkflowIdentifier, baseBranchToken, baseLastEventID, baseLastEventVersion, targetWorkflowIdentifier, targetBranchToken, currentMutableState)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RebuildWithCurrentMutableState", reflect.TypeOf((*MockStateRebuilder)(nil).RebuildWithCurrentMutableState), ctx, startTime, baseWorkflowIdentifier, baseBranchToken, baseLastEventID, baseLastEventVersion, targetWorkflowIdentifier, targetBranchToken, currentMutableState)
 }

--- a/service/history/workflow_rebuilder.go
+++ b/service/history/workflow_rebuilder.go
@@ -5,6 +5,7 @@ package history
 import (
 	"context"
 	"math"
+	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
@@ -13,6 +14,7 @@ import (
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/locks"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/versionhistory"
@@ -198,6 +200,31 @@ func (r *workflowRebuilderImpl) getRebuildSpecFromMutableState(
 	}, nil
 }
 
+// rebuildStartTime returns the start time the rebuilt mutable state should carry.
+func (r *workflowRebuilderImpl) rebuildStartTime(
+	workflowKey definition.WorkflowKey,
+	mutableState *persistencespb.WorkflowMutableState,
+) time.Time {
+	if startTime := mutableState.GetExecutionState().GetStartTime(); startTime != nil {
+		return startTime.AsTime()
+	}
+	// Fallback to ExecutionInfo.StartTime if ExecutionState.StartTime is unexpectedly nil.
+	if startTime := mutableState.GetExecutionInfo().GetStartTime(); startTime != nil {
+		r.logger.Warn("workflowRebuilder unable to find a recorded start time, falling back to ExecutionInfo.StartTime",
+			tag.WorkflowNamespaceID(workflowKey.NamespaceID),
+			tag.WorkflowID(workflowKey.WorkflowID),
+			tag.WorkflowRunID(workflowKey.RunID),
+		)
+		return startTime.AsTime()
+	}
+	r.logger.Warn("workflowRebuilder unable to find a recorded start time, falling back to current time",
+		tag.WorkflowNamespaceID(workflowKey.NamespaceID),
+		tag.WorkflowID(workflowKey.WorkflowID),
+		tag.WorkflowRunID(workflowKey.RunID),
+	)
+	return r.shard.GetTimeSource().Now()
+}
+
 func (r *workflowRebuilderImpl) replayResetWorkflow(
 	ctx context.Context,
 	workflowKey definition.WorkflowKey,
@@ -208,7 +235,7 @@ func (r *workflowRebuilderImpl) replayResetWorkflow(
 ) (historyi.MutableState, error) {
 	rebuildMutableState, rebuildStats, err := ndc.NewStateRebuilder(r.shard, r.logger).RebuildWithCurrentMutableState(
 		ctx,
-		r.shard.GetTimeSource().Now(),
+		r.rebuildStartTime(workflowKey, mutableState),
 		workflowKey,
 		branchToken,
 		math.MaxInt64-1, // NOTE: this is last event ID, layer below will +1 to calculate the next event ID

--- a/service/history/workflow_rebuilder.go
+++ b/service/history/workflow_rebuilder.go
@@ -23,6 +23,7 @@ import (
 	"go.temporal.io/server/service/history/ndc"
 	"go.temporal.io/server/service/history/workflow"
 	wcache "go.temporal.io/server/service/history/workflow/cache"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type (
@@ -100,6 +101,14 @@ func (r *workflowRebuilderImpl) rebuild(
 		rebuildSpec.mutableState,
 	)
 	if err != nil {
+		return err
+	}
+	rebuildMutableState.GetExecutionInfo().MutableStateRebuildTime = timestamppb.New(r.shard.GetTimeSource().Now())
+	// The run deadline is recomputed from the original start time and the execution deadline is
+	// copied from the started event, so either can already be in the past and its refreshed
+	// timer task would fire at once. Re-anchor both deadlines at the current time and regenerate
+	// the timeout timer tasks from them, similarly to what reset does.
+	if err := rebuildMutableState.RefreshExpirationTimeoutTask(ctx); err != nil {
 		return err
 	}
 	return r.overwriteToDB(ctx, rebuildMutableState)

--- a/service/history/workflow_rebuilder_test.go
+++ b/service/history/workflow_rebuilder_test.go
@@ -2,13 +2,20 @@ package history
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/api/serviceerror"
 	historyspb "go.temporal.io/server/api/history/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/service/history/shard"
+	"go.temporal.io/server/service/history/tests"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestWorkflowRebuilderImpl_RebuildableCheck(t *testing.T) {
@@ -212,6 +219,68 @@ func TestWorkflowRebuilderImpl_RebuildableCheck(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestWorkflowRebuilderImpl_RebuildStartTime(t *testing.T) {
+	recordedStartTime := time.Date(2026, 7, 15, 10, 0, 0, 0, time.UTC)
+	rebuildTime := time.Date(2026, 8, 19, 10, 0, 0, 0, time.UTC)
+
+	testCases := []struct {
+		name         string
+		mutableState *persistencespb.WorkflowMutableState
+		expected     time.Time
+	}{
+		{
+			name: "start time on execution state",
+			mutableState: &persistencespb.WorkflowMutableState{
+				ExecutionState: &persistencespb.WorkflowExecutionState{
+					StartTime: timestamppb.New(recordedStartTime),
+				},
+				ExecutionInfo: &persistencespb.WorkflowExecutionInfo{},
+			},
+			expected: recordedStartTime,
+		},
+		{
+			name: "fallback to start time on execution info",
+			mutableState: &persistencespb.WorkflowMutableState{
+				ExecutionState: &persistencespb.WorkflowExecutionState{},
+				ExecutionInfo: &persistencespb.WorkflowExecutionInfo{
+					StartTime: timestamppb.New(recordedStartTime),
+				},
+			},
+			expected: recordedStartTime,
+		},
+		{
+			name: "no start time recorded anywhere",
+			mutableState: &persistencespb.WorkflowMutableState{
+				ExecutionState: &persistencespb.WorkflowExecutionState{},
+				ExecutionInfo:  &persistencespb.WorkflowExecutionInfo{},
+			},
+			expected: rebuildTime,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockShard := shard.NewTestContextWithTimeSource(
+				ctrl,
+				&persistencespb.ShardInfo{ShardId: 0, RangeId: 1},
+				tests.NewDynamicConfig(),
+				clock.NewEventTimeSource().Update(rebuildTime),
+			)
+			rebuilder := &workflowRebuilderImpl{
+				shard:  mockShard,
+				logger: log.NewTestLogger(),
+			}
+
+			startTime := rebuilder.rebuildStartTime(
+				definition.NewWorkflowKey(tests.NamespaceID.String(), tests.WorkflowID, tests.RunID),
+				tc.mutableState,
+			)
+			require.Equal(t, tc.expected, startTime.UTC())
 		})
 	}
 }

--- a/tests/admin_test.go
+++ b/tests/admin_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
 	sdkclient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/workflow"
 	"go.temporal.io/server/api/adminservice/v1"
@@ -32,18 +33,7 @@ func TestAdminRebuildMutableState_ChasmEnabled(t *testing.T) {
 }
 
 func (s *AdminTestSuite) TestAdminRebuildMutableState(testWithChasm bool) {
-	var opts []testcore.TestOption
-	if testWithChasm {
-		opts = append(opts, testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true))
-	}
-	env := testcore.NewEnv(s.T(), opts...)
-
-	if testWithChasm {
-		configValues := env.GetTestCluster().Host().DcClient().GetValue(dynamicconfig.EnableChasm.Key())
-		s.NotEmpty(configValues, "EnableChasm config should be set")
-		configValue, _ := configValues[0].Value.(bool)
-		s.True(configValue, "EnableChasm config should be true")
-	}
+	env := s.newRebuildEnv(testWithChasm)
 
 	tv := testvars.New(s.T())
 	workflowFn := func(ctx workflow.Context) error {
@@ -150,8 +140,189 @@ func (s *AdminTestSuite) TestAdminRebuildMutableState(testWithChasm bool) {
 		timestamp.TimeValue(response1.DatabaseMutableState.ExecutionInfo.ExecutionTime),
 		timestamp.TimeValue(response2.DatabaseMutableState.ExecutionInfo.ExecutionTime),
 	)
-	s.Equal(
-		timestamp.TimeValue(response1.DatabaseMutableState.ExecutionInfo.WorkflowRunExpirationTime),
-		timestamp.TimeValue(response2.DatabaseMutableState.ExecutionInfo.WorkflowRunExpirationTime),
+	s.Nil(response1.DatabaseMutableState.ExecutionInfo.MutableStateRebuildTime)
+	s.NotNil(response2.DatabaseMutableState.ExecutionInfo.MutableStateRebuildTime)
+}
+
+// TestAdminRebuildMutableStateRunTimeout checks that the rebuild re-anchors the run timeout
+// deadline at the rebuild time, the way reset does, and that the run still times out there.
+func (s *AdminTestSuite) TestAdminRebuildMutableStateRunTimeout(testWithChasm bool) {
+	const runTimeout = 10 * time.Second
+
+	env := s.newRebuildEnv(testWithChasm)
+	ctx, cancel := context.WithTimeout(s.Context(), 90*time.Second)
+	defer cancel()
+
+	workflowFn := func(ctx workflow.Context) error {
+		return workflow.Sleep(ctx, time.Hour)
+	}
+	env.SdkWorker().RegisterWorkflow(workflowFn)
+
+	workflowID := testvars.New(s.T()).Any().String()
+	_, err := env.SdkClient().ExecuteWorkflow(ctx, sdkclient.StartWorkflowOptions{
+		ID:        workflowID,
+		TaskQueue: env.WorkerTaskQueue(),
+		// No execution timeout, so the run deadline is purely start time plus run timeout.
+		WorkflowRunTimeout: runTimeout,
+	}, workflowFn)
+	s.NoError(err)
+
+	before := s.awaitRebuildableMutableState(ctx, env, workflowID)
+	originalRunExpiration := timestamp.TimeValue(before.ExecutionInfo.WorkflowRunExpirationTime)
+	s.False(originalRunExpiration.IsZero())
+	s.Zero(timestamp.TimeValue(before.ExecutionInfo.WorkflowExecutionExpirationTime))
+
+	s.rebuildMutableState(ctx, env, workflowID)
+
+	after := s.describeMutableState(ctx, env, workflowID)
+	runExpiration := timestamp.TimeValue(after.ExecutionInfo.WorkflowRunExpirationTime)
+	s.True(runExpiration.After(originalRunExpiration))
+	s.NotNil(after.ExecutionInfo.MutableStateRebuildTime)
+	s.Zero(
+		timestamp.TimeValue(after.ExecutionInfo.WorkflowExecutionExpirationTime),
 	)
+
+	s.assertTimesOutAt(ctx, env, workflowID, runExpiration)
+}
+
+// TestAdminRebuildMutableStateExecutionTimeout checks that the rebuild re-anchors the execution
+// timeout deadline at the rebuild time and that the workflow still times out there, the same thing
+// TestAdminRebuildMutableStateRunTimeout checks for the run timeout deadline.
+//
+// The continue-as-new is what puts the execution timeout timer under test. The server skips the
+// WorkflowExecutionTimeoutTask on a chain's first run and lets the run
+// timeout timer enforce the deadline there, so a first run would exercise the same path as
+// TestAdminRebuildMutableStateRunTimeout. On the second run the opposite holds: the run timeout
+// defaults to the execution timeout, which makes both deadlines the same instant, and
+// GenerateWorkflowStartTasks then skips the run timeout task, leaving the execution timeout timer
+// as the only thing that can end the workflow.
+func (s *AdminTestSuite) TestAdminRebuildMutableStateExecutionTimeout(testWithChasm bool) {
+	const executionTimeout = 15 * time.Second
+
+	env := s.newRebuildEnv(testWithChasm)
+	ctx, cancel := context.WithTimeout(s.Context(), 90*time.Second)
+	defer cancel()
+
+	var workflowFn func(ctx workflow.Context) error
+	workflowFn = func(ctx workflow.Context) error {
+		if workflow.GetInfo(ctx).ContinuedExecutionRunID == "" {
+			return workflow.NewContinueAsNewError(ctx, workflowFn)
+		}
+		return workflow.Sleep(ctx, time.Hour)
+	}
+	env.SdkWorker().RegisterWorkflow(workflowFn)
+
+	workflowID := testvars.New(s.T()).Any().String()
+	run, err := env.SdkClient().ExecuteWorkflow(ctx, sdkclient.StartWorkflowOptions{
+		ID:                       workflowID,
+		TaskQueue:                env.WorkerTaskQueue(),
+		WorkflowExecutionTimeout: executionTimeout,
+	}, workflowFn)
+	s.NoError(err)
+	firstRunID := run.GetRunID()
+
+	s.Await(func(s *AdminTestSuite) {
+		desc, err := env.SdkClient().DescribeWorkflowExecution(ctx, workflowID, "")
+		s.NoError(err)
+		s.NotEqual(firstRunID, desc.GetWorkflowExecutionInfo().GetExecution().GetRunId(),
+			"workflow should continue as new")
+	}, 20*time.Second, 100*time.Millisecond)
+
+	before := s.awaitRebuildableMutableState(ctx, env, workflowID)
+	originalExecutionExpiration := timestamp.TimeValue(before.ExecutionInfo.WorkflowExecutionExpirationTime)
+	originalRunExpiration := timestamp.TimeValue(before.ExecutionInfo.WorkflowRunExpirationTime)
+	s.False(originalExecutionExpiration.IsZero(), "execution timeout deadline should be set before the rebuild")
+	s.NotZero(before.ExecutionInfo.WorkflowExecutionTimerTaskStatus,
+		"the second run should carry an execution timeout timer task")
+
+	s.rebuildMutableState(ctx, env, workflowID)
+
+	after := s.describeMutableState(ctx, env, workflowID)
+	executionExpiration := timestamp.TimeValue(after.ExecutionInfo.WorkflowExecutionExpirationTime)
+	runExpiration := timestamp.TimeValue(after.ExecutionInfo.WorkflowRunExpirationTime)
+	s.True(executionExpiration.After(originalExecutionExpiration),
+		"rebuild should re-anchor the execution deadline")
+	s.True(runExpiration.After(originalRunExpiration), "rebuild should re-anchor the run deadline")
+	s.NotZero(after.ExecutionInfo.WorkflowExecutionTimerTaskStatus,
+		"the execution timeout timer task should survive the rebuild")
+
+	s.assertTimesOutAt(ctx, env, workflowID, executionExpiration)
+}
+
+func (s *AdminTestSuite) newRebuildEnv(testWithChasm bool) *testcore.TestEnv {
+	var opts []testcore.TestOption
+	if testWithChasm {
+		opts = append(opts, testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true))
+	}
+	env := testcore.NewEnv(s.T(), opts...)
+
+	if testWithChasm {
+		configValues := env.GetTestCluster().Host().DcClient().GetValue(dynamicconfig.EnableChasm.Key())
+		s.NotEmpty(configValues, "EnableChasm config should be set")
+		configValue, _ := configValues[0].Value.(bool)
+		s.True(configValue, "EnableChasm config should be true")
+	}
+	return env
+}
+
+func (s *AdminTestSuite) describeMutableState(
+	ctx context.Context,
+	env *testcore.TestEnv,
+	workflowID string,
+) *persistencespb.WorkflowMutableState {
+	resp, err := env.AdminClient().DescribeMutableState(ctx, &adminservice.DescribeMutableStateRequest{
+		Namespace: env.Namespace().String(),
+		Execution: &commonpb.WorkflowExecution{WorkflowId: workflowID},
+		Archetype: chasm.WorkflowArchetype,
+	})
+	s.NoError(err)
+	return resp.DatabaseMutableState
+}
+
+// awaitRebuildableMutableState waits until the current run has completed its first workflow task,
+// so that the rebuild replays more than just the start event.
+func (s *AdminTestSuite) awaitRebuildableMutableState(
+	ctx context.Context,
+	env *testcore.TestEnv,
+	workflowID string,
+) *persistencespb.WorkflowMutableState {
+	var mutableState *persistencespb.WorkflowMutableState
+	s.Await(func(s *AdminTestSuite) {
+		mutableState = s.describeMutableState(ctx, env, workflowID)
+		s.Positive(mutableState.ExecutionInfo.LastCompletedWorkflowTaskStartedEventId,
+			"workflow should complete its first workflow task")
+	}, 20*time.Second, 50*time.Millisecond)
+	return mutableState
+}
+
+func (s *AdminTestSuite) rebuildMutableState(
+	ctx context.Context,
+	env *testcore.TestEnv,
+	workflowID string,
+) {
+	_, err := env.AdminClient().RebuildMutableState(ctx, &adminservice.RebuildMutableStateRequest{
+		Namespace: env.Namespace().String(),
+		Execution: &commonpb.WorkflowExecution{WorkflowId: workflowID},
+	})
+	s.NoError(err)
+}
+
+// assertTimesOutAt asserts that the workflow survives the rebuild and then times out at deadline.
+func (s *AdminTestSuite) assertTimesOutAt(
+	ctx context.Context,
+	env *testcore.TestEnv,
+	workflowID string,
+	deadline time.Time,
+) {
+	desc, err := env.SdkClient().DescribeWorkflowExecution(ctx, workflowID, "")
+	s.NoError(err)
+	s.NotEqual(enumspb.WORKFLOW_EXECUTION_STATUS_TIMED_OUT, desc.GetWorkflowExecutionInfo().GetStatus(),
+		"workflow should not time out immediately after the rebuild")
+
+	s.Await(func(s *AdminTestSuite) {
+		desc, err := env.SdkClient().DescribeWorkflowExecution(ctx, workflowID, "")
+		s.NoError(err)
+		s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_TIMED_OUT, desc.GetWorkflowExecutionInfo().GetStatus(),
+			"workflow did not time out at its deadline")
+	}, time.Until(deadline)+5*time.Second, 250*time.Millisecond)
 }

--- a/tests/admin_test.go
+++ b/tests/admin_test.go
@@ -138,11 +138,20 @@ func (s *AdminTestSuite) TestAdminRebuildMutableState(testWithChasm bool) {
 		TransitionCount:          response1.DatabaseMutableState.ExecutionInfo.StateTransitionCount + 1,
 	}, response2.DatabaseMutableState.ExecutionState.LastUpdateVersionedTransition)
 
-	// Rebuild explicitly sets start time, thus start time will change after rebuild.
+	// Rebuild recreates mutable state for the same run, so the recorded start time must survive it.
 	s.NotNil(response1.DatabaseMutableState.ExecutionState.StartTime)
 	s.NotNil(response2.DatabaseMutableState.ExecutionState.StartTime)
 
 	timeBefore := timestamp.TimeValue(response1.DatabaseMutableState.ExecutionState.StartTime)
 	timeAfter := timestamp.TimeValue(response2.DatabaseMutableState.ExecutionState.StartTime)
-	s.False(timeAfter.Before(timeBefore))
+	s.Equal(timeBefore, timeAfter)
+
+	s.Equal(
+		timestamp.TimeValue(response1.DatabaseMutableState.ExecutionInfo.ExecutionTime),
+		timestamp.TimeValue(response2.DatabaseMutableState.ExecutionInfo.ExecutionTime),
+	)
+	s.Equal(
+		timestamp.TimeValue(response1.DatabaseMutableState.ExecutionInfo.WorkflowRunExpirationTime),
+		timestamp.TimeValue(response2.DatabaseMutableState.ExecutionInfo.WorkflowRunExpirationTime),
+	)
 }


### PR DESCRIPTION
## What changed?
`AdminRebuildMutableState`, invoked by `tdbg workflow rebuild`, no longer replaces the mutable state
start time with the current time. It reuses the run's recorded start time, falling back to
`ExecutionInfo.StartTime`. Only if both `ExecutionState.StartTime` and `ExecutionInfo.StartTime` are
empty, the current time will be used.

The rebuild now also refreshes the timeout timer tasks so the run and execution deadlines are anchoraed at the time of the call, which is what reset already does. Without it, preserving the start time would make a workflow rebuild after its deadline timeout immediately. It also records ExecutionInfo.MutableStateRebuildTime so that a repaired run could be identify by operator.

## Why?
Moving the start time to now, often results in workflow with a negative duration, since the end time is kept as is. Downstream systems may handle this incorrectly.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
1) Some downstream systems may prefer the workflow start time to move.
2) Admin may intent for the workflow to have a new timeout instead of getting a timeout
