### PR TITLE
Treat missing Worker Deployment Version as deleted

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1631,6 +1631,7 @@ var (
 	WorkerDeploymentCreated                           = NewCounterDef("worker_deployment_created")
 	WorkerDeploymentVersionCreated                    = NewCounterDef("worker_deployment_version_created")
 	WorkerDeploymentVersionCreatedManagedByController = NewCounterDef("worker_deployment_version_created_managed_by_controller")
+	WorkerDeploymentVersionNotFoundDuringDelete       = NewCounterDef("worker_deployment_version_not_found_during_delete")
 	WorkerDeploymentVersionVisibilityQueryCount       = NewCounterDef("worker_deployment_version_visibility_query_count")
 	WorkerDeploymentVersioningOverrideCounter         = NewCounterDef("worker_deployment_versioning_override_count")
 	WorkerDeploymentVersioningOneTimeOverrideCounter  = NewCounterDef("worker_deployment_versioning_one_time_override_count")

--- a/service/worker/workerdeployment/activities.go
+++ b/service/worker/workerdeployment/activities.go
@@ -14,6 +14,7 @@ import (
 	"go.temporal.io/sdk/temporal"
 	deploymentspb "go.temporal.io/server/api/deployment/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/sdk"
 	"go.temporal.io/server/common/worker_versioning"
@@ -179,6 +180,10 @@ func (a *Activities) DeleteWorkerDeploymentVersion(ctx context.Context, args *de
 		// this update or when its history no longer exists. Allow the Deployment workflow
 		// to remove its stale reference.
 		if errors.As(err, &notFoundErr) {
+			metrics.WorkerDeploymentVersionNotFoundDuringDelete.With(a.MetricsHandler).Record(
+				1,
+				metrics.NamespaceTag(a.namespace.Name().String()),
+			)
 			activity.GetLogger(ctx).Warn(
 				"version workflow not found during deletion; allowing deployment workflow to remove stale reference",
 				"namespace", a.namespace.Name().String(),

--- a/service/worker/workerdeployment/activities.go
+++ b/service/worker/workerdeployment/activities.go
@@ -174,6 +174,10 @@ func (a *Activities) DeleteWorkerDeploymentVersion(ctx context.Context, args *de
 		},
 	)
 	if err != nil {
+		var notFoundErr *serviceerror.NotFound
+		if errors.As(err, &notFoundErr) {
+			return nil
+		}
 		return err
 	}
 

--- a/service/worker/workerdeployment/activities.go
+++ b/service/worker/workerdeployment/activities.go
@@ -175,7 +175,19 @@ func (a *Activities) DeleteWorkerDeploymentVersion(ctx context.Context, args *de
 	)
 	if err != nil {
 		var notFoundErr *serviceerror.NotFound
+		// History returns NotFound when the Version workflow is already closed without
+		// this update or when its history no longer exists. Allow the Deployment workflow
+		// to remove its stale reference.
 		if errors.As(err, &notFoundErr) {
+			activity.GetLogger(ctx).Warn(
+				"version workflow not found during deletion; allowing deployment workflow to remove stale reference",
+				"namespace", a.namespace.Name().String(),
+				"deploymentName", args.DeploymentName,
+				"version", args.Version,
+				"versionWorkflowID", workflowID,
+				"requestID", args.RequestId,
+				"error", err,
+			)
 			return nil
 		}
 		return err

--- a/service/worker/workerdeployment/activities_test.go
+++ b/service/worker/workerdeployment/activities_test.go
@@ -1,0 +1,70 @@
+package workerdeployment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/sdk/testsuite"
+	deploymentspb "go.temporal.io/server/api/deployment/v1"
+	"go.temporal.io/server/api/historyservicemock/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/testing/testvars"
+	"go.uber.org/mock/gomock"
+)
+
+func TestDeleteWorkerDeploymentVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		historyErr error
+		wantErr    bool
+	}{
+		{
+			name:       "version workflow not found",
+			historyErr: serviceerror.NewNotFound("version workflow not found"),
+		},
+		{
+			name:       "other history error",
+			historyErr: serviceerror.NewUnavailable("history unavailable"),
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			controller := gomock.NewController(t)
+			historyClient := historyservicemock.NewMockHistoryServiceClient(controller)
+			historyClient.EXPECT().
+				UpdateWorkflowExecution(gomock.Any(), gomock.Any()).
+				Return(nil, tt.historyErr)
+
+			tv := testvars.New(t)
+			activity := &Activities{
+				activityDeps: activityDeps{HistoryClient: historyClient},
+				namespace: namespace.NewLocalNamespaceForTest(
+					&persistencespb.NamespaceInfo{Id: tv.NamespaceID().String(), Name: tv.NamespaceName().String()},
+					nil,
+					"",
+				),
+			}
+			env := (&testsuite.WorkflowTestSuite{}).NewTestActivityEnvironment()
+			env.RegisterActivity(activity)
+
+			_, err := env.ExecuteActivity(activity.DeleteWorkerDeploymentVersion, &deploymentspb.DeleteVersionActivityArgs{
+				DeploymentName: tv.DeploymentSeries(),
+				Version:        tv.DeploymentVersionString(),
+				RequestId:      tv.RequestID(),
+			})
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/service/worker/workerdeployment/activities_test.go
+++ b/service/worker/workerdeployment/activities_test.go
@@ -9,6 +9,8 @@ import (
 	deploymentspb "go.temporal.io/server/api/deployment/v1"
 	"go.temporal.io/server/api/historyservicemock/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/metrics/metricstest"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/testing/testvars"
 	"go.uber.org/mock/gomock"
@@ -44,8 +46,14 @@ func TestDeleteWorkerDeploymentVersion(t *testing.T) {
 				Return(nil, tt.historyErr)
 
 			tv := testvars.New(t)
+			metricsHandler := metricstest.NewCaptureHandler()
+			capture := metricsHandler.StartCapture()
+			defer metricsHandler.StopCapture(capture)
 			activity := &Activities{
-				activityDeps: activityDeps{HistoryClient: historyClient},
+				activityDeps: activityDeps{
+					HistoryClient:  historyClient,
+					MetricsHandler: metricsHandler,
+				},
 				namespace: namespace.NewLocalNamespaceForTest(
 					&persistencespb.NamespaceInfo{Id: tv.NamespaceID().String(), Name: tv.NamespaceName().String()},
 					nil,
@@ -62,8 +70,14 @@ func TestDeleteWorkerDeploymentVersion(t *testing.T) {
 			})
 			if tt.wantErr {
 				require.Error(t, err)
+				require.Empty(t, capture.Snapshot()[metrics.WorkerDeploymentVersionNotFoundDuringDelete.Name()])
 			} else {
 				require.NoError(t, err)
+				recordings := capture.Snapshot()[metrics.WorkerDeploymentVersionNotFoundDuringDelete.Name()]
+				require.Len(t, recordings, 1)
+				require.Equal(t, int64(1), recordings[0].Value)
+				namespaceTag := metrics.NamespaceTag(tv.NamespaceName().String())
+				require.Equal(t, namespaceTag.Value, recordings[0].Tags[namespaceTag.Key])
 			}
 		})
 	}


### PR DESCRIPTION
## What

Treat `NotFound` from the Version workflow delete update as success, so the Deployment workflow can clean up its stale version reference.

## Why

When a Version workflow is already closed or its history is gone, the delete update returns `NotFound`, blocking the Deployment workflow from removing the reference. Fixes #11539.

## How did you test it?

Unit test covering the `NotFound` → success path and verifying other History errors still propagate.