### PR TITLE
Make all force replication tasks low priority

### DIFF
--- a/common/persistence/serialization/task_serializers.go
+++ b/common/persistence/serialization/task_serializers.go
@@ -1207,6 +1207,7 @@ func replicationActivityTaskToProto(
 		BranchToken:       nil,
 		NewRunBranchToken: nil,
 		VisibilityTime:    timestamppb.New(activityTask.VisibilityTimestamp),
+		Priority:          activityTask.Priority,
 		TargetClusters:    activityTask.TargetClusters,
 	}
 }
@@ -1228,6 +1229,7 @@ func replicationActivityTaskFromProto(
 		Version:             activityTask.Version,
 		TaskID:              activityTask.TaskId,
 		ScheduledEventID:    activityTask.ScheduledEventId,
+		Priority:            activityTask.Priority,
 		TargetClusters:      activityTask.TargetClusters,
 	}
 }
@@ -1249,6 +1251,7 @@ func replicationHistoryTaskToProto(
 		NewRunBranchToken: historyTask.NewRunBranchToken,
 		NewRunId:          historyTask.NewRunID,
 		VisibilityTime:    timestamppb.New(historyTask.VisibilityTimestamp),
+		Priority:          historyTask.Priority,
 		TargetClusters:    historyTask.TargetClusters,
 	}
 }
@@ -1274,6 +1277,7 @@ func replicationHistoryTaskFromProto(
 		BranchToken:         historyTask.BranchToken,
 		NewRunBranchToken:   historyTask.NewRunBranchToken,
 		NewRunID:            historyTask.NewRunId,
+		Priority:            historyTask.Priority,
 		TargetClusters:      historyTask.TargetClusters,
 	}
 }
@@ -1360,6 +1364,7 @@ func replicationSyncHSMTaskToProto(
 		TaskType:       enumsspb.TASK_TYPE_REPLICATION_SYNC_HSM,
 		TaskId:         syncHSMTask.TaskID,
 		VisibilityTime: timestamppb.New(syncHSMTask.VisibilityTimestamp),
+		Priority:       syncHSMTask.Priority,
 		TargetClusters: syncHSMTask.TargetClusters,
 	}
 }
@@ -1379,6 +1384,7 @@ func replicationSyncHSMTaskFromProto(
 		),
 		VisibilityTimestamp: visibilityTimestamp,
 		TaskID:              syncHSMTask.TaskId,
+		Priority:            syncHSMTask.Priority,
 		TargetClusters:      syncHSMTask.TargetClusters,
 	}
 }
