### PR TITLE
Make Nexus link warnings aggregatable

### DIFF
--- a/common/nexus/links.go
+++ b/common/nexus/links.go
@@ -43,7 +43,9 @@ func ConvertNexusLinksToProtoLinks(nexusLinks []nexus.Link, logger log.Logger) [
 				Variant: &commonpb.Link_Activity_{Activity: link},
 			})
 		default:
-			logger.Warn("invalid Nexus link data type", tag.NewStringTag("link-type", nexusLink.Type))
+			logger.Warn("invalid Nexus link data type",
+				tag.NewStringTag("nexus-link-type", nexusLink.Type),
+			)
 		}
 	}
 	return out

--- a/common/nexus/links.go
+++ b/common/nexus/links.go
@@ -20,7 +20,7 @@ func ConvertNexusLinksToProtoLinks(nexusLinks []nexus.Link, logger log.Logger) [
 				logger.Warn(
 					"failed to parse Nexus link",
 					tag.Error(err),
-					tag.NewStringTag("link-type", nexusLink.Type),
+					tag.NewStringTag("nexus-link-type", nexusLink.Type),
 					tag.URL(nexusLink.URL.String()),
 				)
 				continue
@@ -34,7 +34,7 @@ func ConvertNexusLinksToProtoLinks(nexusLinks []nexus.Link, logger log.Logger) [
 				logger.Warn(
 					"failed to parse Nexus link",
 					tag.Error(err),
-					tag.NewStringTag("link-type", nexusLink.Type),
+					tag.NewStringTag("nexus-link-type", nexusLink.Type),
 					tag.URL(nexusLink.URL.String()),
 				)
 				continue

--- a/common/nexus/links.go
+++ b/common/nexus/links.go
@@ -1,8 +1,6 @@
 package nexus
 
 import (
-	"fmt"
-
 	"github.com/nexus-rpc/sdk-go/nexus"
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/server/common/log"
@@ -20,8 +18,10 @@ func ConvertNexusLinksToProtoLinks(nexusLinks []nexus.Link, logger log.Logger) [
 			link, err := ConvertNexusLinkToLinkWorkflowEvent(nexusLink)
 			if err != nil {
 				logger.Warn(
-					fmt.Sprintf("failed to parse link to %q: %s", nexusLink.Type, nexusLink.URL),
+					"failed to parse Nexus link",
 					tag.Error(err),
+					tag.NewStringTag("link-type", nexusLink.Type),
+					tag.URL(nexusLink.URL.String()),
 				)
 				continue
 			}
@@ -32,8 +32,10 @@ func ConvertNexusLinksToProtoLinks(nexusLinks []nexus.Link, logger log.Logger) [
 			link, err := ConvertNexusLinkToLinkActivity(nexusLink)
 			if err != nil {
 				logger.Warn(
-					fmt.Sprintf("failed to parse link to %q: %s", nexusLink.Type, nexusLink.URL),
+					"failed to parse Nexus link",
 					tag.Error(err),
+					tag.NewStringTag("link-type", nexusLink.Type),
+					tag.URL(nexusLink.URL.String()),
 				)
 				continue
 			}
@@ -41,7 +43,7 @@ func ConvertNexusLinksToProtoLinks(nexusLinks []nexus.Link, logger log.Logger) [
 				Variant: &commonpb.Link_Activity_{Activity: link},
 			})
 		default:
-			logger.Warn(fmt.Sprintf("invalid link data type: %q", nexusLink.Type))
+			logger.Warn("invalid Nexus link data type", tag.NewStringTag("link-type", nexusLink.Type))
 		}
 	}
 	return out


### PR DESCRIPTION
## What changed

All three warnings in `ConvertNexusLinksToProtoLinks` interpolated the link type into the message, and two also embedded the link URL. Moved both into tags and kept the message static.

