### PR TITLE
Make UnprocessableTaskError pointer-only

### DIFF
--- a/service/history/queues/errors/errors.go
+++ b/service/history/queues/errors/errors.go
@@ -42,6 +42,6 @@ func NewUnprocessableTaskError(message string) *UnprocessableTaskError {
 	return &UnprocessableTaskError{Message: message}
 }
 
-func (e UnprocessableTaskError) Error() string {
+func (e *UnprocessableTaskError) Error() string {
 	return "unprocessable task: " + e.Message
 }


### PR DESCRIPTION
Go 1.27 prerequisite that makes `UnprocessableTaskError` pointer-only for the stricter errortype vet check.