@@ -1404,6 +1410,7 @@ func replicationSyncVersionedTransitionTaskToProto(
 		TaskId:                 syncVersionedTransitionTask.TaskID,
 		VisibilityTime:         timestamppb.New(syncVersionedTransitionTask.VisibilityTimestamp),
 		ArchetypeId:            syncVersionedTransitionTask.ArchetypeID,
+		Priority:               syncVersionedTransitionTask.Priority,
 		VersionedTransition:    syncVersionedTransitionTask.VersionedTransition,
 		FirstEventId:           syncVersionedTransitionTask.FirstEventID,
 		Version:                syncVersionedTransitionTask.FirstEventVersion,
@@ -1444,6 +1451,7 @@ func replicationSyncVersionedTransitionTaskFromProto(
 		VisibilityTimestamp:    visibilityTimestamp,
 		TaskID:                 syncVersionedTransitionTask.TaskId,
 		ArchetypeID:            syncVersionedTransitionTask.ArchetypeId,
+		Priority:               syncVersionedTransitionTask.Priority,
 		FirstEventID:           syncVersionedTransitionTask.FirstEventId,
 		FirstEventVersion:      syncVersionedTransitionTask.Version,
 		NextEventID:            syncVersionedTransitionTask.NextEventId,

--- a/common/persistence/serialization/task_serializers_test.go
+++ b/common/persistence/serialization/task_serializers_test.go
@@ -371,6 +371,7 @@ func (s *taskSerializerSuite) TestSyncActivityTask() {
 		TaskID:              rand.Int63(),
 		Version:             rand.Int63(),
 		ScheduledEventID:    rand.Int63(),
+		Priority:            enumsspb.TASK_PRIORITY_LOW,
 	}
 
 	s.assertEqualTasks(syncActivityTask)
@@ -386,6 +387,7 @@ func (s *taskSerializerSuite) TestHistoryReplicationTask() {
 		NextEventID:         rand.Int63(),
 		BranchToken:         shuffle.Bytes([]byte("random branch token")),
 		NewRunBranchToken:   shuffle.Bytes([]byte("random new branch token")),
+		Priority:            enumsspb.TASK_PRIORITY_LOW,
 	}
 
 	s.assertEqualTasks(historyReplicationTask)
@@ -396,6 +398,7 @@ func (s *taskSerializerSuite) TestSyncHSMTask() {
 		WorkflowKey:         s.workflowKey,
 		VisibilityTimestamp: time.Unix(0, 0).UTC(), // go == compare for location as well which is striped during marshaling/unmarshaling
 		TaskID:              rand.Int63(),
+		Priority:            enumsspb.TASK_PRIORITY_LOW,
 	}
 
 	s.assertEqualTasks(syncHSMTask)
@@ -410,6 +413,7 @@ func (s *taskSerializerSuite) TestSyncVersionedTransitionTask() {
 		FirstEventID:        rand.Int63(),
 		NextEventID:         rand.Int63(),
 		NewRunID:            uuid.New().String(),
+		Priority:            enumsspb.TASK_PRIORITY_LOW,
 		VersionedTransition: &persistencespb.VersionedTransition{
 			NamespaceFailoverVersion: rand.Int63(),
 			TransitionCount:          rand.Int63(),
@@ -422,6 +426,7 @@ func (s *taskSerializerSuite) TestSyncVersionedTransitionTask() {
 				NextEventID:         rand.Int63(),
 				Version:             rand.Int63(),
 				NewRunID:            uuid.New().String(),
+				Priority:            enumsspb.TASK_PRIORITY_LOW,
 			},
 		},
 	}

--- a/service/history/replication/stream_sender.go
+++ b/service/history/replication/stream_sender.go
@@ -776,9 +776,24 @@ func (s *StreamSenderImpl) getTaskPriority(task tasks.Task) enumsspb.TaskPriorit
 			return enumsspb.TASK_PRIORITY_LOW
 		}
 		return t.Priority
+	case *tasks.SyncVersionedTransitionTask:
+		return defaultHighTaskPriority(t.Priority)
+	case *tasks.HistoryReplicationTask:
+		return defaultHighTaskPriority(t.Priority)
+	case *tasks.SyncActivityTask:
+		return defaultHighTaskPriority(t.Priority)
+	case *tasks.SyncHSMTask:
+		return defaultHighTaskPriority(t.Priority)
 	default:
 		return enumsspb.TASK_PRIORITY_HIGH
 	}
+}
+
+func defaultHighTaskPriority(priority enumsspb.TaskPriority) enumsspb.TaskPriority {
+	if priority == enumsspb.TASK_PRIORITY_UNSPECIFIED {
+		return enumsspb.TASK_PRIORITY_HIGH
+	}
+	return priority
 }
 
 func (s *StreamSenderImpl) getTaskTargetCluster(task tasks.Task) []string {

--- a/service/history/tasks/activity_replication_task.go
+++ b/service/history/tasks/activity_replication_task.go
@@ -16,6 +16,7 @@ type (
 		TaskID              int64
 		Version             int64
 		ScheduledEventID    int64
+		Priority            enumsspb.TaskPriority
 		TargetClusters      []string
 	}
 )

