### PR TITLE
Use typed atomic values

### DIFF
--- a/common/collection/concurrent_tx_map.go
+++ b/common/collection/concurrent_tx_map.go
@@ -21,7 +21,7 @@ type (
 	ShardedConcurrentTxMap struct {
 		shards     [nShards]mapShard
 		hashfn     HashFunc
-		size       int32
+		size       atomic.Int32
 		initialCap int
 	}
 
@@ -87,7 +87,7 @@ func (cmap *ShardedConcurrentTxMap) Put(key any, value any) {
 	cmap.lazyInitShard(shard)
 	_, ok := shard.items[key]
 	if !ok {
-		atomic.AddInt32(&cmap.size, 1)
+		cmap.size.Add(1)
 	}
 	shard.items[key] = value
 	shard.Unlock()
@@ -103,7 +103,7 @@ func (cmap *ShardedConcurrentTxMap) PutIfNotExist(key any, value any) bool {
 	_, ok = shard.items[key]
 	if !ok {
 		shard.items[key] = value
-		atomic.AddInt32(&cmap.size, 1)
+		cmap.size.Add(1)
 	}
 	shard.Unlock()
 	return !ok
@@ -117,7 +117,7 @@ func (cmap *ShardedConcurrentTxMap) Remove(key any) {
 	_, ok := shard.items[key]
 	if ok {
 		delete(shard.items, key)
-		atomic.AddInt32(&cmap.size, -1)
+		cmap.size.Add(-1)
 	}
 	shard.Unlock()
 }
@@ -151,7 +151,7 @@ func (cmap *ShardedConcurrentTxMap) PutOrDo(key any, value any, fn ActionFunc) (
 	if !ok {
 		shard.items[key] = value
 		v = value
-		atomic.AddInt32(&cmap.size, 1)
+		cmap.size.Add(1)
 	} else {
 		err = fn(key, v)
 	}
@@ -169,7 +169,7 @@ func (cmap *ShardedConcurrentTxMap) RemoveIf(key any, fn PredicateFunc) bool {
 		if ok && fn(key, value) {
 			removed = true
 			delete(shard.items, key)
-			atomic.AddInt32(&cmap.size, -1)
+			cmap.size.Add(-1)
 		}
 	}
 	shard.Unlock()
@@ -218,7 +218,7 @@ func (cmap *ShardedConcurrentTxMap) Iter() MapIterator {
 
 // Len returns the number of items in the map
 func (cmap *ShardedConcurrentTxMap) Len() int {
-	return int(atomic.LoadInt32(&cmap.size))
+	return int(cmap.size.Load())
 }
 
 func (cmap *ShardedConcurrentTxMap) getShard(key any) *mapShard {

--- a/common/persistence/persistence-tests/persistence_test_base.go
+++ b/common/persistence/persistence-tests/persistence_test_base.go
@@ -116,7 +116,7 @@ type (
 
 	// TestTransferTaskIDGenerator helper
 	TestTransferTaskIDGenerator struct {
-		seqNum int64
+		seqNum atomic.Int64
 	}
 )
 
@@ -365,7 +365,7 @@ func (s *TestBase) EqualTimes(t1, t2 time.Time) {
 
 // GenerateTransferTaskID helper
 func (g *TestTransferTaskIDGenerator) GenerateTransferTaskID() (int64, error) {
-	return atomic.AddInt64(&g.seqNum, 1), nil
+	return g.seqNum.Add(1), nil
 }
 
 // Publish is a utility method to add messages to the queue

--- a/common/tasks/execution_queue_scheduler_test.go
+++ b/common/tasks/execution_queue_scheduler_test.go
@@ -380,7 +380,7 @@ func (s *executionQueueSchedulerSuite) TestTTLExpiryRace_NoTaskOrphaning() {
 	defer scheduler.Stop()
 
 	const iterations = 50
-	var processedCount int32
+	var processedCount atomic.Int32
 	testWG := sync.WaitGroup{}
 
 	for range iterations {
@@ -390,7 +390,7 @@ func (s *executionQueueSchedulerSuite) TestTTLExpiryRace_NoTaskOrphaning() {
 		mockTask.EXPECT().RetryPolicy().Return(s.retryPolicy).AnyTimes()
 		mockTask.EXPECT().Execute().Return(nil).Times(1)
 		mockTask.EXPECT().Ack().Do(func() {
-			atomic.AddInt32(&processedCount, 1)
+			processedCount.Add(1)
 			testWG.Done()
 		}).Times(1)
 
@@ -416,10 +416,10 @@ func (s *executionQueueSchedulerSuite) TestTTLExpiryRace_NoTaskOrphaning() {
 		// Success
 	case <-time.After(30 * time.Second):
 		s.Fail("Timed out waiting for tasks — possible task orphaning",
-			"processed %d/%d tasks", atomic.LoadInt32(&processedCount), iterations)
+			"processed %d/%d tasks", processedCount.Load(), iterations)
 	}
 
-	s.Equal(int32(iterations), atomic.LoadInt32(&processedCount),
+	s.Equal(int32(iterations), processedCount.Load(),
 		"All tasks must be processed, none orphaned")
 }
 
@@ -523,7 +523,7 @@ func (s *executionQueueSchedulerSuite) TestParallelTrySubmit_SameWorkflow() {
 	numSubmitters := 50
 	tasksPerSubmitter := 20
 
-	var executionCount int32
+	var executionCount atomic.Int32
 	testWG := sync.WaitGroup{}
 	testWG.Add(numSubmitters * tasksPerSubmitter)
 
@@ -539,7 +539,7 @@ func (s *executionQueueSchedulerSuite) TestParallelTrySubmit_SameWorkflow() {
 				mockTask := NewMockTask(s.controller)
 				mockTask.EXPECT().RetryPolicy().Return(s.retryPolicy).AnyTimes()
 				mockTask.EXPECT().Execute().DoAndReturn(func() error {
-					atomic.AddInt32(&executionCount, 1)
+					executionCount.Add(1)
 					return nil
 				}).Times(1)
 				mockTask.EXPECT().Ack().Do(func() { testWG.Done() }).Times(1)
@@ -563,7 +563,7 @@ func (s *executionQueueSchedulerSuite) TestParallelTrySubmit_SameWorkflow() {
 		s.Fail("Timed out waiting for parallel tasks to same workflow")
 	}
 
-	s.Equal(int32(numSubmitters*tasksPerSubmitter), atomic.LoadInt32(&executionCount))
+	s.Equal(int32(numSubmitters*tasksPerSubmitter), executionCount.Load())
 }
 
 // =============================================================================

--- a/service/history/shard/controller_impl.go
+++ b/service/history/shard/controller_impl.go
@@ -50,7 +50,7 @@ type (
 		contextTaggedLogger  log.Logger
 		hostInfoProvider     membership.HostInfoProvider
 		ownership            *ownership
-		status               int32
+		status               atomic.Int32
 		taggedMetricsHandler metrics.Handler
 		// shardCountSubscriptions is a set of subscriptions that receive shard count updates whenever the set of
 		// shards that this controller owns changes.
@@ -103,11 +103,7 @@ func ControllerProvider(
 }
 
 func (c *ControllerImpl) Start() {
-	if !atomic.CompareAndSwapInt32(
-		&c.status,
-		common.DaemonStatusInitialized,
-		common.DaemonStatusStarted,
-	) {
+	if !c.status.CompareAndSwap(common.DaemonStatusInitialized, common.DaemonStatusStarted) {
 		return
 	}
 
@@ -117,11 +113,7 @@ func (c *ControllerImpl) Start() {
 }
 
 func (c *ControllerImpl) Stop() {
-	if !atomic.CompareAndSwapInt32(
-		&c.status,
-		common.DaemonStatusStarted,
-		common.DaemonStatusStopped,
-	) {
+	if !c.status.CompareAndSwap(common.DaemonStatusStarted, common.DaemonStatusStopped) {
 		return
 	}
 
@@ -153,7 +145,7 @@ func (c *ControllerImpl) GetPingChecks() []pingable.Check {
 }
 
 func (c *ControllerImpl) Status() int32 {
-	return atomic.LoadInt32(&c.status)
+	return c.status.Load()
 }
 
 func (c *ControllerImpl) InitialShardsAcquired(ctx context.Context) error {
@@ -259,7 +251,7 @@ func (c *ControllerImpl) getOrCreateShardContext(shardID int32) (historyi.Contro
 		return nil, err
 	}
 
-	if atomic.LoadInt32(&c.status) == common.DaemonStatusStopped {
+	if c.status.Load() == common.DaemonStatusStopped {
 		hostInfo := c.hostInfoProvider.HostInfo()
 		return nil, fmt.Errorf("ControllerImpl for host '%v' shutting down", hostInfo.Identity())
 	}

--- a/service/matching/task_gc.go
+++ b/service/matching/task_gc.go
@@ -13,7 +13,7 @@ type taskGC struct {
 	db     *taskQueueDB
 	config *taskQueueConfig
 
-	lock           atomic.Int64
+	lock           atomic.Bool
 	ackLevel       int64
 	lastDeleteTime time.Time
 }
@@ -93,9 +93,9 @@ func (tgc *taskGC) checkPrecond(ackLevel int64, batchSize int, ignoreTimeCond bo
 }
 
 func (tgc *taskGC) tryLock() bool {
-	return tgc.lock.CompareAndSwap(0, 1)
+	return tgc.lock.CompareAndSwap(false, true)
 }
 
 func (tgc *taskGC) unlock() {
-	tgc.lock.Store(0)
+	tgc.lock.Store(false)
 }

--- a/service/matching/task_gc.go
+++ b/service/matching/task_gc.go
@@ -13,7 +13,7 @@ type taskGC struct {
 	db     *taskQueueDB
 	config *taskQueueConfig
 
-	lock           int64
+	lock           atomic.Int64
 	ackLevel       int64
 	lastDeleteTime time.Time
 }
@@ -93,9 +93,9 @@ func (tgc *taskGC) checkPrecond(ackLevel int64, batchSize int, ignoreTimeCond bo
 }
 
 func (tgc *taskGC) tryLock() bool {
-	return atomic.CompareAndSwapInt64(&tgc.lock, 0, 1)
+	return tgc.lock.CompareAndSwap(0, 1)
 }
 
 func (tgc *taskGC) unlock() {
-	atomic.StoreInt64(&tgc.lock, 0)
+	tgc.lock.Store(0)
 }

--- a/service/worker/batcher/activities_test.go
+++ b/service/worker/batcher/activities_test.go
@@ -1071,7 +1071,7 @@ func (s *activitiesSuite) TestProcessWorkflowsWithProactiveFetching_ProcessesAll
 	}
 
 	// Fake worker pool: drain taskCh and report success for every real task.
-	var processed int64
+	var processed atomic.Int64
 	fakeWorker := func(
 		ctx context.Context,
 		taskCh chan task,
@@ -1090,7 +1090,7 @@ func (s *activitiesSuite) TestProcessWorkflowsWithProactiveFetching_ProcessesAll
 				if t.executionInfo == nil {
 					continue
 				}
-				atomic.AddInt64(&processed, 1)
+				processed.Add(1)
 				select {
 				case respCh <- taskResponse{err: nil, page: t.page}:
 				case <-ctx.Done():
@@ -1123,7 +1123,7 @@ func (s *activitiesSuite) TestProcessWorkflowsWithProactiveFetching_ProcessesAll
 	s.NoError(encoded.Get(&hbd))
 	s.Equal(total, hbd.SuccessCount)
 	s.Equal(0, hbd.ErrorCount)
-	s.Equal(int64(total), atomic.LoadInt64(&processed))
+	s.Equal(int64(total), processed.Load())
 	mockSdk.AssertExpectations(s.T())
 }
 
@@ -1162,8 +1162,8 @@ func (s *activitiesSuite) TestProcessWorkflowsWithProactiveFetching_ProcessesAll
 	mockSdk := &mocks.Client{}
 	mockSdk.On("WorkflowService").Return(s.mockFrontendClient)
 
-	var processed int64
-	var invalidTargets int64
+	var processed atomic.Int64
+	var invalidTargets atomic.Int64
 	fakeWorker := func(
 		ctx context.Context,
 		taskCh chan task,
@@ -1182,9 +1182,9 @@ func (s *activitiesSuite) TestProcessWorkflowsWithProactiveFetching_ProcessesAll
 				if task.targetExecution == nil ||
 					task.targetExecution.GetType() != enumspb.EXECUTION_TYPE_ACTIVITY ||
 					task.targetExecution.GetBusinessId() == "" || task.targetExecution.GetRunId() == "" {
-					atomic.AddInt64(&invalidTargets, 1)
+					invalidTargets.Add(1)
 				}
-				atomic.AddInt64(&processed, 1)
+				processed.Add(1)
 				select {
 				case respCh <- taskResponse{page: task.page}:
 				case <-ctx.Done():
@@ -1218,8 +1218,8 @@ func (s *activitiesSuite) TestProcessWorkflowsWithProactiveFetching_ProcessesAll
 	s.Require().NoError(encoded.Get(&hbd))
 	s.Equal(total, hbd.SuccessCount)
 	s.Equal(0, hbd.ErrorCount)
-	s.Equal(int64(total), atomic.LoadInt64(&processed))
-	s.Zero(atomic.LoadInt64(&invalidTargets))
+	s.Equal(int64(total), processed.Load())
+	s.Zero(invalidTargets.Load())
 	mockSdk.AssertExpectations(s.T())
 }
 

--- a/service/worker/pernamespaceworker.go
+++ b/service/worker/pernamespaceworker.go
@@ -42,7 +42,7 @@ const (
 
 type (
 	PerNamespaceWorkerManager struct {
-		status int32
+		status atomic.Int32
 
 		// from init params or Start
 		logger            log.Logger
@@ -129,18 +129,14 @@ func NewPerNamespaceWorkerManager(
 }
 
 func (wm *PerNamespaceWorkerManager) Running() bool {
-	return atomic.LoadInt32(&wm.status) == common.DaemonStatusStarted
+	return wm.status.Load() == common.DaemonStatusStarted
 }
 
 func (wm *PerNamespaceWorkerManager) Start(
 	self membership.HostInfo,
 	serviceResolver membership.ServiceResolver,
 ) {
-	if !atomic.CompareAndSwapInt32(
-		&wm.status,
-		common.DaemonStatusInitialized,
-		common.DaemonStatusStarted,
-	) {
+	if !wm.status.CompareAndSwap(common.DaemonStatusInitialized, common.DaemonStatusStarted) {
 		return
 	}
 
@@ -163,11 +159,7 @@ func (wm *PerNamespaceWorkerManager) Start(
 }
 
 func (wm *PerNamespaceWorkerManager) Stop() {
-	if !atomic.CompareAndSwapInt32(
-		&wm.status,
-		common.DaemonStatusStarted,
-		common.DaemonStatusStopped,
-	) {
+	if !wm.status.CompareAndSwap(common.DaemonStatusStarted, common.DaemonStatusStopped) {
 		return
 	}
 

--- a/service/worker/scanner/executions/scavenger.go
+++ b/service/worker/scanner/executions/scavenger.go
@@ -27,7 +27,7 @@ const (
 type (
 	// Scavenger is the type that holds the state for executions scavenger daemon
 	Scavenger struct {
-		status           int32
+		status           atomic.Int32
 		numHistoryShards int32
 		activityContext  context.Context
 
@@ -101,11 +101,7 @@ func NewScavenger(
 
 // Start starts the scavenger
 func (s *Scavenger) Start() {
-	if !atomic.CompareAndSwapInt32(
-		&s.status,
-		common.DaemonStatusInitialized,
-		common.DaemonStatusStarted,
-	) {
+	if !s.status.CompareAndSwap(common.DaemonStatusInitialized, common.DaemonStatusStarted) {
 		return
 	}
 	s.logger.Info("Executions scavenger starting")
@@ -118,11 +114,7 @@ func (s *Scavenger) Start() {
 
 // Stop stops the scavenger
 func (s *Scavenger) Stop() {
-	if !atomic.CompareAndSwapInt32(
-		&s.status,
-		common.DaemonStatusStarted,
-		common.DaemonStatusStopped,
-	) {
+	if !s.status.CompareAndSwap(common.DaemonStatusStarted, common.DaemonStatusStopped) {
 		return
 	}
 	metrics.StoppedCount.With(s.metricsHandler).Record(1)
@@ -135,7 +127,7 @@ func (s *Scavenger) Stop() {
 
 // Alive returns true if the scavenger is still running
 func (s *Scavenger) Alive() bool {
-	return atomic.LoadInt32(&s.status) == common.DaemonStatusStarted
+	return s.status.Load() == common.DaemonStatusStarted
 }
 
 // run does a single run over all executions and validates them

--- a/service/worker/scanner/executor/executor.go
+++ b/service/worker/scanner/executor/executor.go
@@ -36,8 +36,8 @@ type (
 		size           int
 		maxDeferred    int
 		runQ           *runQueue
-		outstanding    int64
-		status         int32
+		outstanding    atomic.Int64
+		status         atomic.Int32
 		metricsHandler metrics.Handler
 		stopC          chan struct{}
 		stopWG         sync.WaitGroup
@@ -74,7 +74,7 @@ func NewFixedSizePoolExecutor(size int, maxDeferred int, metricsHandler metrics.
 
 // Start starts the executor
 func (e *fixedPoolExecutor) Start() {
-	if !atomic.CompareAndSwapInt32(&e.status, common.DaemonStatusInitialized, common.DaemonStatusStarted) {
+	if !e.status.CompareAndSwap(common.DaemonStatusInitialized, common.DaemonStatusStarted) {
 		return
 	}
 	for i := 0; i < e.size; i++ {
@@ -85,7 +85,7 @@ func (e *fixedPoolExecutor) Start() {
 
 // Stop stops the executor
 func (e *fixedPoolExecutor) Stop() {
-	if !atomic.CompareAndSwapInt32(&e.status, common.DaemonStatusStarted, common.DaemonStatusStopped) {
+	if !e.status.CompareAndSwap(common.DaemonStatusStarted, common.DaemonStatusStopped) {
 		return
 	}
 	close(e.stopC)
@@ -99,14 +99,14 @@ func (e *fixedPoolExecutor) Submit(task Task) bool {
 	}
 	added := e.runQ.add(task)
 	if added {
-		atomic.AddInt64(&e.outstanding, 1)
+		e.outstanding.Add(1)
 	}
 	return added
 }
 
 // TaskCount returns the total of number of tasks currently outstanding
 func (e *fixedPoolExecutor) TaskCount() int64 {
-	return atomic.LoadInt64(&e.outstanding)
+	return e.outstanding.Load()
 }
 
 func (e *fixedPoolExecutor) worker() {
@@ -120,18 +120,18 @@ func (e *fixedPoolExecutor) worker() {
 		status := task.Run()
 		switch status {
 		case TaskStatusDone:
-			atomic.AddInt64(&e.outstanding, -1)
+			e.outstanding.Add(-1)
 			metrics.ExecutorTasksDoneCount.With(e.metricsHandler).Record(1)
 		case TaskStatusDefer:
 			if e.runQ.deferredCount() < e.maxDeferred {
 				e.runQ.addAndDefer(task)
 				metrics.ExecutorTasksDeferredCount.With(e.metricsHandler).Record(1)
 			} else {
-				atomic.AddInt64(&e.outstanding, -1)
+				e.outstanding.Add(-1)
 				metrics.ExecutorTasksDroppedCount.With(e.metricsHandler).Record(1)
 			}
 		case TaskStatusErr:
-			atomic.AddInt64(&e.outstanding, -1)
+			e.outstanding.Add(-1)
 			metrics.ExecutorTasksErrCount.With(e.metricsHandler).Record(1)
 		default:
 			panic(fmt.Sprintf("unknown task status: %v", status))
@@ -140,5 +140,5 @@ func (e *fixedPoolExecutor) worker() {
 }
 
 func (e *fixedPoolExecutor) alive() bool {
-	return atomic.LoadInt32(&e.status) == common.DaemonStatusStarted
+	return e.status.Load() == common.DaemonStatusStarted
 }

--- a/service/worker/scanner/taskqueue/scavenger.go
+++ b/service/worker/scanner/taskqueue/scavenger.go
@@ -23,7 +23,7 @@ type (
 		metricsHandler metrics.Handler
 		logger         log.Logger
 		stats          stats
-		status         int32
+		status         atomic.Int32
 		stopC          chan struct{}
 		stopWG         sync.WaitGroup
 
@@ -100,7 +100,7 @@ func NewScavenger(db p.TaskManager, metricsHandler metrics.Handler, logger log.L
 
 // Start starts the scavenger
 func (s *Scavenger) Start() {
-	if !atomic.CompareAndSwapInt32(&s.status, common.DaemonStatusInitialized, common.DaemonStatusStarted) {
+	if !s.status.CompareAndSwap(common.DaemonStatusInitialized, common.DaemonStatusStarted) {
 		return
 	}
 	s.logger.Info("Taskqueue scavenger starting")
@@ -113,7 +113,7 @@ func (s *Scavenger) Start() {
 
 // Stop stops the scavenger
 func (s *Scavenger) Stop() {
-	if !atomic.CompareAndSwapInt32(&s.status, common.DaemonStatusStarted, common.DaemonStatusStopped) {
+	if !s.status.CompareAndSwap(common.DaemonStatusStarted, common.DaemonStatusStopped) {
 		return
 	}
 	metrics.StoppedCount.With(s.metricsHandler).Record(1)
@@ -127,7 +127,7 @@ func (s *Scavenger) Stop() {
 
 // Alive returns true if the scavenger is still running
 func (s *Scavenger) Alive() bool {
-	return atomic.LoadInt32(&s.status) == common.DaemonStatusStarted
+	return s.status.Load() == common.DaemonStatusStarted
 }
 
 // run does a single run over all executorTask queues

--- a/service/worker/worker.go
+++ b/service/worker/worker.go
@@ -18,7 +18,7 @@ import (
 type (
 	// workerManager maintains list of SDK workers.
 	workerManager struct {
-		status           int32
+		status           atomic.Int32
 		hostInfo         membership.HostInfo
 		logger           log.Logger
 		sdkClientFactory sdk.ClientFactory
@@ -44,11 +44,7 @@ func NewWorkerManager(
 }
 
 func (wm *workerManager) Start() {
-	if !atomic.CompareAndSwapInt32(
-		&wm.status,
-		common.DaemonStatusInitialized,
-		common.DaemonStatusStarted,
-	) {
+	if !wm.status.CompareAndSwap(common.DaemonStatusInitialized, common.DaemonStatusStarted) {
 		return
 	}
 
@@ -101,11 +97,7 @@ func (wm *workerManager) Start() {
 }
 
 func (wm *workerManager) Stop() {
-	if !atomic.CompareAndSwapInt32(
-		&wm.status,
-		common.DaemonStatusStarted,
-		common.DaemonStatusStopped,
-	) {
+	if !wm.status.CompareAndSwap(common.DaemonStatusStarted, common.DaemonStatusStopped) {
 		return
 	}
 

--- a/tests/ndc/replication_migration_back_test.go
+++ b/tests/ndc/replication_migration_back_test.go
@@ -49,7 +49,7 @@ type (
 		mockAdminClient             map[string]adminservice.AdminServiceClient
 		namespace                   namespace.Name
 		namespaceID                 namespace.ID
-		standByTaskID               int64
+		standByTaskID               atomic.Int64
 		autoIncrementTaskID         int64
 		passiveClusterName          string
 
@@ -559,7 +559,7 @@ func (s *ReplicationMigrationBackTestSuite) registerNamespace() {
 
 func (s *ReplicationMigrationBackTestSuite) GetReplicationMessagesMock() (*adminservice.StreamWorkflowReplicationMessagesResponse, error) {
 	task := <-s.standByReplicationTasksChan
-	taskID := atomic.AddInt64(&s.standByTaskID, 1)
+	taskID := s.standByTaskID.Add(1)
 	task.SourceTaskId = taskID
 	tasks := []*replicationspb.ReplicationTask{task}
 

--- a/tests/ndc/replication_task_batching_test.go
+++ b/tests/ndc/replication_task_batching_test.go
@@ -45,7 +45,7 @@ type (
 		mockAdminClient             map[string]adminservice.AdminServiceClient
 		namespace                   namespace.Name
 		namespaceID                 namespace.ID
-		standByTaskID               int64
+		standByTaskID               atomic.Int64
 		autoIncrementTaskID         int64
 		passiveClusterName          string
 
@@ -222,7 +222,7 @@ func (s *NDCReplicationTaskBatchingTestSuite) registerNamespace() {
 
 func (s *NDCReplicationTaskBatchingTestSuite) GetReplicationMessagesMock() (*adminservice.StreamWorkflowReplicationMessagesResponse, error) {
 	task := <-s.standByReplicationTasksChan
-	taskID := atomic.AddInt64(&s.standByTaskID, 1)
+	taskID := s.standByTaskID.Add(1)
 	task.SourceTaskId = taskID
 	tasks := []*replicationspb.ReplicationTask{task}
 

--- a/tests/query_workflow_test.go
+++ b/tests/query_workflow_test.go
@@ -272,7 +272,7 @@ func (s *QueryWorkflowSuite) TestQueryWorkflow_QueryBeforeStart() {
 func (s *QueryWorkflowSuite) TestQueryWorkflow_QueryFailedWorkflowTask() {
 	env := testcore.NewEnv(s.T())
 	testname := s.T().Name()
-	var failures int32
+	var failures atomic.Int32
 	workflowFn := func(ctx workflow.Context) (string, error) {
 		err := workflow.SetQueryHandler(ctx, testname, func() (string, error) {
 			return "", nil
@@ -281,7 +281,7 @@ func (s *QueryWorkflowSuite) TestQueryWorkflow_QueryFailedWorkflowTask() {
 		if err != nil {
 			s.T().Fatalf("SetQueryHandler failed: %s", err.Error())
 		}
-		atomic.AddInt32(&failures, 1)
+		failures.Add(1)
 		// force workflow task to fail
 		panic("Workflow failed")
 	}
@@ -305,7 +305,7 @@ func (s *QueryWorkflowSuite) TestQueryWorkflow_QueryFailedWorkflowTask() {
 
 	s.AwaitTrue(func() bool {
 		// wait for workflow task to fail 3 times
-		return atomic.LoadInt32(&failures) >= 3
+		return failures.Load() >= 3
 	}, 10*time.Second, 50*time.Millisecond)
 
 	_, err = env.SdkClient().QueryWorkflow(ctx, id, "", testname)

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -1379,12 +1379,12 @@ func testInput(t *testing.T, newContext contextFactory) {
 		RequestId:  uuid.NewString(),
 	}
 
-	var runs int32
+	var runs atomic.Int32
 	workflowFn := func(ctx workflow.Context, arg1 *myData, arg2 map[int]float64) error {
 		workflow.SideEffect(ctx, func(ctx workflow.Context) any {
 			s.Equal(*input1, *arg1)
 			s.Equal(input2, arg2)
-			atomic.AddInt32(&runs, 1)
+			runs.Add(1)
 			return 0
 		})
 		return nil
@@ -1395,7 +1395,7 @@ func testInput(t *testing.T, newContext contextFactory) {
 	_, err = s.FrontendClient().CreateSchedule(ctx, req)
 	s.NoError(err)
 
-	s.Eventually(func() bool { return atomic.LoadInt32(&runs) == 1 }, 8*time.Second, 200*time.Millisecond)
+	s.Eventually(func() bool { return runs.Load() == 1 }, 8*time.Second, 200*time.Millisecond)
 }
 
 func testLastCompletionAndError(t *testing.T, newContext contextFactory) {
@@ -1430,7 +1430,7 @@ func testLastCompletionAndError(t *testing.T, newContext contextFactory) {
 	}
 
 	runs := make(map[string]struct{})
-	var testComplete int32
+	var testComplete atomic.Int32
 
 	workflowFn := func(ctx workflow.Context) (string, error) {
 		var num int
@@ -1458,7 +1458,7 @@ func testLastCompletionAndError(t *testing.T, newContext contextFactory) {
 		case 3:
 			s.Equal("this one succeeds", lcr)
 			s.ErrorContains(lastErr, "this one fails")
-			atomic.StoreInt32(&testComplete, 1)
+			testComplete.Store(1)
 			return "done", nil
 		default:
 			panic("shouldn't be running anymore")
@@ -1470,7 +1470,7 @@ func testLastCompletionAndError(t *testing.T, newContext contextFactory) {
 	_, err := s.FrontendClient().CreateSchedule(ctx, req)
 	s.NoError(err)
 
-	s.Eventually(func() bool { return atomic.LoadInt32(&testComplete) == 1 }, 20*time.Second, 200*time.Millisecond)
+	s.Eventually(func() bool { return testComplete.Load() == 1 }, 20*time.Second, 200*time.Millisecond)
 }
 
 // testScheduleContinuesAfterWorkflowRetryFailure verifies a schedule keeps firing actions
@@ -1487,10 +1487,10 @@ func testScheduleContinuesAfterWorkflowRetryFailure(t *testing.T, newContext con
 	wid := testcore.RandomizeStr("sched-retry-fail-wf")
 	wt := testcore.RandomizeStr("sched-retry-fail-wt")
 
-	var sawRetry int32
+	var sawRetry atomic.Int32
 	workflowFn := func(ctx workflow.Context) error {
 		if workflow.GetInfo(ctx).Attempt > 1 {
-			atomic.StoreInt32(&sawRetry, 1)
+			sawRetry.Store(1)
 		}
 		return errors.New("intentional failure to force a retry")
 	}
@@ -1546,11 +1546,11 @@ func testScheduleContinuesAfterWorkflowRetryFailure(t *testing.T, newContext con
 				failedActions++
 			}
 		}
-		return atomic.LoadInt32(&sawRetry) == 1 && failedActions >= 2
+		return sawRetry.Load() == 1 && failedActions >= 2
 	}, 30*time.Second, 500*time.Millisecond,
 		"schedule should keep recording FAILED actions after the workflow retry-fails")
 
-	s.Equal(int32(1), atomic.LoadInt32(&sawRetry), "scheduled workflow should have retried (attempt > 1)")
+	s.Equal(int32(1), sawRetry.Load(), "scheduled workflow should have retried (attempt > 1)")
 	s.GreaterOrEqual(failedActions, 2, "schedule should record multiple retry-failed actions")
 	s.GreaterOrEqual(lastDescribe.GetInfo().GetActionCount(), int64(2))
 	s.False(lastDescribe.GetSchedule().GetState().GetPaused(), "a retry-failed workflow must not pause the schedule")
@@ -1830,10 +1830,10 @@ func testUpdateIntervalTakesEffect(t *testing.T, newContext contextFactory) {
 	wid := "sched-test-update-interval-wf"
 	wt := "sched-test-update-interval-wt"
 
-	var runs int32
+	var runs atomic.Int32
 	workflowFn := func(ctx workflow.Context) error {
 		workflow.SideEffect(ctx, func(ctx workflow.Context) any {
-			atomic.AddInt32(&runs, 1)
+			runs.Add(1)
 			return 0
 		})
 		return nil
@@ -1881,7 +1881,7 @@ func testUpdateIntervalTakesEffect(t *testing.T, newContext contextFactory) {
 
 	// After updating to 1s interval, we should see runs start within a few seconds.
 	s.Eventually(
-		func() bool { return atomic.LoadInt32(&runs) >= 2 },
+		func() bool { return runs.Load() >= 2 },
 		10*time.Second,
 		500*time.Millisecond,
 		"expected at least 2 runs within 10s after updating interval to 1s",
@@ -3496,10 +3496,10 @@ func testRefresh(t *testing.T, newContext contextFactory) {
 		RequestId:  uuid.NewString(),
 	}
 
-	var runs int32
+	var runs atomic.Int32
 	workflowFn := func(ctx workflow.Context) error {
 		workflow.SideEffect(ctx, func(ctx workflow.Context) any {
-			atomic.AddInt32(&runs, 1)
+			runs.Add(1)
 			return 0
 		})
 		s.NoError(workflow.Sleep(ctx, 10*time.Second)) // longer than execution timeout
@@ -3510,7 +3510,7 @@ func testRefresh(t *testing.T, newContext contextFactory) {
 	_, err := s.FrontendClient().CreateSchedule(newContext(s.Context()), req)
 	s.NoError(err)
 
-	s.Eventually(func() bool { return atomic.LoadInt32(&runs) == 1 }, 20*time.Second, 200*time.Millisecond)
+	s.Eventually(func() bool { return runs.Load() == 1 }, 20*time.Second, 200*time.Millisecond)
 
 	// workflow has started but is now sleeping. it will timeout in 2 seconds.
 
@@ -3623,10 +3623,10 @@ func testRateLimit(t *testing.T, newContext contextFactory) {
 	wid := "sched-test-rate-limit-wf-%d"
 	wt := "sched-test-rate-limit-wt"
 
-	var runs int32
+	var runs atomic.Int32
 	workflowFn := func(ctx workflow.Context) error {
 		workflow.SideEffect(ctx, func(ctx workflow.Context) any {
-			atomic.AddInt32(&runs, 1)
+			runs.Add(1)
 			return 0
 		})
 		return nil
@@ -3665,7 +3665,7 @@ func testRateLimit(t *testing.T, newContext contextFactory) {
 
 	// With no rate limit, we'd see 10/second == 50 workflows run. With a limit of 1/sec, we
 	// expect to see around 5.
-	s.Less(atomic.LoadInt32(&runs), int32(10))
+	s.Less(runs.Load(), int32(10))
 }
 
 // testNextTimeCache only applies to V1.
@@ -4090,11 +4090,11 @@ func testCHASMUnpauseResumesProcessing(t *testing.T, newContext contextFactory) 
 	wid := "sched-test-unpause-resumes-wf"
 	wt := "sched-test-unpause-resumes-wt"
 
-	var runs int32
+	var runs atomic.Int32
 	s.SdkWorker().RegisterWorkflowWithOptions(
 		func(ctx workflow.Context) error {
 			workflow.SideEffect(ctx, func(ctx workflow.Context) any {
-				atomic.AddInt32(&runs, 1)
+				runs.Add(1)
 				return 0
 			})
 			return nil
@@ -4125,7 +4125,7 @@ func testCHASMUnpauseResumesProcessing(t *testing.T, newContext contextFactory) 
 	s.NoError(err)
 
 	// Wait for the schedule to fire at least once, confirming it's running.
-	s.Eventually(func() bool { return atomic.LoadInt32(&runs) >= 1 }, 15*time.Second, 500*time.Millisecond)
+	s.Eventually(func() bool { return runs.Load() >= 1 }, 15*time.Second, 500*time.Millisecond)
 
 	// Pause.
 	_, err = s.FrontendClient().PatchSchedule(newContext(s.Context()), &workflowservice.PatchScheduleRequest{
@@ -4141,9 +4141,9 @@ func testCHASMUnpauseResumesProcessing(t *testing.T, newContext contextFactory) 
 	// observes paused state, performs no-op scheduling, and then the schedule
 	// becomes quiescent (no new runs over a stability window).
 	stableSamples := 0
-	lastRuns := atomic.LoadInt32(&runs)
+	lastRuns := runs.Load()
 	s.Eventually(func() bool {
-		currentRuns := atomic.LoadInt32(&runs)
+		currentRuns := runs.Load()
 		if currentRuns == lastRuns {
 			stableSamples++
 		} else {
@@ -4152,7 +4152,7 @@ func testCHASMUnpauseResumesProcessing(t *testing.T, newContext contextFactory) 
 		}
 		return stableSamples >= 6
 	}, 15*time.Second, 500*time.Millisecond)
-	runsBeforeUnpause := atomic.LoadInt32(&runs)
+	runsBeforeUnpause := runs.Load()
 
 	// Unpause.
 	_, err = s.FrontendClient().PatchSchedule(newContext(s.Context()), &workflowservice.PatchScheduleRequest{
@@ -4166,7 +4166,7 @@ func testCHASMUnpauseResumesProcessing(t *testing.T, newContext contextFactory) 
 
 	// The generator should be kicked immediately on unpause and new runs should follow.
 	s.Eventually(
-		func() bool { return atomic.LoadInt32(&runs) > runsBeforeUnpause },
+		func() bool { return runs.Load() > runsBeforeUnpause },
 		15*time.Second,
 		500*time.Millisecond,
 		"schedule should resume processing after unpause",

--- a/tests/xdc/stream_based_replication_test.go
+++ b/tests/xdc/stream_based_replication_test.go
@@ -1071,7 +1071,7 @@ func (s *streamBasedReplicationTestSuite) TestPassiveActivityRetryTimerReplicati
 	s.NoError(err)
 	defer sdkClient.Close()
 
-	var activityAttempts int32
+	var activityAttempts atomic.Int32
 
 	// Workflow with activity that retries with 3 second intervals
 	simpleWorkflow := func(ctx workflow.Context) (string, error) {
@@ -1096,7 +1096,7 @@ func (s *streamBasedReplicationTestSuite) TestPassiveActivityRetryTimerReplicati
 
 	// Activity that sleeps 3 seconds and fails twice, succeeds on 3rd attempt
 	simpleActivity := func(ctx context.Context) (string, error) {
-		attempt := atomic.AddInt32(&activityAttempts, 1)
+		attempt := activityAttempts.Add(1)
 		if attempt < 3 {
 			return "", fmt.Errorf("failed attempt %d", attempt)
 		}


### PR DESCRIPTION
Go 1.27 prerequisite that applies the `atomictypes` Go fixer to use typed atomic values.
