### PR TITLE
Clarify functionality; cleanup testcases

### DIFF
--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -6569,6 +6569,7 @@ func (wh *WorkflowHandler) checkWorkerDeploymentReadRateLimit(ctx context.Contex
 }
 
 // Returns the provited links, but filtering out any which are also present on the supplied callbacks.
+// Links from non-Nexus callbacks are not considered for deduping.
 func dedupLinksFromCallbacks(
 	links []*commonpb.Link,
 	callbacks []*commonpb.Callback,

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -6568,6 +6568,7 @@ func (wh *WorkflowHandler) checkWorkerDeploymentReadRateLimit(ctx context.Contex
 	return nil
 }
 
+// Returns the provited links, but filtering out any which are also present on the supplied callbacks.
 func dedupLinksFromCallbacks(
 	links []*commonpb.Link,
 	callbacks []*commonpb.Callback,
@@ -6575,7 +6576,6 @@ func dedupLinksFromCallbacks(
 	if len(links) == 0 {
 		return nil
 	}
-	var res []*commonpb.Link
 	callbacksLinks := make([]*commonpb.Link, 0, len(callbacks))
 	for _, cb := range callbacks {
 		if cb.GetNexus() != nil {
@@ -6583,6 +6583,8 @@ func dedupLinksFromCallbacks(
 			callbacksLinks = append(callbacksLinks, cb.GetLinks()...)
 		}
 	}
+
+	var res []*commonpb.Link
 	for _, link := range links {
 		isDup := false
 		for _, cbLink := range callbacksLinks {

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -6568,7 +6568,7 @@ func (wh *WorkflowHandler) checkWorkerDeploymentReadRateLimit(ctx context.Contex
 	return nil
 }
 
-// Returns the provited links, but filtering out any which are also present on the supplied callbacks.
+// Returns the provided links, but filtering out any which are also present on the supplied callbacks.
 // Links from non-Nexus callbacks are not considered for deduping.
 func dedupLinksFromCallbacks(
 	links []*commonpb.Link,

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -1143,9 +1143,7 @@ func (s *WorkflowHandlerSuite) TestStartWorkflowExecution_Failed_InvalidCallback
 		RequestId: uuid.NewString(),
 		CompletionCallbacks: []*commonpb.Callback{
 			{
-				Variant: &commonpb.Callback_Internal_{
-					Internal: &commonpb.Callback_Internal{},
-				},
+				Variant: nexusVariantCallback(),
 				Links: []*commonpb.Link{
 					{
 						Variant: &commonpb.Link_WorkflowEvent_{
@@ -1189,11 +1187,7 @@ func (s *WorkflowHandlerSuite) TestStartWorkflowExecution_Failed_InvalidAggregat
 		RequestId: uuid.NewString(),
 		CompletionCallbacks: []*commonpb.Callback{
 			{
-				Variant: &commonpb.Callback_Nexus_{
-					Nexus: &commonpb.Callback_Nexus{
-						Url: "http://localhost/test",
-					},
-				},
+				Variant: nexusVariantCallback(),
 				Links: []*commonpb.Link{
 					{
 						Variant: &commonpb.Link_WorkflowEvent_{
@@ -4469,87 +4463,36 @@ func TestDedupLinksFromCallbacks(t *testing.T) {
 	}
 	callbacks := []*commonpb.Callback{
 		{
-			Variant: &commonpb.Callback_Nexus_{
-				Nexus: &commonpb.Callback_Nexus{},
-			},
+			Variant: nexusVariantCallback(),
 			Links: []*commonpb.Link{
-				{
-					Variant: &commonpb.Link_WorkflowEvent_{
-						WorkflowEvent: &commonpb.Link_WorkflowEvent{
-							Namespace:  "test-ns",
-							WorkflowId: "test-workflow-id",
-							RunId:      "test-run-id",
-							Reference: &commonpb.Link_WorkflowEvent_EventRef{
-								EventRef: &commonpb.Link_WorkflowEvent_EventReference{
-									EventId:   3,
-									EventType: enumspb.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED,
-								},
-							},
-						},
-					},
-				},
-				{
-					Variant: &commonpb.Link_WorkflowEvent_{
-						WorkflowEvent: &commonpb.Link_WorkflowEvent{
-							Namespace:  "test-ns",
-							WorkflowId: "test-workflow-id",
-							RunId:      "test-run-id",
-							Reference: &commonpb.Link_WorkflowEvent_EventRef{
-								EventRef: &commonpb.Link_WorkflowEvent_EventReference{
-									EventId:   5,
-									EventType: enumspb.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED,
-								},
-							},
-						},
-					},
-				},
+				common.CloneProto(links[0]),
+				common.CloneProto(links[1]),
 			},
 		},
 		{
-			Variant: &commonpb.Callback_Internal_{
-				Internal: &commonpb.Callback_Internal{},
-			},
+			Variant: nexusVariantCallback(),
 			Links: []*commonpb.Link{
-				{
-					Variant: &commonpb.Link_WorkflowEvent_{
-						WorkflowEvent: &commonpb.Link_WorkflowEvent{
-							Namespace:  "test-ns",
-							WorkflowId: "test-workflow-id",
-							RunId:      "test-run-id",
-							Reference: &commonpb.Link_WorkflowEvent_RequestIdRef{
-								RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
-									RequestId: "test-request-id",
-									EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED,
-								},
-							},
-						},
-					},
-				},
+				common.CloneProto(links[2]),
 			},
 		},
 	}
 
+	// The two callbacks have all members of links attached to them.
+	// The result is an empty slice, because all links are duplicates.
 	dedupedLinks := dedupLinksFromCallbacks(links, callbacks)
+	assert.Len(t, dedupedLinks, 0)
+
+	// Remove one of the links from a callback. Retry, confirm
+	// the link will not be deduped.
+
+	// Remove links[1] from callbacks[0].Links.
+	protoassert.ProtoEqual(t, callbacks[0].Links[1], links[1])
+	callbacks[0].Links = callbacks[0].Links[:1]
+
+	// Confirm links[1] is no longer deduped.
+	dedupedLinks = dedupLinksFromCallbacks(links, callbacks)
 	assert.Len(t, dedupedLinks, 1)
-	protoassert.ProtoEqual(
-		t,
-		&commonpb.Link{
-			Variant: &commonpb.Link_WorkflowEvent_{
-				WorkflowEvent: &commonpb.Link_WorkflowEvent{
-					Namespace:  "test-ns",
-					WorkflowId: "test-workflow-id",
-					RunId:      "test-run-id",
-					Reference: &commonpb.Link_WorkflowEvent_RequestIdRef{
-						RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
-							RequestId: "test-request-id",
-							EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED,
-						},
-					},
-				},
-			},
-		},
-		dedupedLinks[0],
-	)
+	protoassert.ProtoEqual(t, links[1], dedupedLinks[0])
 }
 
 func (s *WorkflowHandlerSuite) Test_DeleteWorkflowExecution() {
@@ -5874,9 +5817,7 @@ func (s *WorkflowHandlerSuite) TestPrepareUpdateWorkflowRequest_ValidatesComplet
 			context.Background(),
 			s.testNamespace,
 			newRequest([]*commonpb.Callback{{
-				Variant: &commonpb.Callback_Internal_{
-					Internal: &commonpb.Callback_Internal{},
-				},
+				Variant: nexusVariantCallback(),
 				Links: []*commonpb.Link{{
 					Variant: &commonpb.Link_BatchJob_{
 						BatchJob: &commonpb.Link_BatchJob{},
@@ -5892,9 +5833,7 @@ func (s *WorkflowHandlerSuite) TestPrepareUpdateWorkflowRequest_ValidatesComplet
 
 	s.Run("rejects too many combined links", func() {
 		request := newRequest([]*commonpb.Callback{{
-			Variant: &commonpb.Callback_Internal_{
-				Internal: &commonpb.Callback_Internal{},
-			},
+			Variant: nexusVariantCallback(),
 			Links: []*commonpb.Link{{
 				Variant: &commonpb.Link_BatchJob_{
 					BatchJob: &commonpb.Link_BatchJob{JobId: "callback-job"},
@@ -5950,4 +5889,12 @@ type routingMatchingClient struct {
 
 func (r *routingMatchingClient) Route(p tqid.Partition) (string, error) {
 	return r.routeFn(p)
+}
+
+func nexusVariantCallback() *commonpb.Callback_Nexus_ {
+	return &commonpb.Callback_Nexus_{
+		Nexus: &commonpb.Callback_Nexus{
+			Url: "https://localhost/nexus-callback",
+		},
+	}
 }

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -1143,7 +1143,7 @@ func (s *WorkflowHandlerSuite) TestStartWorkflowExecution_Failed_InvalidCallback
 		RequestId: uuid.NewString(),
 		CompletionCallbacks: []*commonpb.Callback{
 			{
-				Variant: nexusVariantCallback(),
+				Variant: nexusCallbackVariant(),
 				Links: []*commonpb.Link{
 					{
 						Variant: &commonpb.Link_WorkflowEvent_{
@@ -1187,7 +1187,7 @@ func (s *WorkflowHandlerSuite) TestStartWorkflowExecution_Failed_InvalidAggregat
 		RequestId: uuid.NewString(),
 		CompletionCallbacks: []*commonpb.Callback{
 			{
-				Variant: nexusVariantCallback(),
+				Variant: nexusCallbackVariant(),
 				Links: []*commonpb.Link{
 					{
 						Variant: &commonpb.Link_WorkflowEvent_{
@@ -4461,38 +4461,59 @@ func TestDedupLinksFromCallbacks(t *testing.T) {
 			},
 		},
 	}
-	callbacks := []*commonpb.Callback{
-		{
-			Variant: nexusVariantCallback(),
-			Links: []*commonpb.Link{
-				common.CloneProto(links[0]),
-				common.CloneProto(links[1]),
+
+	// Returns a new pair of callbacks to be mutated in tests.
+	getCallbacks := func() []*commonpb.Callback {
+		return []*commonpb.Callback{
+			{
+				Variant: nexusCallbackVariant(),
+				Links: []*commonpb.Link{
+					common.CloneProto(links[0]),
+					common.CloneProto(links[1]),
+				},
 			},
-		},
-		{
-			Variant: nexusVariantCallback(),
-			Links: []*commonpb.Link{
-				common.CloneProto(links[2]),
+			{
+				Variant: &commonpb.Callback_Internal_{
+					Internal: &commonpb.Callback_Internal{},
+				},
+				Links: []*commonpb.Link{
+					common.CloneProto(links[2]),
+				},
 			},
-		},
+		}
 	}
 
-	// The two callbacks have all members of links attached to them.
-	// The result is an empty slice, because all links are duplicates.
-	dedupedLinks := dedupLinksFromCallbacks(links, callbacks)
-	assert.Len(t, dedupedLinks, 0)
+	// Because the second Callback is the Internal-variant, the link
+	// it carries will not be considered for deduping.
+	t.Run("IgnoreNonNexusCallbackLinks", func(t *testing.T) {
+		callbacks := getCallbacks()
+		dedupedLinks := dedupLinksFromCallbacks(links, callbacks)
+		require.Len(t, dedupedLinks, 1)
+		protoassert.ProtoEqual(t, dedupedLinks[0], links[2])
+	})
 
-	// Remove one of the links from a callback. Retry, confirm
-	// the link will not be deduped.
+	// Remove links[1] from callbacks[0].Links. links[1] should then not
+	// be deduped, and be in the resulting slice.
+	t.Run("UniqueNexusLink", func(t *testing.T) {
+		callbacks := getCallbacks()
+		callbacks[0].Links = callbacks[0].Links[:1]
 
-	// Remove links[1] from callbacks[0].Links.
-	protoassert.ProtoEqual(t, callbacks[0].Links[1], links[1])
-	callbacks[0].Links = callbacks[0].Links[:1]
+		dedupedLinks := dedupLinksFromCallbacks(links, callbacks)
+		require.Len(t, dedupedLinks, 2)
+		protoassert.ProtoEqual(t, dedupedLinks[0], links[1])
+		protoassert.ProtoEqual(t, dedupedLinks[1], links[2]) // Same as before.
+	})
 
-	// Confirm links[1] is no longer deduped.
-	dedupedLinks = dedupLinksFromCallbacks(links, callbacks)
-	assert.Len(t, dedupedLinks, 1)
-	protoassert.ProtoEqual(t, links[1], dedupedLinks[0])
+	// Change the type of the second callback to be a Nexus-variant.
+	// Now all callback links will be considered for deduping, filtering
+	// everything out.
+	t.Run("AllDupes", func(t *testing.T) {
+		callbacks := getCallbacks()
+		callbacks[1].Variant = nexusCallbackVariant()
+
+		dedupedLinks := dedupLinksFromCallbacks(links, callbacks)
+		require.Len(t, dedupedLinks, 0)
+	})
 }
 
 func (s *WorkflowHandlerSuite) Test_DeleteWorkflowExecution() {
@@ -5799,10 +5820,8 @@ func (s *WorkflowHandlerSuite) TestPrepareUpdateWorkflowRequest_ValidatesComplet
 			},
 		}
 		request := newRequest([]*commonpb.Callback{{
-			Variant: &commonpb.Callback_Nexus_{
-				Nexus: &commonpb.Callback_Nexus{Url: "http://localhost/callback"},
-			},
-			Links: []*commonpb.Link{callbackLink},
+			Variant: nexusCallbackVariant(),
+			Links:   []*commonpb.Link{callbackLink},
 		}})
 		request.Request.Links = []*commonpb.Link{common.CloneProto(callbackLink)}
 
@@ -5817,7 +5836,7 @@ func (s *WorkflowHandlerSuite) TestPrepareUpdateWorkflowRequest_ValidatesComplet
 			context.Background(),
 			s.testNamespace,
 			newRequest([]*commonpb.Callback{{
-				Variant: nexusVariantCallback(),
+				Variant: nexusCallbackVariant(),
 				Links: []*commonpb.Link{{
 					Variant: &commonpb.Link_BatchJob_{
 						BatchJob: &commonpb.Link_BatchJob{},
@@ -5833,7 +5852,7 @@ func (s *WorkflowHandlerSuite) TestPrepareUpdateWorkflowRequest_ValidatesComplet
 
 	s.Run("rejects too many combined links", func() {
 		request := newRequest([]*commonpb.Callback{{
-			Variant: nexusVariantCallback(),
+			Variant: nexusCallbackVariant(),
 			Links: []*commonpb.Link{{
 				Variant: &commonpb.Link_BatchJob_{
 					BatchJob: &commonpb.Link_BatchJob{JobId: "callback-job"},
@@ -5891,7 +5910,7 @@ func (r *routingMatchingClient) Route(p tqid.Partition) (string, error) {
 	return r.routeFn(p)
 }
 
-func nexusVariantCallback() *commonpb.Callback_Nexus_ {
+func nexusCallbackVariant() *commonpb.Callback_Nexus_ {
 	return &commonpb.Callback_Nexus_{
 		Nexus: &commonpb.Callback_Nexus{
 			Url: "https://localhost/nexus-callback",

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -66,7 +66,6 @@ import (
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.temporal.io/server/common/tasktoken"
-	"go.temporal.io/server/common/testing/protoassert"
 	"go.temporal.io/server/common/testing/protorequire"
 	"go.temporal.io/server/common/tqid"
 	"go.temporal.io/server/common/wideevents"
@@ -4489,7 +4488,7 @@ func TestDedupLinksFromCallbacks(t *testing.T) {
 		callbacks := getCallbacks()
 		dedupedLinks := dedupLinksFromCallbacks(links, callbacks)
 		require.Len(t, dedupedLinks, 1)
-		protoassert.ProtoEqual(t, dedupedLinks[0], links[2])
+		protorequire.ProtoEqual(t, dedupedLinks[0], links[2])
 	})
 
 	// Remove links[1] from callbacks[0].Links. links[1] should then not
@@ -4500,8 +4499,8 @@ func TestDedupLinksFromCallbacks(t *testing.T) {
 
 		dedupedLinks := dedupLinksFromCallbacks(links, callbacks)
 		require.Len(t, dedupedLinks, 2)
-		protoassert.ProtoEqual(t, dedupedLinks[0], links[1])
-		protoassert.ProtoEqual(t, dedupedLinks[1], links[2]) // Same as before.
+		protorequire.ProtoEqual(t, dedupedLinks[0], links[1])
+		protorequire.ProtoEqual(t, dedupedLinks[1], links[2]) // Same as before.
 	})
 
 	// Change the type of the second callback to be a Nexus-variant.
@@ -4512,7 +4511,7 @@ func TestDedupLinksFromCallbacks(t *testing.T) {
 		callbacks[1].Variant = nexusCallbackVariant()
 
 		dedupedLinks := dedupLinksFromCallbacks(links, callbacks)
-		require.Len(t, dedupedLinks, 0)
+		require.Empty(t, dedupedLinks)
 	})
 }
 

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -4488,7 +4488,7 @@ func TestDedupLinksFromCallbacks(t *testing.T) {
 		callbacks := getCallbacks()
 		dedupedLinks := dedupLinksFromCallbacks(links, callbacks)
 		require.Len(t, dedupedLinks, 1)
-		protorequire.ProtoEqual(t, dedupedLinks[0], links[2])
+		protorequire.ProtoEqual(t, links[2], dedupedLinks[0])
 	})
 
 	// Remove links[1] from callbacks[0].Links. links[1] should then not
@@ -4499,8 +4499,8 @@ func TestDedupLinksFromCallbacks(t *testing.T) {
 
 		dedupedLinks := dedupLinksFromCallbacks(links, callbacks)
 		require.Len(t, dedupedLinks, 2)
-		protorequire.ProtoEqual(t, dedupedLinks[0], links[1])
-		protorequire.ProtoEqual(t, dedupedLinks[1], links[2]) // Same as before.
+		protorequire.ProtoEqual(t, links[1], dedupedLinks[0])
+		protorequire.ProtoEqual(t, links[2], dedupedLinks[1]) // Same as before.
 	})
 
 	// Change the type of the second callback to be a Nexus-variant.


### PR DESCRIPTION
## What changed?

The `commonpb.Callback`-variant of `commonpb.Callback_Internal` is unused and should be removed entirely. This PR removes the remaining unnecessary instances of that type.

(My actual motivation is really to avoid a larger diff later, since introducing Worker-variant callbacks will start returning errors when you try to attach an `Internal`-variant callback.)

However, changing `Callback_Internal` to `Callback_Nexus` changed the behavior of `TestDedupLinksFromCallbacks`. After scratching my head for a while, I add a doc comment to clarify exactly what the function does, and then updated the tests to be easier to read and understand.

## Why?

The call to `dedupLinksFromCallbacks(...)` in the testcase did _not_ dedupe the links attached to `callbacks[0]` because it was the `commonpb.Callback_Internal` variant. (Relying on a quirk of the function only filtering callbacks from Nexus-variant callbacks.)

I kept that behavior in, but added a couple more test scenarios to provide better coverage and clarify the expected behavior.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

None.
