### PR TITLE
Update Go lint tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ $(LOCALBIN):
 .PHONY: golangci-lint
 GOLANGCI_LINT_BASE_REV ?= $(MAIN_BRANCH)
 GOLANGCI_LINT_FIX ?= true
-GOLANGCI_LINT_VERSION := v2.9.0
+GOLANGCI_LINT_VERSION := v2.13.0
 GOLANGCI_LINT := $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
@@ -229,7 +229,7 @@ YAMLFMT := $(LOCALBIN)/yamlfmt-$(YAMLFMT_VER)
 $(YAMLFMT): | $(LOCALBIN)
 	$(call go-install-tool,$(YAMLFMT),github.com/google/yamlfmt/cmd/yamlfmt,$(YAMLFMT_VER))
 
-GOIMPORTS_VER := v0.36.0
+GOIMPORTS_VER := v0.49.0
 GOIMPORTS := $(LOCALBIN)/goimports-$(GOIMPORTS_VER)
 $(STAMPDIR)/goimports-$(GOIMPORTS_VER): | $(STAMPDIR) $(LOCALBIN)
 	$(call go-install-tool,$(GOIMPORTS),golang.org/x/tools/cmd/goimports,$(GOIMPORTS_VER))
@@ -263,9 +263,10 @@ $(STAMPDIR)/mockgen-$(MOCKGEN_VER): | $(STAMPDIR) $(LOCALBIN)
 	@touch $@
 $(MOCKGEN): $(STAMPDIR)/mockgen-$(MOCKGEN_VER)
 
-STRINGER_VER := v0.36.0
+STRINGER_VER := v0.49.0
 STRINGER := $(LOCALBIN)/stringer
 $(STAMPDIR)/stringer-$(STRINGER_VER): | $(STAMPDIR) $(LOCALBIN)
+	@rm -f $(STRINGER)
 	$(call go-install-tool,$(STRINGER),golang.org/x/tools/cmd/stringer,$(STRINGER_VER))
 	@touch $@
 $(STRINGER): $(STAMPDIR)/stringer-$(STRINGER_VER)

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,6 @@ $(STAMPDIR):
 $(LOCALBIN):
 	@mkdir -p $(LOCALBIN)
 
-# When updating the version, update the golangci-lint GHA workflow as well.
 .PHONY: golangci-lint
 GOLANGCI_LINT_BASE_REV ?= $(MAIN_BRANCH)
 GOLANGCI_LINT_FIX ?= true

--- a/Makefile
+++ b/Makefile
@@ -265,7 +265,6 @@ $(MOCKGEN): $(STAMPDIR)/mockgen-$(MOCKGEN_VER)
 STRINGER_VER := v0.49.0
 STRINGER := $(LOCALBIN)/stringer
 $(STAMPDIR)/stringer-$(STRINGER_VER): | $(STAMPDIR) $(LOCALBIN)
-	@rm -f $(STRINGER)
 	$(call go-install-tool,$(STRINGER),golang.org/x/tools/cmd/stringer,$(STRINGER_VER))
 	@touch $@
 $(STRINGER): $(STAMPDIR)/stringer-$(STRINGER_VER)

--- a/common/testing/testlogger/testlogger.gen.go
+++ b/common/testing/testlogger/testlogger.gen.go
@@ -22,8 +22,9 @@ const _Level_name = "DebugInfoWarnErrorFatalDPanicPanic"
 var _Level_index = [...]uint8{0, 5, 9, 13, 18, 23, 29, 34}
 
 func (i Level) String() string {
-	if i < 0 || i >= Level(len(_Level_index)-1) {
+	idx := int(i) - 0
+	if i < 0 || idx >= len(_Level_index)-1 {
 		return "Level(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
-	return _Level_name[_Level_index[i]:_Level_index[i+1]]
+	return _Level_name[_Level_index[idx]:_Level_index[idx+1]]
 }

--- a/service/matching/loadcause_string_gen.go
+++ b/service/matching/loadcause_string_gen.go
@@ -25,8 +25,9 @@ const _loadCause_name = "UnspecifiedTaskQueryDescribeUserDataNexusTaskPollOtherR
 var _loadCause_index = [...]uint8{0, 11, 15, 20, 28, 36, 45, 49, 58, 68, 73}
 
 func (i loadCause) String() string {
-	if i < 0 || i >= loadCause(len(_loadCause_index)-1) {
+	idx := int(i) - 0
+	if i < 0 || idx >= len(_loadCause_index)-1 {
 		return "loadCause(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
-	return _loadCause_name[_loadCause_index[i]:_loadCause_index[i+1]]
+	return _loadCause_name[_loadCause_index[idx]:_loadCause_index[idx+1]]
 }

--- a/service/matching/unloadcause_string_gen.go
+++ b/service/matching/unloadcause_string_gen.go
@@ -24,8 +24,9 @@ const _unloadCause_name = "UnspecifiedInitErrorIdleMembershipConflictShuttingDow
 var _unloadCause_index = [...]uint8{0, 11, 20, 24, 34, 42, 54, 59, 71, 81}
 
 func (i unloadCause) String() string {
-	if i < 0 || i >= unloadCause(len(_unloadCause_index)-1) {
+	idx := int(i) - 0
+	if i < 0 || idx >= len(_unloadCause_index)-1 {
 		return "unloadCause(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
-	return _unloadCause_name[_unloadCause_index[i]:_unloadCause_index[i+1]]
+	return _unloadCause_name[_unloadCause_index[idx]:_unloadCause_index[idx+1]]
 }


### PR DESCRIPTION
Go 1.27 prerequisite that upgrades golangci-lint, goimports, and stringer to versions compatible with the new toolchain.