--- a/service/history/tasks/history_replication_task.go
+++ b/service/history/tasks/history_replication_task.go
@@ -18,6 +18,7 @@ type (
 		NextEventID         int64
 		Version             int64
 		NewRunID            string
+		Priority            enumsspb.TaskPriority
 		TargetClusters      []string
 
 		// deprecated

--- a/service/history/tasks/sync_hsm_task.go
+++ b/service/history/tasks/sync_hsm_task.go
@@ -14,6 +14,7 @@ type (
 		definition.WorkflowKey
 		VisibilityTimestamp time.Time
 		TaskID              int64
+		Priority            enumsspb.TaskPriority
 		TargetClusters      []string
 	}
 )

--- a/service/history/workflow/task_generator.go
+++ b/service/history/workflow/task_generator.go
@@ -87,6 +87,8 @@ type (
 		GenerateHistoryReplicationTasks(
 			eventBatches [][]*historypb.HistoryEvent,
 		) ([]tasks.Task, error)
+		// GenerateMigrationTasks generates low priority replication tasks and is
+		// for the force replication path only. Do not call it for live replication.
 		GenerateMigrationTasks(targetClusters []string) ([]tasks.Task, int64, error)
 
 		// Generate tasks for any updated state machines on mutable state.
@@ -767,6 +769,11 @@ func (r *TaskGeneratorImpl) GenerateHistoryReplicationTasks(
 	}, nil
 }
 
+// GenerateMigrationTasks must only be called from the force replication path
+// (i.e. GenerateLastHistoryReplicationTasks), never from live replication.
+// Every task it returns is marked TASK_PRIORITY_LOW so that bulk backfill does
+// not compete with live replication traffic; using it for live replication
+// would silently demote those tasks.
 func (r *TaskGeneratorImpl) GenerateMigrationTasks(targetClusters []string) ([]tasks.Task, int64, error) {
 	executionInfo := r.mutableState.GetExecutionInfo()
 	versionHistory, err := versionhistory.GetCurrentVersionHistory(executionInfo.GetVersionHistories())

--- a/service/history/workflow/task_generator.go
+++ b/service/history/workflow/task_generator.go
@@ -843,22 +843,27 @@ func (r *TaskGeneratorImpl) GenerateMigrationTasks(targetClusters []string) ([]t
 			FirstEventID:   executionInfo.LastFirstEventId,
 			NextEventID:    nextEventID,
 			Version:        lastItem.GetVersion(),
+			Priority:       enumsspb.TASK_PRIORITY_LOW,
 			TargetClusters: targetClusters,
 		})
 		activityIDs := make(map[int64]struct{}, len(r.mutableState.GetPendingActivityInfos()))
 		for activityID := range r.mutableState.GetPendingActivityInfos() {
 			activityIDs[activityID] = struct{}{}
 		}
-		taskEquivalents = append(taskEquivalents, convertSyncActivityInfos(
+		for _, syncActivityTask := range convertSyncActivityInfos(
 			now,
 			workflowKey,
 			r.mutableState.GetPendingActivityInfos(),
 			activityIDs,
 			targetClusters,
-		)...)
+		) {
+			syncActivityTask.(*tasks.SyncActivityTask).Priority = enumsspb.TASK_PRIORITY_LOW
+			taskEquivalents = append(taskEquivalents, syncActivityTask)
+		}
 		taskEquivalents = append(taskEquivalents, &tasks.SyncHSMTask{
 			WorkflowKey: workflowKey,
 			// TaskID and VisibilityTimestamp are set by shard
+			Priority:       enumsspb.TASK_PRIORITY_LOW,
 			TargetClusters: targetClusters,
 		})
 	}

