### PR TITLE
Emit remote cluster lifecycle wide events

### DIFF
--- a/common/wideevents/remote_cluster_events.go
+++ b/common/wideevents/remote_cluster_events.go
@@ -1,0 +1,22 @@
+package wideevents
+
+import "go.opentelemetry.io/otel/log"
+
+const RemoteClusterLifecycleEventName = "remote_cluster_lifecycle"
+
+const (
+	PhaseRemoteClusterUpsert = "remote_cluster_upsert"
+	PhaseRemoteClusterRemove = "remote_cluster_remove"
+)
+
+// RemoteClusterLifecyclePayload preserves the namespace lifecycle event envelope
+// while using a distinct event name and remote-cluster-specific details.
+type RemoteClusterLifecyclePayload NamespaceLifecyclePayload
+
+func (p RemoteClusterLifecyclePayload) EventName() string {
+	return RemoteClusterLifecycleEventName
+}
+
+func (p RemoteClusterLifecyclePayload) Attributes() []log.KeyValue {
+	return NamespaceLifecyclePayload(p).Attributes()
+}

--- a/common/wideevents/remote_cluster_events_test.go
+++ b/common/wideevents/remote_cluster_events_test.go
@@ -1,0 +1,22 @@
+package wideevents
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoteClusterLifecycleEventName(t *testing.T) {
+	require.Equal(t, "remote_cluster_lifecycle", RemoteClusterLifecyclePayload{}.EventName())
+}
+
+func TestRemoteClusterLifecycleFieldSetMatchesNamespaceLifecycle(t *testing.T) {
+	payload := RemoteClusterLifecyclePayload{
+		Phase:       "remote_cluster_upsert",
+		Namespace:   "N/A",
+		NamespaceID: "N/A",
+		Details:     map[string]any{"outcome": "succeeded"},
+	}
+
+	require.Equal(t, NamespaceLifecyclePayload(payload).Attributes(), payload.Attributes())
+}

--- a/service/frontend/admin_handler.go
+++ b/service/frontend/admin_handler.go
@@ -874,7 +874,9 @@ func (adh *AdminHandler) AddOrUpdateRemoteCluster(
 		persistedBefore    *persistence.GetClusterMetadataResponse
 		persistenceRequest *persistence.SaveClusterMetadataRequest
 	)
-	// Register failure emission first so CapturePanic runs before it during unwinding.
+	// Bracket deferred emission with panic capture: the inner capture converts handler panics
+	// into retError for the event, while the outer capture recovers panics from emission itself.
+	defer log.CapturePanic(adh.logger, &retError)
 	defer func() {
 		lifecycleEvent.emitUpsertFailure(retError, remoteResponse, persistedBefore, persistenceRequest)
 	}()
@@ -980,7 +982,9 @@ func (adh *AdminHandler) RemoveRemoteCluster(
 		cachedBefore       cachedRemoteClusterLookup
 		persistenceRequest *persistence.DeleteClusterMetadataRequest
 	)
-	// Register failure emission first so CapturePanic runs before it during unwinding.
+	// Bracket deferred emission with panic capture: the inner capture converts handler panics
+	// into retError for the event, while the outer capture recovers panics from emission itself.
+	defer log.CapturePanic(adh.logger, &retError)
 	defer func() {
 		lifecycleEvent.emitRemoveFailure(retError, cachedBefore, persistenceRequest)
 	}()

