### PR TITLE
Replace errors.As with errors.AsType

### DIFF
--- a/chasm/lib/activity/handler.go
+++ b/chasm/lib/activity/handler.go
@@ -112,8 +112,7 @@ func (h *handler) StartActivityExecution(ctx context.Context, req *activitypb.St
 	)
 
 	if err != nil {
-		var alreadyStartedErr *chasm.ExecutionAlreadyStartedError
-		if errors.As(err, &alreadyStartedErr) {
+		if alreadyStartedErr, ok := errors.AsType[*chasm.ExecutionAlreadyStartedError](err); ok {
 			return nil, serviceerror.NewActivityExecutionAlreadyStarted("activity execution already started", alreadyStartedErr.CurrentRequestID, alreadyStartedErr.CurrentRunID)
 		}
 

--- a/chasm/lib/callback/invocable_outbound.go
+++ b/chasm/lib/callback/invocable_outbound.go
@@ -88,8 +88,7 @@ func (n invocableOutbound) Invoke(
 }
 
 func isRetryableCallError(err error) bool {
-	var handlerError *nexus.HandlerError
-	if errors.As(err, &handlerError) {
+	if handlerError, ok := errors.AsType[*nexus.HandlerError](err); ok {
 		return handlerError.Retryable()
 	}
 	return true
@@ -100,8 +99,7 @@ func outcomeTag(callCtx context.Context, callErr error) string {
 		if callCtx.Err() != nil {
 			return "request-timeout"
 		}
-		var handlerErr *nexus.HandlerError
-		if errors.As(callErr, &handlerErr) {
+		if handlerErr, ok := errors.AsType[*nexus.HandlerError](callErr); ok {
 			return "handler-error:" + string(handlerErr.Type)
 		}
 		return "unknown-error"

--- a/chasm/lib/callback/request.go
+++ b/chasm/lib/callback/request.go
@@ -70,8 +70,7 @@ func routeSystemCallbackRequest(
 		ns, err := namespaceRegistry.GetNamespaceByID(namespace.ID(namespaceID))
 		if err != nil {
 			logger.Error("failed to get namespace for nexus completion request", tag.WorkflowNamespaceID(namespaceID), tag.Error(err))
-			var nfe *serviceerror.NamespaceNotFound
-			if errors.As(err, &nfe) {
+			if _, ok := errors.AsType[*serviceerror.NamespaceNotFound](err); ok {
 				return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeNotFound, "namespace %q not found", namespaceID)
 			}
 			return nil, commonnexus.ConvertGRPCError(err, false)

--- a/chasm/lib/scheduler/handler.go
+++ b/chasm/lib/scheduler/handler.go
@@ -42,8 +42,7 @@ func (h *handler) CreateSchedule(ctx context.Context, req *schedulerpb.CreateSch
 		chasm.WithRequestID(req.FrontendRequest.RequestId),
 	)
 
-	var alreadyStartedErr *chasm.ExecutionAlreadyStartedError
-	if errors.As(err, &alreadyStartedErr) {
+	if _, ok := errors.AsType[*chasm.ExecutionAlreadyStartedError](err); ok {
 		// Check if the existing schedule is a sentinel.
 		//
 		// TODO lina@ - this can be removed (as well as all other sentinel business)
@@ -93,8 +92,7 @@ func (h *handler) CreateFromMigrationState(ctx context.Context, req *schedulerpb
 		req,
 	)
 
-	var alreadyStartedErr *chasm.ExecutionAlreadyStartedError
-	if errors.As(err, &alreadyStartedErr) {
+	if _, ok := errors.AsType[*chasm.ExecutionAlreadyStartedError](err); ok {
 		// Check if the existing schedule is a sentinel. Sentinels are
 		// auto-deleted SentinelIdleTime after schedule creation; the
 		// V1 schedule will keep retrying migration until it expires.
@@ -143,8 +141,7 @@ func (h *handler) CreateSentinel(ctx context.Context, req *schedulerpb.CreateSen
 		req,
 	)
 
-	var alreadyStartedErr *chasm.ExecutionAlreadyStartedError
-	if errors.As(err, &alreadyStartedErr) {
+	if _, ok := errors.AsType[*chasm.ExecutionAlreadyStartedError](err); ok {
 		// If a sentinel already exists, succeed idempotently.
 		// If a real scheduler exists, fail.
 		_, readErr := chasm.ReadComponent(

--- a/chasm/lib/scheduler/invoker_tasks.go
+++ b/chasm/lib/scheduler/invoker_tasks.go
@@ -779,8 +779,7 @@ func isAlreadyStartedError(err error) bool {
 }
 
 func isRateLimitedError(err error) (time.Duration, bool) {
-	var expectedErr *rateLimitedError
-	if errors.As(err, &expectedErr) {
+	if expectedErr, ok := errors.AsType[*rateLimitedError](err); ok {
 		return expectedErr.delay, true
 	}
 	return 0, false

--- a/chasm/lib/scheduler/scheduler_migrate_task.go
+++ b/chasm/lib/scheduler/scheduler_migrate_task.go
@@ -225,8 +225,7 @@ func (h *SchedulerMigrateToWorkflowTaskHandler) Execute(
 	)
 	if err != nil {
 		// Treat already-started as success for idempotency.
-		var alreadyStartedErr *serviceerror.WorkflowExecutionAlreadyStarted
-		if !errors.As(err, &alreadyStartedErr) {
+		if _, ok := errors.AsType[*serviceerror.WorkflowExecutionAlreadyStarted](err); !ok {
 			return fmt.Errorf("failed to start V1 scheduler workflow: %w", err)
 		}
 	}

--- a/chasm/lib/scheduler/scheduler_tasks.go
+++ b/chasm/lib/scheduler/scheduler_tasks.go
@@ -258,8 +258,7 @@ func (r *SchedulerCallbacksTaskHandler) watchRunningStart(
 		},
 	})
 	if err != nil {
-		var notFoundErr *serviceerror.NotFound
-		if errors.As(err, &notFoundErr) {
+		if _, ok := errors.AsType[*serviceerror.NotFound](err); ok {
 			return &watchResult{
 				completed: &schedulespb.CompletedResult{
 					Status:    enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED,

--- a/chasm/lib/workflow/nexus_commands.go
+++ b/chasm/lib/workflow/nexus_commands.go
@@ -69,8 +69,7 @@ func (ch *nexusCommandHandler) handleScheduleCommand(
 			// Links are not needed for validation.
 		}, attrs.Service, attrs.Operation, attrs.Input)
 		if err != nil {
-			var handlerErr *nexus.HandlerError
-			if errors.As(err, &handlerErr) {
+			if handlerErr, ok := errors.AsType[*nexus.HandlerError](err); ok {
 				//nolint:exhaustive
 				switch handlerErr.Type {
 				case nexus.HandlerErrorTypeNotFound, nexus.HandlerErrorTypeBadRequest:

--- a/client/history/caching_redirector.go
+++ b/client/history/caching_redirector.go
@@ -225,8 +225,7 @@ func (r *CachingRedirector[C]) handleSolError(opEntry cacheEntry[C], solErr *ser
 }
 
 func maybeHostDownError(opErr error) bool {
-	var unavail *serviceerror.Unavailable
-	if errors.As(opErr, &unavail) {
+	if _, ok := errors.AsType[*serviceerror.Unavailable](opErr); ok {
 		return true
 	}
 	return common.IsContextDeadlineExceededErr(opErr)

--- a/common/nexus/nexusrpc/server.go
+++ b/common/nexus/nexusrpc/server.go
@@ -94,13 +94,11 @@ func (h *httpHandler) writeResult(writer http.ResponseWriter, request *http.Requ
 // nolint:revive // Keeping all of the logic together for readability, even if it means the function is long.
 func (h *BaseHTTPHandler) WriteFailure(writer http.ResponseWriter, r *http.Request, err error) {
 	var failure nexus.Failure
-	var failureError *nexus.FailureError
-	var opError *nexus.OperationError
 	var handlerError *nexus.HandlerError
 	var operationState nexus.OperationState
 	statusCode := http.StatusInternalServerError
 
-	if errors.As(err, &opError) {
+	if opError, ok := errors.AsType[*nexus.OperationError](err); ok {
 		operationState = opError.State
 		var convErr error
 		failure, convErr = h.FailureConverter.ErrorToFailure(opError)
@@ -160,7 +158,7 @@ func (h *BaseHTTPHandler) WriteFailure(writer http.ResponseWriter, r *http.Reque
 		default:
 			h.Logger.Error("unexpected handler error type", "type", handlerError.Type)
 		}
-	} else if errors.As(err, &failureError) {
+	} else if failureError, ok := errors.AsType[*nexus.FailureError](err); ok {
 		failure = failureError.Failure
 	} else {
 		failure = nexus.Failure{

--- a/common/persistence/client/fx.go
+++ b/common/persistence/client/fx.go
@@ -227,8 +227,7 @@ func managerProvider[T persistence.Closeable](newManagerFn func(Factory) (T, err
 	return func(f Factory, lc fx.Lifecycle) (T, error) {
 		manager, err := newManagerFn(f) // passing receiver (Factory) as first argument.
 		if err != nil {
-			var unimpl *serviceerror.Unimplemented
-			if errors.As(err, &unimpl) {
+			if _, ok := errors.AsType[*serviceerror.Unimplemented](err); ok {
 				// allow factories to return Unimplemented, and turn into nil so that fx init doesn't fail.
 				err = nil
 			}

--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -473,8 +473,7 @@ func (m *executionManagerImpl) GetWorkflowExecution(
 	}
 	response, respErr := m.persistence.GetWorkflowExecution(ctx, request)
 
-	var notFound *serviceerror.NotFound
-	if errors.As(respErr, &notFound) {
+	if _, ok := errors.AsType[*serviceerror.NotFound](respErr); ok {
 		// strip persistence-specific error message
 		respErr = serviceerror.NewNotFoundf(
 			"workflow execution not found for workflow ID %q and run ID %q", request.WorkflowID, request.RunID)
@@ -894,8 +893,7 @@ func (m *executionManagerImpl) GetCurrentExecution(
 
 	response, respErr := m.persistence.GetCurrentExecution(ctx, request)
 
-	var notFound *serviceerror.NotFound
-	if errors.As(respErr, &notFound) {
+	if _, ok := errors.AsType[*serviceerror.NotFound](respErr); ok {
 		// strip persistence-specific error message
 		respErr = serviceerror.NewNotFoundf("workflow not found for ID: %v", request.WorkflowID)
 	}

--- a/common/persistence/faultinjection/store_fault_generator_test.go
+++ b/common/persistence/faultinjection/store_fault_generator_test.go
@@ -39,8 +39,7 @@ func TestFaultInjection_Inject(t *testing.T) {
 		if expectErr {
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), "fault injection error")
-			var reErr *serviceerror.ResourceExhausted
-			if errors.As(err, &reErr) {
+			if reErr, ok := errors.AsType[*serviceerror.ResourceExhausted](err); ok {
 				assert.ErrorAs(t, err, &reErr)
 			} else {
 				var timeoutErr *persistence.TimeoutError

--- a/common/persistence/faultinjection/store_fault_generator_test.go
+++ b/common/persistence/faultinjection/store_fault_generator_test.go
@@ -39,9 +39,7 @@ func TestFaultInjection_Inject(t *testing.T) {
 		if expectErr {
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), "fault injection error")
-			if reErr, ok := errors.AsType[*serviceerror.ResourceExhausted](err); ok {
-				assert.ErrorAs(t, err, &reErr)
-			} else {
+			if _, ok := errors.AsType[*serviceerror.ResourceExhausted](err); !ok {
 				var timeoutErr *persistence.TimeoutError
 				assert.ErrorAs(t, err, &timeoutErr)
 			}

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/errors.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/errors.go
@@ -27,13 +27,11 @@ func ConvertError(
 		return serviceerror.NewNotFoundf("operation %v encountered %v", operation, err.Error())
 	}
 
-	var cqlTimeoutErr *gocql.RequestErrWriteTimeout
-	if errors.As(err, &cqlTimeoutErr) {
+	if cqlTimeoutErr, ok := errors.AsType[*gocql.RequestErrWriteTimeout](err); ok {
 		return &persistence.TimeoutError{Msg: fmt.Sprintf("operation %v encountered %v", operation, cqlTimeoutErr.Error())}
 	}
 
-	var cqlRequestErr gocql.RequestError
-	if errors.As(err, &cqlRequestErr) {
+	if cqlRequestErr, ok := errors.AsType[gocql.RequestError](err); ok {
 		if cqlRequestErr.Code() == gocql.ErrCodeOverloaded {
 			return &serviceerror.ResourceExhausted{
 				Cause:   enumspb.RESOURCE_EXHAUSTED_CAUSE_SYSTEM_OVERLOADED,

--- a/common/persistence/persistence_metric_clients.go
+++ b/common/persistence/persistence_metric_clients.go
@@ -1425,8 +1425,7 @@ func (p *metricEmitter) recordRequestMetrics(operation string, caller string, la
 
 func (p *metricEmitter) recordDataLossMetrics(operation string, caller string, err error, workflowID, runID string) {
 	// Emit data loss metrics if enabled and error is DataLoss
-	var dataLoss *serviceerror.DataLoss
-	if errors.As(err, &dataLoss) {
+	if _, ok := errors.AsType[*serviceerror.DataLoss](err); ok {
 		if p.enableDataLossMetrics() {
 			EmitDataLossMetric(p.metricsHandler, caller, workflowID, runID, operation, err)
 		}

--- a/common/persistence/sql/sqlplugin/sqlite/driver.go
+++ b/common/persistence/sql/sqlplugin/sqlite/driver.go
@@ -17,8 +17,7 @@ const (
 var sqlTableExistsRegex = regexp.MustCompile(sqlTableExistsPattern)
 
 func (*db) IsDupEntryError(err error) bool {
-	var sqlErr *sqlite.Error
-	if errors.As(err, &sqlErr) {
+	if sqlErr, ok := errors.AsType[*sqlite.Error](err); ok {
 		return sqlErr.Code()&sqlConstraintCodes != 0
 	}
 
@@ -26,8 +25,7 @@ func (*db) IsDupEntryError(err error) bool {
 }
 
 func isTableExistsError(err error) bool {
-	var sqlErr *sqlite.Error
-	if errors.As(err, &sqlErr) {
+	if sqlErr, ok := errors.AsType[*sqlite.Error](err); ok {
 		return sqlTableExistsRegex.MatchString(sqlErr.Error())
 	}
 

--- a/common/persistence/visibility/store/elasticsearch/processor.go
+++ b/common/persistence/visibility/store/elasticsearch/processor.go
@@ -209,8 +209,7 @@ func (p *processorImpl) bulkAfterAction(_ int64, requests []elastic.BulkableRequ
 	if err != nil {
 		const logFirstNRequests = 5
 		var httpStatus int
-		var esErr *elastic.Error
-		if errors.As(err, &esErr) {
+		if esErr, ok := errors.AsType[*elastic.Error](err); ok {
 			httpStatus = esErr.Status
 		}
 

--- a/common/persistence/visibility/store/query/errors.go
+++ b/common/persistence/visibility/store/query/errors.go
@@ -49,8 +49,7 @@ func NewOperatorNotSupportedError(
 }
 
 func wrapConverterError(message string, err error) error {
-	var converterErr *ConverterError
-	if errors.As(err, &converterErr) {
+	if converterErr, ok := errors.AsType[*ConverterError](err); ok {
 		return NewConverterError("%s: %v", message, converterErr)
 	}
 	return err

--- a/common/persistence/visibility/store/sql/visibility_store.go
+++ b/common/persistence/visibility/store/sql/visibility_store.go
@@ -277,8 +277,7 @@ func (s *VisibilityStore) countChasmExecutions(
 		request.ArchetypeId,
 	)
 	if err != nil {
-		var converterErr *query.ConverterError
-		if errors.As(err, &converterErr) {
+		if converterErr, ok := errors.AsType[*query.ConverterError](err); ok {
 			return nil, converterErr.ToInvalidArgument()
 		}
 		return nil, err
@@ -326,8 +325,7 @@ func (s *VisibilityStore) countChasmExecutionsLegacy(
 	)
 	selectFilter, err := converter.BuildCountStmt()
 	if err != nil {
-		var converterErr *query.ConverterError
-		if errors.As(err, &converterErr) {
+		if converterErr, ok := errors.AsType[*query.ConverterError](err); ok {
 			return nil, converterErr.ToInvalidArgument()
 		}
 		return nil, err
@@ -391,8 +389,7 @@ func (s *VisibilityStore) listExecutionsInternal(
 	if err != nil {
 		// Convert ConverterError to InvalidArgument and pass through all other errors (which should be
 		// only mapper errors).
-		var converterErr *query.ConverterError
-		if errors.As(err, &converterErr) {
+		if converterErr, ok := errors.AsType[*query.ConverterError](err); ok {
 			return nil, converterErr.ToInvalidArgument()
 		}
 		return nil, err
@@ -493,8 +490,7 @@ func (s *VisibilityStore) listExecutionsInternalLegacy(
 	selectFilter, err := converter.BuildSelectStmt(request.PageSize, request.NextPageToken)
 	if err != nil {
 		// Convert ConverterError to InvalidArgument and pass through all other errors (which should be only mapper errors).
-		var converterErr *query.ConverterError
-		if errors.As(err, &converterErr) {
+		if converterErr, ok := errors.AsType[*query.ConverterError](err); ok {
 			return nil, converterErr.ToInvalidArgument()
 		}
 		return nil, err
@@ -575,8 +571,7 @@ func (s *VisibilityStore) countWorkflowExecutionsLegacy(
 	selectFilter, err := converter.BuildCountStmt()
 	if err != nil {
 		// Convert ConverterError to InvalidArgument and pass through all other errors (which should be only mapper errors).
-		var converterErr *query.ConverterError
-		if errors.As(err, &converterErr) {
+		if converterErr, ok := errors.AsType[*query.ConverterError](err); ok {
 			return nil, converterErr.ToInvalidArgument()
 		}
 		return nil, err
@@ -626,8 +621,7 @@ func (s *VisibilityStore) countWorkflowExecutions(
 	if err != nil {
 		// Convert ConverterError to InvalidArgument and pass through all other errors (which should be
 		// only mapper errors).
-		var converterErr *query.ConverterError
-		if errors.As(err, &converterErr) {
+		if converterErr, ok := errors.AsType[*query.ConverterError](err); ok {
 			return nil, converterErr.ToInvalidArgument()
 		}
 		return nil, err

--- a/common/persistence/visibility/visibility_manager_impl.go
+++ b/common/persistence/visibility/visibility_manager_impl.go
@@ -605,8 +605,7 @@ func aliasChasmSearchAttributes(
 		if err != nil {
 			// Silently ignore serviceerror.InvalidArgument because it indicates unregistered field.
 			// INFO: Chasm search attributes must be registered with the CHASM Registry using the WithSearchAttributes() option.
-			var invalidArgumentErr *serviceerror.InvalidArgument
-			if errors.As(err, &invalidArgumentErr) {
+			if _, ok := errors.AsType[*serviceerror.InvalidArgument](err); ok {
 				continue
 			}
 			return nil, err

--- a/common/rpc/interceptor/request_error_handler.go
+++ b/common/rpc/interceptor/request_error_handler.go
@@ -99,8 +99,7 @@ func (eh *RequestErrorHandler) logError(
 func recordErrorMetrics(metricsHandler metrics.Handler, err error, isExpectedError bool) {
 	metrics.ServiceErrorWithType.With(metricsHandler).Record(1, metrics.ServiceErrorTypeTag(err))
 
-	var resourceExhaustedErr *serviceerror.ResourceExhausted
-	if errors.As(err, &resourceExhaustedErr) {
+	if resourceExhaustedErr, ok := errors.AsType[*serviceerror.ResourceExhausted](err); ok {
 		metrics.ServiceErrResourceExhaustedCounter.With(metricsHandler).Record(
 			1,
 			metrics.ResourceExhaustedCauseTag(resourceExhaustedErr.Cause),

--- a/common/searchattribute/mapper.go
+++ b/common/searchattribute/mapper.go
@@ -163,8 +163,7 @@ func AliasFields(
 			// Silently ignore serviceerror.InvalidArgument because it indicates unmapped field (alias was deleted, for example).
 			// IMPORTANT: AliasFields should never return serviceerror.InvalidArgument because it is used by Poll API and the error
 			// goes through up to SDK, which shutdowns worker when it receives serviceerror.InvalidArgument as poll response.
-			var invalidArgumentErr *serviceerror.InvalidArgument
-			if errors.As(err, &invalidArgumentErr) {
+			if _, ok := errors.AsType[*serviceerror.InvalidArgument](err); ok {
 				continue
 			}
 			return nil, err

--- a/common/util/error_type.go
+++ b/common/util/error_type.go
@@ -11,6 +11,7 @@ import (
 // It is useful for attaching low-cardinality type names to errors that are suitable for telemetry tags.
 // See ErrorType for more details.
 type typedError interface {
+	error
 	ErrorTypeName() string
 }
 
@@ -28,8 +29,7 @@ var wrapperErrorTypes = map[string]bool{
 // We consider errors wrapped via [fmt.Errorf], [errors.Join] and some pkg/errors functions to be wrapper errors.
 func ErrorType(err error) string {
 	// If any error in the tree has an explicit type name, use it, preferring the first one in the DFS traversal.
-	var typedErr typedError
-	if errors.As(err, &typedErr) {
+	if typedErr, ok := errors.AsType[typedError](err); ok {
 		return typedErr.ErrorTypeName()
 	}
 

--- a/common/worker_versioning/worker_versioning.go
+++ b/common/worker_versioning/worker_versioning.go
@@ -349,8 +349,7 @@ func checkVersionMembershipAndReactivationEligibility(
 	if err != nil {
 		// If matching is on an older version that doesn't have this RPC,
 		// fall back to fetching full user data and checking version membership based on the received information.
-		var unimplErr *serviceerror.Unimplemented
-		if errors.As(err, &unimplErr) {
+		if _, ok := errors.AsType[*serviceerror.Unimplemented](err); ok {
 			return checkVersionMembershipViaUserData(ctx, matchingClient, namespaceID, tq, tqType, version)
 		}
 		return false, false, 0, err

--- a/common/workercommands/dispatcher.go
+++ b/common/workercommands/dispatcher.go
@@ -159,8 +159,7 @@ func (d *Dispatcher) dispatchToWorker(
 }
 
 func (d *Dispatcher) handleError(nexusErr error, task *tasks.WorkerCommandsTask, namespaceName string) error {
-	var handlerErr *nexus.HandlerError
-	if errors.As(nexusErr, &handlerErr) {
+	if handlerErr, ok := errors.AsType[*nexus.HandlerError](nexusErr); ok {
 		// Handler-level error (transport, timeout, internal). These are constructed by
 		// MatchingDispatchResponseToError for non-worker-returned failures.
 		if handlerErr.Type == nexus.HandlerErrorTypeUpstreamTimeout {

--- a/components/callbacks/nexus_invocation.go
+++ b/components/callbacks/nexus_invocation.go
@@ -93,8 +93,7 @@ func outcomeTag(callCtx context.Context, callErr error) string {
 		if callCtx.Err() != nil {
 			return "request-timeout"
 		}
-		var handlerErr *nexus.HandlerError
-		if errors.As(callErr, &handlerErr) {
+		if handlerErr, ok := errors.AsType[*nexus.HandlerError](callErr); ok {
 			return "handler-error:" + string(handlerErr.Type)
 		}
 		return "unknown-error"
@@ -103,8 +102,7 @@ func outcomeTag(callCtx context.Context, callErr error) string {
 }
 
 func isRetryableCallError(err error) bool {
-	var handlerError *nexus.HandlerError
-	if errors.As(err, &handlerError) {
+	if handlerError, ok := errors.AsType[*nexus.HandlerError](err); ok {
 		return handlerError.Retryable()
 	}
 	return true

--- a/components/callbacks/request.go
+++ b/components/callbacks/request.go
@@ -54,8 +54,7 @@ func routeSystemCallbackRequest(
 		ns, err := namespaceRegistry.GetNamespaceByID(namespace.ID(namespaceID))
 		if err != nil {
 			logger.Error("failed to get namespace for nexus completion request", tag.WorkflowNamespaceID(namespaceID), tag.Error(err))
-			var nfe *serviceerror.NamespaceNotFound
-			if errors.As(err, &nfe) {
+			if _, ok := errors.AsType[*serviceerror.NamespaceNotFound](err); ok {
 				return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeNotFound, "namespace %q not found", namespaceID)
 			}
 			return nil, commonnexus.ConvertGRPCError(err, false)

--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -503,8 +503,7 @@ func (e taskExecutor) deferredOperationMetric(op Operation, callErr error, names
 		}
 	case enumsspb.NEXUS_OPERATION_STATE_TIMED_OUT:
 		timeoutType := enumspb.TIMEOUT_TYPE_UNSPECIFIED
-		var belowMin *operationTimeoutBelowMinError
-		if errors.As(callErr, &belowMin) {
+		if belowMin, ok := errors.AsType[*operationTimeoutBelowMinError](callErr); ok {
 			timeoutType = belowMin.timeoutType
 		}
 		return func() {
@@ -961,8 +960,7 @@ func createNexusOperationFailure(operation Operation, scheduledEventID int64, ca
 func startCallOutcomeTag(callCtx context.Context, result *nexusrpc.ClientStartOperationResponse[*commonpb.Payload], callErr error) string {
 
 	if callErr != nil {
-		var opTimeoutBelowMinErr *operationTimeoutBelowMinError
-		if errors.As(callErr, &opTimeoutBelowMinErr) {
+		if _, ok := errors.AsType[*operationTimeoutBelowMinError](callErr); ok {
 			return "operation-timeout"
 		}
 		if errors.Is(callErr, ErrInvalidOperationToken) {
@@ -974,16 +972,13 @@ func startCallOutcomeTag(callCtx context.Context, result *nexusrpc.ClientStartOp
 		if callCtx.Err() != nil {
 			return "request-timeout"
 		}
-		var serviceErr serviceerror.ServiceError
-		if errors.As(callErr, &serviceErr) {
+		if serviceErr, ok := errors.AsType[serviceerror.ServiceError](callErr); ok {
 			return "service-error:" + strings.Replace(fmt.Sprintf("%T", serviceErr), "*serviceerror.", "", 1)
 		}
-		var opFailedError *nexus.OperationError
-		if errors.As(callErr, &opFailedError) {
+		if opFailedError, ok := errors.AsType[*nexus.OperationError](callErr); ok {
 			return "operation-unsuccessful:" + string(opFailedError.State)
 		}
-		var handlerError *nexus.HandlerError
-		if errors.As(callErr, &handlerError) {
+		if handlerError, ok := errors.AsType[*nexus.HandlerError](callErr); ok {
 			return "handler-error:" + string(handlerError.Type)
 		}
 		return "unknown-error"
@@ -999,19 +994,16 @@ func cancelCallOutcomeTag(callCtx context.Context, callErr error) string {
 		if errors.Is(callErr, errOpProcessorFailed) {
 			return "operation-processor-failed"
 		}
-		var opTimeoutBelowMinErr *operationTimeoutBelowMinError
-		if errors.As(callErr, &opTimeoutBelowMinErr) {
+		if _, ok := errors.AsType[*operationTimeoutBelowMinError](callErr); ok {
 			return "operation-timeout"
 		}
 		if callCtx.Err() != nil {
 			return "request-timeout"
 		}
-		var handlerErr *nexus.HandlerError
-		if errors.As(callErr, &handlerErr) {
+		if handlerErr, ok := errors.AsType[*nexus.HandlerError](callErr); ok {
 			return "handler-error:" + string(handlerErr.Type)
 		}
-		var serviceErr serviceerror.ServiceError
-		if errors.As(callErr, &serviceErr) {
+		if serviceErr, ok := errors.AsType[serviceerror.ServiceError](callErr); ok {
 			return "service-error:" + strings.Replace(fmt.Sprintf("%T", serviceErr), "*serviceerror.", "", 1)
 		}
 		return "unknown-error"
@@ -1065,17 +1057,14 @@ func (e taskExecutor) logCallFailure(traceCtx invocationTraceContext, callErr er
 }
 
 func isDestinationDown(err error) bool {
-	var serviceErr serviceerror.ServiceError
 	// For the system endpoint, we don't even consider the destination down since it's internal.
-	if errors.As(err, &serviceErr) {
+	if _, ok := errors.AsType[serviceerror.ServiceError](err); ok {
 		return false
 	}
-	var opFailedErr *nexus.OperationError
-	if errors.As(err, &opFailedErr) {
+	if _, ok := errors.AsType[*nexus.OperationError](err); ok {
 		return false
 	}
-	var handlerError *nexus.HandlerError
-	if errors.As(err, &handlerError) {
+	if handlerError, ok := errors.AsType[*nexus.HandlerError](err); ok {
 		return handlerError.Retryable()
 	}
 	if errors.Is(err, errOpProcessorFailed) {
@@ -1092,8 +1081,7 @@ func isDestinationDown(err error) bool {
 }
 
 func callErrToFailure(callErr error, retryable bool) (*failurepb.Failure, error) {
-	var serviceErr serviceerror.ServiceError
-	if errors.As(callErr, &serviceErr) {
+	if serviceErr, ok := errors.AsType[serviceerror.ServiceError](callErr); ok {
 		return &failurepb.Failure{
 			Message: fmt.Sprintf("%s: %s", strings.Replace(fmt.Sprintf("%T", serviceErr), "*serviceerror.", "", 1), serviceErr.Error()),
 			FailureInfo: &failurepb.Failure_ServerFailureInfo{
@@ -1103,8 +1091,7 @@ func callErrToFailure(callErr error, retryable bool) (*failurepb.Failure, error)
 			},
 		}, nil
 	}
-	var handlerErr *nexus.HandlerError
-	if errors.As(callErr, &handlerErr) {
+	if handlerErr, ok := errors.AsType[*nexus.HandlerError](callErr); ok {
 		var nf nexus.Failure
 		if handlerErr.OriginalFailure != nil {
 			nf = *handlerErr.OriginalFailure

--- a/service/frontend/admin_handler.go
+++ b/service/frontend/admin_handler.go
@@ -402,8 +402,7 @@ func (adh *AdminHandler) unaliasAndValidateSearchAttributes(historyBatches []*co
 
 			unaliasedSas, err := searchattribute.UnaliasFields(adh.saMapperProvider, sas, nsName.String())
 			if err != nil {
-				var invArgErr *serviceerror.InvalidArgument
-				if !errors.As(err, &invArgErr) {
+				if _, ok := errors.AsType[*serviceerror.InvalidArgument](err); !ok {
 					return nil, err
 				}
 				// Mapper returns InvalidArgument if alias is not found. It means that history has field names, not aliases.

--- a/service/frontend/nexus_completion_http_handler.go
+++ b/service/frontend/nexus_completion_http_handler.go
@@ -149,8 +149,7 @@ func (h *nexusCompletionHandler) CompleteOperation(ctx context.Context, r *nexus
 	if err != nil {
 		h.Logger.Error("failed to get namespace for nexus completion request", tag.WorkflowNamespaceID(targetNamespaceID), tag.Error(err))
 		h.preProcessErrorsCounter.Record(1)
-		var nfe *serviceerror.NamespaceNotFound
-		if errors.As(err, &nfe) {
+		if _, ok := errors.AsType[*serviceerror.NamespaceNotFound](err); ok {
 			return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeNotFound, "namespace %q not found", targetNamespaceID)
 		}
 		return commonnexus.ConvertGRPCError(err, false)
@@ -200,8 +199,7 @@ func (h *nexusCompletionHandler) CompleteOperation(ctx context.Context, r *nexus
 	}
 
 	if err := rCtx.interceptRequest(ctx, r); err != nil {
-		var notActiveErr *serviceerror.NamespaceNotActive
-		if errors.As(err, &notActiveErr) {
+		if _, ok := errors.AsType[*serviceerror.NamespaceNotActive](err); ok {
 			return h.forwardCompleteOperation(ctx, r, rCtx)
 		}
 		return err
@@ -239,12 +237,10 @@ func (h *nexusCompletionHandler) CompleteOperation(ctx context.Context, r *nexus
 		return nil
 	}
 	logger.Error("failed to process nexus completion request", tag.Error(err))
-	var namespaceInactiveErr *serviceerror.NamespaceNotActive
-	if errors.As(err, &namespaceInactiveErr) {
+	if _, ok := errors.AsType[*serviceerror.NamespaceNotActive](err); ok {
 		return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeUnavailable, "cluster inactive")
 	}
-	var notFoundErr *serviceerror.NotFound
-	if errors.As(err, &notFoundErr) {
+	if _, ok := errors.AsType[*serviceerror.NotFound](err); ok {
 		return commonnexus.ConvertGRPCError(err, true)
 	}
 	return commonnexus.ConvertGRPCError(err, false)
@@ -551,8 +547,7 @@ func (c *requestContext) capturePanicAndRecordMetrics(ctxPtr *context.Context, e
 	} else if c.outcomeTag.Key != "" {
 		c.metricsHandler = c.metricsHandler.WithTags(c.outcomeTag)
 	} else {
-		var he *nexus.HandlerError
-		if errors.As(*errPtr, &he) {
+		if he, ok := errors.AsType[*nexus.HandlerError](*errPtr); ok {
 			c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("error_" + strings.ToLower(string(he.Type))))
 		} else {
 			c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("error_internal"))
@@ -606,8 +601,7 @@ func (c *requestContext) interceptRequest(ctx context.Context, request *nexusrpc
 		// If frontend.exposeAuthorizerErrors is false, Authorize err is either an explicitly set reason, or a generic
 		// "Request unauthorized." message.
 		// Otherwise, expose the underlying error.
-		var permissionDeniedError *serviceerror.PermissionDenied
-		if errors.As(err, &permissionDeniedError) {
+		if permissionDeniedError, ok := errors.AsType[*serviceerror.PermissionDenied](err); ok {
 			c.outcomeTag = metrics.OutcomeTag("unauthorized")
 			return commonnexus.AdaptAuthorizeError(permissionDeniedError)
 		}

--- a/service/frontend/nexus_endpoint_client.go
+++ b/service/frontend/nexus_endpoint_client.go
@@ -416,8 +416,7 @@ func (c *NexusEndpointClient) transformServiceError(err error, message string) e
 	if err == nil {
 		return nil
 	}
-	var notFound *serviceerror.NotFound
-	if errors.As(err, &notFound) {
+	if _, ok := errors.AsType[*serviceerror.NotFound](err); ok {
 		return err
 	}
 	c.logger.Error(message, tag.Error(err))

--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -184,8 +184,7 @@ func (c *operationContext) interceptRequest(
 		// If frontend.exposeAuthorizerErrors is false, Authorize err is either an explicitly set reason, or a generic
 		// "Request unauthorized." message.
 		// Otherwise, expose the underlying error.
-		var permissionDeniedError *serviceerror.PermissionDenied
-		if errors.As(err, &permissionDeniedError) {
+		if permissionDeniedError, ok := errors.AsType[*serviceerror.PermissionDenied](err); ok {
 			c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("unauthorized"))
 			return commonnexus.AdaptAuthorizeError(permissionDeniedError)
 		}
@@ -404,8 +403,7 @@ func (h *nexusHandler) getOperationContext(ctx context.Context, method string) (
 			metrics.OutcomeTag("namespace_not_found"),
 		)
 
-		var nfe *serviceerror.NamespaceNotFound
-		if errors.As(err, &nfe) {
+		if _, ok := errors.AsType[*serviceerror.NamespaceNotFound](err); ok {
 			return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeNotFound, "namespace not found: %q", nc.namespaceName)
 		}
 		return nil, commonnexus.ConvertGRPCError(err, false)
@@ -460,8 +458,7 @@ func (h *nexusHandler) StartOperation(
 	})
 
 	if err := oc.interceptRequest(ctx, request, options.Header); err != nil {
-		var notActiveErr *serviceerror.NamespaceNotActive
-		if errors.As(err, &notActiveErr) {
+		if _, ok := errors.AsType[*serviceerror.NamespaceNotActive](err); ok {
 			return h.forwardStartOperation(ctx, service, operation, input, options, oc)
 		}
 		return nil, err
@@ -691,8 +688,7 @@ func (h *nexusHandler) CancelOperation(ctx context.Context, service, operation, 
 		},
 	})
 	if err := oc.interceptRequest(ctx, request, options.Header); err != nil {
-		var notActiveErr *serviceerror.NamespaceNotActive
-		if errors.As(err, &notActiveErr) {
+		if _, ok := errors.AsType[*serviceerror.NamespaceNotActive](err); ok {
 			return h.forwardCancelOperation(ctx, service, operation, token, options, oc)
 		}
 		return err

--- a/service/frontend/nexus_operation_http_handler.go
+++ b/service/frontend/nexus_operation_http_handler.go
@@ -275,8 +275,7 @@ func (h *NexusOperationHTTPHandler) nexusContextFromEndpoint(
 				tag.Error(err),
 				tag.NexusEndpointTargetNamespaceID(v.Worker.GetNamespaceId()),
 			)
-			var notFoundErr *serviceerror.NamespaceNotFound
-			if errors.As(err, &notFoundErr) {
+			if _, ok := errors.AsType[*serviceerror.NamespaceNotFound](err); ok {
 				h.writeFailure(w, r, &nexus.HandlerError{
 					Type:          nexus.HandlerErrorTypeNotFound,
 					Message:       "invalid endpoint target",

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -795,8 +795,7 @@ func (wh *WorkflowHandler) ExecuteMultiOperation(
 
 	historyResp, err := wh.historyClient.ExecuteMultiOperation(ctx, historyReq)
 	if err != nil {
-		var multiErr *serviceerror.MultiOperationExecution
-		if errors.As(err, &multiErr) {
+		if multiErr, ok := errors.AsType[*serviceerror.MultiOperationExecution](err); ok {
 			// Tweak error message for end-users to match the feature name.
 			// The per-operation errors are embedded inside the error and unpacked by the SDK.
 			multiErr.Message = "Update-with-Start could not be executed."
@@ -3587,8 +3586,7 @@ func (wh *WorkflowHandler) createScheduleCHASM(
 	// concurrent V1 CreateSchedule from succeeding for the same schedule ID.
 	if wh.scheduleSentinelsEnabled(request.Namespace) {
 		if err := wh.writeSchedulerWorkflowSentinel(ctx, namespaceID.String(), request); err != nil {
-			var alreadyStartedErr *serviceerror.WorkflowExecutionAlreadyStarted
-			if !errors.As(err, &alreadyStartedErr) {
+			if _, ok := errors.AsType[*serviceerror.WorkflowExecutionAlreadyStarted](err); !ok {
 				return nil, err
 			}
 			// V1 key is occupied. Check if it's a sentinel (proceed) or real scheduler (fail).
@@ -3619,8 +3617,7 @@ func (wh *WorkflowHandler) createScheduleCHASM(
 			return nil, serviceerror.NewWorkflowExecutionAlreadyStarted(
 				fmt.Sprintf("schedule %q: concurrent creation detected", request.ScheduleId), "", "")
 		}
-		var alreadyExistsErr *serviceerror.AlreadyExists
-		if errors.As(err, &alreadyExistsErr) {
+		if alreadyExistsErr, ok := errors.AsType[*serviceerror.AlreadyExists](err); ok {
 			return nil, serviceerror.NewWorkflowExecutionAlreadyStarted(alreadyExistsErr.Message, "", "")
 		}
 		return nil, err
@@ -3646,16 +3643,14 @@ func (wh *WorkflowHandler) createScheduleWorkflow(
 		if err := wh.writeSchedulerCHASMSentinel(ctx, namespaceID.String(), namespaceName.String(), request.ScheduleId); err != nil {
 			// Translate AlreadyExists (from CHASM handler) to
 			// WorkflowExecutionAlreadyStarted for SDK compatibility.
-			var alreadyExistsErr *serviceerror.AlreadyExists
-			if errors.As(err, &alreadyExistsErr) {
+			if alreadyExistsErr, ok := errors.AsType[*serviceerror.AlreadyExists](err); ok {
 				return nil, serviceerror.NewWorkflowExecutionAlreadyStarted(alreadyExistsErr.Message, "", "")
 			}
 			// Ignore unimplemented to avoid issues with mixed brain testing.
 			//
 			// We wouldn't hit this condition in prod, as we wouldn't migrate with the fleet
 			// halfway deployed to the target version.
-			var unimplErr *serviceerror.Unimplemented
-			if !errors.As(err, &unimplErr) {
+			if _, ok := errors.AsType[*serviceerror.Unimplemented](err); !ok {
 				return nil, err
 			}
 		}
@@ -3732,8 +3727,7 @@ func (wh *WorkflowHandler) createScheduleWorkflow(
 	)
 
 	if err != nil {
-		var alreadyStartedErr *serviceerror.WorkflowExecutionAlreadyStarted
-		if errors.As(err, &alreadyStartedErr) {
+		if _, ok := errors.AsType[*serviceerror.WorkflowExecutionAlreadyStarted](err); ok {
 			// V1 key is occupied. Check if it's a sentinel (race) or real scheduler.
 			isReal, checkErr := wh.isRealSchedulerInV1KeySpace(ctx, namespaceID.String(), request.Namespace, request.ScheduleId)
 			if checkErr != nil {
@@ -3821,8 +3815,7 @@ func (wh *WorkflowHandler) isRealSchedulerInV1KeySpace(
 		},
 	})
 	if err != nil {
-		var notFoundErr *serviceerror.NotFound
-		if errors.As(err, &notFoundErr) {
+		if _, ok := errors.AsType[*serviceerror.NotFound](err); ok {
 			return false, nil
 		}
 		return false, err
@@ -3939,12 +3932,10 @@ func (wh *WorkflowHandler) scheduleSentinelsEnabled(namespaceName string) bool {
 //   - ErrClosed: the CHASM schedule was migrated to V1 and marked closed; the
 //     request should be retried against the workflow-backed stack.
 func isSchedulerErrorLegacyRoutable(err error) bool {
-	var notFoundErr *serviceerror.NotFound
-	if errors.As(err, &notFoundErr) {
+	if _, ok := errors.AsType[*serviceerror.NotFound](err); ok {
 		return true
 	}
-	var failedPreconditionErr *serviceerror.FailedPrecondition
-	if errors.As(err, &failedPreconditionErr) {
+	if failedPreconditionErr, ok := errors.AsType[*serviceerror.FailedPrecondition](err); ok {
 		return failedPreconditionErr.Message == chasmscheduler.ErrClosed.(*serviceerror.FailedPrecondition).Message
 	}
 	return false
@@ -5757,8 +5748,7 @@ func (wh *WorkflowHandler) GetWorkerTaskReachability(ctx context.Context, reques
 
 	response, err := wh.getWorkerTaskReachabilityValidated(ctx, ns, request)
 	if err != nil {
-		var invalidArgument *serviceerror.InvalidArgument
-		if errors.As(err, &invalidArgument) {
+		if _, ok := errors.AsType[*serviceerror.InvalidArgument](err); ok {
 			return nil, err
 		}
 		// Intentionally treat all errors as internal errors

--- a/service/history/api/get_history_util.go
+++ b/service/history/api/get_history_util.go
@@ -42,8 +42,7 @@ func GetRawHistory(
 	branchToken []byte,
 ) (_ []*commonpb.DataBlob, _ []byte, retError error) {
 	defer func() {
-		var dataLossErr *serviceerror.DataLoss
-		if errors.As(retError, &dataLossErr) {
+		if _, ok := errors.AsType[*serviceerror.DataLoss](retError); ok {
 			if shardContext.GetConfig().EnableDataLossMetrics() {
 				persistence.EmitDataLossMetric(
 					shardContext.GetMetricsHandler(),

--- a/service/history/api/getworkflowexecutionhistory/api.go
+++ b/service/history/api/getworkflowexecutionhistory/api.go
@@ -294,8 +294,7 @@ func Invoke(
 	// when data inconsistency occurs. Long term solution should check event
 	// batch pointing backwards within history store.
 	defer func() {
-		var dataLossErr *serviceerror.DataLoss
-		if errors.As(retError, &dataLossErr) {
+		if _, ok := errors.AsType[*serviceerror.DataLoss](retError); ok {
 			api.TrimHistoryNode(
 				ctx,
 				shardContext,

--- a/service/history/api/multioperation/api.go
+++ b/service/history/api/multioperation/api.go
@@ -293,8 +293,7 @@ func (uws *updateWithStart) getWorkflowLease(ctx context.Context) (api.WorkflowL
 		definition.NewWorkflowKey(uws.namespaceId.String(), uws.startReq.StartRequest.WorkflowId, ""),
 		locks.PriorityHigh,
 	)
-	var notFound *serviceerror.NotFound
-	if errors.As(err, &notFound) {
+	if _, ok := errors.AsType[*serviceerror.NotFound](err); ok {
 		return nil, nil
 	}
 	if err != nil {

--- a/service/history/api/recordworkflowtaskstarted/api.go
+++ b/service/history/api/recordworkflowtaskstarted/api.go
@@ -281,8 +281,7 @@ func setHistoryForRecordWfTaskStartedResp(
 	//  when data inconsistency occurs
 	//  long term solution should check event batch pointing backwards within history store
 	defer func() {
-		var dataLossErr *serviceerror.DataLoss
-		if errors.As(retError, &dataLossErr) {
+		if _, ok := errors.AsType[*serviceerror.DataLoss](retError); ok {
 			api.TrimHistoryNode(
 				ctx,
 				shardContext,

--- a/service/history/api/respondworkflowtaskcompleted/api.go
+++ b/service/history/api/respondworkflowtaskcompleted/api.go
@@ -908,8 +908,7 @@ func (handler *WorkflowTaskCompletedHandler) createPollWorkflowTaskQueueResponse
 		//  when data inconsistency occurs
 		//  long term solution should check event batch pointing backwards within history store
 		defer func() {
-			var dataLossErr *serviceerror.DataLoss
-			if errors.As(retError, &dataLossErr) {
+			if _, ok := errors.AsType[*serviceerror.DataLoss](retError); ok {
 				api.TrimHistoryNode(
 					ctx,
 					handler.shardContext,

--- a/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
+++ b/service/history/api/respondworkflowtaskcompleted/workflow_task_completed_handler.go
@@ -365,8 +365,7 @@ func (handler *workflowTaskCompletedHandler) handleCommand(
 			err = hsmHandler(ctx, handler.mutableState, validator, handlerOpts.WorkflowTaskCompletedEventID, command)
 		}
 
-		var failWFTErr chasmworkflow.FailWorkflowTaskError
-		if errors.As(err, &failWFTErr) {
+		if failWFTErr, ok := errors.AsType[chasmworkflow.FailWorkflowTaskError](err); ok {
 			if failWFTErr.TerminateWorkflow {
 				return nil, handler.terminateWorkflow(failWFTErr.Cause, failWFTErr)
 			}
@@ -1563,8 +1562,7 @@ func (handler *workflowTaskCompletedHandler) failWorkflowTaskOnInvalidArgument(
 	wtFailedCause enumspb.WorkflowTaskFailedCause,
 	err error,
 ) error {
-	var invalidArgument *serviceerror.InvalidArgument
-	if errors.As(err, &invalidArgument) {
+	if _, ok := errors.AsType[*serviceerror.InvalidArgument](err); ok {
 		return handler.failWorkflowTask(wtFailedCause, err)
 	}
 	return err

--- a/service/history/api/verifychildworkflowcompletionrecorded/api.go
+++ b/service/history/api/verifychildworkflowcompletionrecorded/api.go
@@ -245,8 +245,7 @@ func resendParentAndVerify(
 			// TODO: add parent workflow to workflowNotFoundCache
 			return &historyservice.VerifyChildExecutionCompletionRecordedResponse{}, nil
 		}
-		var failedPreconditionErr *serviceerror.FailedPrecondition
-		if errors.As(err, &failedPreconditionErr) {
+		if _, ok := errors.AsType[*serviceerror.FailedPrecondition](err); ok {
 			// Unable to perform sync state. Transition history maybe disabled in source cluster.
 			return nil, errVerify
 		}

--- a/service/history/archival/archiver.go
+++ b/service/history/archival/archiver.go
@@ -122,9 +122,7 @@ func (a *archiver) Archive(ctx context.Context, request *Request) (res *Response
 		if err != nil {
 			status = "err"
 
-			var rateLimitExceededErr *serviceerror.ResourceExhausted
-
-			if errors.As(err, &rateLimitExceededErr) {
+			if _, ok := errors.AsType[*serviceerror.ResourceExhausted](err); ok {
 				status = "rate_limit_exceeded"
 			}
 

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -2571,8 +2571,7 @@ func (h *Handler) StartNexusOperation(
 	}
 	result, err := h.nexusHandler.StartOperation(ctx, req.GetRequest().GetService(), req.GetRequest().GetOperation(), input, options)
 	if err != nil {
-		var opErr *nexus.OperationError
-		if errors.As(err, &opErr) {
+		if opErr, ok := errors.AsType[*nexus.OperationError](err); ok {
 			nexusFailure, convErr := nexusrpc.DefaultFailureConverter().ErrorToFailure(opErr)
 			if convErr != nil {
 				return nil, convErr

--- a/service/history/ndc/mutable_state_initializer.go
+++ b/service/history/ndc/mutable_state_initializer.go
@@ -112,36 +112,36 @@ func (r *MutableStateInitializerImpl) InitializeFromDB(
 		_, dbRecordVersion := mutableState.GetUpdateCondition()
 		dbHistorySize := mutableState.GetHistorySize()
 		return NewWorkflow(
-				r.shardContext.GetClusterMetadata(),
-				wfContext,
-				mutableState,
-				releaseFn,
-			), MutableStateInitializationSpec{
-				ExistsInDB:      true,
-				IsBrandNew:      false,
-				DBRecordVersion: dbRecordVersion,
-				DBHistorySize:   dbHistorySize,
-			}, nil
+			r.shardContext.GetClusterMetadata(),
+			wfContext,
+			mutableState,
+			releaseFn,
+		), MutableStateInitializationSpec{
+			ExistsInDB:      true,
+			IsBrandNew:      false,
+			DBRecordVersion: dbRecordVersion,
+			DBHistorySize:   dbHistorySize,
+		}, nil
 	case *serviceerror.NotFound:
 		return NewWorkflow(
-				r.shardContext.GetClusterMetadata(),
-				wfContext,
-				workflow.NewMutableState(
-					r.shardContext,
-					r.shardContext.GetEventsCache(),
-					r.logger,
-					namespaceEntry,
-					workflowKey.WorkflowID,
-					workflowKey.RunID,
-					time.Now().UTC(),
-				),
-				releaseFn,
-			), MutableStateInitializationSpec{
-				ExistsInDB:      false,
-				IsBrandNew:      true,
-				DBRecordVersion: 1,
-				DBHistorySize:   0,
-			}, nil
+			r.shardContext.GetClusterMetadata(),
+			wfContext,
+			workflow.NewMutableState(
+				r.shardContext,
+				r.shardContext.GetEventsCache(),
+				r.logger,
+				namespaceEntry,
+				workflowKey.WorkflowID,
+				workflowKey.RunID,
+				time.Now().UTC(),
+			),
+			releaseFn,
+		), MutableStateInitializationSpec{
+			ExistsInDB:      false,
+			IsBrandNew:      true,
+			DBRecordVersion: 1,
+			DBHistorySize:   0,
+		}, nil
 	default:
 		releaseFn(err)
 		return nil, MutableStateInitializationSpec{}, err
@@ -179,16 +179,16 @@ func (r *MutableStateInitializerImpl) InitializeFromToken(
 		return nil, MutableStateInitializationSpec{}, err
 	}
 	return NewWorkflow(
-			r.shardContext.GetClusterMetadata(),
-			wfContext,
-			mutableState,
-			wcache.NoopReleaseFn,
-		), MutableStateInitializationSpec{
-			ExistsInDB:      existsInDB,
-			IsBrandNew:      false,
-			DBRecordVersion: dbRecordVersion,
-			DBHistorySize:   dbHistorySize,
-		}, nil
+		r.shardContext.GetClusterMetadata(),
+		wfContext,
+		mutableState,
+		wcache.NoopReleaseFn,
+	), MutableStateInitializationSpec{
+		ExistsInDB:      existsInDB,
+		IsBrandNew:      false,
+		DBRecordVersion: dbRecordVersion,
+		DBHistorySize:   dbHistorySize,
+	}, nil
 }
 
 func (r *MutableStateInitializerImpl) flushBufferEvents(

--- a/service/history/ndc/mutable_state_initializer.go
+++ b/service/history/ndc/mutable_state_initializer.go
@@ -112,36 +112,36 @@ func (r *MutableStateInitializerImpl) InitializeFromDB(
 		_, dbRecordVersion := mutableState.GetUpdateCondition()
 		dbHistorySize := mutableState.GetHistorySize()
 		return NewWorkflow(
-			r.shardContext.GetClusterMetadata(),
-			wfContext,
-			mutableState,
-			releaseFn,
-		), MutableStateInitializationSpec{
-			ExistsInDB:      true,
-			IsBrandNew:      false,
-			DBRecordVersion: dbRecordVersion,
-			DBHistorySize:   dbHistorySize,
-		}, nil
+				r.shardContext.GetClusterMetadata(),
+				wfContext,
+				mutableState,
+				releaseFn,
+			), MutableStateInitializationSpec{
+				ExistsInDB:      true,
+				IsBrandNew:      false,
+				DBRecordVersion: dbRecordVersion,
+				DBHistorySize:   dbHistorySize,
+			}, nil
 	case *serviceerror.NotFound:
 		return NewWorkflow(
-			r.shardContext.GetClusterMetadata(),
-			wfContext,
-			workflow.NewMutableState(
-				r.shardContext,
-				r.shardContext.GetEventsCache(),
-				r.logger,
-				namespaceEntry,
-				workflowKey.WorkflowID,
-				workflowKey.RunID,
-				time.Now().UTC(),
-			),
-			releaseFn,
-		), MutableStateInitializationSpec{
-			ExistsInDB:      false,
-			IsBrandNew:      true,
-			DBRecordVersion: 1,
-			DBHistorySize:   0,
-		}, nil
+				r.shardContext.GetClusterMetadata(),
+				wfContext,
+				workflow.NewMutableState(
+					r.shardContext,
+					r.shardContext.GetEventsCache(),
+					r.logger,
+					namespaceEntry,
+					workflowKey.WorkflowID,
+					workflowKey.RunID,
+					time.Now().UTC(),
+				),
+				releaseFn,
+			), MutableStateInitializationSpec{
+				ExistsInDB:      false,
+				IsBrandNew:      true,
+				DBRecordVersion: 1,
+				DBHistorySize:   0,
+			}, nil
 	default:
 		releaseFn(err)
 		return nil, MutableStateInitializationSpec{}, err
@@ -179,16 +179,16 @@ func (r *MutableStateInitializerImpl) InitializeFromToken(
 		return nil, MutableStateInitializationSpec{}, err
 	}
 	return NewWorkflow(
-		r.shardContext.GetClusterMetadata(),
-		wfContext,
-		mutableState,
-		wcache.NoopReleaseFn,
-	), MutableStateInitializationSpec{
-		ExistsInDB:      existsInDB,
-		IsBrandNew:      false,
-		DBRecordVersion: dbRecordVersion,
-		DBHistorySize:   dbHistorySize,
-	}, nil
+			r.shardContext.GetClusterMetadata(),
+			wfContext,
+			mutableState,
+			wcache.NoopReleaseFn,
+		), MutableStateInitializationSpec{
+			ExistsInDB:      existsInDB,
+			IsBrandNew:      false,
+			DBRecordVersion: dbRecordVersion,
+			DBHistorySize:   dbHistorySize,
+		}, nil
 }
 
 func (r *MutableStateInitializerImpl) flushBufferEvents(

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -811,8 +811,7 @@ func (r *workflowResetterImpl) reapplyContinueAsNewWorkflowEvents(
 		if err != nil {
 			// A deleted run truncates the chain; other errors must fail the reset so a retry
 			// can reapply the full surviving chain, since reset is one-shot.
-			var notFound *serviceerror.NotFound
-			if errors.As(err, &notFound) {
+			if _, ok := errors.AsType[*serviceerror.NotFound](err); ok {
 				break
 			}
 			return "", err

--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -73,6 +73,7 @@ type (
 	// MaybeTerminalTaskError are errors which (if IsTerminalTaskError returns true) cannot be retried and should
 	// not be rescheduled. Tasks should be enqueued to the DLQ immediately if an error is marked as terminal.
 	MaybeTerminalTaskError interface {
+		error
 		IsTerminalTaskError() bool
 	}
 )
@@ -476,8 +477,7 @@ func (e *executableImpl) isExpectedRetryableError(err error) (isRetryable bool, 
 		}
 	}()
 
-	var resourceExhaustedErr *serviceerror.ResourceExhausted
-	if errors.As(err, &resourceExhaustedErr) {
+	if resourceExhaustedErr, ok := errors.AsType[*serviceerror.ResourceExhausted](err); ok {
 		switch resourceExhaustedErr.Cause { //nolint:exhaustive
 		case enumspb.RESOURCE_EXHAUSTED_CAUSE_BUSY_WORKFLOW:
 			err = consts.ErrResourceExhaustedBusyWorkflow
@@ -520,8 +520,7 @@ func (e *executableImpl) isExpectedRetryableError(err error) (isRetryable bool, 
 }
 
 func (e *executableImpl) isUnexpectedNonRetryableError(err error) bool {
-	var terr MaybeTerminalTaskError
-	if errors.As(err, &terr) {
+	if terr, ok := errors.AsType[MaybeTerminalTaskError](err); ok {
 		return terr.IsTerminalTaskError()
 	}
 

--- a/service/history/queues/executable_mock.go
+++ b/service/history/queues/executable_mock.go
@@ -479,6 +479,20 @@ func (m *MockMaybeTerminalTaskError) EXPECT() *MockMaybeTerminalTaskErrorMockRec
 	return m.recorder
 }
 
+// Error mocks base method.
+func (m *MockMaybeTerminalTaskError) Error() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Error")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Error indicates an expected call of Error.
+func (mr *MockMaybeTerminalTaskErrorMockRecorder) Error() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockMaybeTerminalTaskError)(nil).Error))
+}
+
 // IsTerminalTaskError mocks base method.
 func (m *MockMaybeTerminalTaskError) IsTerminalTaskError() bool {
 	m.ctrl.T.Helper()

--- a/service/history/replication/executable_task.go
+++ b/service/history/replication/executable_task.go
@@ -734,8 +734,7 @@ func (e *ExecutableTaskImpl) SyncState(
 	}
 	resp, err := remoteAdminClient.SyncWorkflowState(ctx, req)
 	if err != nil {
-		var resourceExhaustedError *serviceerror.ResourceExhausted
-		if errors.As(err, &resourceExhaustedError) {
+		if _, ok := errors.AsType[*serviceerror.ResourceExhausted](err); ok {
 			e.emitReplicationTaskError(wideevents.ReplOperationSyncState, "Sync workflow state request exceeded resource limits", err, map[string]any{
 				"request_payload_size": req.Size(),
 			})
@@ -748,16 +747,14 @@ func (e *ExecutableTaskImpl) SyncState(
 			tag.ReplicationTask(e.replicationTask),
 		)
 
-		var workflowNotReady *serviceerror.WorkflowNotReady
-		if errors.As(err, &workflowNotReady) {
+		if _, ok := errors.AsType[*serviceerror.WorkflowNotReady](err); ok {
 			logger.Info("Dropped replication task as source mutable state has buffered events.", tag.Error(err))
 			e.emitReplicationTaskError(wideevents.ReplOperationSyncState, "Dropped replication task because source mutable state has buffered events", err, map[string]any{
 				"disposition": wideevents.ReplDispositionDiscarded,
 			})
 			return false, nil
 		}
-		var notFoundErr *serviceerror.NotFound
-		if errors.As(err, &notFoundErr) {
+		if _, ok := errors.AsType[*serviceerror.NotFound](err); ok {
 			logger.Error(
 				"workflow not found in source cluster, proceed to cleanup")
 			e.emitReplicationTaskError(wideevents.ReplOperationSyncState, "Workflow not found in source cluster; cleaning up target", err, map[string]any{
@@ -773,8 +770,7 @@ func (e *ExecutableTaskImpl) SyncState(
 				),
 			)
 		}
-		var failedPreconditionErr *serviceerror.FailedPrecondition
-		if !errors.As(err, &failedPreconditionErr) {
+		if _, ok := errors.AsType[*serviceerror.FailedPrecondition](err); !ok {
 			return false, err
 		}
 		// Unable to perform sync state. Transition history maybe disabled in source cluster.
@@ -860,8 +856,7 @@ func (e *ExecutableTaskImpl) DeleteWorkflow(
 		},
 		ClosedWorkflowOnly: false,
 	})
-	var notFoundErr *serviceerror.NotFound
-	if errors.As(err, &notFoundErr) {
+	if _, ok := errors.AsType[*serviceerror.NotFound](err); ok {
 		return nil
 	}
 	return err

--- a/service/history/replication/replication_events.go
+++ b/service/history/replication/replication_events.go
@@ -542,8 +542,7 @@ func (e *ExecutableVerifyVersionedTransitionTask) emitReplicationVerifyApplied(
 	outcome := "verified"
 	errStr := ""
 	if retErr != nil {
-		var syncStateErr *serviceerrors.SyncState
-		if errors.As(retErr, &syncStateErr) {
+		if _, ok := errors.AsType[*serviceerrors.SyncState](retErr); ok {
 			outcome = "resend_needed"
 		} else {
 			outcome = "error"

--- a/service/history/replication/stream.go
+++ b/service/history/replication/stream.go
@@ -65,8 +65,7 @@ func WrapEventLoop(
 		err := originalEventLoop()
 
 		if err != nil {
-			var streamError *StreamError
-			if errors.As(err, &streamError) {
+			if streamError, ok := errors.AsType[*StreamError](err); ok {
 				metrics.ReplicationStreamError.With(metricsHandler).Record(
 					int64(1),
 					metrics.ServiceErrorTypeTag(streamError.cause),

--- a/service/history/replication/sync_state_retriever_test.go
+++ b/service/history/replication/sync_state_retriever_test.go
@@ -475,13 +475,13 @@ func (s *syncWorkflowStateSuite) TestSyncWorkflowState_ReturnSnapshot() {
 					},
 				}
 				return versionHistories, []*persistencespb.VersionedTransition{
-					{NamespaceFailoverVersion: 1, TransitionCount: 12},
-					{NamespaceFailoverVersion: 2, TransitionCount: 15},
-				}, []*persistencespb.StateMachineTombstoneBatch{
-					{
-						VersionedTransition: &persistencespb.VersionedTransition{NamespaceFailoverVersion: 1, TransitionCount: 12},
-					},
-				}, nil
+						{NamespaceFailoverVersion: 1, TransitionCount: 12},
+						{NamespaceFailoverVersion: 2, TransitionCount: 15},
+					}, []*persistencespb.StateMachineTombstoneBatch{
+						{
+							VersionedTransition: &persistencespb.VersionedTransition{NamespaceFailoverVersion: 1, TransitionCount: 12},
+						},
+					}, nil
 			},
 		},
 		{
@@ -500,13 +500,13 @@ func (s *syncWorkflowStateSuite) TestSyncWorkflowState_ReturnSnapshot() {
 					},
 				}
 				return versionHistories, []*persistencespb.VersionedTransition{
-					{NamespaceFailoverVersion: 1, TransitionCount: 13},
-					{NamespaceFailoverVersion: 2, TransitionCount: 15},
-				}, []*persistencespb.StateMachineTombstoneBatch{
-					{
-						VersionedTransition: &persistencespb.VersionedTransition{NamespaceFailoverVersion: 1, TransitionCount: 12},
-					},
-				}, &persistencespb.VersionedTransition{NamespaceFailoverVersion: 1, TransitionCount: 13}
+						{NamespaceFailoverVersion: 1, TransitionCount: 13},
+						{NamespaceFailoverVersion: 2, TransitionCount: 15},
+					}, []*persistencespb.StateMachineTombstoneBatch{
+						{
+							VersionedTransition: &persistencespb.VersionedTransition{NamespaceFailoverVersion: 1, TransitionCount: 12},
+						},
+					}, &persistencespb.VersionedTransition{NamespaceFailoverVersion: 1, TransitionCount: 13}
 			},
 		},
 	}

--- a/service/history/replication/sync_state_retriever_test.go
+++ b/service/history/replication/sync_state_retriever_test.go
@@ -475,13 +475,13 @@ func (s *syncWorkflowStateSuite) TestSyncWorkflowState_ReturnSnapshot() {
 					},
 				}
 				return versionHistories, []*persistencespb.VersionedTransition{
-						{NamespaceFailoverVersion: 1, TransitionCount: 12},
-						{NamespaceFailoverVersion: 2, TransitionCount: 15},
-					}, []*persistencespb.StateMachineTombstoneBatch{
-						{
-							VersionedTransition: &persistencespb.VersionedTransition{NamespaceFailoverVersion: 1, TransitionCount: 12},
-						},
-					}, nil
+					{NamespaceFailoverVersion: 1, TransitionCount: 12},
+					{NamespaceFailoverVersion: 2, TransitionCount: 15},
+				}, []*persistencespb.StateMachineTombstoneBatch{
+					{
+						VersionedTransition: &persistencespb.VersionedTransition{NamespaceFailoverVersion: 1, TransitionCount: 12},
+					},
+				}, nil
 			},
 		},
 		{
@@ -500,13 +500,13 @@ func (s *syncWorkflowStateSuite) TestSyncWorkflowState_ReturnSnapshot() {
 					},
 				}
 				return versionHistories, []*persistencespb.VersionedTransition{
-						{NamespaceFailoverVersion: 1, TransitionCount: 13},
-						{NamespaceFailoverVersion: 2, TransitionCount: 15},
-					}, []*persistencespb.StateMachineTombstoneBatch{
-						{
-							VersionedTransition: &persistencespb.VersionedTransition{NamespaceFailoverVersion: 1, TransitionCount: 12},
-						},
-					}, &persistencespb.VersionedTransition{NamespaceFailoverVersion: 1, TransitionCount: 13}
+					{NamespaceFailoverVersion: 1, TransitionCount: 13},
+					{NamespaceFailoverVersion: 2, TransitionCount: 15},
+				}, []*persistencespb.StateMachineTombstoneBatch{
+					{
+						VersionedTransition: &persistencespb.VersionedTransition{NamespaceFailoverVersion: 1, TransitionCount: 12},
+					},
+				}, &persistencespb.VersionedTransition{NamespaceFailoverVersion: 1, TransitionCount: 13}
 			},
 		},
 	}

--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -463,8 +463,7 @@ func (r *registry) Find(ctx context.Context, id string) *Update {
 	updOutcome, err := r.store.GetUpdateOutcome(ctx, id)
 
 	// Swallow NotFound error because it means that Update doesn't exist.
-	var notFound *serviceerror.NotFound
-	if errors.As(err, &notFound) {
+	if _, ok := errors.AsType[*serviceerror.NotFound](err); ok {
 		return nil
 	}
 

--- a/service/matching/backlog_manager.go
+++ b/service/matching/backlog_manager.go
@@ -115,8 +115,7 @@ func (c *backlogManagerImpl) signalIfFatal(err error) bool {
 	if err == nil {
 		return false
 	}
-	var condfail *persistence.ConditionFailedError
-	if errors.As(err, &condfail) {
+	if _, ok := errors.AsType[*persistence.ConditionFailedError](err); ok {
 		c.metricsHandler.Counter(metrics.ConditionFailedErrorPerTaskQueueCounter.Name()).Record(1)
 		c.skipFinalUpdate.Store(true)
 		c.pqMgr.UnloadFromPartitionManager(unloadCauseConflict)

--- a/service/matching/fair_backlog_manager.go
+++ b/service/matching/fair_backlog_manager.go
@@ -96,8 +96,7 @@ func (c *fairBacklogManagerImpl) signalIfFatal(err error) bool {
 	if err == nil {
 		return false
 	}
-	var condfail *persistence.ConditionFailedError
-	if errors.As(err, &condfail) {
+	if _, ok := errors.AsType[*persistence.ConditionFailedError](err); ok {
 		c.metricsHandler.Counter(metrics.ConditionFailedErrorPerTaskQueueCounter.Name()).Record(1)
 		c.skipFinalUpdate.Store(true)
 		c.pqMgr.UnloadFromPartitionManager(unloadCauseConflict)

--- a/service/matching/fair_task_reader.go
+++ b/service/matching/fair_task_reader.go
@@ -349,8 +349,7 @@ func (tr *fairTaskReader) addErrorBehavior(err error) (drop, retry bool) {
 		// retry here. if tqCtx is closing, addTaskToMatcher will give up.
 		return false, true
 	}
-	var stickyUnavailable *serviceerrors.StickyWorkerUnavailable
-	if errors.As(err, &stickyUnavailable) {
+	if _, ok := errors.AsType[*serviceerrors.StickyWorkerUnavailable](err); ok {
 		return true, false // drop the task
 	}
 	var invalid *serviceerror.InvalidArgument

--- a/service/matching/pri_backlog_manager.go
+++ b/service/matching/pri_backlog_manager.go
@@ -109,8 +109,7 @@ func (c *priBacklogManagerImpl) signalIfFatal(err error) bool {
 	if err == nil {
 		return false
 	}
-	var condfail *persistence.ConditionFailedError
-	if errors.As(err, &condfail) {
+	if _, ok := errors.AsType[*persistence.ConditionFailedError](err); ok {
 		c.metricsHandler.Counter(metrics.ConditionFailedErrorPerTaskQueueCounter.Name()).Record(1)
 		c.skipFinalUpdate.Store(true)
 		c.pqMgr.UnloadFromPartitionManager(unloadCauseConflict)

--- a/service/matching/pri_task_reader.go
+++ b/service/matching/pri_task_reader.go
@@ -337,8 +337,7 @@ func (tr *priTaskReader) addErrorBehavior(err error) (drop, retry bool) {
 		// retry here. if tqCtx is closing, addTaskToMatcher will give up.
 		return false, true
 	}
-	var stickyUnavailable *serviceerrors.StickyWorkerUnavailable
-	if errors.As(err, &stickyUnavailable) {
+	if _, ok := errors.AsType[*serviceerrors.StickyWorkerUnavailable](err); ok {
 		return true, false // drop the task
 	}
 	var invalid *serviceerror.InvalidArgument

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -701,8 +701,7 @@ func (pm *taskQueuePartitionManagerImpl) processTaskAddHooks(ctx context.Context
 }
 
 func taskAddErrResult(err error) string {
-	var resourceExhausted *serviceerror.ResourceExhausted
-	if errors.As(err, &resourceExhausted) {
+	if _, ok := errors.AsType[*serviceerror.ResourceExhausted](err); ok {
 		return metrics.TaskAddResultThrottled
 	}
 	return metrics.TaskAddResultFailure

--- a/service/matching/user_data_manager.go
+++ b/service/matching/user_data_manager.go
@@ -330,8 +330,7 @@ func (m *userDataManagerImpl) fetchUserData(ctx context.Context) error {
 			if !common.IsContextCanceledErr(err) {
 				m.logger.Error("error fetching user data from parent", tag.Error(err))
 			}
-			var unimplErr *serviceerror.Unimplemented
-			if errors.As(err, &unimplErr) {
+			if _, ok := errors.AsType[*serviceerror.Unimplemented](err); ok {
 				// This might happen during a deployment. The older version couldn't have had any user data,
 				// so we act as if it just returned an empty response and set ourselves ready.
 				// Return the error so that we backoff with retry, and do not set hasFetchedUserData so that
@@ -700,8 +699,7 @@ func (m *userDataManagerImpl) CheckTaskQueueUserDataPropagation(
 				OnlyIfLoaded:             true,
 			})
 			if err != nil {
-				var failed *serviceerror.FailedPrecondition
-				if errors.As(err, &failed) {
+				if _, ok := errors.AsType[*serviceerror.FailedPrecondition](err); ok {
 					// this means the partition was not loaded, so skip it (if it loads, it will get the newest data)
 					err = nil
 				}

--- a/service/worker/batcher/activities.go
+++ b/service/worker/batcher/activities.go
@@ -184,8 +184,7 @@ func fetchPage(
 				Query:         config.adjustedQuery,
 			})
 		if err != nil {
-			var invalidArgErr *serviceerror.InvalidArgument
-			if errors.As(err, &invalidArgErr) {
+			if _, ok := errors.AsType[*serviceerror.InvalidArgument](err); ok {
 				return nil, temporal.NewNonRetryableApplicationError(err.Error(), "InvalidArgument", err)
 			}
 			return nil, err
@@ -207,8 +206,7 @@ func fetchPage(
 			Query:         config.adjustedQuery,
 		})
 		if err != nil {
-			var invalidArgErr *serviceerror.InvalidArgument
-			if errors.As(err, &invalidArgErr) {
+			if _, ok := errors.AsType[*serviceerror.InvalidArgument](err); ok {
 				return nil, temporal.NewNonRetryableApplicationError(err.Error(), "InvalidArgument", err)
 			}
 			return nil, err
@@ -479,8 +477,7 @@ func (a *activities) BatchActivityWithProtobuf(ctx context.Context, batchParams 
 			if err != nil {
 				metrics.BatcherOperationFailures.With(metricsHandler).Record(1)
 				logger.Error("Failed to get estimate execution count", tag.Error(err))
-				var invalidArgErr *serviceerror.InvalidArgument
-				if errors.As(err, &invalidArgErr) {
+				if _, ok := errors.AsType[*serviceerror.InvalidArgument](err); ok {
 					return HeartBeatDetails{}, temporal.NewNonRetryableApplicationError(err.Error(), "InvalidArgument", err)
 				}
 				return HeartBeatDetails{}, err

--- a/service/worker/deletenamespace/activities.go
+++ b/service/worker/deletenamespace/activities.go
@@ -78,8 +78,7 @@ func (a *localActivities) GetNamespaceInfoActivity(ctx context.Context, nsID nam
 
 	getNamespaceResponse, err := a.metadataManager.GetNamespace(ctx, getNamespaceRequest)
 	if err != nil {
-		var nsNotFoundErr *serviceerror.NamespaceNotFound
-		if stderrors.As(err, &nsNotFoundErr) {
+		if _, ok := stderrors.AsType[*serviceerror.NamespaceNotFound](err); ok {
 			ns := nsName.String()
 			if ns == "" {
 				ns = nsID.String()

--- a/service/worker/deletenamespace/errors/errors.go
+++ b/service/worker/deletenamespace/errors/errors.go
@@ -38,8 +38,7 @@ func NewNotDeletedExecutionsStillExist(count int) error {
 }
 
 func ToServiceError(err error, workflowID, runID string) error {
-	var appErr *temporal.ApplicationError
-	if errors.As(err, &appErr) {
+	if appErr, ok := errors.AsType[*temporal.ApplicationError](err); ok {
 		switch appErr.Type() {
 		case InvalidArgumentErrType:
 			return serviceerror.NewInvalidArgument(appErr.Message())

--- a/service/worker/deletenamespace/reclaimresources/workflow.go
+++ b/service/worker/deletenamespace/reclaimresources/workflow.go
@@ -247,8 +247,7 @@ func deleteWorkflowExecutions(ctx workflow.Context, logger log.Logger, params Re
 	ctx3 := workflow.WithActivityOptions(ctx, ensureNoExecutionsAdvVisibilityActivityOptions)
 	err = workflow.ExecuteActivity(ctx3, a.EnsureNoExecutionsAdvVisibilityActivity, params.NamespaceID, params.Namespace, der.ErrorCount).Get(ctx, nil)
 	if err != nil {
-		var appErr *temporal.ApplicationError
-		if stderrors.As(err, &appErr) {
+		if appErr, ok := stderrors.AsType[*temporal.ApplicationError](err); ok {
 			switch appErr.Type() {
 			case errors.ExecutionsStillExistErrType, errors.NoProgressErrType, errors.NotDeletedExecutionsStillExistErrType:
 				var notDeletedCount int

--- a/service/worker/scheduler/activities.go
+++ b/service/worker/scheduler/activities.go
@@ -397,13 +397,11 @@ func (a *activities) MigrateScheduleToChasm(ctx context.Context, req *schedulerp
 	_, err := a.SchedulerClient.CreateFromMigrationState(ctx, req)
 	if err != nil {
 		// Treat "already exists" as success (idempotency).
-		var alreadyExists *serviceerror.AlreadyExists
-		if errors.As(err, &alreadyExists) {
+		if _, ok := errors.AsType[*serviceerror.AlreadyExists](err); ok {
 			return nil
 		}
 		// Sentinel blocking migration is transient; will retry on next workflow wake-up.
-		var unavailableErr *serviceerror.Unavailable
-		if errors.As(err, &unavailableErr) {
+		if _, ok := errors.AsType[*serviceerror.Unavailable](err); ok {
 			return translateError(err, "MigrateScheduleToChasm: blocked by sentinel, will retry")
 		}
 		return translateError(err, "MigrateScheduleToChasm")

--- a/service/worker/scheduler/query.go
+++ b/service/worker/scheduler/query.go
@@ -118,8 +118,7 @@ func getQueryFields(
 	).WithChasmMapper(chasmMapper).WithSearchAttributeInterceptor(saInterceptor)
 	_, err = queryConverter.Convert(queryString)
 	if err != nil {
-		var converterErr *query.ConverterError
-		if errors.As(err, &converterErr) {
+		if converterErr, ok := errors.AsType[*query.ConverterError](err); ok {
 			return nil, converterErr.ToInvalidArgument()
 		}
 		return nil, err
@@ -141,8 +140,7 @@ func getQueryFieldsLegacy(
 	queryConverter := elasticsearch.NewQueryConverterLegacy(fnInterceptor, nil, saNameType, chasmMapper)
 	_, err := queryConverter.ConvertWhereOrderBy(queryString)
 	if err != nil {
-		var converterErr *query.ConverterError
-		if errors.As(err, &converterErr) {
+		if converterErr, ok := errors.AsType[*query.ConverterError](err); ok {
 			return nil, converterErr.ToInvalidArgument()
 		}
 		return nil, err

--- a/service/worker/workerdeployment/activities.go
+++ b/service/worker/workerdeployment/activities.go
@@ -304,8 +304,7 @@ func (a *Activities) UpdateWorkerControllerInstanceFromDeployment(ctx context.Co
 	upserts := scalingGroupUpdatesToWCI(input.GetUpsertScalingGroups())
 	resp, err := a.WorkerControllerInstanceClient.UpdateWorkerControllerInstance(ctx, a.namespace, input.GetVersion(), nil, input.GetIdentity(), upserts, input.GetRemoveScalingGroups())
 	if err != nil {
-		var invalidArgs *serviceerror.InvalidArgument
-		if errors.As(err, &invalidArgs) {
+		if _, ok := errors.AsType[*serviceerror.InvalidArgument](err); ok {
 			return nil, temporal.NewNonRetryableApplicationError(err.Error(), errInvalidComputeConfig, nil)
 		}
 		return nil, err

--- a/service/worker/workerdeployment/client.go
+++ b/service/worker/workerdeployment/client.go
@@ -446,8 +446,7 @@ func (d *ClientImpl) DescribeVersion(
 
 	versionState, err := d.queryVersionState(ctx, namespaceEntry, deploymentName, buildID)
 	if err != nil {
-		var notFound *serviceerror.NotFound
-		if errors.As(err, &notFound) {
+		if _, ok := errors.AsType[*serviceerror.NotFound](err); ok {
 			return nil, nil, serviceerror.NewNotFound("Worker Deployment Version not found")
 		}
 		return nil, nil, err
@@ -464,8 +463,7 @@ func (d *ClientImpl) DescribeVersion(
 	wciDesc, _, err := d.workerControllerInstanceClient.DescribeWorkerControllerInstance(ctx, namespaceEntry, apiVersion)
 	if err != nil {
 		// WCI may not exist if no compute config was ever set.
-		var notFound *serviceerror.NotFound
-		if !errors.As(err, &notFound) {
+		if _, ok := errors.AsType[*serviceerror.NotFound](err); !ok {
 			return nil, nil, err
 		}
 	} else {
@@ -555,8 +553,7 @@ func (d *ClientImpl) UpdateVersionComputeConfig(
 		Meta:  &updatepb.Meta{UpdateId: "_update_compute_config_" + requestID, Identity: identity},
 	})
 	if err != nil {
-		var notFound *serviceerror.NotFound
-		if errors.As(err, &notFound) {
+		if _, ok := errors.AsType[*serviceerror.NotFound](err); ok {
 			return serviceerror.NewNotFound(fmt.Sprintf(ErrWorkerDeploymentVersionNotFound, version.GetBuildId(), version.GetDeploymentName()))
 		}
 		return err
@@ -601,8 +598,7 @@ func (d *ClientImpl) DescribeWorkerDeployment(
 
 	res, err := d.queryWorkflowWithRetry(ctx, req)
 	if err != nil {
-		var notFound *serviceerror.NotFound
-		if errors.As(err, &notFound) {
+		if _, ok := errors.AsType[*serviceerror.NotFound](err); ok {
 			return nil, nil, serviceerror.NewNotFoundf(ErrWorkerDeploymentNotFound, deploymentName)
 		}
 		var queryFailed *serviceerror.QueryFailed
@@ -655,8 +651,7 @@ func (d *ClientImpl) queryCreateRequestID(
 
 	res, err := d.queryWorkflowWithRetry(ctx, req)
 	if err != nil {
-		var notFound *serviceerror.NotFound
-		if errors.As(err, &notFound) {
+		if _, ok := errors.AsType[*serviceerror.NotFound](err); ok {
 			return nil, err
 		}
 		var queryFailed *serviceerror.QueryFailed
@@ -700,8 +695,7 @@ func (d *ClientImpl) workerDeploymentExists(
 		},
 	})
 	if err != nil {
-		var notFound *serviceerror.NotFound
-		if errors.As(err, &notFound) {
+		if _, ok := errors.AsType[*serviceerror.NotFound](err); ok {
 			return false, nil
 		}
 		return false, err
@@ -894,8 +888,7 @@ func (d *ClientImpl) SetCurrentVersion(
 			},
 		)
 		if err != nil {
-			var notFound *serviceerror.NotFound
-			if errors.As(err, &notFound) {
+			if _, ok := errors.AsType[*serviceerror.NotFound](err); ok {
 				return nil, serviceerror.NewNotFoundf(ErrWorkerDeploymentNotFound, deploymentName)
 			}
 			return nil, err
@@ -1011,8 +1004,7 @@ func (d *ClientImpl) SetRampingVersion(
 			},
 		)
 		if err != nil {
-			var notFound *serviceerror.NotFound
-			if errors.As(err, &notFound) {
+			if _, ok := errors.AsType[*serviceerror.NotFound](err); ok {
 				return nil, serviceerror.NewNotFoundf(ErrWorkerDeploymentNotFound, deploymentName)
 			}
 			return nil, err
@@ -1152,8 +1144,7 @@ func (d *ClientImpl) DeleteWorkerDeployment(
 		},
 	)
 	if err != nil {
-		var notFound *serviceerror.NotFound
-		if errors.As(err, &notFound) {
+		if _, ok := errors.AsType[*serviceerror.NotFound](err); ok {
 			return nil
 		}
 		return err
@@ -1277,8 +1268,7 @@ func (d *ClientImpl) ensureWorkerDeploymentDoesNotExist(
 	// right nothing in case of duplicate request ID.)
 	res, err := d.queryCreateRequestID(ctx, namespaceEntry, deploymentName)
 	if err != nil {
-		var notFound *serviceerror.NotFound
-		if errors.As(err, &notFound) {
+		if _, ok := errors.AsType[*serviceerror.NotFound](err); ok {
 			return nil, nil
 		}
 		return nil, err
@@ -1352,8 +1342,7 @@ func (d *ClientImpl) CreateWorkerDeploymentVersion(
 		updateRequest,
 	)
 	if err != nil {
-		var notFound *serviceerror.NotFound
-		if errors.As(err, &notFound) {
+		if _, ok := errors.AsType[*serviceerror.NotFound](err); ok {
 			return serviceerror.NewNotFound(fmt.Sprintf(ErrWorkerDeploymentNotFound, deploymentName))
 		}
 		return err

--- a/service/worker/workerdeployment/util.go
+++ b/service/worker/workerdeployment/util.go
@@ -386,16 +386,14 @@ func isRetryableUpdateError(err error) bool {
 		return true
 	}
 
-	var errWfNotReady *serviceerror.WorkflowNotReady
-	if errors.As(err, &errWfNotReady) {
+	if _, ok := errors.AsType[*serviceerror.WorkflowNotReady](err); ok {
 		// Update edge cases, can retry.
 		return true
 	}
 
 	// All updates that are admitted as the workflow is closing due to CaN are considered retryable.
 	// The ErrWorkflowClosing and ResourceExhausted could be nested.
-	var errMultiOps *serviceerror.MultiOperationExecution
-	if errors.As(err, &errMultiOps) {
+	if errMultiOps, ok := errors.AsType[*serviceerror.MultiOperationExecution](err); ok {
 		for _, e := range errMultiOps.OperationErrors() {
 			if e == nil {
 				continue

--- a/service/worker/workerdeployment/version_activities.go
+++ b/service/worker/workerdeployment/version_activities.go
@@ -43,8 +43,7 @@ func (a *VersionActivities) StartWorkerDeploymentWorkflow(
 	logger.Info("starting worker-deployment workflow", "deploymentName", input.DeploymentName)
 	identity := "deployment-version workflow " + activity.GetInfo(ctx).WorkflowExecution.ID
 	err := a.WorkerDeploymentClient.StartWorkerDeployment(ctx, a.namespace, input.DeploymentName, identity, input.RequestId)
-	var precond *serviceerror.FailedPrecondition
-	if errors.As(err, &precond) {
+	if _, ok := errors.AsType[*serviceerror.FailedPrecondition](err); ok {
 		return temporal.NewNonRetryableApplicationError("failed to create deployment", errTooManyDeployments, err)
 	}
 	return err
@@ -217,8 +216,7 @@ func (a *VersionActivities) UpdateWorkerControllerInstance(ctx context.Context, 
 	upserts := scalingGroupUpdatesToWCI(input.GetUpsertScalingGroups())
 	resp, err := a.WorkerControllerInstanceClient.UpdateWorkerControllerInstance(ctx, a.namespace, input.GetVersion(), nil, input.GetIdentity(), upserts, input.GetRemoveScalingGroups())
 	if err != nil {
-		var invalidArgs *serviceerror.InvalidArgument
-		if errors.As(err, &invalidArgs) {
+		if _, ok := errors.AsType[*serviceerror.InvalidArgument](err); ok {
 			return nil, temporal.NewNonRetryableApplicationError(err.Error(), errInvalidComputeConfig, nil)
 		}
 		return nil, err

--- a/service/worker/workerdeployment/workflow.go
+++ b/service/worker/workerdeployment/workflow.go
@@ -740,8 +740,7 @@ func (d *WorkflowRunner) handleRegisterWorker(ctx workflow.Context, args *deploy
 		RoutingConfig: routingConfigToSync,
 	}).Get(ctx, nil)
 	if err != nil {
-		var appError *temporal.ApplicationError
-		if errors.As(err, &appError) {
+		if appError, ok := errors.AsType[*temporal.ApplicationError](err); ok {
 			if appError.Type() == errMaxTaskQueuesInVersionType {
 				return temporal.NewApplicationError(
 					fmt.Sprintf("cannot add task queue %v since maximum number of task queues (%d) have been registered in deployment", args.TaskQueueName, args.MaxTaskQueues),

--- a/tests/activity_workflow_driver.go
+++ b/tests/activity_workflow_driver.go
@@ -95,8 +95,7 @@ func (a *wfaHandle) timeoutInfo(t require.TestingT) activityTimeoutInfo {
 			attempt: pa.GetAttempt(),
 		}
 	}
-	var timeoutErr *temporal.TimeoutError
-	if errors.As(a.run.Get(a.testContext(), nil), &timeoutErr) {
+	if timeoutErr, ok := errors.AsType[*temporal.TimeoutError](a.run.Get(a.testContext(), nil)); ok {
 		return activityTimeoutInfo{timeout: timeoutErr.TimeoutType(), terminal: true}
 	}
 	return activityTimeoutInfo{terminal: true}

--- a/tests/chasm_test.go
+++ b/tests/chasm_test.go
@@ -1110,8 +1110,7 @@ func (s *ChasmSuite) TestNamespaceDelete_WithChasmExecutions() {
 				PageSize:  10,
 				Query:     visQuery,
 			})
-			var notFound *serviceerror.NamespaceNotFound
-			if errors.As(err, &notFound) {
+			if _, ok := errors.AsType[*serviceerror.NamespaceNotFound](err); ok {
 				return // namespace fully deleted is also acceptable
 			}
 			require.NoError(t, err)

--- a/tests/namespace_test.go
+++ b/tests/namespace_test.go
@@ -77,8 +77,7 @@ func (s *namespaceTestSuite) Test_NamespaceDelete_Empty() {
 		_, err := env.FrontendClient().DescribeNamespace(s.Context(), &workflowservice.DescribeNamespaceRequest{
 			Id: nsID,
 		})
-		var notFound *serviceerror.NamespaceNotFound
-		if !errors.As(err, &notFound) {
+		if _, ok := errors.AsType[*serviceerror.NamespaceNotFound](err); !ok {
 			return false
 		}
 
@@ -121,8 +120,7 @@ func (s *namespaceTestSuite) Test_NamespaceDelete_OverrideDelay() {
 		_, err := env.FrontendClient().DescribeNamespace(s.Context(), &workflowservice.DescribeNamespaceRequest{
 			Id: nsID,
 		})
-		var notFound *serviceerror.NamespaceNotFound
-		if !errors.As(err, &notFound) {
+		if _, ok := errors.AsType[*serviceerror.NamespaceNotFound](err); !ok {
 			return false
 		}
 
@@ -164,8 +162,7 @@ func (s *namespaceTestSuite) Test_NamespaceDelete_Empty_WithID() {
 		_, err := env.FrontendClient().DescribeNamespace(s.Context(), &workflowservice.DescribeNamespaceRequest{
 			Id: nsID,
 		})
-		var notFound *serviceerror.NamespaceNotFound
-		if !errors.As(err, &notFound) {
+		if _, ok := errors.AsType[*serviceerror.NamespaceNotFound](err); !ok {
 			return false
 		}
 

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -2509,8 +2509,7 @@ func (s *NexusWorkflowTestSuite) TestNexusAsyncOperationErrorRehydration(chasmEn
 				if !errors.As(err, &opErr) {
 					return nil, fmt.Errorf("expected NexusOperationError, got %w", err)
 				}
-				var canceledErr *temporal.CanceledError
-				if !errors.As(opErr, &canceledErr) {
+				if _, ok := errors.AsType[*temporal.CanceledError](opErr); !ok {
 					return nil, fmt.Errorf("expected CanceledError, got %w", err)
 				}
 			default:

--- a/tests/testcore/taskpoller.go
+++ b/tests/testcore/taskpoller.go
@@ -525,8 +525,7 @@ func getQueryResults(queries map[string]*querypb.WorkflowQuery, queryResult *que
 }
 
 func newApplicationFailure(err error, nonRetryable bool, details *commonpb.Payloads) *failurepb.Failure {
-	var applicationErr *temporal.ApplicationError
-	if errors.As(err, &applicationErr) {
+	if applicationErr, ok := errors.AsType[*temporal.ApplicationError](err); ok {
 		nonRetryable = applicationErr.NonRetryable()
 	}
 

--- a/tests/versioning_test_env.go
+++ b/tests/versioning_test_env.go
@@ -408,8 +408,7 @@ func (env *VersioningTestEnv) pollUntilRegistered(s parallelsuite.Scope, tv *tes
 			Namespace: env.Namespace().String(),
 			Version:   tv.DeploymentVersionString(),
 		})
-		var notFound *serviceerror.NotFound
-		if errors.As(err, &notFound) {
+		if _, ok := errors.AsType[*serviceerror.NotFound](err); ok {
 			t.Require().NoError(err)
 			return
 		}

--- a/tools/elasticsearch/tasks.go
+++ b/tools/elasticsearch/tasks.go
@@ -76,8 +76,7 @@ func (task *SetupTask) setupIndex(ctx context.Context) error {
 	success, err := task.esClient.CreateIndex(ctx, config.VisibilityIndex, nil)
 	if err != nil {
 		// Check if the error is an Elasticsearch error and if so check if the index already exists.
-		var esErr *elastic.Error
-		if errors.As(err, &esErr) {
+		if esErr, ok := errors.AsType[*elastic.Error](err); ok {
 			if esErr.Status == 400 && esErr.Details != nil && esErr.Details.Type == "resource_already_exists_exception" {
 				task.logger.Info("Index already exists, skipping creation", tag.String("indexName", config.VisibilityIndex))
 				return nil


### PR DESCRIPTION
Go 1.27 prerequisite that applies the `errorsastype` Go fixer and its required error-interface updates.