--- a/service/history/workflow/task_generator_test.go
+++ b/service/history/workflow/task_generator_test.go
@@ -836,17 +836,38 @@ func TestTaskGeneratorImpl_GenerateMigrationTasks(t *testing.T) {
 				syncVersionTask, ok := resultTasks[0].(*tasks.SyncVersionedTransitionTask)
 				require.True(t, ok)
 				require.Equal(t, chasm.WorkflowArchetypeID, syncVersionTask.GetArchetypeID())
+				require.Equal(t, enumsspb.TASK_PRIORITY_LOW, syncVersionTask.Priority)
 				taskEquivalent := syncVersionTask.TaskEquivalents
 				require.Len(t, taskEquivalent, len(tc.expectedTaskEquivalentTypes))
 				for i, equivalent := range taskEquivalent {
 					require.Equal(t, tc.expectedTaskEquivalentTypes[i], equivalent.GetType())
+					requireLowReplicationPriority(t, equivalent)
 				}
 			} else {
 				for i, task := range resultTasks {
 					require.Equal(t, tc.expectedTaskTypes[i], task.GetType())
+					requireLowReplicationPriority(t, task)
 				}
 			}
 		})
+	}
+}
+
+func requireLowReplicationPriority(t *testing.T, task tasks.Task) {
+	t.Helper()
+	switch task := task.(type) {
+	case *tasks.SyncWorkflowStateTask:
+		require.Equal(t, enumsspb.TASK_PRIORITY_LOW, task.Priority)
+	case *tasks.SyncVersionedTransitionTask:
+		require.Equal(t, enumsspb.TASK_PRIORITY_LOW, task.Priority)
+	case *tasks.HistoryReplicationTask:
+		require.Equal(t, enumsspb.TASK_PRIORITY_LOW, task.Priority)
+	case *tasks.SyncActivityTask:
+		require.Equal(t, enumsspb.TASK_PRIORITY_LOW, task.Priority)
+	case *tasks.SyncHSMTask:
+		require.Equal(t, enumsspb.TASK_PRIORITY_LOW, task.Priority)
+	default:
+		require.Fail(t, "unexpected migration task type", "%T", task)
 	}
 }
 


### PR DESCRIPTION
## What changed?
Every task produced by `GenerateMigrationTasks` is now low priority end to end:

- Added a `Priority` field to `HistoryReplicationTask`, `SyncActivityTask` and `SyncHSMTask`.
- Round-tripped `Priority` through the replication task serializer for those three, plus `SyncVersionedTransitionTask` (its `Priority` field existed but was never persisted). The proto `ReplicationTaskInfo.Priority` field already existed, so no proto change.
- `StreamSenderImpl.getTaskPriority` now honors `Priority` on all five replication task types, defaulting to high when unspecified.
- `GenerateMigrationTasks` stamps `TASK_PRIORITY_LOW` on the `HistoryReplicationTask`, the sync activity tasks and the `SyncHSMTask` it returns (`SyncWorkflowStateTask` and `SyncVersionedTransitionTask` already set it).

## Why?
`GenerateMigrationTasks` is only reachable through force replication (`GenerateLastHistoryReplicationTasks`, called by the migration/force-replication workflow and by tdbg). That traffic is bulk backfill and should not compete with live replication. Only `SyncWorkflowStateTask` was actually being treated as low priority; everything else fell through to `TASK_PRIORITY_HIGH` in the stream sender, and `SyncVersionedTransitionTask`'s low priority was silently dropped on write.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)

`TestTaskGeneratorImpl_GenerateMigrationTasks` now asserts `TASK_PRIORITY_LOW` on every returned task and every task equivalent. `service/history/replication`, `common/persistence/serialization` and `service/history/tasks` pass.

Note: `service/history/workflow` has a pre-existing failure in `TestTaskRefresherSuite/TestRefreshSubStateMachineTasks` that reproduces on unmodified `main` at 39fc2c45e and is unrelated to this change.

## Potential risks
- `SyncVersionedTransitionTask.Priority` is now persisted where it was previously dropped. Tasks written before this change still deserialize with `TASK_PRIORITY_UNSPECIFIED`.
- `getTaskPriority` defaults to high on `UNSPECIFIED` for the newly-handled types, so normal (non-force) replication keeps its current priority. Only tasks explicitly stamped low move to the low priority stream.
- Force replication tasks now share the low priority stream and its rate limiting with sync-state traffic, so a large force replication may progress more slowly than before — which is the intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)