--- a/service/frontend/admin_handler.go
+++ b/service/frontend/admin_handler.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	otellog "go.opentelemetry.io/otel/log"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	namespacepb "go.temporal.io/api/namespace/v1"
@@ -85,6 +86,7 @@ type (
 		status int32
 
 		logger                     log.Logger
+		eventLogger                otellog.Logger
 		numberOfHistoryShards      int32
 		config                     *Config
 		namespaceDLQHandler        nsreplication.DLQMessageHandler
@@ -123,6 +125,7 @@ type (
 		ReplicatorNamespaceReplicationQueue persistence.NamespaceReplicationQueue
 		visibilityMgr                       manager.VisibilityManager
 		Logger                              log.Logger
+		EventLogger                         otellog.Logger
 		TaskManager                         persistence.TaskManager
 		FairTaskManager                     persistence.FairTaskManager
 		PersistenceExecutionManager         persistence.ExecutionManager
@@ -173,6 +176,7 @@ func NewAdminHandler(
 
 	return &AdminHandler{
 		logger:                     args.Logger,
+		eventLogger:                args.EventLogger,
 		status:                     common.DaemonStatusInitialized,
 		numberOfHistoryShards:      args.PersistenceConfig.NumHistoryShards,
 		config:                     args.Config,
@@ -864,7 +868,30 @@ func (adh *AdminHandler) AddOrUpdateRemoteCluster(
 	ctx context.Context,
 	request *adminservice.AddOrUpdateRemoteClusterRequest,
 ) (_ *adminservice.AddOrUpdateRemoteClusterResponse, retError error) {
+	var (
+		lifecycleEvent     *remoteClusterLifecycleEvent
+		remoteResponse     *adminservice.DescribeClusterResponse
+		persistedBefore    *persistence.GetClusterMetadataResponse
+		persistenceRequest *persistence.SaveClusterMetadataRequest
+	)
+	// Register failure emission first so CapturePanic runs before it during unwinding.
+	defer func() {
+		lifecycleEvent.emitUpsertFailure(retError, remoteResponse, persistedBefore, persistenceRequest)
+	}()
 	defer log.CapturePanic(adh.logger, &retError)
+	lifecycleEvent = newRemoteClusterUpsertLifecycleEvent(
+		ctx,
+		adh.eventLogger,
+		adh.clusterMetadata,
+		adh.config,
+		remoteClusterAPIAdmin,
+		remoteClusterUpsertRequestFields{
+			FrontendAddress:               request.GetFrontendAddress(),
+			FrontendHTTPAddress:           request.GetFrontendHttpAddress(), //nolint:staticcheck // Audit the deprecated API request as received.
+			EnableRemoteClusterConnection: request.GetEnableRemoteClusterConnection(),
+			EnableReplication:             request.GetEnableReplication(),
+		},
+	)
 
 	adminClient := adh.clientFactory.NewRemoteAdminClientWithTimeout(
 		request.GetFrontendAddress(),
@@ -874,6 +901,7 @@ func (adh *AdminHandler) AddOrUpdateRemoteCluster(
 
 	// Fetch cluster metadata from remote cluster
 	resp, err := adminClient.DescribeCluster(ctx, &adminservice.DescribeClusterRequest{})
+	remoteResponse = resp
 	if err != nil {
 		return nil, err
 	}
@@ -905,14 +933,14 @@ func (adh *AdminHandler) AddOrUpdateRemoteCluster(
 	)
 	switch err.(type) {
 	case nil:
+		persistedBefore = clusterData
 		updateRequestVersion = clusterData.Version
 	case *serviceerror.NotFound:
 		updateRequestVersion = 0
 	default:
 		return nil, err
 	}
-
-	applied, err := clusterMetadataMrg.SaveClusterMetadata(ctx, &persistence.SaveClusterMetadataRequest{
+	saveRequest := &persistence.SaveClusterMetadataRequest{
 		ClusterMetadata: &persistencespb.ClusterMetadata{
 			ClusterName:              resp.GetClusterName(),
 			HistoryShardCount:        resp.GetHistoryShardCount(),
@@ -927,7 +955,9 @@ func (adh *AdminHandler) AddOrUpdateRemoteCluster(
 			Tags:                     resp.GetTags(),
 		},
 		Version: updateRequestVersion,
-	})
+	}
+	persistenceRequest = saveRequest
+	applied, err := clusterMetadataMrg.SaveClusterMetadata(ctx, saveRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -935,6 +965,7 @@ func (adh *AdminHandler) AddOrUpdateRemoteCluster(
 		return nil, serviceerror.NewInvalidArgument(
 			"Cannot update remote cluster due to update immutable fields")
 	}
+	lifecycleEvent.emitUpsertSuccess(persistedBefore, persistenceRequest)
 	return &adminservice.AddOrUpdateRemoteClusterResponse{}, nil
 }
 
@@ -944,18 +975,40 @@ func (adh *AdminHandler) RemoveRemoteCluster(
 	ctx context.Context,
 	request *adminservice.RemoveRemoteClusterRequest,
 ) (_ *adminservice.RemoveRemoteClusterResponse, retError error) {
+	var (
+		lifecycleEvent     *remoteClusterLifecycleEvent
+		cachedBefore       cachedRemoteClusterLookup
+		persistenceRequest *persistence.DeleteClusterMetadataRequest
+	)
+	// Register failure emission first so CapturePanic runs before it during unwinding.
+	defer func() {
+		lifecycleEvent.emitRemoveFailure(retError, cachedBefore, persistenceRequest)
+	}()
 	defer log.CapturePanic(adh.logger, &retError)
-
-	if err := validateClusterNotInUseByNamespaces(adh.namespaceRegistry, adh.clusterMetadata.GetCurrentClusterName(), request.GetClusterName()); err != nil {
-		return nil, err
-	}
-
-	if err := adh.clusterMetadataManager.DeleteClusterMetadata(
+	clusterName := request.GetClusterName()
+	lifecycleEvent = newRemoteClusterRemoveLifecycleEvent(
 		ctx,
-		&persistence.DeleteClusterMetadataRequest{ClusterName: request.GetClusterName()},
-	); err != nil {
+		adh.eventLogger,
+		adh.clusterMetadata,
+		adh.config,
+		remoteClusterAPIAdmin,
+		remoteClusterRemoveRequestFields{ClusterName: clusterName},
+	)
+	if lifecycleEvent != nil {
+		// Admin does not use the cluster cache for removal; this lookup is audit-only.
+		cachedBefore = lookupCachedRemoteCluster(adh.clusterMetadata, clusterName)
+	}
+
+	if err := validateClusterNotInUseByNamespaces(adh.namespaceRegistry, adh.clusterMetadata.GetCurrentClusterName(), clusterName); err != nil {
 		return nil, err
 	}
+
+	deleteRequest := &persistence.DeleteClusterMetadataRequest{ClusterName: clusterName}
+	persistenceRequest = deleteRequest
+	if err := adh.clusterMetadataManager.DeleteClusterMetadata(ctx, deleteRequest); err != nil {
+		return nil, err
+	}
+	lifecycleEvent.emitRemoveSuccess(cachedBefore, persistenceRequest)
 	return &adminservice.RemoveRemoteClusterResponse{}, nil
 }
 

--- a/service/frontend/admin_handler_test.go
+++ b/service/frontend/admin_handler_test.go
@@ -293,6 +293,22 @@ func (s *adminHandlerSuite) Test_RemoveRemoteCluster_PanicEmitsFailure() {
 	s.Equal("Internal", details["error_code"])
 }
 
+func (s *adminHandlerSuite) Test_RemoveRemoteCluster_EventEmissionPanicCaptured() {
+	clusterName := "cluster"
+	s.handler.eventLogger = &panicRemoteClusterEventLogger{}
+	s.handler.config.EmitNamespaceLifecycleEvents = dynamicconfig.GetBoolPropertyFn(true)
+	s.mockMetadata.EXPECT().GetAllClusterInfo().DoAndReturn(func() map[string]cluster.ClusterInformation {
+		panic("handler panic")
+	})
+
+	_, err := s.handler.RemoveRemoteCluster(
+		context.Background(),
+		&adminservice.RemoveRemoteClusterRequest{ClusterName: clusterName},
+	)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "event logger panic")
+}
+
 func (s *adminHandlerSuite) Test_RemoveRemoteCluster_BlockedByGlobalNamespace() {
 	var clusterName = "cluster"
 	// The namespace lists both the current cluster and the cluster being
@@ -761,6 +777,28 @@ func (s *adminHandlerSuite) Test_AddOrUpdateRemoteCluster_PanicEmitsFailure() {
 	_, details := remoteClusterEventValues(s.T(), eventLogger.records)
 	s.Equal(remoteClusterOutcomeFailed, details["outcome"])
 	s.Equal("Internal", details["error_code"])
+}
+
+func (s *adminHandlerSuite) Test_AddOrUpdateRemoteCluster_EventEmissionPanicCaptured() {
+	rpcAddress := uuid.NewString()
+	s.handler.eventLogger = &panicRemoteClusterEventLogger{}
+	s.handler.config.EmitNamespaceLifecycleEvents = dynamicconfig.GetBoolPropertyFn(true)
+	s.mockClientFactory.EXPECT().NewRemoteAdminClientWithTimeout(rpcAddress, gomock.Any(), gomock.Any()).Return(
+		s.mockAdminClient,
+	)
+	s.mockAdminClient.EXPECT().DescribeCluster(
+		gomock.Any(),
+		&adminservice.DescribeClusterRequest{},
+	).DoAndReturn(func(context.Context, *adminservice.DescribeClusterRequest, ...grpc.CallOption) (*adminservice.DescribeClusterResponse, error) {
+		panic("handler panic")
+	})
+
+	_, err := s.handler.AddOrUpdateRemoteCluster(
+		context.Background(),
+		&adminservice.AddOrUpdateRemoteClusterRequest{FrontendAddress: rpcAddress},
+	)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "event logger panic")
 }
 
 func (s *adminHandlerSuite) Test_AddOrUpdateRemoteCluster_GetClusterMetadata_Error() {

--- a/service/frontend/admin_handler_test.go
+++ b/service/frontend/admin_handler_test.go
@@ -184,6 +184,7 @@ func (s *adminHandlerSuite) SetupTest() {
 		s.mockProducer,
 		s.mockVisibilityMgr,
 		s.mockResource.GetLogger(),
+		nil,
 		s.mockResource.GetTaskManager(),
 		s.mockResource.GetTaskManager(),
 		s.mockResource.GetExecutionManager(),
@@ -231,6 +232,12 @@ func (s *adminHandlerSuite) TearDownTest() {
 
 func (s *adminHandlerSuite) Test_RemoveRemoteCluster_Success() {
 	var clusterName = "cluster"
+	eventLogger := &captureRemoteClusterEventLogger{}
+	s.handler.eventLogger = eventLogger
+	s.handler.config.EmitNamespaceLifecycleEvents = dynamicconfig.GetBoolPropertyFn(true)
+	s.mockMetadata.EXPECT().GetAllClusterInfo().Return(map[string]cluster.ClusterInformation{
+		clusterName: {ClusterID: "cluster-id"},
+	})
 	s.mockNamespaceCache.EXPECT().GetAllNamespaces().Return(nil)
 	s.mockClusterMetadataManager.EXPECT().DeleteClusterMetadata(
 		gomock.Any(),
@@ -239,10 +246,20 @@ func (s *adminHandlerSuite) Test_RemoveRemoteCluster_Success() {
 
 	_, err := s.handler.RemoveRemoteCluster(context.Background(), &adminservice.RemoveRemoteClusterRequest{ClusterName: clusterName})
 	s.NoError(err)
+	_, details := remoteClusterEventValues(s.T(), eventLogger.records)
+	s.Equal(remoteClusterOutcomeSucceeded, details["outcome"])
+	s.Equal(remoteClusterMutationRemoved, details["mutation"])
+	s.Equal("cluster-id", details["remote_cluster_id"])
 }
 
 func (s *adminHandlerSuite) Test_RemoveRemoteCluster_Error() {
 	var clusterName = "cluster"
+	eventLogger := &captureRemoteClusterEventLogger{}
+	s.handler.eventLogger = eventLogger
+	s.handler.config.EmitNamespaceLifecycleEvents = dynamicconfig.GetBoolPropertyFn(true)
+	s.mockMetadata.EXPECT().GetAllClusterInfo().Return(map[string]cluster.ClusterInformation{
+		clusterName: {},
+	})
 	s.mockNamespaceCache.EXPECT().GetAllNamespaces().Return(nil)
 	s.mockClusterMetadataManager.EXPECT().DeleteClusterMetadata(
 		gomock.Any(),
@@ -251,6 +268,29 @@ func (s *adminHandlerSuite) Test_RemoveRemoteCluster_Error() {
 
 	_, err := s.handler.RemoveRemoteCluster(context.Background(), &adminservice.RemoveRemoteClusterRequest{ClusterName: clusterName})
 	s.Error(err)
+	_, details := remoteClusterEventValues(s.T(), eventLogger.records)
+	s.Equal(remoteClusterOutcomeFailed, details["outcome"])
+	s.Equal(remoteClusterMutationUnknown, details["mutation"])
+	s.NotNil(details["persistence_request"])
+}
+
+func (s *adminHandlerSuite) Test_RemoveRemoteCluster_PanicEmitsFailure() {
+	clusterName := "cluster"
+	eventLogger := &captureRemoteClusterEventLogger{}
+	s.handler.eventLogger = eventLogger
+	s.handler.config.EmitNamespaceLifecycleEvents = dynamicconfig.GetBoolPropertyFn(true)
+	s.mockMetadata.EXPECT().GetAllClusterInfo().DoAndReturn(func() map[string]cluster.ClusterInformation {
+		panic("test panic")
+	})
+
+	_, err := s.handler.RemoveRemoteCluster(
+		context.Background(),
+		&adminservice.RemoveRemoteClusterRequest{ClusterName: clusterName},
+	)
+	s.Require().Error(err)
+	_, details := remoteClusterEventValues(s.T(), eventLogger.records)
+	s.Equal(remoteClusterOutcomeFailed, details["outcome"])
+	s.Equal("Internal", details["error_code"])
 }
 
 func (s *adminHandlerSuite) Test_RemoveRemoteCluster_BlockedByGlobalNamespace() {
@@ -376,6 +416,9 @@ func (s *adminHandlerSuite) Test_AddOrUpdateRemoteCluster_RecordFound_Success() 
 	var clusterName = uuid.NewString()
 	var clusterID = uuid.NewString()
 	var recordVersion int64 = 5
+	eventLogger := &captureRemoteClusterEventLogger{}
+	s.handler.eventLogger = eventLogger
+	s.handler.config.EmitNamespaceLifecycleEvents = dynamicconfig.GetBoolPropertyFn(true)
 
 	s.mockMetadata.EXPECT().GetFailoverVersionIncrement().Return(int64(10)).Times(2)
 	s.mockMetadata.EXPECT().GetAllClusterInfo().Return(make(map[string]cluster.ClusterInformation))
@@ -413,6 +456,11 @@ func (s *adminHandlerSuite) Test_AddOrUpdateRemoteCluster_RecordFound_Success() 
 		FrontendAddress: rpcAddress,
 	})
 	s.NoError(err)
+	_, details := remoteClusterEventValues(s.T(), eventLogger.records)
+	s.Equal(remoteClusterOutcomeSucceeded, details["outcome"])
+	s.Equal(remoteClusterMutationUpdated, details["mutation"])
+	s.Equal(remoteClusterTransitionUnchanged, details["requested_connection_transition"])
+	s.Equal(remoteClusterTransitionUnchanged, details["requested_replication_transition"])
 }
 
 func (s *adminHandlerSuite) Test_AddOrUpdateRemoteCluster_RecordNotFound_Success() {
@@ -672,6 +720,9 @@ func (s *adminHandlerSuite) Test_AddOrUpdateRemoteCluster_ValidationError_EmptyR
 
 func (s *adminHandlerSuite) Test_AddOrUpdateRemoteCluster_DescribeCluster_Error() {
 	var rpcAddress = uuid.NewString()
+	eventLogger := &captureRemoteClusterEventLogger{}
+	s.handler.eventLogger = eventLogger
+	s.handler.config.EmitNamespaceLifecycleEvents = dynamicconfig.GetBoolPropertyFn(true)
 
 	s.mockClientFactory.EXPECT().NewRemoteAdminClientWithTimeout(rpcAddress, gomock.Any(), gomock.Any()).Return(
 		s.mockAdminClient,
@@ -682,6 +733,34 @@ func (s *adminHandlerSuite) Test_AddOrUpdateRemoteCluster_DescribeCluster_Error(
 	)
 	_, err := s.handler.AddOrUpdateRemoteCluster(context.Background(), &adminservice.AddOrUpdateRemoteClusterRequest{FrontendAddress: rpcAddress})
 	s.Error(err)
+	_, details := remoteClusterEventValues(s.T(), eventLogger.records)
+	s.Equal(remoteClusterOutcomeFailed, details["outcome"])
+	s.Equal("Unknown", details["error_code"])
+}
+
+func (s *adminHandlerSuite) Test_AddOrUpdateRemoteCluster_PanicEmitsFailure() {
+	rpcAddress := uuid.NewString()
+	eventLogger := &captureRemoteClusterEventLogger{}
+	s.handler.eventLogger = eventLogger
+	s.handler.config.EmitNamespaceLifecycleEvents = dynamicconfig.GetBoolPropertyFn(true)
+	s.mockClientFactory.EXPECT().NewRemoteAdminClientWithTimeout(rpcAddress, gomock.Any(), gomock.Any()).Return(
+		s.mockAdminClient,
+	)
+	s.mockAdminClient.EXPECT().DescribeCluster(
+		gomock.Any(),
+		&adminservice.DescribeClusterRequest{},
+	).DoAndReturn(func(context.Context, *adminservice.DescribeClusterRequest, ...grpc.CallOption) (*adminservice.DescribeClusterResponse, error) {
+		panic("test panic")
+	})
+
+	_, err := s.handler.AddOrUpdateRemoteCluster(
+		context.Background(),
+		&adminservice.AddOrUpdateRemoteClusterRequest{FrontendAddress: rpcAddress},
+	)
+	s.Require().Error(err)
+	_, details := remoteClusterEventValues(s.T(), eventLogger.records)
+	s.Equal(remoteClusterOutcomeFailed, details["outcome"])
+	s.Equal("Internal", details["error_code"])
 }
 
 func (s *adminHandlerSuite) Test_AddOrUpdateRemoteCluster_GetClusterMetadata_Error() {

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -782,6 +782,7 @@ func AdminHandlerProvider(
 	replicatorNamespaceReplicationQueue FEReplicatorNamespaceReplicationQueue,
 	visibilityMgr manager.VisibilityManager,
 	logger log.SnTaggedLogger,
+	eventLogger otellog.Logger,
 	namespaceReplicationQueue persistence.NamespaceReplicationQueue,
 	taskManager persistence.TaskManager,
 	fairTaskManager persistence.FairTaskManager,
@@ -814,6 +815,7 @@ func AdminHandlerProvider(
 		replicatorNamespaceReplicationQueue,
 		visibilityMgr,
 		logger,
+		eventLogger,
 		taskManager,
 		fairTaskManager,
 		persistenceExecutionManager,
@@ -868,6 +870,7 @@ func NamespaceDLQHandlerProvider(
 func OperatorHandlerProvider(
 	configuration *Config,
 	logger log.SnTaggedLogger,
+	eventLogger otellog.Logger,
 	sdkClientFactory sdk.ClientFactory,
 	metricsHandler metrics.Handler,
 	visibilityMgr manager.VisibilityManager,
@@ -883,6 +886,7 @@ func OperatorHandlerProvider(
 	args := NewOperatorHandlerImplArgs{
 		configuration,
 		logger,
+		eventLogger,
 		sdkClientFactory,
 		metricsHandler,
 		visibilityMgr,

--- a/service/frontend/operator_handler.go
+++ b/service/frontend/operator_handler.go
@@ -615,7 +615,9 @@ func (h *OperatorHandlerImpl) AddOrUpdateRemoteCluster(
 		persistedBefore    *persistence.GetClusterMetadataResponse
 		persistenceRequest *persistence.SaveClusterMetadataRequest
 	)
-	// Register failure emission first so CapturePanic runs before it during unwinding.
+	// Bracket deferred emission with panic capture: the inner capture converts handler panics
+	// into retError for the event, while the outer capture recovers panics from emission itself.
+	defer log.CapturePanic(h.logger, &retError)
 	defer func() {
 		lifecycleEvent.emitUpsertFailure(retError, remoteResponse, persistedBefore, persistenceRequest)
 	}()
@@ -721,7 +723,9 @@ func (h *OperatorHandlerImpl) RemoveRemoteCluster(
 		cachedBefore       cachedRemoteClusterLookup
 		persistenceRequest *persistence.DeleteClusterMetadataRequest
 	)
-	// Register failure emission first so CapturePanic runs before it during unwinding.
+	// Bracket deferred emission with panic capture: the inner capture converts handler panics
+	// into retError for the event, while the outer capture recovers panics from emission itself.
+	defer log.CapturePanic(h.logger, &retError)
 	defer func() {
 		lifecycleEvent.emitRemoveFailure(retError, cachedBefore, persistenceRequest)
 	}()

--- a/service/frontend/operator_handler.go
+++ b/service/frontend/operator_handler.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	otellog "go.opentelemetry.io/otel/log"
 	enumspb "go.temporal.io/api/enums/v1"
 	namespacepb "go.temporal.io/api/namespace/v1"
 	"go.temporal.io/api/operatorservice/v1"
@@ -51,6 +52,7 @@ type (
 		status int32
 
 		logger                 log.Logger
+		eventLogger            otellog.Logger
 		config                 *Config
 		sdkClientFactory       sdk.ClientFactory
 		metricsHandler         metrics.Handler
@@ -68,6 +70,7 @@ type (
 	NewOperatorHandlerImplArgs struct {
 		config                 *Config
 		Logger                 log.Logger
+		EventLogger            otellog.Logger
 		sdkClientFactory       sdk.ClientFactory
 		MetricsHandler         metrics.Handler
 		VisibilityMgr          manager.VisibilityManager
@@ -95,6 +98,7 @@ func NewOperatorHandlerImpl(
 
 	handler := &OperatorHandlerImpl{
 		logger:                 args.Logger,
+		eventLogger:            args.EventLogger,
 		status:                 common.DaemonStatusInitialized,
 		config:                 args.config,
 		sdkClientFactory:       args.sdkClientFactory,
@@ -605,7 +609,30 @@ func (h *OperatorHandlerImpl) AddOrUpdateRemoteCluster(
 	ctx context.Context,
 	request *operatorservice.AddOrUpdateRemoteClusterRequest,
 ) (_ *operatorservice.AddOrUpdateRemoteClusterResponse, retError error) {
+	var (
+		lifecycleEvent     *remoteClusterLifecycleEvent
+		remoteResponse     *adminservice.DescribeClusterResponse
+		persistedBefore    *persistence.GetClusterMetadataResponse
+		persistenceRequest *persistence.SaveClusterMetadataRequest
+	)
+	// Register failure emission first so CapturePanic runs before it during unwinding.
+	defer func() {
+		lifecycleEvent.emitUpsertFailure(retError, remoteResponse, persistedBefore, persistenceRequest)
+	}()
 	defer log.CapturePanic(h.logger, &retError)
+	lifecycleEvent = newRemoteClusterUpsertLifecycleEvent(
+		ctx,
+		h.eventLogger,
+		h.clusterMetadata,
+		h.config,
+		remoteClusterAPIOperator,
+		remoteClusterUpsertRequestFields{
+			FrontendAddress:               request.GetFrontendAddress(),
+			FrontendHTTPAddress:           request.GetFrontendHttpAddress(),
+			EnableRemoteClusterConnection: request.GetEnableRemoteClusterConnection(),
+			EnableReplication:             request.GetEnableReplication(),
+		},
+	)
 
 	adminClient := h.clientFactory.NewRemoteAdminClientWithTimeout(
 		request.GetFrontendAddress(),
@@ -615,6 +642,7 @@ func (h *OperatorHandlerImpl) AddOrUpdateRemoteCluster(
 
 	// Fetch cluster metadata from remote cluster
 	resp, err := adminClient.DescribeCluster(ctx, &adminservice.DescribeClusterRequest{})
+	remoteResponse = resp
 	if err != nil {
 		return nil, serviceerror.NewUnavailablef(
 			errUnableConnectRemoteClusterMessage,
@@ -649,14 +677,14 @@ func (h *OperatorHandlerImpl) AddOrUpdateRemoteCluster(
 	)
 	switch err.(type) {
 	case nil:
+		persistedBefore = clusterData
 		updateRequestVersion = clusterData.Version
 	case *serviceerror.NotFound:
 		updateRequestVersion = 0
 	default:
 		return nil, serviceerror.NewInternalf(errUnableToStoreClusterInfo, err)
 	}
-
-	applied, err := h.clusterMetadataManager.SaveClusterMetadata(ctx, &persistence.SaveClusterMetadataRequest{
+	saveRequest := &persistence.SaveClusterMetadataRequest{
 		ClusterMetadata: &persistencespb.ClusterMetadata{
 			ClusterName:              resp.GetClusterName(),
 			HistoryShardCount:        resp.GetHistoryShardCount(),
@@ -671,13 +699,16 @@ func (h *OperatorHandlerImpl) AddOrUpdateRemoteCluster(
 			Tags:                     resp.GetTags(),
 		},
 		Version: updateRequestVersion,
-	})
+	}
+	persistenceRequest = saveRequest
+	applied, err := h.clusterMetadataManager.SaveClusterMetadata(ctx, saveRequest)
 	if err != nil {
 		return nil, serviceerror.NewInternalf(errUnableToStoreClusterInfo, err)
 	}
 	if !applied {
 		return nil, serviceerror.NewInvalidArgumentf(errUnableToStoreClusterInfo, err)
 	}
+	lifecycleEvent.emitUpsertSuccess(persistedBefore, persistenceRequest)
 	return &operatorservice.AddOrUpdateRemoteClusterResponse{}, nil
 }
 
@@ -685,29 +716,41 @@ func (h *OperatorHandlerImpl) RemoveRemoteCluster(
 	ctx context.Context,
 	request *operatorservice.RemoveRemoteClusterRequest,
 ) (_ *operatorservice.RemoveRemoteClusterResponse, retError error) {
+	var (
+		lifecycleEvent     *remoteClusterLifecycleEvent
+		cachedBefore       cachedRemoteClusterLookup
+		persistenceRequest *persistence.DeleteClusterMetadataRequest
+	)
+	// Register failure emission first so CapturePanic runs before it during unwinding.
+	defer func() {
+		lifecycleEvent.emitRemoveFailure(retError, cachedBefore, persistenceRequest)
+	}()
 	defer log.CapturePanic(h.logger, &retError)
+	clusterName := request.GetClusterName()
+	lifecycleEvent = newRemoteClusterRemoveLifecycleEvent(
+		ctx,
+		h.eventLogger,
+		h.clusterMetadata,
+		h.config,
+		remoteClusterAPIOperator,
+		remoteClusterRemoveRequestFields{ClusterName: clusterName},
+	)
 
-	var isClusterNameExist bool
-	for clusterName := range h.clusterMetadata.GetAllClusterInfo() {
-		if clusterName == request.GetClusterName() {
-			isClusterNameExist = true
-			break
-		}
-	}
-	if !isClusterNameExist {
+	cachedBefore = lookupCachedRemoteCluster(h.clusterMetadata, clusterName)
+	if !cachedBefore.found {
 		return nil, serviceerror.NewNotFound("The cluster to be deleted cannot be found in clusters cache.")
 	}
 
-	if err := validateClusterNotInUseByNamespaces(h.namespaceRegistry, h.clusterMetadata.GetCurrentClusterName(), request.GetClusterName()); err != nil {
+	if err := validateClusterNotInUseByNamespaces(h.namespaceRegistry, h.clusterMetadata.GetCurrentClusterName(), clusterName); err != nil {
 		return nil, err
 	}
 
-	if err := h.clusterMetadataManager.DeleteClusterMetadata(
-		ctx,
-		&persistence.DeleteClusterMetadataRequest{ClusterName: request.GetClusterName()},
-	); err != nil {
+	deleteRequest := &persistence.DeleteClusterMetadataRequest{ClusterName: clusterName}
+	persistenceRequest = deleteRequest
+	if err := h.clusterMetadataManager.DeleteClusterMetadata(ctx, deleteRequest); err != nil {
 		return nil, serviceerror.NewInternalf(errUnableToDeleteClusterInfo, err)
 	}
+	lifecycleEvent.emitRemoveSuccess(cachedBefore, persistenceRequest)
 	return &operatorservice.RemoveRemoteClusterResponse{}, nil
 }
 

--- a/service/frontend/operator_handler_test.go
+++ b/service/frontend/operator_handler_test.go
@@ -1202,6 +1202,22 @@ func (s *operatorHandlerSuite) Test_RemoveRemoteCluster_PanicEmitsFailure() {
 	s.Equal("Internal", details["error_code"])
 }
 
+func (s *operatorHandlerSuite) Test_RemoveRemoteCluster_EventEmissionPanicCaptured() {
+	clusterName := "cluster"
+	s.handler.eventLogger = &panicRemoteClusterEventLogger{}
+	s.handler.config.EmitNamespaceLifecycleEvents = dynamicconfig.GetBoolPropertyFn(true)
+	s.mockResource.ClusterMetadata.EXPECT().GetAllClusterInfo().DoAndReturn(func() map[string]cluster.ClusterInformation {
+		panic("handler panic")
+	})
+
+	_, err := s.handler.RemoveRemoteCluster(
+		context.Background(),
+		&operatorservice.RemoveRemoteClusterRequest{ClusterName: clusterName},
+	)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "event logger panic")
+}
+
 func (s *operatorHandlerSuite) Test_RemoveRemoteCluster_BlockedByGlobalNamespace() {
 	var clusterName = "cluster"
 	eventLogger := &captureRemoteClusterEventLogger{}
@@ -1689,6 +1705,28 @@ func (s *operatorHandlerSuite) Test_AddOrUpdateRemoteCluster_PanicEmitsFailure()
 	_, details := remoteClusterEventValues(s.T(), eventLogger.records)
 	s.Equal(remoteClusterOutcomeFailed, details["outcome"])
 	s.Equal("Internal", details["error_code"])
+}
+
+func (s *operatorHandlerSuite) Test_AddOrUpdateRemoteCluster_EventEmissionPanicCaptured() {
+	rpcAddress := uuid.NewString()
+	s.handler.eventLogger = &panicRemoteClusterEventLogger{}
+	s.handler.config.EmitNamespaceLifecycleEvents = dynamicconfig.GetBoolPropertyFn(true)
+	s.mockResource.ClientFactory.EXPECT().NewRemoteAdminClientWithTimeout(rpcAddress, gomock.Any(), gomock.Any()).Return(
+		s.mockResource.RemoteAdminClient,
+	)
+	s.mockResource.RemoteAdminClient.EXPECT().DescribeCluster(
+		gomock.Any(),
+		&adminservice.DescribeClusterRequest{},
+	).DoAndReturn(func(context.Context, *adminservice.DescribeClusterRequest, ...grpc.CallOption) (*adminservice.DescribeClusterResponse, error) {
+		panic("handler panic")
+	})
+
+	_, err := s.handler.AddOrUpdateRemoteCluster(
+		context.Background(),
+		&operatorservice.AddOrUpdateRemoteClusterRequest{FrontendAddress: rpcAddress},
+	)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "event logger panic")
 }
 
 func (s *operatorHandlerSuite) Test_AddOrUpdateRemoteCluster_GetClusterMetadata_Error() {

--- a/service/frontend/operator_handler_test.go
+++ b/service/frontend/operator_handler_test.go
@@ -34,6 +34,7 @@ import (
 	delnserrors "go.temporal.io/server/service/worker/deletenamespace/errors"
 	"go.uber.org/mock/gomock"
 	expmaps "golang.org/x/exp/maps"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 )
 
@@ -77,6 +78,7 @@ func (s *operatorHandlerSuite) SetupTest() {
 	args := NewOperatorHandlerImplArgs{
 		&Config{NumHistoryShards: 4},
 		s.mockResource.Logger,
+		nil,
 		s.mockResource.GetSDKClientFactory(),
 		s.mockResource.GetMetricsHandler(),
 		s.mockResource.GetVisibilityManager(),
@@ -1144,7 +1146,12 @@ func (s *operatorHandlerSuite) Test_DeleteNamespace() {
 
 func (s *operatorHandlerSuite) Test_RemoveRemoteCluster_Success() {
 	var clusterName = "cluster"
-	s.mockResource.ClusterMetadata.EXPECT().GetAllClusterInfo().Return(map[string]cluster.ClusterInformation{clusterName: {}})
+	eventLogger := &captureRemoteClusterEventLogger{}
+	s.handler.eventLogger = eventLogger
+	s.handler.config.EmitNamespaceLifecycleEvents = dynamicconfig.GetBoolPropertyFn(true)
+	s.mockResource.ClusterMetadata.EXPECT().GetAllClusterInfo().Return(map[string]cluster.ClusterInformation{
+		clusterName: {ClusterID: "cluster-id", Enabled: true, ReplicationEnabled: true},
+	})
 	s.mockResource.NamespaceCache.EXPECT().GetAllNamespaces().Return(nil)
 	s.mockResource.ClusterMetadataMgr.EXPECT().DeleteClusterMetadata(
 		gomock.Any(),
@@ -1153,10 +1160,17 @@ func (s *operatorHandlerSuite) Test_RemoveRemoteCluster_Success() {
 
 	_, err := s.handler.RemoveRemoteCluster(context.Background(), &operatorservice.RemoveRemoteClusterRequest{ClusterName: clusterName})
 	s.NoError(err)
+	_, details := remoteClusterEventValues(s.T(), eventLogger.records)
+	s.Equal(remoteClusterOutcomeSucceeded, details["outcome"])
+	s.Equal(remoteClusterMutationRemoved, details["mutation"])
+	s.Equal("cluster-id", details["remote_cluster_id"])
 }
 
 func (s *operatorHandlerSuite) Test_RemoveRemoteCluster_Error() {
 	var clusterName = "cluster"
+	eventLogger := &captureRemoteClusterEventLogger{}
+	s.handler.eventLogger = eventLogger
+	s.handler.config.EmitNamespaceLifecycleEvents = dynamicconfig.GetBoolPropertyFn(false)
 	s.mockResource.ClusterMetadata.EXPECT().GetAllClusterInfo().Return(map[string]cluster.ClusterInformation{clusterName: {}})
 	s.mockResource.NamespaceCache.EXPECT().GetAllNamespaces().Return(nil)
 	s.mockResource.ClusterMetadataMgr.EXPECT().DeleteClusterMetadata(
@@ -1166,10 +1180,33 @@ func (s *operatorHandlerSuite) Test_RemoveRemoteCluster_Error() {
 
 	_, err := s.handler.RemoveRemoteCluster(context.Background(), &operatorservice.RemoveRemoteClusterRequest{ClusterName: clusterName})
 	s.Error(err)
+	s.Empty(eventLogger.records)
+}
+
+func (s *operatorHandlerSuite) Test_RemoveRemoteCluster_PanicEmitsFailure() {
+	clusterName := "cluster"
+	eventLogger := &captureRemoteClusterEventLogger{}
+	s.handler.eventLogger = eventLogger
+	s.handler.config.EmitNamespaceLifecycleEvents = dynamicconfig.GetBoolPropertyFn(true)
+	s.mockResource.ClusterMetadata.EXPECT().GetAllClusterInfo().DoAndReturn(func() map[string]cluster.ClusterInformation {
+		panic("test panic")
+	})
+
+	_, err := s.handler.RemoveRemoteCluster(
+		context.Background(),
+		&operatorservice.RemoveRemoteClusterRequest{ClusterName: clusterName},
+	)
+	s.Require().Error(err)
+	_, details := remoteClusterEventValues(s.T(), eventLogger.records)
+	s.Equal(remoteClusterOutcomeFailed, details["outcome"])
+	s.Equal("Internal", details["error_code"])
 }
 
 func (s *operatorHandlerSuite) Test_RemoveRemoteCluster_BlockedByGlobalNamespace() {
 	var clusterName = "cluster"
+	eventLogger := &captureRemoteClusterEventLogger{}
+	s.handler.eventLogger = eventLogger
+	s.handler.config.EmitNamespaceLifecycleEvents = dynamicconfig.GetBoolPropertyFn(true)
 	// The namespace lists both the current cluster and the cluster being
 	// removed, so removing clusterName would sever a link the current cluster
 	// relies on -> blocked.
@@ -1189,6 +1226,10 @@ func (s *operatorHandlerSuite) Test_RemoveRemoteCluster_BlockedByGlobalNamespace
 	var failedPrecondition *serviceerror.FailedPrecondition
 	s.Require().ErrorAs(err, &failedPrecondition)
 	s.Contains(err.Error(), "global-ns")
+	_, details := remoteClusterEventValues(s.T(), eventLogger.records)
+	s.Equal(remoteClusterOutcomeFailed, details["outcome"])
+	s.NotNil(details["cached_before"])
+	s.NotContains(details, "persistence_request")
 }
 
 // Test_RemoveRemoteCluster_OrphanedNamespaceDoesNotBlock covers the case that
@@ -1340,6 +1381,9 @@ func (s *operatorHandlerSuite) Test_AddOrUpdateRemoteCluster_RecordNotFound_Succ
 	var httpAddress = uuid.NewString()
 	var clusterName = uuid.NewString()
 	var clusterID = uuid.NewString()
+	eventLogger := &captureRemoteClusterEventLogger{}
+	s.handler.eventLogger = eventLogger
+	s.handler.config.EmitNamespaceLifecycleEvents = dynamicconfig.GetBoolPropertyFn(true)
 
 	s.mockResource.ClusterMetadata.EXPECT().GetFailoverVersionIncrement().Return(int64(10)).Times(2)
 	s.mockResource.ClusterMetadata.EXPECT().GetAllClusterInfo().Return(make(map[string]cluster.ClusterInformation))
@@ -1377,6 +1421,13 @@ func (s *operatorHandlerSuite) Test_AddOrUpdateRemoteCluster_RecordNotFound_Succ
 		FrontendAddress: rpcAddress,
 	})
 	s.NoError(err)
+	_, details := remoteClusterEventValues(s.T(), eventLogger.records)
+	s.Equal(remoteClusterOutcomeSucceeded, details["outcome"])
+	s.Equal(remoteClusterMutationCreated, details["mutation"])
+	s.Equal(remoteClusterTransitionInitializedDisabled, details["requested_connection_transition"])
+	s.Equal(remoteClusterTransitionInitializedDisabled, details["requested_replication_transition"])
+	s.Nil(details["persisted_before"])
+	s.NotNil(details["persistence_request"])
 }
 
 func (s *operatorHandlerSuite) Test_AddOrUpdateRemoteCluster_ValidationError_ClusterNameConflict() {
@@ -1595,6 +1646,9 @@ func (s *operatorHandlerSuite) Test_AddOrUpdateRemoteCluster_ValidationError_Emp
 
 func (s *operatorHandlerSuite) Test_AddOrUpdateRemoteCluster_DescribeCluster_Error() {
 	var rpcAddress = uuid.NewString()
+	eventLogger := &captureRemoteClusterEventLogger{}
+	s.handler.eventLogger = eventLogger
+	s.handler.config.EmitNamespaceLifecycleEvents = dynamicconfig.GetBoolPropertyFn(true)
 
 	s.mockResource.ClientFactory.EXPECT().NewRemoteAdminClientWithTimeout(rpcAddress, gomock.Any(), gomock.Any()).Return(
 		s.mockResource.RemoteAdminClient,
@@ -1605,12 +1659,45 @@ func (s *operatorHandlerSuite) Test_AddOrUpdateRemoteCluster_DescribeCluster_Err
 	)
 	_, err := s.handler.AddOrUpdateRemoteCluster(context.Background(), &operatorservice.AddOrUpdateRemoteClusterRequest{FrontendAddress: rpcAddress})
 	s.Error(err)
+	_, details := remoteClusterEventValues(s.T(), eventLogger.records)
+	s.Equal(remoteClusterOutcomeFailed, details["outcome"])
+	s.Equal("Unavailable", details["error_code"])
+	s.NotContains(details, "persisted_before")
+	s.NotContains(details, "persistence_request")
+}
+
+func (s *operatorHandlerSuite) Test_AddOrUpdateRemoteCluster_PanicEmitsFailure() {
+	rpcAddress := uuid.NewString()
+	eventLogger := &captureRemoteClusterEventLogger{}
+	s.handler.eventLogger = eventLogger
+	s.handler.config.EmitNamespaceLifecycleEvents = dynamicconfig.GetBoolPropertyFn(true)
+	s.mockResource.ClientFactory.EXPECT().NewRemoteAdminClientWithTimeout(rpcAddress, gomock.Any(), gomock.Any()).Return(
+		s.mockResource.RemoteAdminClient,
+	)
+	s.mockResource.RemoteAdminClient.EXPECT().DescribeCluster(
+		gomock.Any(),
+		&adminservice.DescribeClusterRequest{},
+	).DoAndReturn(func(context.Context, *adminservice.DescribeClusterRequest, ...grpc.CallOption) (*adminservice.DescribeClusterResponse, error) {
+		panic("test panic")
+	})
+
+	_, err := s.handler.AddOrUpdateRemoteCluster(
+		context.Background(),
+		&operatorservice.AddOrUpdateRemoteClusterRequest{FrontendAddress: rpcAddress},
+	)
+	s.Require().Error(err)
+	_, details := remoteClusterEventValues(s.T(), eventLogger.records)
+	s.Equal(remoteClusterOutcomeFailed, details["outcome"])
+	s.Equal("Internal", details["error_code"])
 }
 
 func (s *operatorHandlerSuite) Test_AddOrUpdateRemoteCluster_GetClusterMetadata_Error() {
 	var rpcAddress = uuid.NewString()
 	var clusterName = uuid.NewString()
 	var clusterID = uuid.NewString()
+	eventLogger := &captureRemoteClusterEventLogger{}
+	s.handler.eventLogger = eventLogger
+	s.handler.config.EmitNamespaceLifecycleEvents = dynamicconfig.GetBoolPropertyFn(true)
 
 	s.mockResource.ClusterMetadata.EXPECT().GetFailoverVersionIncrement().Return(int64(10)).Times(2)
 	s.mockResource.ClusterMetadata.EXPECT().GetAllClusterInfo().Return(make(map[string]cluster.ClusterInformation))
@@ -1632,6 +1719,9 @@ func (s *operatorHandlerSuite) Test_AddOrUpdateRemoteCluster_GetClusterMetadata_
 	)
 	_, err := s.handler.AddOrUpdateRemoteCluster(context.Background(), &operatorservice.AddOrUpdateRemoteClusterRequest{FrontendAddress: rpcAddress})
 	s.Error(err)
+	_, details := remoteClusterEventValues(s.T(), eventLogger.records)
+	s.NotContains(details, "persisted_before")
+	s.NotContains(details, "persistence_request")
 }
 
 func (s *operatorHandlerSuite) Test_AddOrUpdateRemoteCluster_SaveClusterMetadata_Error() {
@@ -1683,6 +1773,9 @@ func (s *operatorHandlerSuite) Test_AddOrUpdateRemoteCluster_SaveClusterMetadata
 	var httpAddress = uuid.NewString()
 	var clusterName = uuid.NewString()
 	var clusterID = uuid.NewString()
+	eventLogger := &captureRemoteClusterEventLogger{}
+	s.handler.eventLogger = eventLogger
+	s.handler.config.EmitNamespaceLifecycleEvents = dynamicconfig.GetBoolPropertyFn(true)
 
 	s.mockResource.ClusterMetadata.EXPECT().GetFailoverVersionIncrement().Return(int64(10)).Times(2)
 	s.mockResource.ClusterMetadata.EXPECT().GetAllClusterInfo().Return(make(map[string]cluster.ClusterInformation))
@@ -1721,4 +1814,7 @@ func (s *operatorHandlerSuite) Test_AddOrUpdateRemoteCluster_SaveClusterMetadata
 	})
 	s.Error(err)
 	s.IsType(&serviceerror.InvalidArgument{}, err)
+	_, details := remoteClusterEventValues(s.T(), eventLogger.records)
+	s.Equal(remoteClusterMutationCreated, details["mutation"])
+	s.NotNil(details["persistence_request"])
 }

--- a/service/frontend/remote_cluster_lifecycle_events.go
+++ b/service/frontend/remote_cluster_lifecycle_events.go
@@ -1,0 +1,453 @@
+package frontend
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"maps"
+
+	"go.opentelemetry.io/otel/log"
+	"go.temporal.io/api/serviceerror"
+	versionpb "go.temporal.io/api/version/v1"
+	"go.temporal.io/server/api/adminservice/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/authorization"
+	"go.temporal.io/server/common/cluster"
+	"go.temporal.io/server/common/headers"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/wideevents"
+)
+
+const (
+	remoteClusterLifecycleNotApplicable = "N/A"
+
+	remoteClusterAPIAdmin    = "admin"
+	remoteClusterAPIOperator = "operator"
+
+	remoteClusterOutcomeSucceeded = "succeeded"
+	remoteClusterOutcomeFailed    = "failed"
+
+	remoteClusterMutationCreated = "created"
+	remoteClusterMutationUpdated = "updated"
+	remoteClusterMutationRemoved = "removed"
+	remoteClusterMutationUnknown = "unknown"
+
+	remoteClusterTransitionEnabled             = "enabled"
+	remoteClusterTransitionDisabled            = "disabled"
+	remoteClusterTransitionUnchanged           = "unchanged"
+	remoteClusterTransitionInitializedEnabled  = "initialized_enabled"
+	remoteClusterTransitionInitializedDisabled = "initialized_disabled"
+)
+
+type remoteClusterLifecycleEvent struct {
+	logger        log.Logger
+	phase         string
+	details       map[string]any
+	upsertRequest remoteClusterUpsertRequestFields
+	removeRequest remoteClusterRemoveRequestFields
+}
+
+func newRemoteClusterUpsertLifecycleEvent(
+	ctx context.Context,
+	logger log.Logger,
+	clusterMetadata cluster.Metadata,
+	config *Config,
+	api string,
+	request remoteClusterUpsertRequestFields,
+) *remoteClusterLifecycleEvent {
+	event := newRemoteClusterLifecycleEvent(
+		ctx,
+		logger,
+		clusterMetadata,
+		config,
+		api,
+		wideevents.PhaseRemoteClusterUpsert,
+		request,
+	)
+	if event != nil {
+		event.upsertRequest = request
+	}
+	return event
+}
+
+func newRemoteClusterRemoveLifecycleEvent(
+	ctx context.Context,
+	logger log.Logger,
+	clusterMetadata cluster.Metadata,
+	config *Config,
+	api string,
+	request remoteClusterRemoveRequestFields,
+) *remoteClusterLifecycleEvent {
+	event := newRemoteClusterLifecycleEvent(
+		ctx,
+		logger,
+		clusterMetadata,
+		config,
+		api,
+		wideevents.PhaseRemoteClusterRemove,
+		request,
+	)
+	if event != nil {
+		event.removeRequest = request
+	}
+	return event
+}
+
+type remoteClusterUpsertRequestFields struct {
+	FrontendAddress               string `json:"frontend_address"`
+	FrontendHTTPAddress           string `json:"frontend_http_address"`
+	EnableRemoteClusterConnection bool   `json:"enable_remote_cluster_connection"`
+	EnableReplication             bool   `json:"enable_replication"`
+}
+
+type remoteClusterRemoveRequestFields struct {
+	ClusterName string `json:"cluster_name"`
+}
+
+type cachedRemoteClusterLookup struct {
+	information     cluster.ClusterInformation
+	lookupPerformed bool
+	found           bool
+}
+
+type remoteClusterMetadataFields struct {
+	ClusterName              string                                           `json:"cluster_name"`
+	HistoryShardCount        int32                                            `json:"history_shard_count"`
+	ClusterID                string                                           `json:"cluster_id"`
+	VersionInfo              *versionpb.VersionInfo                           `json:"version_info"`
+	IndexSearchAttributes    map[string]*persistencespb.IndexSearchAttributes `json:"index_search_attributes"`
+	ClusterAddress           string                                           `json:"cluster_address"`
+	HTTPAddress              string                                           `json:"http_address"`
+	FailoverVersionIncrement int64                                            `json:"failover_version_increment"`
+	InitialFailoverVersion   int64                                            `json:"initial_failover_version"`
+	IsGlobalNamespaceEnabled bool                                             `json:"is_global_namespace_enabled"`
+	IsConnectionEnabled      bool                                             `json:"is_connection_enabled"`
+	UseClusterIDMembership   bool                                             `json:"use_cluster_id_membership"`
+	Tags                     map[string]string                                `json:"tags"`
+	IsReplicationEnabled     bool                                             `json:"is_replication_enabled"`
+}
+
+type persistedRemoteClusterFields struct {
+	*remoteClusterMetadataFields
+	Version int64 `json:"version"`
+}
+
+type cachedRemoteClusterFields struct {
+	ClusterName            string            `json:"cluster_name"`
+	ClusterID              string            `json:"cluster_id"`
+	RPCAddress             string            `json:"rpc_address"`
+	HTTPAddress            string            `json:"http_address"`
+	IsConnectionEnabled    bool              `json:"is_connection_enabled"`
+	IsReplicationEnabled   bool              `json:"is_replication_enabled"`
+	InitialFailoverVersion int64             `json:"initial_failover_version"`
+	ShardCount             int32             `json:"shard_count"`
+	Tags                   map[string]string `json:"tags"`
+}
+
+type saveClusterMetadataFields struct {
+	ClusterMetadata *remoteClusterMetadataFields `json:"cluster_metadata"`
+	Version         int64                        `json:"version"`
+}
+
+type deleteClusterMetadataFields struct {
+	ClusterName string `json:"cluster_name"`
+}
+
+type remoteClusterRequestFingerprintFields struct {
+	LocalCluster string `json:"local_cluster"`
+	API          string `json:"api"`
+	Phase        string `json:"phase"`
+	Request      any    `json:"request"`
+}
+
+func newRemoteClusterLifecycleEvent(
+	ctx context.Context,
+	logger log.Logger,
+	clusterMetadata cluster.Metadata,
+	config *Config,
+	api string,
+	phase string,
+	request any,
+) *remoteClusterLifecycleEvent {
+	if !remoteClusterLifecycleEventsEnabled(config) {
+		return nil
+	}
+	localCluster := clusterMetadata.GetCurrentClusterName()
+	details := map[string]any{
+		"api":                 api,
+		"local_cluster":       localCluster,
+		"mutation":            remoteClusterMutationUnknown,
+		"request":             request,
+		"request_fingerprint": remoteClusterRequestFingerprint(localCluster, api, phase, request),
+	}
+	callerInfo := headers.GetCallerInfo(ctx)
+	setStringDetailIfNotEmpty(details, "caller_type", callerInfo.CallerType)
+	setStringDetailIfNotEmpty(details, "call_origin", callerInfo.CallOrigin)
+	if claims, ok := ctx.Value(authorization.MappedClaims).(*authorization.Claims); ok {
+		setStringDetailIfNotEmpty(details, "auth_subject", claims.Subject)
+		setStringDetailIfNotEmpty(details, "auth_type", claims.AuthType)
+	}
+	return &remoteClusterLifecycleEvent{
+		logger:  logger,
+		phase:   phase,
+		details: details,
+	}
+}
+
+func remoteClusterLifecycleEventsEnabled(config *Config) bool {
+	// Remote cluster lifecycle events intentionally share the namespace lifecycle gate.
+	return config != nil &&
+		config.EmitNamespaceLifecycleEvents != nil &&
+		config.EmitNamespaceLifecycleEvents()
+}
+
+func (e *remoteClusterLifecycleEvent) emitUpsertSuccess(
+	persistedBefore *persistence.GetClusterMetadataResponse,
+	saveRequest *persistence.SaveClusterMetadataRequest,
+) {
+	if e == nil {
+		return
+	}
+	if saveRequest != nil {
+		e.setRemoteCluster(saveRequest.GetClusterName(), saveRequest.GetClusterId())
+	}
+	e.populateUpsertPersistence(persistedBefore, saveRequest)
+	e.emit(nil)
+}
+
+func (e *remoteClusterLifecycleEvent) emitUpsertFailure(
+	err error,
+	remoteResponse *adminservice.DescribeClusterResponse,
+	persistedBefore *persistence.GetClusterMetadataResponse,
+	saveRequest *persistence.SaveClusterMetadataRequest,
+) {
+	if e == nil || err == nil {
+		return
+	}
+	if remoteResponse != nil {
+		e.setRemoteCluster(remoteResponse.GetClusterName(), remoteResponse.GetClusterId())
+	} else if saveRequest != nil {
+		e.setRemoteCluster(saveRequest.GetClusterName(), saveRequest.GetClusterId())
+	}
+	e.populateUpsertPersistence(persistedBefore, saveRequest)
+	e.emit(err)
+}
+
+func (e *remoteClusterLifecycleEvent) populateUpsertPersistence(
+	persistedBefore *persistence.GetClusterMetadataResponse,
+	saveRequest *persistence.SaveClusterMetadataRequest,
+) {
+	// A nil persistedBefore only means the mutation is a create once the save request exists.
+	// If both are nil, the handler failed before determining the persistence mutation.
+	persistenceMutationKnown := persistedBefore != nil || saveRequest != nil
+	if !persistenceMutationKnown {
+		return
+	}
+	if persistedBefore == nil {
+		e.setUpsertCreated()
+	} else {
+		e.setUpsertUpdated(persistedBefore)
+	}
+	if saveRequest != nil {
+		e.setSaveRequest(saveRequest)
+	}
+}
+
+func (e *remoteClusterLifecycleEvent) emitRemoveSuccess(
+	cachedBefore cachedRemoteClusterLookup,
+	deleteRequest *persistence.DeleteClusterMetadataRequest,
+) {
+	if e == nil {
+		return
+	}
+	e.populateRemove(cachedBefore, deleteRequest)
+	e.setRemoved()
+	e.emit(nil)
+}
+
+func (e *remoteClusterLifecycleEvent) emitRemoveFailure(
+	err error,
+	cachedBefore cachedRemoteClusterLookup,
+	deleteRequest *persistence.DeleteClusterMetadataRequest,
+) {
+	if e == nil || err == nil {
+		return
+	}
+	e.populateRemove(cachedBefore, deleteRequest)
+	e.emit(err)
+}
+
+func (e *remoteClusterLifecycleEvent) populateRemove(
+	cachedBefore cachedRemoteClusterLookup,
+	deleteRequest *persistence.DeleteClusterMetadataRequest,
+) {
+	e.setRemoteCluster(e.removeRequest.ClusterName, "")
+	if cachedBefore.lookupPerformed {
+		e.setCachedBefore(e.removeRequest.ClusterName, cachedBefore.information, cachedBefore.found)
+	}
+	if deleteRequest != nil {
+		e.setDeleteRequest(deleteRequest)
+	}
+}
+
+func lookupCachedRemoteCluster(
+	clusterMetadata cluster.Metadata,
+	clusterName string,
+) cachedRemoteClusterLookup {
+	information, found := clusterMetadata.GetAllClusterInfo()[clusterName]
+	return cachedRemoteClusterLookup{
+		information:     information,
+		lookupPerformed: true,
+		found:           found,
+	}
+}
+
+func (e *remoteClusterLifecycleEvent) emit(err error) {
+	if err == nil {
+		e.details["outcome"] = remoteClusterOutcomeSucceeded
+	} else {
+		e.details["outcome"] = remoteClusterOutcomeFailed
+		e.details["error_code"] = serviceerror.ToStatus(err).Code().String()
+		e.details["error_type"] = fmt.Sprintf("%T", err)
+		e.details["error"] = err.Error()
+	}
+	wideevents.Emit(e.logger, wideevents.RemoteClusterLifecyclePayload{
+		Phase:       e.phase,
+		Namespace:   remoteClusterLifecycleNotApplicable,
+		NamespaceID: remoteClusterLifecycleNotApplicable,
+		Details:     e.details,
+	})
+}
+
+func (e *remoteClusterLifecycleEvent) setRemoteCluster(clusterName string, clusterID string) {
+	setStringDetailIfNotEmpty(e.details, "remote_cluster", clusterName)
+	setStringDetailIfNotEmpty(e.details, "remote_cluster_id", clusterID)
+}
+
+func (e *remoteClusterLifecycleEvent) setUpsertCreated() {
+	e.details["persisted_before"] = nil
+	e.details["mutation"] = remoteClusterMutationCreated
+	e.details["requested_connection_transition"] = transitionForCreate(
+		e.upsertRequest.EnableRemoteClusterConnection,
+	)
+	e.details["requested_replication_transition"] = transitionForCreate(
+		e.upsertRequest.EnableReplication,
+	)
+}
+
+func (e *remoteClusterLifecycleEvent) setUpsertUpdated(
+	persistedBefore *persistence.GetClusterMetadataResponse,
+) {
+	e.details["persisted_before"] = persistedRemoteClusterFields{
+		remoteClusterMetadataFields: clusterMetadataEventFields(persistedBefore.ClusterMetadata),
+		Version:                     persistedBefore.Version,
+	}
+	e.details["mutation"] = remoteClusterMutationUpdated
+	e.details["requested_connection_transition"] = transitionForUpdate(
+		persistedBefore.GetIsConnectionEnabled(),
+		e.upsertRequest.EnableRemoteClusterConnection,
+	)
+	e.details["requested_replication_transition"] = transitionForUpdate(
+		persistedBefore.GetIsReplicationEnabled(),
+		e.upsertRequest.EnableReplication,
+	)
+}
+
+func (e *remoteClusterLifecycleEvent) setSaveRequest(request *persistence.SaveClusterMetadataRequest) {
+	e.details["persistence_request"] = saveClusterMetadataFields{
+		ClusterMetadata: clusterMetadataEventFields(request.ClusterMetadata),
+		Version:         request.Version,
+	}
+}
+
+func (e *remoteClusterLifecycleEvent) setCachedBefore(
+	clusterName string,
+	info cluster.ClusterInformation,
+	found bool,
+) {
+	e.setRemoteCluster(clusterName, info.ClusterID)
+	if !found {
+		e.details["cached_before"] = nil
+		return
+	}
+	e.details["cached_before"] = cachedRemoteClusterFields{
+		ClusterName:            clusterName,
+		ClusterID:              info.ClusterID,
+		RPCAddress:             info.RPCAddress,
+		HTTPAddress:            info.HTTPAddress,
+		IsConnectionEnabled:    info.Enabled,
+		IsReplicationEnabled:   info.ReplicationEnabled,
+		InitialFailoverVersion: info.InitialFailoverVersion,
+		ShardCount:             info.ShardCount,
+		Tags:                   maps.Clone(info.Tags),
+	}
+}
+
+func (e *remoteClusterLifecycleEvent) setDeleteRequest(request *persistence.DeleteClusterMetadataRequest) {
+	e.details["persistence_request"] = deleteClusterMetadataFields{ClusterName: request.ClusterName}
+}
+
+func (e *remoteClusterLifecycleEvent) setRemoved() {
+	e.details["mutation"] = remoteClusterMutationRemoved
+}
+
+func remoteClusterRequestFingerprint(localCluster string, api string, phase string, request any) string {
+	encoded, err := json.Marshal(remoteClusterRequestFingerprintFields{
+		LocalCluster: localCluster,
+		API:          api,
+		Phase:        phase,
+		Request:      request,
+	})
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("%x", sha256.Sum256(encoded))
+}
+
+func clusterMetadataEventFields(
+	metadata *persistencespb.ClusterMetadata,
+) *remoteClusterMetadataFields {
+	if metadata == nil {
+		return &remoteClusterMetadataFields{}
+	}
+	return &remoteClusterMetadataFields{
+		ClusterName:              metadata.GetClusterName(),
+		HistoryShardCount:        metadata.GetHistoryShardCount(),
+		ClusterID:                metadata.GetClusterId(),
+		VersionInfo:              metadata.GetVersionInfo(),
+		IndexSearchAttributes:    maps.Clone(metadata.GetIndexSearchAttributes()),
+		ClusterAddress:           metadata.GetClusterAddress(),
+		HTTPAddress:              metadata.GetHttpAddress(),
+		FailoverVersionIncrement: metadata.GetFailoverVersionIncrement(),
+		InitialFailoverVersion:   metadata.GetInitialFailoverVersion(),
+		IsGlobalNamespaceEnabled: metadata.GetIsGlobalNamespaceEnabled(),
+		IsConnectionEnabled:      metadata.GetIsConnectionEnabled(),
+		UseClusterIDMembership:   metadata.GetUseClusterIdMembership(),
+		Tags:                     maps.Clone(metadata.GetTags()),
+		IsReplicationEnabled:     metadata.GetIsReplicationEnabled(),
+	}
+}
+
+func transitionForCreate(enabled bool) string {
+	if enabled {
+		return remoteClusterTransitionInitializedEnabled
+	}
+	return remoteClusterTransitionInitializedDisabled
+}
+
+func transitionForUpdate(before bool, requested bool) string {
+	if before == requested {
+		return remoteClusterTransitionUnchanged
+	}
+	if requested {
+		return remoteClusterTransitionEnabled
+	}
+	return remoteClusterTransitionDisabled
+}
+
+func setStringDetailIfNotEmpty(details map[string]any, key string, value string) {
+	if value != "" {
+		details[key] = value
+	}
+}

--- a/service/frontend/remote_cluster_lifecycle_events_test.go
+++ b/service/frontend/remote_cluster_lifecycle_events_test.go
@@ -1,0 +1,295 @@
+package frontend
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	otellog "go.opentelemetry.io/otel/log"
+	"go.opentelemetry.io/otel/log/embedded"
+	"go.temporal.io/server/api/adminservice/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/authorization"
+	"go.temporal.io/server/common/cluster"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/headers"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/wideevents"
+	"go.uber.org/mock/gomock"
+)
+
+type captureRemoteClusterEventLogger struct {
+	embedded.Logger
+	records []otellog.Record
+}
+
+func (l *captureRemoteClusterEventLogger) Emit(_ context.Context, record otellog.Record) {
+	l.records = append(l.records, record)
+}
+
+func (l *captureRemoteClusterEventLogger) Enabled(context.Context, otellog.EnabledParameters) bool {
+	return true
+}
+
+func TestRemoteClusterLifecycleUpsertCreated(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	metadata := cluster.NewMockMetadata(ctrl)
+	metadata.EXPECT().GetCurrentClusterName().Return("cluster-a")
+	logger := &captureRemoteClusterEventLogger{}
+	ctx := headers.SetCallerInfo(context.Background(), headers.NewCallerInfo("", "operator", "AddOrUpdateRemoteCluster"))
+	ctx = context.WithValue(ctx, authorization.MappedClaims, &authorization.Claims{
+		Subject:  "alice",
+		AuthType: "jwt",
+	})
+	request := remoteClusterUpsertRequestFields{
+		FrontendAddress:               "cluster-b:7233",
+		FrontendHTTPAddress:           "cluster-b:7243",
+		EnableRemoteClusterConnection: true,
+		EnableReplication:             true,
+	}
+	event := newRemoteClusterUpsertLifecycleEvent(
+		ctx,
+		logger,
+		metadata,
+		remoteClusterLifecycleTestConfig(true),
+		remoteClusterAPIOperator,
+		request,
+	)
+	saveRequest := &persistence.SaveClusterMetadataRequest{
+		ClusterMetadata: &persistencespb.ClusterMetadata{
+			ClusterName:          "cluster-b",
+			ClusterId:            "cluster-b-id",
+			ClusterAddress:       "cluster-b:7233",
+			IsConnectionEnabled:  true,
+			IsReplicationEnabled: true,
+			Tags:                 map[string]string{"environment": "test"},
+		},
+		Version: 0,
+	}
+	event.emitUpsertSuccess(nil, saveRequest)
+
+	attrs, details := remoteClusterEventValues(t, logger.records)
+	require.Equal(t, wideevents.PhaseRemoteClusterUpsert, attrs["phase"])
+	require.Equal(t, "N/A", attrs["namespace"])
+	require.Equal(t, "N/A", attrs["namespace_id"])
+	require.Equal(t, remoteClusterOutcomeSucceeded, details["outcome"])
+	require.Equal(t, remoteClusterMutationCreated, details["mutation"])
+	require.Equal(t, remoteClusterTransitionInitializedEnabled, details["requested_connection_transition"])
+	require.Equal(t, remoteClusterTransitionInitializedEnabled, details["requested_replication_transition"])
+	require.Equal(t, "cluster-b", details["remote_cluster"])
+	require.Equal(t, "cluster-b-id", details["remote_cluster_id"])
+	require.Nil(t, details["persisted_before"])
+	require.Equal(t, "operator", details["caller_type"])
+	require.Equal(t, "AddOrUpdateRemoteCluster", details["call_origin"])
+	require.Equal(t, "alice", details["auth_subject"])
+	require.Equal(t, "jwt", details["auth_type"])
+	require.NotEmpty(t, details["request_fingerprint"])
+	require.NotNil(t, details["persistence_request"])
+}
+
+func TestRemoteClusterLifecycleUpsertUpdatedFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	metadata := cluster.NewMockMetadata(ctrl)
+	metadata.EXPECT().GetCurrentClusterName().Return("cluster-a")
+	logger := &captureRemoteClusterEventLogger{}
+	event := newRemoteClusterUpsertLifecycleEvent(
+		context.Background(),
+		logger,
+		metadata,
+		remoteClusterLifecycleTestConfig(true),
+		remoteClusterAPIAdmin,
+		remoteClusterUpsertRequestFields{
+			EnableRemoteClusterConnection: false,
+			EnableReplication:             true,
+		},
+	)
+	persistedBefore := &persistence.GetClusterMetadataResponse{
+		ClusterMetadata: &persistencespb.ClusterMetadata{
+			IsConnectionEnabled:  true,
+			IsReplicationEnabled: false,
+		},
+		Version: 7,
+	}
+	remoteResponse := &adminservice.DescribeClusterResponse{
+		ClusterName: "cluster-b",
+		ClusterId:   "cluster-b-id",
+	}
+	retError := errors.New("save failed")
+	event.emitUpsertFailure(retError, remoteResponse, persistedBefore, nil)
+
+	_, details := remoteClusterEventValues(t, logger.records)
+	require.Equal(t, remoteClusterOutcomeFailed, details["outcome"])
+	require.Equal(t, remoteClusterMutationUpdated, details["mutation"])
+	require.Equal(t, remoteClusterTransitionDisabled, details["requested_connection_transition"])
+	require.Equal(t, remoteClusterTransitionEnabled, details["requested_replication_transition"])
+	require.Equal(t, "cluster-b", details["remote_cluster"])
+	require.Equal(t, "cluster-b-id", details["remote_cluster_id"])
+	require.NotContains(t, details, "failure_stage")
+	require.Equal(t, "Unknown", details["error_code"])
+	require.Equal(t, "save failed", details["error"])
+	persistedBeforeDetails, ok := details["persisted_before"].(map[string]any)
+	require.True(t, ok)
+	require.InDelta(t, 7, persistedBeforeDetails["version"], 0)
+}
+
+func TestRemoteClusterLifecycleRemoveCachedBefore(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	metadata := cluster.NewMockMetadata(ctrl)
+	metadata.EXPECT().GetCurrentClusterName().Return("cluster-a")
+	logger := &captureRemoteClusterEventLogger{}
+	event := newRemoteClusterRemoveLifecycleEvent(
+		context.Background(),
+		logger,
+		metadata,
+		remoteClusterLifecycleTestConfig(true),
+		remoteClusterAPIOperator,
+		remoteClusterRemoveRequestFields{ClusterName: "cluster-b"},
+	)
+	cachedBefore := cluster.ClusterInformation{
+		Enabled:            true,
+		ReplicationEnabled: true,
+		ClusterID:          "cluster-b-id",
+		Tags:               map[string]string{"environment": "test"},
+	}
+	deleteRequest := &persistence.DeleteClusterMetadataRequest{ClusterName: "cluster-b"}
+	event.emitRemoveSuccess(cachedRemoteClusterLookup{
+		information:     cachedBefore,
+		lookupPerformed: true,
+		found:           true,
+	}, deleteRequest)
+
+	_, details := remoteClusterEventValues(t, logger.records)
+	require.Equal(t, remoteClusterMutationRemoved, details["mutation"])
+	require.Equal(t, "cluster-b", details["remote_cluster"])
+	require.Equal(t, "cluster-b-id", details["remote_cluster_id"])
+	require.NotNil(t, details["cached_before"])
+	require.NotNil(t, details["persistence_request"])
+	require.NotContains(t, details, "requested_connection_transition")
+	require.NotContains(t, details, "requested_replication_transition")
+}
+
+func TestRemoteClusterLifecycleRemoveCacheMiss(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	metadata := cluster.NewMockMetadata(ctrl)
+	metadata.EXPECT().GetCurrentClusterName().Return("cluster-a")
+	logger := &captureRemoteClusterEventLogger{}
+	event := newRemoteClusterRemoveLifecycleEvent(
+		context.Background(),
+		logger,
+		metadata,
+		remoteClusterLifecycleTestConfig(true),
+		remoteClusterAPIAdmin,
+		remoteClusterRemoveRequestFields{ClusterName: "missing-cluster"},
+	)
+	retError := errors.New("blocked")
+	event.emitRemoveFailure(retError, cachedRemoteClusterLookup{lookupPerformed: true}, nil)
+
+	_, details := remoteClusterEventValues(t, logger.records)
+	require.Nil(t, details["cached_before"])
+	require.Equal(t, remoteClusterMutationUnknown, details["mutation"])
+	require.NotContains(t, details, "persistence_request")
+}
+
+func TestRemoteClusterLifecycleRequestFingerprint(t *testing.T) {
+	request := remoteClusterUpsertRequestFields{
+		FrontendAddress:               "cluster-b:7233",
+		EnableRemoteClusterConnection: true,
+	}
+	operatorFingerprint := remoteClusterRequestFingerprint(
+		"cluster-a",
+		remoteClusterAPIOperator,
+		wideevents.PhaseRemoteClusterUpsert,
+		request,
+	)
+
+	require.Equal(t, operatorFingerprint, remoteClusterRequestFingerprint(
+		"cluster-a",
+		remoteClusterAPIOperator,
+		wideevents.PhaseRemoteClusterUpsert,
+		request,
+	))
+	require.NotEqual(t, operatorFingerprint, remoteClusterRequestFingerprint(
+		"cluster-a",
+		remoteClusterAPIAdmin,
+		wideevents.PhaseRemoteClusterUpsert,
+		request,
+	))
+}
+
+func TestRemoteClusterLifecycleEventsEnabled(t *testing.T) {
+	require.False(t, remoteClusterLifecycleEventsEnabled(nil))
+	require.False(t, remoteClusterLifecycleEventsEnabled(&Config{}))
+	require.False(t, remoteClusterLifecycleEventsEnabled(&Config{
+		EmitNamespaceLifecycleEvents: dynamicconfig.GetBoolPropertyFn(false),
+	}))
+	require.True(t, remoteClusterLifecycleEventsEnabled(&Config{
+		EmitNamespaceLifecycleEvents: dynamicconfig.GetBoolPropertyFn(true),
+	}))
+}
+
+func TestRemoteClusterLifecycleDisabledEmission(t *testing.T) {
+	config := remoteClusterLifecycleTestConfig(false)
+	upsertEvent := newRemoteClusterUpsertLifecycleEvent(
+		context.Background(),
+		nil,
+		nil,
+		config,
+		remoteClusterAPIOperator,
+		remoteClusterUpsertRequestFields{},
+	)
+	removeEvent := newRemoteClusterRemoveLifecycleEvent(
+		context.Background(),
+		nil,
+		nil,
+		config,
+		remoteClusterAPIOperator,
+		remoteClusterRemoveRequestFields{},
+	)
+	require.Nil(t, upsertEvent)
+	require.Nil(t, removeEvent)
+	require.NotPanics(t, func() {
+		upsertEvent.emitUpsertSuccess(nil, nil)
+		upsertEvent.emitUpsertFailure(errors.New("failed"), nil, nil, nil)
+		removeEvent.emitRemoveSuccess(cachedRemoteClusterLookup{}, nil)
+		removeEvent.emitRemoveFailure(errors.New("failed"), cachedRemoteClusterLookup{}, nil)
+	})
+}
+
+func TestNewRemoteClusterLifecycleEventDisabled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	metadata := cluster.NewMockMetadata(ctrl)
+
+	event := newRemoteClusterUpsertLifecycleEvent(
+		context.Background(),
+		&captureRemoteClusterEventLogger{},
+		metadata,
+		remoteClusterLifecycleTestConfig(false),
+		remoteClusterAPIOperator,
+		remoteClusterUpsertRequestFields{},
+	)
+
+	require.Nil(t, event)
+}
+
+func remoteClusterLifecycleTestConfig(enabled bool) *Config {
+	return &Config{EmitNamespaceLifecycleEvents: dynamicconfig.GetBoolPropertyFn(enabled)}
+}
+
+func remoteClusterEventValues(
+	t *testing.T,
+	records []otellog.Record,
+) (map[string]string, map[string]any) {
+	t.Helper()
+	require.Len(t, records, 1)
+	require.Equal(t, wideevents.RemoteClusterLifecycleEventName, records[0].EventName())
+	attrs := make(map[string]string)
+	records[0].WalkAttributes(func(kv otellog.KeyValue) bool {
+		attrs[kv.Key] = kv.Value.AsString()
+		return true
+	})
+	var details map[string]any
+	require.NoError(t, json.Unmarshal([]byte(attrs["details"]), &details))
+	return attrs, details
+}

--- a/service/frontend/remote_cluster_lifecycle_events_test.go
+++ b/service/frontend/remote_cluster_lifecycle_events_test.go
@@ -25,11 +25,23 @@ type captureRemoteClusterEventLogger struct {
 	records []otellog.Record
 }
 
+type panicRemoteClusterEventLogger struct {
+	embedded.Logger
+}
+
 func (l *captureRemoteClusterEventLogger) Emit(_ context.Context, record otellog.Record) {
 	l.records = append(l.records, record)
 }
 
 func (l *captureRemoteClusterEventLogger) Enabled(context.Context, otellog.EnabledParameters) bool {
+	return true
+}
+
+func (*panicRemoteClusterEventLogger) Emit(context.Context, otellog.Record) {
+	panic("event logger panic")
+}
+
+func (*panicRemoteClusterEventLogger) Enabled(context.Context, otellog.EnabledParameters) bool {
 	return true
 }
 


### PR DESCRIPTION
## What changed?

- Emit `remote_cluster_lifecycle` wide events for successful and failed `AddOrUpdateRemoteCluster` and `RemoveRemoteCluster` calls through both Operator and Admin APIs.
- Capture the request, request fingerprint, caller/auth context when available, remote response, persistence request, authoritative pre-mutation persistence state for upserts, cached pre-mutation state for removals, requested connection/replication transitions, mutation, outcome, and terminal error details.
- Preserve the `NamespaceLifecyclePayload` envelope and place remote-cluster-specific fields in `details`.
- Gate emission with the existing `system.emitNamespaceLifecycleEvents` dynamic config.

## Why?

Remote-cluster connection, replication, and removal changes need an auditable record that shows what was requested, what state existed before the mutation, and whether the request succeeded or failed.

## How did you test it?

- [x] built
- [x] run locally and tested manually
- [x] added new unit test(s)
- [ ] added new functional test(s)

Commands:

```text
go test -tags test_dep ./service/frontend ./common/wideevents
make lint-code
```

Local E2E against `development-cluster-a.yaml` covered:

- Operator: create enabled, update disabled, remove.
- Admin: create disabled, update enabled, remove.
- Operator removal rejected while an intact global namespace referenced both the local and remote clusters.

<details>
<summary>Successful Operator update: connection and replication disabled</summary>

```json
{
  "details": {
    "api": "operator",
    "call_origin": "AddOrUpdateRemoteCluster",
    "caller_type": "api",
    "local_cluster": "cluster-a",
    "mutation": "updated",
    "outcome": "succeeded",
    "persisted_before": {
      "cluster_address": "127.0.0.1:9433",
      "cluster_id": "5234378e-93a3-42e7-9ef0-b0a68ec20a4f",
      "cluster_name": "cluster-remote-lifecycle-update-e2e",
      "failover_version_increment": 100,
      "history_shard_count": 32,
      "http_address": "127.0.0.1:9443",
      "index_search_attributes": null,
      "initial_failover_version": 21,
      "is_connection_enabled": true,
      "is_global_namespace_enabled": true,
      "is_replication_enabled": true,
      "tags": {
        "environment": "local-e2e",
        "purpose": "remote-cluster-lifecycle-update-wide-events"
      },
      "use_cluster_id_membership": false,
      "version": 1,
      "version_info": null
    },
    "persistence_request": {
      "cluster_metadata": {
        "cluster_address": "127.0.0.1:9433",
        "cluster_id": "5234378e-93a3-42e7-9ef0-b0a68ec20a4f",
        "cluster_name": "cluster-remote-lifecycle-update-e2e",
        "failover_version_increment": 100,
        "history_shard_count": 32,
        "http_address": "127.0.0.1:9443",
        "index_search_attributes": null,
        "initial_failover_version": 21,
        "is_connection_enabled": false,
        "is_global_namespace_enabled": true,
        "is_replication_enabled": false,
        "tags": {
          "environment": "local-e2e",
          "purpose": "remote-cluster-lifecycle-update-wide-events"
        },
        "use_cluster_id_membership": false,
        "version_info": null
      },
      "version": 1
    },
    "remote_cluster": "cluster-remote-lifecycle-update-e2e",
    "remote_cluster_id": "5234378e-93a3-42e7-9ef0-b0a68ec20a4f",
    "request": {
      "enable_remote_cluster_connection": false,
      "enable_replication": false,
      "frontend_address": "127.0.0.1:9433",
      "frontend_http_address": "127.0.0.1:9443"
    },
    "request_fingerprint": "e356fbe885b9f750f5e9a35ec01c29dfaf8f82f135bbfefd93304b50dcdbcb89",
    "requested_connection_transition": "disabled",
    "requested_replication_transition": "disabled"
  },
  "event_name": "remote_cluster_lifecycle",
  "instrumentation_scope": "go.temporal.io/server/common/wideevents",
  "namespace": "N/A",
  "namespace_id": "N/A",
  "phase": "remote_cluster_upsert"
}
```

</details>

<details>
<summary>Failed Operator removal: cluster still referenced by global namespace</summary>

```json
{
  "details": {
    "api": "operator",
    "cached_before": {
      "cluster_id": "992aa482-40a4-46ad-a4ec-c15d853cb37c",
      "cluster_name": "cluster-guard-e2e",
      "http_address": "127.0.0.1:9543",
      "initial_failover_version": 31,
      "is_connection_enabled": true,
      "is_replication_enabled": true,
      "rpc_address": "127.0.0.1:9533",
      "shard_count": 32,
      "tags": {
        "environment": "local-e2e",
        "purpose": "cluster-removal-namespace-guard"
      }
    },
    "call_origin": "RemoveRemoteCluster",
    "caller_type": "api",
    "error": "cannot remove cluster \"cluster-guard-e2e\": still referenced by namespace \"cluster-guard-e2e-ns\"",
    "error_code": "FailedPrecondition",
    "error_type": "*serviceerror.FailedPrecondition",
    "local_cluster": "cluster-a",
    "mutation": "unknown",
    "outcome": "failed",
    "remote_cluster": "cluster-guard-e2e",
    "remote_cluster_id": "992aa482-40a4-46ad-a4ec-c15d853cb37c",
    "request": {
      "cluster_name": "cluster-guard-e2e"
    },
    "request_fingerprint": "9992050714897282663c1cc8a216ad99eff3aee746c24ac1c2a510a5aa9fd23e"
  },
  "event_name": "remote_cluster_lifecycle",
  "instrumentation_scope": "go.temporal.io/server/common/wideevents",
  "namespace": "N/A",
  "namespace_id": "N/A",
  "phase": "remote_cluster_remove"
}
```

</details>

