### PR TITLE
Use slices.Backward for reverse iteration

### DIFF
--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -2068,8 +2068,8 @@ func (n *Node) closeTransactionUpdateComponentTasks(
 		}
 
 		sideEffectTasks := componentAttr.GetSideEffectTasks()
-		for idx := len(sideEffectTasks) - 1; idx >= 0; idx-- {
-			sideEffectTask := sideEffectTasks[idx]
+		for _, sideEffectTask := range slices.Backward(sideEffectTasks) {
+
 			if sideEffectTask.PhysicalTaskStatus == physicalTaskStatusCreated {
 				break
 			}

--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -2069,7 +2069,6 @@ func (n *Node) closeTransactionUpdateComponentTasks(
 
 		sideEffectTasks := componentAttr.GetSideEffectTasks()
 		for _, sideEffectTask := range slices.Backward(sideEffectTasks) {
-
 			if sideEffectTask.PhysicalTaskStatus == physicalTaskStatusCreated {
 				break
 			}

--- a/common/dynamicconfig/memory_client.go
+++ b/common/dynamicconfig/memory_client.go
@@ -1,6 +1,7 @@
 package dynamicconfig
 
 import (
+	"slices"
 	"sync"
 	"sync/atomic"
 )
@@ -34,15 +35,15 @@ func (d *MemoryClient) GetValue(key Key) []ConstrainedValue {
 
 func (d *MemoryClient) getValueLocked(key Key) []ConstrainedValue {
 	var result []ConstrainedValue
-	for i := len(d.overrides) - 1; i >= 0; i-- {
-		if d.overrides[i].valid && d.overrides[i].key == key {
-			v := d.overrides[i].value
-			if cvs, ok := v.([]ConstrainedValue); ok {
+	for _, override := range slices.Backward(d.overrides) {
+		if override.valid && override.key == key {
+			value := override.value
+			if cvs, ok := value.([]ConstrainedValue); ok {
 				result = append(result, cvs...)
 			} else {
-				result = append(result, ConstrainedValue{Value: v})
+				result = append(result, ConstrainedValue{Value: value})
 			}
-			if !d.overrides[i].mergeable {
+			if !override.mergeable {
 				// Non-mergeable: take this value and stop.
 				return result
 			}

--- a/common/effect/buffer.go
+++ b/common/effect/buffer.go
@@ -1,6 +1,9 @@
 package effect
 
-import "context"
+import (
+	"context"
+	"slices"
+)
 
 // Buffer holds a set of effect and rollback functions that can be invoked as a
 // batch with a defined order. Once either Apply or Cancel is called, all
@@ -43,8 +46,8 @@ func (b *Buffer) Apply(ctx context.Context) bool {
 func (b *Buffer) Cancel(ctx context.Context) bool {
 	canceled := false
 	b.effects = nil
-	for i := len(b.cancels) - 1; i >= 0; i-- {
-		b.cancels[i](ctx)
+	for _, v := range slices.Backward(b.cancels) {
+		v(ctx)
 		canceled = true
 	}
 	b.cancels = nil

--- a/common/effect/buffer.go
+++ b/common/effect/buffer.go
@@ -46,8 +46,8 @@ func (b *Buffer) Apply(ctx context.Context) bool {
 func (b *Buffer) Cancel(ctx context.Context) bool {
 	canceled := false
 	b.effects = nil
-	for _, v := range slices.Backward(b.cancels) {
-		v(ctx)
+	for _, cancel := range slices.Backward(b.cancels) {
+		cancel(ctx)
 		canceled = true
 	}
 	b.cancels = nil

--- a/common/persistence/history_manager.go
+++ b/common/persistence/history_manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/google/uuid"
 	commonpb "go.temporal.io/api/common/v1"
@@ -179,8 +180,8 @@ func (m *executionManagerImpl) DeleteHistoryBranch(
 	var deleteRanges []InternalDeleteHistoryBranchRange
 	// for each branch range to delete, we iterate from bottom up, and stop when the range is also used by others
 findDeleteRanges:
-	for i := len(brsToDelete) - 1; i >= 0; i-- {
-		br := brsToDelete[i]
+	for _, br := range slices.Backward(brsToDelete) {
+
 		if maxEndNode, ok := usedBranches[br.GetBranchId()]; ok {
 			// branch is used by others, we can only delete from the maxEndNode
 			if maxEndNode != common.LastEventID {

--- a/common/persistence/query_util.go
+++ b/common/persistence/query_util.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strings"
 	"unicode"
 )
@@ -235,7 +236,7 @@ func hasWordsBefore(s string, pos int, words ...string) bool {
 	if pos <= 0 || !unicode.IsSpace(rune(s[pos])) {
 		return false
 	}
-	for i := len(words) - 1; i >= 0; i-- {
+	for _, word := range slices.Backward(words) {
 		// skip spaces
 		for pos >= 0 && unicode.IsSpace(rune(s[pos])) {
 			pos--
@@ -245,7 +246,7 @@ func hasWordsBefore(s string, pos int, words ...string) bool {
 			pos--
 		}
 		// check if current pos matches the word
-		if pos < 0 || !hasWordAt(s, words[i], pos) {
+		if pos < 0 || !hasWordAt(s, word, pos) {
 			return false
 		}
 		pos--

--- a/common/persistence/versionhistory/version_history.go
+++ b/common/persistence/versionhistory/version_history.go
@@ -1,6 +1,8 @@
 package versionhistory
 
 import (
+	"slices"
+
 	"go.temporal.io/api/serviceerror"
 	historyspb "go.temporal.io/server/api/history/v1"
 	"go.temporal.io/server/common"
@@ -185,8 +187,8 @@ func SplitVersionHistoryByLastLocalGeneratedItem(
 	initialFailoverVersion int64,
 	failoverVersionIncrement int64,
 ) (localItems []*historyspb.VersionHistoryItem, remoteItems []*historyspb.VersionHistoryItem) {
-	for i := len(versionHistoryItems) - 1; i >= 0; i-- {
-		if versionHistoryItems[i].Version%failoverVersionIncrement == initialFailoverVersion {
+	for i, versionHistoryItem := range slices.Backward(versionHistoryItems) {
+		if versionHistoryItem.Version%failoverVersionIncrement == initialFailoverVersion {
 			return versionHistoryItems[:i+1], versionHistoryItems[i+1:]
 		}
 	}

--- a/common/testing/await/require_ctx_test.go
+++ b/common/testing/await/require_ctx_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -539,8 +540,8 @@ func (r *recordingTB) runCleanups() {
 	r.cleanups = nil
 	r.mu.Unlock()
 
-	for i := len(cleanups) - 1; i >= 0; i-- {
-		cleanups[i]()
+	for _, cleanup := range slices.Backward(cleanups) {
+		cleanup()
 	}
 }
 

--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"errors"
+	"slices"
 	"strconv"
 
 	"go.opentelemetry.io/otel/trace"
@@ -1034,9 +1035,9 @@ func (c *ContextImpl) mergeUpdateWithNewReplicationTasks(
 			t.NewRunID = newRunID
 			taskEquivalents := t.TaskEquivalents
 			taskEquivalentsUpdated := false
-			for idx := len(taskEquivalents) - 1; idx >= 0; idx-- {
+			for _, taskEquivalent := range slices.Backward(taskEquivalents) {
 				// For state based, we should update a sync versioned transition task and update a history task inside task equivalent.
-				if historyTask, ok := taskEquivalents[idx].(*tasks.HistoryReplicationTask); ok {
+				if historyTask, ok := taskEquivalent.(*tasks.HistoryReplicationTask); ok {
 					historyTask.NewRunBranchToken = newRunBranchToken
 					historyTask.NewRunID = newRunID
 					taskEquivalentsUpdated = true

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -7416,8 +7416,8 @@ func (ms *MutableStateImpl) PopTasks() map[tasks.Category][]tasks.Task {
 }
 
 func (ms *MutableStateImpl) DeleteCHASMPureTasks(maxScheduledTime time.Time) {
-	for lastTaskIdx := len(ms.chasmPureTasks) - 1; lastTaskIdx >= 0; lastTaskIdx-- {
-		task := ms.chasmPureTasks[lastTaskIdx]
+	for lastTaskIdx, task := range slices.Backward(ms.chasmPureTasks) {
+
 		if !task.GetVisibilityTime().Before(maxScheduledTime) {
 			ms.chasmPureTasks = ms.chasmPureTasks[:lastTaskIdx+1]
 			return

--- a/tests/testcore/cluster_poison_test.go
+++ b/tests/testcore/cluster_poison_test.go
@@ -2,6 +2,7 @@ package testcore
 
 import (
 	"fmt"
+	"slices"
 	"sync"
 	"testing"
 
@@ -54,8 +55,8 @@ func (f *mockSubtestT) finish() {
 	cleanups := f.cleanups
 	f.cleanups = nil
 	f.mu.Unlock()
-	for i := len(cleanups) - 1; i >= 0; i-- {
-		cleanups[i]()
+	for _, cleanup := range slices.Backward(cleanups) {
+		cleanup()
 	}
 }
 

--- a/tests/testcore/shared_cluster_t.go
+++ b/tests/testcore/shared_cluster_t.go
@@ -144,7 +144,7 @@ func (s *sharedClusterT) doCleanups() {
 	cs := s.cleanups
 	s.cleanups = nil
 	s.mu.Unlock()
-	for i := len(cs) - 1; i >= 0; i-- {
-		cs[i]()
+	for _, c := range slices.Backward(cs) {
+		c()
 	}
 }

--- a/tools/testrunner/log.go
+++ b/tools/testrunner/log.go
@@ -373,14 +373,14 @@ func normalizedFailureLines(data string) []string {
 
 func findLastAssertionFailureBlock(lines []string) (string, bool) {
 	var failLine string
-	for i := len(lines) - 1; i >= 0; i-- {
-		line := strings.TrimSpace(lines[i])
+	for i, line := range slices.Backward(lines) {
+		line := strings.TrimSpace(line)
 		if failLine == "" && strings.HasPrefix(line, goTestFailLinePrefix) {
 			// Keep the final Go test failure line because it carries the test duration.
 			failLine = line
 			continue
 		}
-		if !strings.Contains(lines[i], "Error Trace:") {
+		if !strings.Contains(line, "Error Trace:") {
 			continue
 		}
 
@@ -422,8 +422,8 @@ func endOfAssertionBlock(lines []string, start int) int {
 }
 
 func findLastTestOutputFailureBlock(lines []string) (start, end int, ok bool) {
-	for start := len(lines) - 1; start >= 0; start-- {
-		if !isTestOutputLine(lines[start]) {
+	for start, line := range slices.Backward(lines) {
+		if !isTestOutputLine(line) {
 			continue
 		}
 		end := start + 1

--- a/tools/testrunner/log.go
+++ b/tools/testrunner/log.go
@@ -374,10 +374,10 @@ func normalizedFailureLines(data string) []string {
 func findLastAssertionFailureBlock(lines []string) (string, bool) {
 	var failLine string
 	for i, line := range slices.Backward(lines) {
-		line := strings.TrimSpace(line)
-		if failLine == "" && strings.HasPrefix(line, goTestFailLinePrefix) {
+		trimmed := strings.TrimSpace(line)
+		if failLine == "" && strings.HasPrefix(trimmed, goTestFailLinePrefix) {
 			// Keep the final Go test failure line because it carries the test duration.
-			failLine = line
+			failLine = trimmed
 			continue
 		}
 		if !strings.Contains(line, "Error Trace:") {


### PR DESCRIPTION
Go 1.27 prerequisite that applies the `slicesbackward` Go fixer for reverse iteration.
