### PR TITLE
Verify Nexus log correlation across hops

### DIFF
--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -2693,6 +2693,8 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncNexusFailure(chasmEnabled
 	handlerRequestID := await.Rcv(s.T(), handlerRequestIDs)
 	s.Require().NotEmpty(handlerRequestID)
 
+	// The attempt tag is off by one between implementations: HSM's task carries the count of
+	// *completed* attempts, CHASM's is 1-based.
 	attempt := int32(0)
 	if chasmEnabled {
 		attempt = 1

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -48,6 +48,7 @@ import (
 	"go.temporal.io/server/common/testing/historyrequire"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/common/testing/protorequire"
+	"go.temporal.io/server/common/testing/testlogger"
 	"go.temporal.io/server/components/nexusoperations"
 	"go.temporal.io/server/service/frontend/configs"
 	"go.temporal.io/server/tests/testcore"
@@ -2628,9 +2629,15 @@ func (s *NexusWorkflowTestSuite) TestNexusCallbackAfterCallerComplete(chasmEnabl
 func (s *NexusWorkflowTestSuite) TestNexusOperationSyncNexusFailure(chasmEnabled bool) {
 	env := s.newTestEnv(chasmEnabled)
 	taskQueue := testcore.RandomizeStr(s.T().Name())
+	handlerRequestIDs := make(chan string, 1)
 
 	h := nexustest.Handler{
 		OnStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
+			select {
+			case handlerRequestIDs <- options.RequestID:
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
 			return nil, &nexus.HandlerError{
 				Type: nexus.HandlerErrorTypeBadRequest,
 				Cause: &nexus.FailureError{
@@ -2661,7 +2668,8 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncNexusFailure(chasmEnabled
 	s.NoError(w.Start())
 	s.T().Cleanup(w.Stop)
 
-	capture := env.StartNamespaceMetricCapture()
+	logCapture := env.StartNamespaceLogCapture()
+	metricCapture := env.StartNamespaceMetricCapture()
 	run, err := env.SdkClient().ExecuteWorkflow(s.Context(), client.StartWorkflowOptions{
 		TaskQueue: taskQueue,
 	}, callerWF)
@@ -2682,7 +2690,32 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncNexusFailure(chasmEnabled
 	s.NoError(json.Unmarshal(failure.Details, &details))
 	s.Equal("details", details)
 
-	outboundRequests := capture.Metric("nexus_outbound_requests")
+	handlerRequestID := await.Rcv(s.T(), handlerRequestIDs)
+	s.Require().NotEmpty(handlerRequestID)
+
+	attempt := int32(0)
+	if chasmEnabled {
+		attempt = 1
+	}
+	logCapture.RequireContains(s.T(), testlogger.CapturedLogPattern{
+		Level:   testlogger.Error,
+		Message: "Nexus StartOperation request failed",
+		Tags: map[string]any{
+			"operation":                          "StartOperation",
+			"wf-namespace":                       env.Namespace().String(),
+			"nexus-endpoint-target-namespace-id": "",
+			"request-id":                         handlerRequestID,
+			"nexus-operation":                    "operation",
+			"endpoint":                           endpointName,
+			"wf-id":                              run.GetID(),
+			"wf-run-id":                          run.GetRunID(),
+			"attempt-start":                      testlogger.AnyTagValue,
+			"attempt":                            attempt,
+			"error":                              "handler error (BAD_REQUEST)",
+		},
+	})
+
+	outboundRequests := metricCapture.Metric("nexus_outbound_requests")
 	s.Len(outboundRequests, 1)
 	// Confirming that requests which do not go through our frontend are not tagged with `failure_source`
 	s.Subset(outboundRequests[0].Tags, map[string]string{"namespace": env.Namespace().String(), "method": "StartOperation", "failure_source": "_unknown_", "outcome": "handler-error:BAD_REQUEST"})

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -2633,11 +2633,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncNexusFailure(chasmEnabled
 
 	h := nexustest.Handler{
 		OnStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
-			select {
-			case handlerRequestIDs <- options.RequestID:
-			default:
-				// A redelivered task carries the same request ID.
-			}
+			handlerRequestIDs <- options.RequestID
 			return nil, &nexus.HandlerError{
 				Type: nexus.HandlerErrorTypeBadRequest,
 				Cause: &nexus.FailureError{

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -2633,11 +2633,7 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncNexusFailure(chasmEnabled
 
 	h := nexustest.Handler{
 		OnStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
-			select {
-			case handlerRequestIDs <- options.RequestID:
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			}
+			await.Snd(s.T(), handlerRequestIDs, options.RequestID)
 			return nil, &nexus.HandlerError{
 				Type: nexus.HandlerErrorTypeBadRequest,
 				Cause: &nexus.FailureError{

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -2633,7 +2633,11 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncNexusFailure(chasmEnabled
 
 	h := nexustest.Handler{
 		OnStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
-			await.Snd(s.T(), handlerRequestIDs, options.RequestID)
+			select {
+			case handlerRequestIDs <- options.RequestID:
+			default:
+				// A redelivered task carries the same request ID.
+			}
 			return nil, &nexus.HandlerError{
 				Type: nexus.HandlerErrorTypeBadRequest,
 				Cause: &nexus.FailureError{

--- a/tests/testcore/test_env.go
+++ b/tests/testcore/test_env.go
@@ -26,6 +26,7 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/testing/taskpoller"
 	"go.temporal.io/server/common/testing/testcontext"
@@ -550,6 +551,23 @@ func (e *TestEnv) OverrideDynamicConfig(setting dynamicconfig.GenericSetting, va
 		e.dedicatedGuard.record("global dynamic config used")
 	}
 	return e.cluster.host.overrideDynamicConfigForTest(e.t, setting.Key(), value)
+}
+
+// StartNamespaceLogCapture starts a log capture scoped to the namespaces owned by this test environment.
+func (e *TestEnv) StartNamespaceLogCapture() *testlogger.Capture {
+	testLogger, ok := e.Logger.(*testlogger.TestLogger)
+	if !ok {
+		e.t.Fatalf("StartNamespaceLogCapture requires a *testlogger.TestLogger logger, got %T", e.Logger)
+	}
+	capture := testLogger.StartCapture(
+		tag.WorkflowNamespace(e.Namespace().String()),
+		tag.WorkflowNamespaceID(e.NamespaceID().String()),
+		tag.WorkflowNamespace(e.ExternalNamespace().String()),
+	)
+	e.t.Cleanup(func() {
+		testLogger.StopCapture(capture)
+	})
+	return capture
 }
 
 // StartGlobalMetricCapture starts a cluster-global metrics capture for this test and automatically stops it during cleanup.

--- a/tests/testcore/test_env.go
+++ b/tests/testcore/test_env.go
@@ -562,7 +562,6 @@ func (e *TestEnv) StartNamespaceLogCapture() *testlogger.Capture {
 	capture := testLogger.StartCapture(
 		tag.WorkflowNamespace(e.Namespace().String()),
 		tag.WorkflowNamespaceID(e.NamespaceID().String()),
-		tag.WorkflowNamespace(e.ExternalNamespace().String()),
 	)
 	e.t.Cleanup(func() {
 		testLogger.StopCapture(capture)

--- a/tests/testcore/test_env.go
+++ b/tests/testcore/test_env.go
@@ -553,7 +553,7 @@ func (e *TestEnv) OverrideDynamicConfig(setting dynamicconfig.GenericSetting, va
 	return e.cluster.host.overrideDynamicConfigForTest(e.t, setting.Key(), value)
 }
 
-// StartNamespaceLogCapture starts a log capture scoped to the namespaces owned by this test environment.
+// StartNamespaceLogCapture starts a log capture scoped to this test environment's namespace.
 func (e *TestEnv) StartNamespaceLogCapture() *testlogger.Capture {
 	testLogger, ok := e.Logger.(*testlogger.TestLogger)
 	if !ok {

--- a/tests/testcore/test_env_test.go
+++ b/tests/testcore/test_env_test.go
@@ -62,11 +62,9 @@ func (s *TestEnvSuite) TestStartNamespaceLogCapture() {
 
 	capture := env.StartNamespaceLogCapture()
 
-	// logs in namespace
 	testLogger.Info("primary name", tag.WorkflowNamespace("primary"))
 	testLogger.Info("primary ID", tag.WorkflowNamespaceID("primary-id"))
 	testLogger.Info("external name", tag.WorkflowNamespace("external"))
-
 	testLogger.Info("unrelated name", tag.WorkflowNamespace("unrelated"))
 	testLogger.Info("unrelated ID", tag.WorkflowNamespaceID("unrelated-id"))
 
@@ -83,11 +81,6 @@ func (s *TestEnvSuite) TestStartNamespaceLogCapture() {
 			Level:   testlogger.Info,
 			Message: "primary ID",
 			Tags:    []tag.Tag{tag.WorkflowNamespaceID("primary-id")},
-		},
-		{
-			Level:   testlogger.Info,
-			Message: "external name",
-			Tags:    []tag.Tag{tag.WorkflowNamespace("external")},
 		},
 	}, capture.Snapshot())
 }

--- a/tests/testcore/test_env_test.go
+++ b/tests/testcore/test_env_test.go
@@ -4,7 +4,10 @@ import (
 	"sync"
 	"testing"
 
+	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/testing/parallelsuite"
+	"go.temporal.io/server/common/testing/testlogger"
 )
 
 type TestEnvSuite struct {
@@ -45,4 +48,46 @@ func (s *TestEnvSuite) TestDedicatedClusterGuard_ConcurrentRecord() {
 	}
 	wg.Wait()
 	s.NoError(guard.validate())
+}
+
+func (s *TestEnvSuite) TestStartNamespaceLogCapture() {
+	testLogger := testlogger.NewTestLogger(s.T(), testlogger.FailOnExpectedErrorOnly)
+	env := &TestEnv{
+		FunctionalTestBase: &FunctionalTestBase{externalNamespace: namespace.Name("external")},
+		Logger:             testLogger,
+		nsName:             namespace.Name("primary"),
+		nsID:               namespace.ID("primary-id"),
+		t:                  s.T(),
+	}
+
+	capture := env.StartNamespaceLogCapture()
+
+	// logs in namespace
+	testLogger.Info("primary name", tag.WorkflowNamespace("primary"))
+	testLogger.Info("primary ID", tag.WorkflowNamespaceID("primary-id"))
+	testLogger.Info("external name", tag.WorkflowNamespace("external"))
+
+	testLogger.Info("unrelated name", tag.WorkflowNamespace("unrelated"))
+	testLogger.Info("unrelated ID", tag.WorkflowNamespaceID("unrelated-id"))
+
+	testLogger.Info("target only", tag.NexusEndpointTargetNamespaceID("primary-id"))
+	testLogger.Info("unscoped")
+
+	s.ElementsMatch([]testlogger.CapturedLog{
+		{
+			Level:   testlogger.Info,
+			Message: "primary name",
+			Tags:    []tag.Tag{tag.WorkflowNamespace("primary")},
+		},
+		{
+			Level:   testlogger.Info,
+			Message: "primary ID",
+			Tags:    []tag.Tag{tag.WorkflowNamespaceID("primary-id")},
+		},
+		{
+			Level:   testlogger.Info,
+			Message: "external name",
+			Tags:    []tag.Tag{tag.WorkflowNamespace("external")},
+		},
+	}, capture.Snapshot())
 }


### PR DESCRIPTION
## What changed

A functional test asserting that the request ID the Nexus handler observes is the same one the caller-side failure log carries, along with the rest of the invocation tag set.

## Why

Ensure we can correlate a caller-side failure with its handler-side counterpart.