### PR TITLE
dynamic partitioning: use probability of AddTask to root partition to estimate overall add task rate

### DIFF
--- a/client/matching/client.go
+++ b/client/matching/client.go
@@ -175,10 +175,11 @@ func (c *clientImpl) addActivityTask(
 	opts []grpc.CallOption,
 ) (*matchingservice.AddActivityTaskResponse, error) {
 	request = common.CloneProto(request)
-	client, err := c.pickClientForWrite(request.GetTaskQueue(), p, loadBalance, pc)
+	client, estimatedTasksAllPartitions, err := c.pickClientForWrite(request.GetTaskQueue(), p, loadBalance, pc)
 	if err != nil {
 		return nil, err
 	}
+	ctx = appendEstimatedTasksAllPartitions(ctx, estimatedTasksAllPartitions)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 
@@ -207,10 +208,11 @@ func (c *clientImpl) addWorkflowTask(
 	opts []grpc.CallOption,
 ) (*matchingservice.AddWorkflowTaskResponse, error) {
 	request = common.CloneProto(request)
-	client, err := c.pickClientForWrite(request.GetTaskQueue(), p, loadBalance, pc)
+	client, estimatedTasksAllPartitions, err := c.pickClientForWrite(request.GetTaskQueue(), p, loadBalance, pc)
 	if err != nil {
 		return nil, err
 	}
+	ctx = appendEstimatedTasksAllPartitions(ctx, estimatedTasksAllPartitions)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return client.AddWorkflowTask(ctx, request, opts...)
@@ -317,10 +319,11 @@ func (c *clientImpl) queryWorkflow(
 		ForwardInfo:      request.ForwardInfo,
 		Priority:         request.Priority,
 	}
-	client, err := c.pickClientForWrite(request.GetTaskQueue(), p, loadBalance, pc)
+	client, estimatedTasksAllPartitions, err := c.pickClientForWrite(request.GetTaskQueue(), p, loadBalance, pc)
 	if err != nil {
 		return nil, err
 	}
+	ctx = appendEstimatedTasksAllPartitions(ctx, estimatedTasksAllPartitions)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return client.QueryWorkflow(ctx, request, opts...)
@@ -355,10 +358,11 @@ func (c *clientImpl) dispatchNexusTask(
 		Request:     request.Request,
 		ForwardInfo: request.ForwardInfo,
 	}
-	client, err := c.pickClientForWrite(request.GetTaskQueue(), p, loadBalance, pc)
+	client, estimatedTasksAllPartitions, err := c.pickClientForWrite(request.GetTaskQueue(), p, loadBalance, pc)
 	if err != nil {
 		return nil, err
 	}
+	ctx = appendEstimatedTasksAllPartitions(ctx, estimatedTasksAllPartitions)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return client.DispatchNexusTask(ctx, request, opts...)
@@ -422,12 +426,14 @@ func (c *clientImpl) pickClientForWrite(
 	p tqid.Partition,
 	loadBalance bool,
 	pc PartitionCounts,
-) (matchingservice.MatchingServiceClient, error) {
+) (matchingservice.MatchingServiceClient, int, error) {
+	estimatedTasksAllPartitions := 0
 	if loadBalance {
-		p = c.loadBalancer.PickWritePartition(p.TaskQueue(), pc)
+		p, estimatedTasksAllPartitions = c.loadBalancer.PickWritePartition(p.TaskQueue(), pc)
 	}
 	proto.Name = p.RpcName()
-	return c.getClientForTaskQueuePartition(p)
+	client, err := c.getClientForTaskQueuePartition(p)
+	return client, estimatedTasksAllPartitions, err
 }
 
 // pickClientForRead mutates the given proto. Callers should copy the proto before if necessary.

--- a/client/matching/client.go
+++ b/client/matching/client.go
@@ -179,7 +179,7 @@ func (c *clientImpl) addActivityTask(
 	if err != nil {
 		return nil, err
 	}
-	ctx = appendEstimatedTasksAllPartitions(ctx, estimatedTasksAllPartitions, p.IsRoot())
+	ctx = appendEstimatedTasksAllPartitions(ctx, estimatedTasksAllPartitions)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 
@@ -212,7 +212,7 @@ func (c *clientImpl) addWorkflowTask(
 	if err != nil {
 		return nil, err
 	}
-	ctx = appendEstimatedTasksAllPartitions(ctx, estimatedTasksAllPartitions, p.IsRoot())
+	ctx = appendEstimatedTasksAllPartitions(ctx, estimatedTasksAllPartitions)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return client.AddWorkflowTask(ctx, request, opts...)
@@ -323,7 +323,7 @@ func (c *clientImpl) queryWorkflow(
 	if err != nil {
 		return nil, err
 	}
-	ctx = appendEstimatedTasksAllPartitions(ctx, estimatedTasksAllPartitions, p.IsRoot())
+	ctx = appendEstimatedTasksAllPartitions(ctx, estimatedTasksAllPartitions)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return client.QueryWorkflow(ctx, request, opts...)
@@ -362,7 +362,7 @@ func (c *clientImpl) dispatchNexusTask(
 	if err != nil {
 		return nil, err
 	}
-	ctx = appendEstimatedTasksAllPartitions(ctx, estimatedTasksAllPartitions, p.IsRoot())
+	ctx = appendEstimatedTasksAllPartitions(ctx, estimatedTasksAllPartitions)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return client.DispatchNexusTask(ctx, request, opts...)

--- a/client/matching/client.go
+++ b/client/matching/client.go
@@ -179,7 +179,7 @@ func (c *clientImpl) addActivityTask(
 	if err != nil {
 		return nil, err
 	}
-	ctx = appendEstimatedTasksAllPartitions(ctx, estimatedTasksAllPartitions)
+	ctx = appendEstimatedTasksAllPartitions(ctx, estimatedTasksAllPartitions, p.IsRoot())
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 
@@ -212,7 +212,7 @@ func (c *clientImpl) addWorkflowTask(
 	if err != nil {
 		return nil, err
 	}
-	ctx = appendEstimatedTasksAllPartitions(ctx, estimatedTasksAllPartitions)
+	ctx = appendEstimatedTasksAllPartitions(ctx, estimatedTasksAllPartitions, p.IsRoot())
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return client.AddWorkflowTask(ctx, request, opts...)
@@ -323,7 +323,7 @@ func (c *clientImpl) queryWorkflow(
 	if err != nil {
 		return nil, err
 	}
-	ctx = appendEstimatedTasksAllPartitions(ctx, estimatedTasksAllPartitions)
+	ctx = appendEstimatedTasksAllPartitions(ctx, estimatedTasksAllPartitions, p.IsRoot())
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return client.QueryWorkflow(ctx, request, opts...)
@@ -362,7 +362,7 @@ func (c *clientImpl) dispatchNexusTask(
 	if err != nil {
 		return nil, err
 	}
-	ctx = appendEstimatedTasksAllPartitions(ctx, estimatedTasksAllPartitions)
+	ctx = appendEstimatedTasksAllPartitions(ctx, estimatedTasksAllPartitions, p.IsRoot())
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return client.DispatchNexusTask(ctx, request, opts...)

--- a/client/matching/loadbalancer.go
+++ b/client/matching/loadbalancer.go
@@ -1,6 +1,7 @@
 package matching
 
 import (
+	"math"
 	"math/rand"
 	"sync"
 
@@ -18,13 +19,18 @@ import (
 // when another partition has encoded-greater-than-zero backlog. 2x feels like a good ratio.
 var readPartitionWeightFloor = number.DecodeCompact8(1)
 
+// Keep a small root sample for estimating total write rate when backlog-aware routing would
+// otherwise make the root probability too small.
+const writePartitionRootProbabilityFloor = 0.01
+
 type (
 	// LoadBalancer is the interface for implementers of
 	// component that distributes add/poll api calls across
 	// available task queue partitions when possible
 	LoadBalancer interface {
-		// PickWritePartition returns the task queue partition for adding
-		// an activity or workflow task. The input is the name of the
+		// PickWritePartition returns the task queue partition for adding an
+		// activity or workflow task and the estimated number of tasks added
+		// across all partitions per root task. The input is the name of the
 		// original task queue (with no partition info). When forwardedFrom
 		// is non-empty, this call is forwardedFrom from a child partition
 		// to a parent partition in which case, no load balancing should be
@@ -32,7 +38,7 @@ type (
 		PickWritePartition(
 			taskQueue *tqid.TaskQueue,
 			pc PartitionCounts,
-		) *tqid.NormalPartition
+		) (*tqid.NormalPartition, int)
 
 		// PickReadPartition returns the task queue partition to send a poller to.
 		// Input is name of the original task queue as specified by caller. When
@@ -86,14 +92,19 @@ func NewLoadBalancer(
 func (lb *defaultLoadBalancer) PickWritePartition(
 	taskQueue *tqid.TaskQueue,
 	pc PartitionCounts,
-) *tqid.NormalPartition {
+) (*tqid.NormalPartition, int) {
 	if n, ok := testhooks.Get(lb.testHooks, testhooks.MatchingLBForceWritePartition, namespace.ID(taskQueue.NamespaceId())); ok {
-		return taskQueue.NormalPartition(n)
+		partition := taskQueue.NormalPartition(n)
+		if partition.IsRoot() {
+			return partition, 1
+		}
+		// probability of reaching root is 0, so root can't know how many tasks were added overall
+		return partition, 0
 	}
 
 	nsName, err := lb.namespaceIDToName(namespace.ID(taskQueue.NamespaceId()))
 	if err != nil {
-		return taskQueue.RootPartition()
+		return taskQueue.RootPartition(), 1
 	}
 
 	var partitionCount int
@@ -103,11 +114,12 @@ func (lb *defaultLoadBalancer) PickWritePartition(
 		partitionCount = max(1, lb.nWritePartitions(nsName.String(), taskQueue.Name(), taskQueue.TaskType()))
 	}
 
-	return taskQueue.NormalPartition(pickWritePartitionByGap(
+	partitionID, estimatedTasksAllPartitions := pickWritePartitionByGap(
 		pc.BacklogCount,
 		partitionCount,
 		number.DecodeCompact8(pc.BacklogCap),
-	))
+	)
+	return taskQueue.NormalPartition(partitionID), estimatedTasksAllPartitions
 }
 
 // pickWritePartitionByGap picks a partition with probability proportional to how far its backlog
@@ -115,10 +127,14 @@ func (lb *defaultLoadBalancer) PickWritePartition(
 //   - every partition is at or above the backlogCap
 //   - backlogCap is 0
 //   - when backlog data is not available for all write partitions
-func pickWritePartitionByGap(counts []number.Compact8, partitionCount int, backlogCap int64) int {
+func pickWritePartitionByGap(
+	counts []number.Compact8,
+	partitionCount int,
+	backlogCap int64,
+) (partitionID int, estimatedTasksAllPartitions int) {
 	if backlogCap == 0 ||
 		len(counts) < partitionCount {
-		return rand.Intn(partitionCount)
+		return rand.Intn(partitionCount), partitionCount
 	}
 
 	var total int64
@@ -128,20 +144,34 @@ func pickWritePartitionByGap(counts []number.Compact8, partitionCount int, backl
 		}
 	}
 	if total <= 0 { // all partitions are at or above cap
-		return rand.Intn(partitionCount)
+		return rand.Intn(partitionCount), partitionCount
 	}
-	r := rand.Int63n(total)
-	for i := range partitionCount {
-		gap := backlogCap - number.DecodeCompact8(counts[i])
-		if gap <= 0 { // this partition is at or above cap
-			continue
+
+	// if rootProbability < 0.01, choose the root with p=0.01
+	rootGap := max(int64(0), backlogCap-number.DecodeCompact8(counts[0]))
+	rootProbability := float64(rootGap) / float64(total)
+	if rootProbability < writePartitionRootProbabilityFloor {
+		if rand.Float64() < writePartitionRootProbabilityFloor {
+			return 0, int(math.Round(1 / writePartitionRootProbabilityFloor))
 		}
+		// choose between non-root partitions according to gap from backlog cap
+		partitionID := pickPartitionByGap(counts[1:partitionCount], backlogCap, total-rootGap) + 1
+		return partitionID, int(math.Round(1 / writePartitionRootProbabilityFloor))
+	}
+
+	return pickPartitionByGap(counts[:partitionCount], backlogCap, total), int(math.Round(1 / rootProbability))
+}
+
+func pickPartitionByGap(counts []number.Compact8, backlogCap int64, total int64) int {
+	r := rand.Int63n(total)
+	for i, count := range counts {
+		gap := max(int64(0), backlogCap-number.DecodeCompact8(count))
 		if r < gap { // more likely to be true the bigger this partition's gap is
 			return i
 		}
 		r -= gap
 	}
-	return partitionCount - 1 // unreachable in practice; guard against compact8 rounding
+	return len(counts) - 1
 }
 
 // PickReadPartition picks a partition for poller to poll task from, and keeps load balanced between partitions.

--- a/client/matching/loadbalancer.go
+++ b/client/matching/loadbalancer.go
@@ -89,15 +89,6 @@ func (lb *defaultLoadBalancer) PickWritePartition(
 	taskQueue *tqid.TaskQueue,
 	pc PartitionCounts,
 ) (*tqid.NormalPartition, int) {
-	if n, ok := testhooks.Get(lb.testHooks, testhooks.MatchingLBForceWritePartition, namespace.ID(taskQueue.NamespaceId())); ok {
-		partition := taskQueue.NormalPartition(n)
-		if partition.IsRoot() {
-			return partition, 1
-		}
-		// probability of reaching root is 0, so root can't know how many tasks were added overall
-		return partition, 0
-	}
-
 	nsName, err := lb.namespaceIDToName(namespace.ID(taskQueue.NamespaceId()))
 	if err != nil {
 		return taskQueue.RootPartition(), 1
@@ -108,6 +99,14 @@ func (lb *defaultLoadBalancer) PickWritePartition(
 		partitionCount = int(pc.Write)
 	} else {
 		partitionCount = max(1, lb.nWritePartitions(nsName.String(), taskQueue.Name(), taskQueue.TaskType()))
+	}
+
+	if n, ok := testhooks.Get(lb.testHooks, testhooks.MatchingLBForceWritePartition, namespace.ID(taskQueue.NamespaceId())); ok {
+		partition := taskQueue.NormalPartition(n)
+		if partition.IsRoot() {
+			return partition, partitionCount
+		}
+		return partition, 0
 	}
 
 	partitionID, estimatedTasksAllPartitions := pickWritePartitionByGap(

--- a/client/matching/loadbalancer.go
+++ b/client/matching/loadbalancer.go
@@ -151,7 +151,7 @@ func pickWritePartitionByGap(
 	// we want to force p(root) >= writePartitionRootProbabilityFloor
 	// so, gap_root / total >= writePartitionRootProbabilityFloor
 	// => gap_root >= total * writePartitionRootProbabilityFloor
-	gap0 := max(backlogCap-count0, int64(float64(total)*writePartitionRootProbabilityFloor))
+	gap0 := max(backlogCap-count0, int64(math.Ceil(float64(total)*writePartitionRootProbabilityFloor)))
 	expectedRoot := float64(total) / float64(gap0)
 	return pickPartitionByGap(counts, gap0, backlogCap, total), randomRound(expectedRoot)
 }

--- a/client/matching/loadbalancer.go
+++ b/client/matching/loadbalancer.go
@@ -146,19 +146,14 @@ func pickWritePartitionByGap(
 		return rand.Intn(partitionCount), partitionCount
 	}
 
-	// if rootProbability < 0.01, choose the root with p=0.01
-	rootGap := max(int64(0), backlogCap-number.DecodeCompact8(counts[0]))
-	rootProbability := float64(rootGap) / float64(total)
-	if rootProbability < writePartitionRootProbabilityFloor {
-		if rand.Float64() < writePartitionRootProbabilityFloor {
-			return 0, int(math.Round(1 / writePartitionRootProbabilityFloor))
-		}
-		// choose between non-root partitions according to gap from backlog cap
-		partitionID := pickPartitionByGap(counts[1:partitionCount], backlogCap, total-rootGap) + 1
-		return partitionID, int(math.Round(1 / writePartitionRootProbabilityFloor))
-	}
-
-	return pickPartitionByGap(counts[:partitionCount], backlogCap, total), randomRound(1 / rootProbability)
+	count0 := number.DecodeCompact8(counts[0])
+	// p(root) = gap_root / total
+	// we want to force p(root) >= writePartitionRootProbabilityFloor
+	// so, gap_root / total >= writePartitionRootProbabilityFloor
+	// => gap_root >= total * writePartitionRootProbabilityFloor
+	gap0 := max(backlogCap-count0, int64(float64(total)*writePartitionRootProbabilityFloor))
+	expectedRoot := float64(total) / float64(gap0)
+	return pickPartitionByGap(counts, gap0, backlogCap, total), randomRound(expectedRoot)
 }
 
 // randomRound rounds without biasing the expected value.
@@ -170,10 +165,15 @@ func randomRound(x float64) int {
 	return int(n)
 }
 
-func pickPartitionByGap(counts []number.Compact8, backlogCap int64, total int64) int {
+func pickPartitionByGap(counts []number.Compact8, gap0, backlogCap, total int64) int {
 	r := rand.Int63n(total)
 	for i, count := range counts {
-		gap := max(int64(0), backlogCap-number.DecodeCompact8(count))
+		var gap int64
+		if i == 0 {
+			gap = gap0
+		} else {
+			gap = max(int64(0), backlogCap-number.DecodeCompact8(count))
+		}
 		if r < gap { // more likely to be true the bigger this partition's gap is
 			return i
 		}

--- a/client/matching/loadbalancer.go
+++ b/client/matching/loadbalancer.go
@@ -89,15 +89,14 @@ func (lb *defaultLoadBalancer) PickWritePartition(
 	taskQueue *tqid.TaskQueue,
 	pc PartitionCounts,
 ) (*tqid.NormalPartition, int) {
-	nsName, err := lb.namespaceIDToName(namespace.ID(taskQueue.NamespaceId()))
-	if err != nil {
-		return taskQueue.RootPartition(), 1
-	}
-
 	var partitionCount int
 	if pc.Write > 0 {
 		partitionCount = int(pc.Write)
 	} else {
+		nsName, err := lb.namespaceIDToName(namespace.ID(taskQueue.NamespaceId()))
+		if err != nil {
+			return taskQueue.RootPartition(), 1
+		}
 		partitionCount = max(1, lb.nWritePartitions(nsName.String(), taskQueue.Name(), taskQueue.TaskType()))
 	}
 

--- a/client/matching/loadbalancer.go
+++ b/client/matching/loadbalancer.go
@@ -31,18 +31,14 @@ type (
 		// PickWritePartition returns the task queue partition for adding an
 		// activity or workflow task and the estimated number of tasks added
 		// across all partitions per root task. The input is the name of the
-		// original task queue (with no partition info). When forwardedFrom
-		// is non-empty, this call is forwardedFrom from a child partition
-		// to a parent partition in which case, no load balancing should be
-		// performed
+		// original task queue (with no partition info).
 		PickWritePartition(
 			taskQueue *tqid.TaskQueue,
 			pc PartitionCounts,
 		) (*tqid.NormalPartition, int)
 
 		// PickReadPartition returns the task queue partition to send a poller to.
-		// Input is name of the original task queue as specified by caller. When
-		// forwardedFrom is non-empty, no load balancing should be done.
+		// Input is name of the original task queue as specified by caller.
 		PickReadPartition(
 			taskQueue *tqid.TaskQueue,
 			pc PartitionCounts,

--- a/client/matching/loadbalancer.go
+++ b/client/matching/loadbalancer.go
@@ -161,7 +161,16 @@ func pickWritePartitionByGap(
 		return partitionID, int(math.Round(1 / writePartitionRootProbabilityFloor))
 	}
 
-	return pickPartitionByGap(counts[:partitionCount], backlogCap, total), int(math.Round(1 / rootProbability))
+	return pickPartitionByGap(counts[:partitionCount], backlogCap, total), randomRound(1 / rootProbability)
+}
+
+// randomRound rounds without biasing the expected value.
+func randomRound(x float64) int {
+	n := math.Floor(x)
+	if rand.Float64() < x-n {
+		n++
+	}
+	return int(n)
 }
 
 func pickPartitionByGap(counts []number.Compact8, backlogCap int64, total int64) int {

--- a/client/matching/loadbalancer.go
+++ b/client/matching/loadbalancer.go
@@ -154,8 +154,10 @@ func pickWritePartitionByGap(
 	minRootGap := math.Ceil(float64(others) * writePartitionRootProbabilityFloor / (1 - writePartitionRootProbabilityFloor))
 	gap0 := max(backlogCap-count0, int64(minRootGap))
 	total = others + gap0
-	expectedRoot := float64(total) / float64(gap0)
-	return pickPartitionByGap(counts, gap0, backlogCap, total), randomRound(expectedRoot)
+	if partitionID := pickPartitionByGap(counts, gap0, backlogCap, total); partitionID != 0 {
+		return partitionID, 0
+	}
+	return 0, randomRound(float64(total) / float64(gap0))
 }
 
 // randomRound rounds without biasing the expected value.

--- a/client/matching/loadbalancer.go
+++ b/client/matching/loadbalancer.go
@@ -147,11 +147,13 @@ func pickWritePartitionByGap(
 	}
 
 	count0 := number.DecodeCompact8(counts[0])
-	// p(root) = gap_root / total
+	// p(root) = gap_root / (others + gap_root)
 	// we want to force p(root) >= writePartitionRootProbabilityFloor
-	// so, gap_root / total >= writePartitionRootProbabilityFloor
-	// => gap_root >= total * writePartitionRootProbabilityFloor
-	gap0 := max(backlogCap-count0, int64(math.Ceil(float64(total)*writePartitionRootProbabilityFloor)))
+	// => gap_root >= others * floor / (1 - floor)
+	others := total - max(int64(0), backlogCap-count0)
+	minRootGap := math.Ceil(float64(others) * writePartitionRootProbabilityFloor / (1 - writePartitionRootProbabilityFloor))
+	gap0 := max(backlogCap-count0, int64(minRootGap))
+	total = others + gap0
 	expectedRoot := float64(total) / float64(gap0)
 	return pickPartitionByGap(counts, gap0, backlogCap, total), randomRound(expectedRoot)
 }

--- a/client/matching/loadbalancer.go
+++ b/client/matching/loadbalancer.go
@@ -154,7 +154,7 @@ func pickWritePartitionByGap(
 	minRootGap := math.Ceil(float64(others) * writePartitionRootProbabilityFloor / (1 - writePartitionRootProbabilityFloor))
 	gap0 := max(backlogCap-count0, int64(minRootGap))
 	total = others + gap0
-	if partitionID := pickPartitionByGap(counts, gap0, backlogCap, total); partitionID != 0 {
+	if partitionID := pickPartitionByGap(counts[:partitionCount], gap0, backlogCap, total); partitionID != 0 {
 		return partitionID, 0
 	}
 	return 0, randomRound(float64(total) / float64(gap0))

--- a/client/matching/loadbalancer.go
+++ b/client/matching/loadbalancer.go
@@ -119,7 +119,9 @@ func (lb *defaultLoadBalancer) PickWritePartition(
 		partitionCount,
 		number.DecodeCompact8(pc.BacklogCap),
 	)
-	return taskQueue.NormalPartition(partitionID), estimatedTasksAllPartitions
+	partition := taskQueue.NormalPartition(partitionID)
+
+	return partition, estimatedTasksAllPartitions
 }
 
 // pickWritePartitionByGap picks a partition with probability proportional to how far its backlog

--- a/client/matching/loadbalancer.go
+++ b/client/matching/loadbalancer.go
@@ -120,6 +120,9 @@ func (lb *defaultLoadBalancer) PickWritePartition(
 		number.DecodeCompact8(pc.BacklogCap),
 	)
 	partition := taskQueue.NormalPartition(partitionID)
+	if !partition.IsRoot() {
+		estimatedTasksAllPartitions = 0
+	}
 
 	return partition, estimatedTasksAllPartitions
 }

--- a/client/matching/loadbalancer_test.go
+++ b/client/matching/loadbalancer_test.go
@@ -1,7 +1,6 @@
 package matching
 
 import (
-	"math"
 	"math/rand"
 	"sync"
 	"testing"
@@ -426,18 +425,24 @@ func TestPickWritePartition_RootProbabilityFloor(t *testing.T) {
 	}
 	const attempts = 100_000
 	rootPicks := 0
-	expectedProbability := writePartitionRootProbabilityFloor
-	expectedTasksAllPartitions := int(math.Round(1 / expectedProbability))
+	estimatedTasks := 0
+	backlogCap := number.DecodeCompact8(pc.BacklogCap)
+	total := backlogCap - number.DecodeCompact8(pc.BacklogCount[1])
+	gap0 := int64(float64(total) * writePartitionRootProbabilityFloor)
+	expectedProbability := float64(gap0) / float64(total)
+	expectedTasksAllPartitions := float64(total) / float64(gap0)
 	for range attempts {
 		partition, estimatedTasksAllPartitions := lb.PickWritePartition(taskQueue, pc)
 		if partition.IsRoot() {
 			rootPicks++
-			require.Equal(t, expectedTasksAllPartitions, estimatedTasksAllPartitions)
+			require.InDelta(t, expectedTasksAllPartitions, estimatedTasksAllPartitions, 1)
+			estimatedTasks += estimatedTasksAllPartitions
 		} else {
 			require.Zero(t, estimatedTasksAllPartitions)
 		}
 	}
 	require.InDelta(t, attempts*expectedProbability, rootPicks, attempts*expectedProbability*0.2)
+	require.InDelta(t, attempts, estimatedTasks, attempts*0.1)
 }
 
 func TestPickWritePartition_NoBacklogUniform(t *testing.T) {

--- a/client/matching/loadbalancer_test.go
+++ b/client/matching/loadbalancer_test.go
@@ -1,6 +1,7 @@
 package matching
 
 import (
+	"math"
 	"math/rand"
 	"sync"
 	"testing"
@@ -420,15 +421,15 @@ func TestPickWritePartition_RootProbabilityFloor(t *testing.T) {
 	pc := PartitionCounts{
 		Read:         2,
 		Write:        2,
-		BacklogCap:   number.EncodeCompact8(1000),
-		BacklogCount: []number.Compact8{number.EncodeCompact8(1000), 0},
+		BacklogCap:   number.EncodeCompact8(50),
+		BacklogCount: []number.Compact8{number.EncodeCompact8(50), 0},
 	}
 	const attempts = 100_000
 	rootPicks := 0
 	estimatedTasks := 0
 	backlogCap := number.DecodeCompact8(pc.BacklogCap)
 	total := backlogCap - number.DecodeCompact8(pc.BacklogCount[1])
-	gap0 := int64(float64(total) * writePartitionRootProbabilityFloor)
+	gap0 := int64(math.Ceil(float64(total) * writePartitionRootProbabilityFloor))
 	expectedProbability := float64(gap0) / float64(total)
 	expectedTasksAllPartitions := float64(total) / float64(gap0)
 	for range attempts {

--- a/client/matching/loadbalancer_test.go
+++ b/client/matching/loadbalancer_test.go
@@ -397,7 +397,11 @@ func TestPickWritePartition_BacklogAware(t *testing.T) {
 	for range n {
 		p, estimatedTasksAllPartitions := lb.PickWritePartition(taskQueue, pcAtCap)
 		atCap[p.PartitionId()]++
-		require.Equal(t, 2, estimatedTasksAllPartitions)
+		if p.IsRoot() {
+			require.Equal(t, 2, estimatedTasksAllPartitions)
+		} else {
+			require.Zero(t, estimatedTasksAllPartitions)
+		}
 	}
 	for i := range atCap {
 		require.InDelta(t, n/2, atCap[i], float64(n)*0.1, "at-cap partition %d roughly uniform", i)
@@ -427,8 +431,10 @@ func TestPickWritePartition_RootProbabilityFloor(t *testing.T) {
 		partition, estimatedTasksAllPartitions := lb.PickWritePartition(taskQueue, pc)
 		if partition.IsRoot() {
 			rootPicks++
+			require.Equal(t, expectedTasksAllPartitions, estimatedTasksAllPartitions)
+		} else {
+			require.Zero(t, estimatedTasksAllPartitions)
 		}
-		require.Equal(t, expectedTasksAllPartitions, estimatedTasksAllPartitions)
 	}
 	require.InDelta(t, attempts*expectedProbability, rootPicks, attempts*expectedProbability*0.2)
 }
@@ -450,7 +456,11 @@ func TestPickWritePartition_NoBacklogUniform(t *testing.T) {
 	for range n {
 		p, estimatedTasksAllPartitions := lb.PickWritePartition(taskQueue, pc)
 		counts[p.PartitionId()]++
-		require.Equal(t, 4, estimatedTasksAllPartitions)
+		if p.IsRoot() {
+			require.Equal(t, 4, estimatedTasksAllPartitions)
+		} else {
+			require.Zero(t, estimatedTasksAllPartitions)
+		}
 	}
 	for i := range counts {
 		require.InDelta(t, n/4, counts[i], float64(n)*0.1, "partition %d roughly uniform", i)

--- a/client/matching/loadbalancer_test.go
+++ b/client/matching/loadbalancer_test.go
@@ -346,6 +346,42 @@ func TestPickReadPartition_IncompleteBacklogFallsBack(t *testing.T) {
 	require.Equal(t, []int{2, 2, 2, 2}, tqlb.pollerCounts)
 }
 
+func TestPickWritePartitionRootFloorPreservesNonRootWeights(t *testing.T) {
+	f, err := tqid.NewTaskQueueFamily("fake-namespace-id", "fake-taskqueue")
+	require.NoError(t, err)
+	taskQueue := f.TaskQueue(enumspb.TASK_QUEUE_TYPE_ACTIVITY)
+	lb := &defaultLoadBalancer{}
+
+	const partitionCount = 32
+	backlogCap := number.EncodeCompact8(1000)
+	backlogCounts := make([]number.Compact8, partitionCount)
+	backlogCounts[0] = backlogCap
+	backlogCounts[partitionCount-1] = number.EncodeCompact8(number.DecodeCompact8(backlogCap) - 100)
+	pc := PartitionCounts{
+		Write:        partitionCount,
+		BacklogCap:   backlogCap,
+		BacklogCount: backlogCounts,
+	}
+
+	decodedCap := number.DecodeCompact8(backlogCap)
+	lastGap := decodedCap - number.DecodeCompact8(backlogCounts[partitionCount-1])
+	nonRootTotal := int64(partitionCount-2)*decodedCap + lastGap
+	rootGap := int64(math.Ceil(float64(nonRootTotal) * writePartitionRootProbabilityFloor /
+		(1 - writePartitionRootProbabilityFloor)))
+	require.Less(t, lastGap, rootGap)
+
+	const attempts = 100_000
+	picks := 0
+	for range attempts {
+		partition, _ := lb.PickWritePartition(taskQueue, pc)
+		if partition.PartitionId() == partitionCount-1 {
+			picks++
+		}
+	}
+	expectedPicks := float64(attempts) * float64(lastGap) / float64(nonRootTotal+rootGap)
+	require.InDelta(t, expectedPicks, picks, expectedPicks*0.3)
+}
+
 func TestPickWritePartition_BacklogAware(t *testing.T) {
 	f, err := tqid.NewTaskQueueFamily("fake-namespace-id", "fake-taskqueue")
 	require.NoError(t, err)

--- a/client/matching/loadbalancer_test.go
+++ b/client/matching/loadbalancer_test.go
@@ -369,16 +369,21 @@ func TestPickWritePartition_BacklogAware(t *testing.T) {
 	gap0 := backlogCap - number.DecodeCompact8(0)
 	gap1 := backlogCap - number.DecodeCompact8(number.EncodeCompact8(13_000_000))
 	counts := make([]int, 2)
+	estimatedTasks := 0
 	const n = 3000
 	for range n {
 		p, estimatedTasksAllPartitions := lb.PickWritePartition(taskQueue, pc)
 		counts[p.PartitionId()]++
-		require.Equal(t, int(math.Round(float64(gap0+gap1)/float64(gap0))), estimatedTasksAllPartitions)
+		if p.IsRoot() {
+			estimatedTasks += estimatedTasksAllPartitions
+		}
 	}
 	require.Greater(t, counts[0], counts[1], "emptier partition should receive more writes")
 	require.Positive(t, counts[1], "the below-cap partition should still receive some writes")
 	require.InDelta(t, float64(n)*float64(gap0)/float64(gap0+gap1), counts[0], float64(n)*0.05,
 		"writes split in proportion to each partition's gap to cap")
+	require.InDelta(t, n, estimatedTasks, float64(n)*0.05,
+		"root samples should estimate total writes without bias")
 
 	// Now, every partition at/above cap -> no gap to weight by, so the picker declines and the caller
 	// falls back to uniform random.

--- a/client/matching/loadbalancer_test.go
+++ b/client/matching/loadbalancer_test.go
@@ -1,6 +1,7 @@
 package matching
 
 import (
+	"math"
 	"math/rand"
 	"sync"
 	"testing"
@@ -365,16 +366,17 @@ func TestPickWritePartition_BacklogAware(t *testing.T) {
 		BacklogCap:   200,
 		BacklogCount: []number.Compact8{0, number.EncodeCompact8(13_000_000)},
 	}
+	gap0 := backlogCap - number.DecodeCompact8(0)
+	gap1 := backlogCap - number.DecodeCompact8(number.EncodeCompact8(13_000_000))
 	counts := make([]int, 2)
 	const n = 3000
 	for range n {
-		p := lb.PickWritePartition(taskQueue, pc)
+		p, estimatedTasksAllPartitions := lb.PickWritePartition(taskQueue, pc)
 		counts[p.PartitionId()]++
+		require.Equal(t, int(math.Round(float64(gap0+gap1)/float64(gap0))), estimatedTasksAllPartitions)
 	}
 	require.Greater(t, counts[0], counts[1], "emptier partition should receive more writes")
 	require.Positive(t, counts[1], "the below-cap partition should still receive some writes")
-	gap0 := backlogCap - number.DecodeCompact8(0)
-	gap1 := backlogCap - number.DecodeCompact8(number.EncodeCompact8(13_000_000))
 	require.InDelta(t, float64(n)*float64(gap0)/float64(gap0+gap1), counts[0], float64(n)*0.05,
 		"writes split in proportion to each partition's gap to cap")
 
@@ -388,12 +390,42 @@ func TestPickWritePartition_BacklogAware(t *testing.T) {
 	}
 	atCap := make([]int, 2)
 	for range n {
-		p := lb.PickWritePartition(taskQueue, pcAtCap)
+		p, estimatedTasksAllPartitions := lb.PickWritePartition(taskQueue, pcAtCap)
 		atCap[p.PartitionId()]++
+		require.Equal(t, 2, estimatedTasksAllPartitions)
 	}
 	for i := range atCap {
 		require.InDelta(t, n/2, atCap[i], float64(n)*0.1, "at-cap partition %d roughly uniform", i)
 	}
+}
+
+func TestPickWritePartition_RootProbabilityFloor(t *testing.T) {
+	f, err := tqid.NewTaskQueueFamily("fake-namespace-id", "fake-taskqueue")
+	require.NoError(t, err)
+	taskQueue := f.TaskQueue(enumspb.TASK_QUEUE_TYPE_ACTIVITY)
+	lb := &defaultLoadBalancer{
+		namespaceIDToName: func(namespace.ID) (namespace.Name, error) { return "fake-namespace", nil },
+		taskQueueLBs:      make(map[tqid.TaskQueue]*tqLoadBalancer),
+	}
+
+	pc := PartitionCounts{
+		Read:         2,
+		Write:        2,
+		BacklogCap:   number.EncodeCompact8(1000),
+		BacklogCount: []number.Compact8{number.EncodeCompact8(1000), 0},
+	}
+	const attempts = 100_000
+	rootPicks := 0
+	expectedProbability := writePartitionRootProbabilityFloor
+	expectedTasksAllPartitions := int(math.Round(1 / expectedProbability))
+	for range attempts {
+		partition, estimatedTasksAllPartitions := lb.PickWritePartition(taskQueue, pc)
+		if partition.IsRoot() {
+			rootPicks++
+		}
+		require.Equal(t, expectedTasksAllPartitions, estimatedTasksAllPartitions)
+	}
+	require.InDelta(t, attempts*expectedProbability, rootPicks, attempts*expectedProbability*0.2)
 }
 
 func TestPickWritePartition_NoBacklogUniform(t *testing.T) {
@@ -411,8 +443,9 @@ func TestPickWritePartition_NoBacklogUniform(t *testing.T) {
 	counts := make([]int, 4)
 	const n = 4000
 	for range n {
-		p := lb.PickWritePartition(taskQueue, pc)
+		p, estimatedTasksAllPartitions := lb.PickWritePartition(taskQueue, pc)
 		counts[p.PartitionId()]++
+		require.Equal(t, 4, estimatedTasksAllPartitions)
 	}
 	for i := range counts {
 		require.InDelta(t, n/4, counts[i], float64(n)*0.1, "partition %d roughly uniform", i)

--- a/client/matching/loadbalancer_test.go
+++ b/client/matching/loadbalancer_test.go
@@ -11,6 +11,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/number"
+	"go.temporal.io/server/common/testing/testhooks"
 	"go.temporal.io/server/common/tqid"
 )
 
@@ -464,6 +465,27 @@ func TestPickWritePartition_NoBacklogUniform(t *testing.T) {
 	}
 	for i := range counts {
 		require.InDelta(t, n/4, counts[i], float64(n)*0.1, "partition %d roughly uniform", i)
+	}
+}
+
+func TestPickWritePartition_Forced(t *testing.T) {
+	f, err := tqid.NewTaskQueueFamily("fake-namespace-id", "fake-taskqueue")
+	require.NoError(t, err)
+	taskQueue := f.TaskQueue(enumspb.TASK_QUEUE_TYPE_ACTIVITY)
+	testHooks := testhooks.NewTestHooks()
+	lb := &defaultLoadBalancer{
+		namespaceIDToName: func(namespace.ID) (namespace.Name, error) { return "fake-namespace", nil },
+		testHooks:         testHooks,
+	}
+	pc := PartitionCounts{Write: 4}
+
+	for partitionID, expectedEstimate := range map[int]int{0: 4, 1: 0} {
+		cleanup := testhooks.Set(testHooks, testhooks.MatchingLBForceWritePartition, partitionID, namespace.ID(taskQueue.NamespaceId()))
+		partition, estimatedTasksAllPartitions := lb.PickWritePartition(taskQueue, pc)
+		cleanup()
+
+		require.Equal(t, partitionID, partition.PartitionId())
+		require.Equal(t, expectedEstimate, estimatedTasksAllPartitions)
 	}
 }
 

--- a/client/matching/partition_counts.go
+++ b/client/matching/partition_counts.go
@@ -100,18 +100,17 @@ func appendEstimatedTasksAllPartitions(ctx context.Context, estimatedTasksAllPar
 	if estimatedTasksAllPartitions <= 0 {
 		return ctx
 	}
-	b := make([]byte, 8)
-	binary.LittleEndian.PutUint64(b, uint64(estimatedTasksAllPartitions))
+	b := binary.AppendUvarint(nil, uint64(estimatedTasksAllPartitions))
 	return metadata.AppendToOutgoingContext(ctx, estimatedTasksAllPartitionsHeaderName, string(b))
 }
 
 func ParseEstimatedTasksAllPartitions(ctx context.Context) int {
 	vals := metadata.ValueFromIncomingContext(ctx, estimatedTasksAllPartitionsHeaderName)
-	if len(vals) == 0 || len(vals[0]) != 8 {
+	if len(vals) == 0 {
 		return 0
 	}
-	estimatedTasksAllPartitions := binary.LittleEndian.Uint64([]byte(vals[0]))
-	if estimatedTasksAllPartitions == 0 || estimatedTasksAllPartitions > uint64(^uint(0)>>1) {
+	estimatedTasksAllPartitions, n := binary.Uvarint([]byte(vals[0]))
+	if n <= 0 || n != len(vals[0]) || estimatedTasksAllPartitions == 0 || estimatedTasksAllPartitions > uint64(^uint(0)>>1) {
 		return 0
 	}
 	return int(estimatedTasksAllPartitions)

--- a/client/matching/partition_counts.go
+++ b/client/matching/partition_counts.go
@@ -96,8 +96,8 @@ func ParsePartitionCountsFromIncomingContext(ctx context.Context) (PartitionCoun
 	return parsePartitionCounts(vals[0])
 }
 
-func appendEstimatedTasksAllPartitions(ctx context.Context, estimatedTasksAllPartitions int, isRoot bool) context.Context {
-	if estimatedTasksAllPartitions <= 0 || !isRoot {
+func appendEstimatedTasksAllPartitions(ctx context.Context, estimatedTasksAllPartitions int) context.Context {
+	if estimatedTasksAllPartitions <= 0 {
 		return ctx
 	}
 	b := make([]byte, 8)

--- a/client/matching/partition_counts.go
+++ b/client/matching/partition_counts.go
@@ -3,6 +3,7 @@ package matching
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"slices"
 
@@ -20,6 +21,7 @@ import (
 // The "-bin" suffix instructs grpc to base64-encode the value, so we can use binary.
 const partitionCountsHeaderName = "pcnt-bin"
 const partitionCountsTrailerName = "pcnt-bin"
+const estimatedTasksAllPartitionsHeaderName = "etap-bin"
 
 // PartitionCounts is a smaller version of taskqueuespb.ClientPartitionCounts that we can more
 // easily pass around and put in a map.
@@ -92,6 +94,24 @@ func ParsePartitionCountsFromIncomingContext(ctx context.Context) (PartitionCoun
 		return PartitionCounts{}, nil
 	}
 	return parsePartitionCounts(vals[0])
+}
+
+func appendEstimatedTasksAllPartitions(ctx context.Context, estimatedTasksAllPartitions int) context.Context {
+	b := make([]byte, 8)
+	binary.LittleEndian.PutUint64(b, uint64(estimatedTasksAllPartitions))
+	return metadata.AppendToOutgoingContext(ctx, estimatedTasksAllPartitionsHeaderName, string(b))
+}
+
+func ParseEstimatedTasksAllPartitions(ctx context.Context) int {
+	vals := metadata.ValueFromIncomingContext(ctx, estimatedTasksAllPartitionsHeaderName)
+	if len(vals) == 0 || len(vals[0]) != 8 {
+		return 0
+	}
+	estimatedTasksAllPartitions := binary.LittleEndian.Uint64([]byte(vals[0]))
+	if estimatedTasksAllPartitions == 0 || estimatedTasksAllPartitions > uint64(^uint(0)>>1) {
+		return 0
+	}
+	return int(estimatedTasksAllPartitions)
 }
 
 func parsePartitionCountsFromTrailer(trailer metadata.MD) (PartitionCounts, error) {

--- a/client/matching/partition_counts.go
+++ b/client/matching/partition_counts.go
@@ -96,7 +96,10 @@ func ParsePartitionCountsFromIncomingContext(ctx context.Context) (PartitionCoun
 	return parsePartitionCounts(vals[0])
 }
 
-func appendEstimatedTasksAllPartitions(ctx context.Context, estimatedTasksAllPartitions int) context.Context {
+func appendEstimatedTasksAllPartitions(ctx context.Context, estimatedTasksAllPartitions int, isRoot bool) context.Context {
+	if estimatedTasksAllPartitions <= 0 || !isRoot {
+		return ctx
+	}
 	b := make([]byte, 8)
 	binary.LittleEndian.PutUint64(b, uint64(estimatedTasksAllPartitions))
 	return metadata.AppendToOutgoingContext(ctx, estimatedTasksAllPartitionsHeaderName, string(b))

--- a/client/matching/partition_counts.go
+++ b/client/matching/partition_counts.go
@@ -3,9 +3,9 @@ package matching
 import (
 	"bytes"
 	"context"
-	"encoding/binary"
 	"errors"
 	"slices"
+	"strconv"
 
 	taskqueuespb "go.temporal.io/server/api/taskqueue/v1"
 	"go.temporal.io/server/common/log"
@@ -21,7 +21,7 @@ import (
 // The "-bin" suffix instructs grpc to base64-encode the value, so we can use binary.
 const partitionCountsHeaderName = "pcnt-bin"
 const partitionCountsTrailerName = "pcnt-bin"
-const estimatedTasksAllPartitionsHeaderName = "etap-bin"
+const estimatedTasksAllPartitionsHeaderName = "etap"
 
 // PartitionCounts is a smaller version of taskqueuespb.ClientPartitionCounts that we can more
 // easily pass around and put in a map.
@@ -100,8 +100,7 @@ func appendEstimatedTasksAllPartitions(ctx context.Context, estimatedTasksAllPar
 	if estimatedTasksAllPartitions <= 0 {
 		return ctx
 	}
-	b := binary.AppendUvarint(nil, uint64(estimatedTasksAllPartitions))
-	return metadata.AppendToOutgoingContext(ctx, estimatedTasksAllPartitionsHeaderName, string(b))
+	return metadata.AppendToOutgoingContext(ctx, estimatedTasksAllPartitionsHeaderName, strconv.Itoa(estimatedTasksAllPartitions))
 }
 
 func ParseEstimatedTasksAllPartitions(ctx context.Context) int {
@@ -109,11 +108,11 @@ func ParseEstimatedTasksAllPartitions(ctx context.Context) int {
 	if len(vals) == 0 {
 		return 0
 	}
-	estimatedTasksAllPartitions, n := binary.Uvarint([]byte(vals[0]))
-	if n <= 0 || n != len(vals[0]) || estimatedTasksAllPartitions == 0 || estimatedTasksAllPartitions > uint64(^uint(0)>>1) {
+	estimatedTasksAllPartitions, err := strconv.Atoi(vals[0])
+	if err != nil || estimatedTasksAllPartitions <= 0 {
 		return 0
 	}
-	return int(estimatedTasksAllPartitions)
+	return estimatedTasksAllPartitions
 }
 
 func parsePartitionCountsFromTrailer(trailer metadata.MD) (PartitionCounts, error) {

--- a/client/matching/partition_counts_test.go
+++ b/client/matching/partition_counts_test.go
@@ -15,6 +15,24 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
+func TestEstimatedTasksAllPartitionsMetadata(t *testing.T) {
+	for _, estimatedTasksAllPartitions := range []int{1, 2, 100, 102} {
+		outgoingCtx := appendEstimatedTasksAllPartitions(context.Background(), estimatedTasksAllPartitions)
+		md, ok := metadata.FromOutgoingContext(outgoingCtx)
+		require.True(t, ok)
+		incomingCtx := metadata.NewIncomingContext(context.Background(), md)
+		require.Equal(t, estimatedTasksAllPartitions, ParseEstimatedTasksAllPartitions(incomingCtx))
+	}
+
+	for _, estimatedTasksAllPartitions := range []int{0, -1} {
+		outgoingCtx := appendEstimatedTasksAllPartitions(context.Background(), estimatedTasksAllPartitions)
+		md, ok := metadata.FromOutgoingContext(outgoingCtx)
+		require.True(t, ok)
+		incomingCtx := metadata.NewIncomingContext(context.Background(), md)
+		require.Zero(t, ParseEstimatedTasksAllPartitions(incomingCtx))
+	}
+}
+
 // setTrailerInOpts finds the grpc.TrailerCallOption in opts and populates it.
 func setTrailerInOpts(opts []grpc.CallOption, pc PartitionCounts) {
 	v, _ := pc.encode(true) // trailer path (server -> client) includes backlog info

--- a/client/matching/partition_counts_test.go
+++ b/client/matching/partition_counts_test.go
@@ -15,24 +15,6 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-func TestEstimatedTasksAllPartitionsMetadata(t *testing.T) {
-	for _, estimatedTasksAllPartitions := range []int{1, 2, 100, 102} {
-		outgoingCtx := appendEstimatedTasksAllPartitions(context.Background(), estimatedTasksAllPartitions)
-		md, ok := metadata.FromOutgoingContext(outgoingCtx)
-		require.True(t, ok)
-		incomingCtx := metadata.NewIncomingContext(context.Background(), md)
-		require.Equal(t, estimatedTasksAllPartitions, ParseEstimatedTasksAllPartitions(incomingCtx))
-	}
-
-	for _, estimatedTasksAllPartitions := range []int{0, -1} {
-		outgoingCtx := appendEstimatedTasksAllPartitions(context.Background(), estimatedTasksAllPartitions)
-		md, ok := metadata.FromOutgoingContext(outgoingCtx)
-		require.False(t, ok)
-		incomingCtx := metadata.NewIncomingContext(context.Background(), md)
-		require.Zero(t, ParseEstimatedTasksAllPartitions(incomingCtx))
-	}
-}
-
 // setTrailerInOpts finds the grpc.TrailerCallOption in opts and populates it.
 func setTrailerInOpts(opts []grpc.CallOption, pc PartitionCounts) {
 	v, _ := pc.encode(true) // trailer path (server -> client) includes backlog info

--- a/client/matching/partition_counts_test.go
+++ b/client/matching/partition_counts_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestEstimatedTasksAllPartitionsMetadata(t *testing.T) {
 	for _, estimatedTasksAllPartitions := range []int{1, 2, 100, 102} {
-		outgoingCtx := appendEstimatedTasksAllPartitions(context.Background(), estimatedTasksAllPartitions)
+		outgoingCtx := appendEstimatedTasksAllPartitions(context.Background(), estimatedTasksAllPartitions, true)
 		md, ok := metadata.FromOutgoingContext(outgoingCtx)
 		require.True(t, ok)
 		incomingCtx := metadata.NewIncomingContext(context.Background(), md)
@@ -25,9 +25,9 @@ func TestEstimatedTasksAllPartitionsMetadata(t *testing.T) {
 	}
 
 	for _, estimatedTasksAllPartitions := range []int{0, -1} {
-		outgoingCtx := appendEstimatedTasksAllPartitions(context.Background(), estimatedTasksAllPartitions)
+		outgoingCtx := appendEstimatedTasksAllPartitions(context.Background(), estimatedTasksAllPartitions, true)
 		md, ok := metadata.FromOutgoingContext(outgoingCtx)
-		require.True(t, ok)
+		require.False(t, ok)
 		incomingCtx := metadata.NewIncomingContext(context.Background(), md)
 		require.Zero(t, ParseEstimatedTasksAllPartitions(incomingCtx))
 	}

--- a/client/matching/partition_counts_test.go
+++ b/client/matching/partition_counts_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestEstimatedTasksAllPartitionsMetadata(t *testing.T) {
 	for _, estimatedTasksAllPartitions := range []int{1, 2, 100, 102} {
-		outgoingCtx := appendEstimatedTasksAllPartitions(context.Background(), estimatedTasksAllPartitions, true)
+		outgoingCtx := appendEstimatedTasksAllPartitions(context.Background(), estimatedTasksAllPartitions)
 		md, ok := metadata.FromOutgoingContext(outgoingCtx)
 		require.True(t, ok)
 		incomingCtx := metadata.NewIncomingContext(context.Background(), md)
@@ -25,7 +25,7 @@ func TestEstimatedTasksAllPartitionsMetadata(t *testing.T) {
 	}
 
 	for _, estimatedTasksAllPartitions := range []int{0, -1} {
-		outgoingCtx := appendEstimatedTasksAllPartitions(context.Background(), estimatedTasksAllPartitions, true)
+		outgoingCtx := appendEstimatedTasksAllPartitions(context.Background(), estimatedTasksAllPartitions)
 		md, ok := metadata.FromOutgoingContext(outgoingCtx)
 		require.False(t, ok)
 		incomingCtx := metadata.NewIncomingContext(context.Background(), md)

--- a/service/matching/partition_scaler_interface.go
+++ b/service/matching/partition_scaler_interface.go
@@ -38,7 +38,7 @@ type PartitionScaler interface {
 }
 
 type PartitionScalerInput struct {
-	NumTasks      int // new tasks added since last call
+	NumTasks      int // estimated tasks added since last call
 	CurrentTarget int
 	BacklogCounts []byte
 	PrivateState  *anypb.Any

--- a/service/matching/scale_manager.go
+++ b/service/matching/scale_manager.go
@@ -55,7 +55,9 @@ type scaleManager struct {
 	nextShadowLog    time.Time
 	prevShadowTarget int32
 
-	currentTarget atomic.Int32
+	// store separately from scaleState to avoid data race
+	currentWrite atomic.Int32
+
 	// batch counts estimated tasks across all partitions in between calls to the scaler
 	batch  atomic.Int64
 	wakeup chan struct{}
@@ -120,7 +122,7 @@ func (sm *scaleManager) Start(scaleState *persistencespb.PartitionScaleState, sc
 }
 
 func (sm *scaleManager) getLatestWritePartitions() int32 {
-	if n := sm.currentTarget.Load(); n > 0 {
+	if n := sm.currentWrite.Load(); n > 0 {
 		return n
 	}
 	return int32(sm.getWritePartitions())
@@ -308,9 +310,9 @@ func (sm *scaleManager) setState(newState *persistencespb.PartitionScaleState, s
 	prevInfo := scaleStateToInfo(sm.scaleState, settings)
 
 	sm.scaleState = newState
-	sm.currentTarget.Store(newState.GetTarget())
 
 	newInfo := scaleStateToInfo(sm.scaleState, settings)
+	sm.currentWrite.Store(newInfo.GetWrite())
 
 	// only push ephemeral data if _info_ changed, not on any state change
 	if !proto.Equal(prevInfo, newInfo) {

--- a/service/matching/scale_manager.go
+++ b/service/matching/scale_manager.go
@@ -128,17 +128,14 @@ func (sm *scaleManager) AddedTasks(estimatedTasksAllPartitions int) {
 		return
 	}
 
-	// If we don't know the latest write partitions, scale batch size by tasks_all_partitions,
-	// so we are comparing total_tasks_all_partitions < batchSize * latest_tasks_all_partitions.
-	// We scale batch size up because latest_tasks_all_partitions scales with partitions, as does total_tasks.
-	batchSize := int64(estimatedTasksAllPartitions) * sm.batchSize
-
-	// If we know the latest write partitions, scale batch size by write partitions,
-	// so we are comparing total_tasks_all_partitions / num_partitions < batchSize.
+	// Wake once ~batchSize tasks per write partition have accumulated. Before the first
+	// scaler decision we don't know the write count, so use the per-sample estimate, which
+	// scales with partitions the same way.
+	threshold := int64(estimatedTasksAllPartitions) * sm.batchSize
 	if currentWrite := sm.currentWrite.Load(); currentWrite > 0 {
-		batchSize = int64(currentWrite) * sm.batchSize
+		threshold = int64(currentWrite) * sm.batchSize
 	}
-	if sm.batch.Add(int64(estimatedTasksAllPartitions)) < batchSize {
+	if sm.batch.Add(int64(estimatedTasksAllPartitions)) < threshold {
 		return // not enough for a batch yet
 	}
 

--- a/service/matching/scale_manager.go
+++ b/service/matching/scale_manager.go
@@ -32,8 +32,8 @@ import (
 // All scaler/state work is funneled through a single background goroutine. That
 // goroutine owns scaleState/scaleDB/lastDecision and is the only caller of
 // partitionScaler, so the scaler implementation can rely on serial calls and
-// scaleState needs no lock. AddedTasks talks to the worker only via the atomic
-// batch counter and the wakeup channel, so it never blocks.
+// scaleState needs no lock. AddedTasks talks to the worker only via atomics and
+// the wakeup channel, so it never blocks.
 type scaleManager struct {
 	partition              tqid.Partition
 	logger                 log.Logger
@@ -55,6 +55,8 @@ type scaleManager struct {
 	nextShadowLog    time.Time
 	prevShadowTarget int32
 
+	currentTarget atomic.Int32
+	// batch counts estimated tasks across all partitions in between calls to the scaler
 	batch  atomic.Int64
 	wakeup chan struct{}
 }
@@ -117,16 +119,22 @@ func (sm *scaleManager) Start(scaleState *persistencespb.PartitionScaleState, sc
 	sm.background.Go(sm.backgroundWork)
 }
 
-// AddedTasks is called on a batch of tasks added.
+func (sm *scaleManager) getLatestWritePartitions() int32 {
+	if n := sm.currentTarget.Load(); n > 0 {
+		return n
+	}
+	return int32(sm.getWritePartitions())
+}
+
+// AddedTasks records one root sample representing estimated queue-wide task additions.
 // This is called in the task add path, so it shouldn't block.
-func (sm *scaleManager) AddedTasks(numTasks int) {
+func (sm *scaleManager) AddedTasks(estimatedTasksAllPartitions int) {
 	if sm == nil {
 		return
 	}
 
-	// scale target batch size by numTasks (since numTasks is scaled by partitions)
-	batchSize := int64(numTasks) * sm.batchSize
-	if sm.batch.Add(int64(numTasks)) < batchSize {
+	// wait until the batch has accumulated ~batchSize tasks per partition
+	if sm.batch.Add(int64(estimatedTasksAllPartitions)) < sm.batchSize*int64(sm.getLatestWritePartitions()) {
 		return // not enough for a batch yet
 	}
 
@@ -300,6 +308,7 @@ func (sm *scaleManager) setState(newState *persistencespb.PartitionScaleState, s
 	prevInfo := scaleStateToInfo(sm.scaleState, settings)
 
 	sm.scaleState = newState
+	sm.currentTarget.Store(newState.GetTarget())
 
 	newInfo := scaleStateToInfo(sm.scaleState, settings)
 

--- a/service/matching/scale_manager.go
+++ b/service/matching/scale_manager.go
@@ -128,7 +128,13 @@ func (sm *scaleManager) AddedTasks(estimatedTasksAllPartitions int) {
 		return
 	}
 
+	// If we don't know the latest write partitions, scale batch size by tasks_all_partitions,
+	// so we are comparing total_tasks_all_partitions < batchSize * latest_tasks_all_partitions.
+	// We scale batch size up because latest_tasks_all_partitions scales with partitions, as does total_tasks.
 	batchSize := int64(estimatedTasksAllPartitions) * sm.batchSize
+
+	// If we know the latest write partitions, scale batch size by write partitions,
+	// so we are comparing total_tasks_all_partitions / num_partitions < batchSize.
 	if currentWrite := sm.currentWrite.Load(); currentWrite > 0 {
 		batchSize = int64(currentWrite) * sm.batchSize
 	}

--- a/service/matching/scale_manager.go
+++ b/service/matching/scale_manager.go
@@ -121,13 +121,6 @@ func (sm *scaleManager) Start(scaleState *persistencespb.PartitionScaleState, sc
 	sm.background.Go(sm.backgroundWork)
 }
 
-func (sm *scaleManager) getLatestWritePartitions() int32 {
-	if n := sm.currentWrite.Load(); n > 0 {
-		return n
-	}
-	return int32(sm.getWritePartitions())
-}
-
 // AddedTasks records one root sample representing estimated queue-wide task additions.
 // This is called in the task add path, so it shouldn't block.
 func (sm *scaleManager) AddedTasks(estimatedTasksAllPartitions int) {
@@ -135,8 +128,11 @@ func (sm *scaleManager) AddedTasks(estimatedTasksAllPartitions int) {
 		return
 	}
 
-	// wait until the batch has accumulated ~batchSize tasks per partition
-	if sm.batch.Add(int64(estimatedTasksAllPartitions)) < sm.batchSize*int64(sm.getLatestWritePartitions()) {
+	batchSize := int64(estimatedTasksAllPartitions) * sm.batchSize
+	if currentWrite := sm.currentWrite.Load(); currentWrite > 0 {
+		batchSize = int64(currentWrite) * sm.batchSize
+	}
+	if sm.batch.Add(int64(estimatedTasksAllPartitions)) < batchSize {
 		return // not enough for a batch yet
 	}
 

--- a/service/matching/scale_manager_test.go
+++ b/service/matching/scale_manager_test.go
@@ -66,6 +66,29 @@ func TestScaleManagerSuite(t *testing.T) {
 	suite.Run(t, new(ScaleManagerSuite))
 }
 
+func TestScaleManagerAddedTasksBatchThreshold(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		currentWrite    int32
+		callsBeforeWake int
+	}{
+		{name: "current write", currentWrite: 2, callsBeforeWake: 3},
+		{name: "estimate fallback", callsBeforeWake: 4},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sm := &scaleManager{batchSize: 5, wakeup: make(chan struct{}, 1)}
+			sm.currentWrite.Store(tc.currentWrite)
+			for range tc.callsBeforeWake {
+				sm.AddedTasks(3)
+			}
+			require.Empty(t, sm.wakeup)
+
+			sm.AddedTasks(3)
+			require.Len(t, sm.wakeup, 1)
+		})
+	}
+}
+
 func (s *ScaleManagerSuite) SetupTest() {
 	s.ProtoAssertions = protorequire.New(s.T())
 	s.userDataValue = nil

--- a/service/matching/scale_manager_test.go
+++ b/service/matching/scale_manager_test.go
@@ -290,7 +290,7 @@ func (s *ScaleManagerSuite) TestUnavailablePartitionPreservesBacklogAndDrainStat
 }
 
 // TestAddedTasksWakesScalerOnFullBatch verifies that the scaler is only called
-// once cumulative batch reaches numTasks*BatchSize.
+// once cumulative batch reaches BatchSize*numPartitions.
 func (s *ScaleManagerSuite) TestAddedTasksWakesScalerOnFullBatch() {
 	s.settings.BatchSize = 5
 
@@ -302,13 +302,13 @@ func (s *ScaleManagerSuite) TestAddedTasksWakesScalerOnFullBatch() {
 	s.startManager(4, nil)
 
 	for range 4 {
-		s.sm.AddedTasks(1)
+		s.sm.AddedTasks(4)
 	}
 	assertNoRecv(s, inputs, 30*time.Millisecond, "scaler called below threshold")
 
-	s.sm.AddedTasks(1) // cumulative 5 hits threshold
+	s.sm.AddedTasks(4) // cumulative 20 hits threshold
 	in := waitRecv(s, inputs, "scaler never called")
-	s.Equal(5, in.NumTasks, "all 5 tasks should accumulate before firing")
+	s.Equal(20, in.NumTasks, "all 20 tasks should accumulate before firing")
 }
 
 // TestPeriodicTimerCallsScaler verifies that the scaler is called periodically
@@ -354,7 +354,7 @@ func (s *ScaleManagerSuite) TestDecisionPersistsAndUpdatesEphemeralData() {
 
 	s.startManager(4, nil) // 4 write partitions in dynamic config
 
-	s.sm.AddedTasks(1)
+	s.sm.AddedTasks(4)
 	state := waitRecv(s, dbWrites, "no db write")
 	s.Equal(int32(2), state.Target)
 	s.Equal(int32(2), state.MaxTarget)
@@ -388,7 +388,7 @@ func (s *ScaleManagerSuite) TestEmitsGaugeMetrics() {
 
 	s.startManager(4, nil) // 4 write partitions in dynamic config
 
-	s.sm.AddedTasks(1)
+	s.sm.AddedTasks(4)
 	waitRecv(s, dbWrites, "no db write")
 
 	// setState records the gauges after the ephemeral push, so poll the snapshot
@@ -475,8 +475,8 @@ func (s *ScaleManagerSuite) TestShadowModeEmitsExpectedGauges() {
 	defer s.capture.StopCapture(capt)
 
 	// call AddedTasks 2x (# of tasks added does not impact decision, decision is mocked)
-	for i := range 2 {
-		s.sm.AddedTasks(1)
+	for i, tasks := range []int{5, 4} {
+		s.sm.AddedTasks(tasks)
 		waitRecv(s, inputs, "shadow call missing")
 
 		// wait for log indicating nextDecision was set before we advance
@@ -486,7 +486,7 @@ func (s *ScaleManagerSuite) TestShadowModeEmitsExpectedGauges() {
 		s.timeSource.Advance(110 * time.Millisecond)
 	}
 	// call a third time, but don't expect the decision applied log, because shadow target didn't change
-	s.sm.AddedTasks(1)
+	s.sm.AddedTasks(4)
 	waitRecv(s, inputs, "third shadow call missing")
 
 	// Wait for three scale events (the first two record gauges, the last does not).
@@ -522,7 +522,7 @@ func (s *ScaleManagerSuite) TestNonPositiveShadowLogIntervalDisabled() {
 
 	s.startManager(4, nil)
 
-	s.sm.AddedTasks(1)
+	s.sm.AddedTasks(4)
 	state := waitRecv(s, dbWrites, "no db write")
 	s.Equal(int32(2), state.Target)
 	info := waitRecv(s, scaleInfos, "no ephemeral data update")
@@ -604,7 +604,7 @@ func (s *ScaleManagerSuite) TestShadowModeColdStartsScalerFromBaseline() {
 
 	s.awaitDecisionApplied(1)                    // barrier: nextDecision set before we advance
 	s.timeSource.Advance(110 * time.Millisecond) // past the 100ms cooldown
-	s.sm.AddedTasks(1)
+	s.sm.AddedTasks(4)
 	in2 := waitRecv(s, inputs, "second shadow call missing")
 	s.Equal(0, in2.CurrentTarget)
 	s.Nil(in2.PrivateState)
@@ -625,7 +625,7 @@ func (s *ScaleManagerSuite) TestShadowModeDoesNotLogNoChange() {
 
 	s.startManagerWithLogger(logger, 4, nil)
 
-	s.sm.AddedTasks(1)
+	s.sm.AddedTasks(4)
 	waitRecv(s, inputs, "shadow scaler call missing")
 	assertNoNewLogs(s, s.newTarget, 30*time.Millisecond, "NoChange decision should not log")
 }
@@ -654,24 +654,24 @@ func (s *ScaleManagerSuite) TestShadowLoggingCadence() {
 
 	s.startManagerWithLogger(logger, 4, nil)
 
-	s.sm.AddedTasks(1)
+	s.sm.AddedTasks(4)
 	waitRecv(s, inputs, "first shadow call missing")
 	waitLogMatches(s, s.newTarget, 1, "first shadow log missing")
 
-	s.sm.AddedTasks(1)
+	s.sm.AddedTasks(4)
 	assertNoRecv(s, inputs, 30*time.Millisecond, "shadow scaler called inside cooldown")
 
 	s.timeSource.Advance(110 * time.Millisecond) // past the 100ms cooldown
-	s.sm.AddedTasks(1)
+	s.sm.AddedTasks(4)
 	waitRecv(s, inputs, "second shadow call missing")
 	assertNoNewLogs(s, s.newTarget, 30*time.Millisecond, "shadow log repeated before cadence")
 
 	s.timeSource.Advance(time.Minute)
-	s.sm.AddedTasks(1)
+	s.sm.AddedTasks(4)
 	waitRecv(s, inputs, "third shadow call missing")
 	assertNoNewLogs(s, s.newTarget, 30*time.Millisecond, "unchanged shadow decision logged after cadence")
 
-	s.sm.AddedTasks(1)
+	s.sm.AddedTasks(4)
 	waitRecv(s, inputs, "fourth shadow call missing")
 	waitLogMatches(s, s.newTarget, 2, "second shadow log missing")
 }
@@ -690,7 +690,7 @@ func (s *ScaleManagerSuite) TestShadowModeDoesNotLogDisabledScaler() {
 	s.userData.EXPECT().SetPartitionScale(gomock.Any()).Times(2)
 
 	s.startManagerWithLogger(logger, 4, &persistencespb.PartitionScaleState{Target: 2})
-	s.sm.AddedTasks(1)
+	s.sm.AddedTasks(2)
 	waitRecv(s, inputs, "shadow scaler call missing")
 	assertNoNewLogs(s, s.newTarget, 30*time.Millisecond, "disabled scaler should not log")
 }
@@ -778,7 +778,7 @@ func (s *ScaleManagerSuite) TestShadowModeReleasesManagedTargetToBaseline() {
 	}
 	s.startManager(4, initial)
 
-	s.sm.AddedTasks(1)
+	s.sm.AddedTasks(10)
 
 	w := waitRecv(s, dbWrites, "release write missing")
 	s.Equal(int32(0), w.Target)
@@ -819,17 +819,17 @@ func (s *ScaleManagerSuite) TestShadowModeLogsOscillationFromBaseline() {
 
 	s.startManagerWithLogger(logger, 4, &persistencespb.PartitionScaleState{Target: 2})
 
-	s.sm.AddedTasks(1)
+	s.sm.AddedTasks(2)
 	waitRecv(s, inputs, "first shadow call missing")
 	waitLogMatches(s, s.newTarget, 1, "shadow target 3 not logged")
 
 	s.timeSource.Advance(time.Minute) // past cooldown and cadence
-	s.sm.AddedTasks(1)
+	s.sm.AddedTasks(4)
 	waitRecv(s, inputs, "second shadow call missing")
 	waitLogMatches(s, s.newTarget, 2, "shadow target 2 not logged")
 
 	s.timeSource.Advance(time.Minute)
-	s.sm.AddedTasks(1)
+	s.sm.AddedTasks(4)
 	waitRecv(s, inputs, "third shadow call missing")
 	waitLogMatches(s, s.newTarget, 3, "shadow target 3 after oscillation not logged")
 }
@@ -864,9 +864,9 @@ func (s *ScaleManagerSuite) TestNoChangeDecisionSkipsWrite() {
 		time.Second, time.Millisecond)
 	baseline := scalePushes.Load()
 
-	s.sm.AddedTasks(1)
+	s.sm.AddedTasks(3)
 	waitRecv(s, inputs, "first decision never delivered")
-	s.sm.AddedTasks(1)
+	s.sm.AddedTasks(3)
 	waitRecv(s, inputs, "second decision never delivered")
 
 	s.Require().Never(func() bool {
@@ -901,9 +901,9 @@ func (s *ScaleManagerSuite) TestCooldown() {
 	s.startManager(4, nil)
 
 	// First decision lands immediately (lastDecision is zero, no cooldown).
-	s.sm.AddedTasks(1)
+	s.sm.AddedTasks(4)
 	in1 := waitRecv(s, inputs, "first decision never delivered")
-	s.Equal(1, in1.NumTasks)
+	s.Equal(4, in1.NumTasks)
 	waitRecv(s, dbWrites, "first db write missing")
 
 	// Within cooldown: another wakeup carrying 7 tasks. Scaler must NOT be
@@ -949,14 +949,14 @@ func (s *ScaleManagerSuite) TestPrivateStatePropagation() {
 
 	s.startManager(4, nil)
 
-	s.sm.AddedTasks(1)
+	s.sm.AddedTasks(4)
 	in1 := waitRecv(s, inputs, "first call missing")
 	s.Nil(in1.PrivateState, "first call should have no private state")
 	waitRecv(s, dbWrites, "first db write missing")
 
 	s.awaitDecisionApplied(1)                    // barrier: nextDecision set before we advance
 	s.timeSource.Advance(110 * time.Millisecond) // past 100ms cooldown
-	s.sm.AddedTasks(1)
+	s.sm.AddedTasks(2)
 	in2 := waitRecv(s, inputs, "second call missing")
 	s.ProtoEqual(priv1, in2.PrivateState)
 	w2 := waitRecv(s, dbWrites, "second db write missing")
@@ -1366,14 +1366,14 @@ func (s *ScaleManagerSuite) TestDBWriteFailureKeepsState() {
 
 	// First decision: scaler called, DB write fails. lastDecision is not set,
 	// so cooldown is not engaged.
-	s.sm.AddedTasks(1)
+	s.sm.AddedTasks(4)
 	waitRecv(s, inputs, "first decision missing")
 
 	// No ephemeral push yet; the failed write must not have advanced state.
 	assertNoRecv(s, scaleInfos, 30*time.Millisecond, "ephemeral data pushed after failed write")
 
 	// Recovery: trigger another decision; this one persists.
-	s.sm.AddedTasks(1)
+	s.sm.AddedTasks(4)
 	waitRecv(s, inputs, "second decision missing")
 	state := waitRecv(s, dbWrites, "second db write missing")
 	s.Equal(int32(3), state.Target, "second decision's target landed (first was dropped)")
@@ -1503,7 +1503,7 @@ func (s *ScaleManagerSuite) TestBacklogCapChangePersists() {
 	// Current target is already 3, so only the backlog cap differs from the decision.
 	s.startManager(4, &persistencespb.PartitionScaleState{Target: 3, MaxTarget: 3})
 
-	s.sm.AddedTasks(1)
+	s.sm.AddedTasks(3)
 	state := waitRecv(s, dbWrites, "cap-only change never persisted")
 	s.Equal(int32(3), state.Target, "target unchanged; the cap change alone must trigger the write")
 	s.Equal(int32(number.EncodeCompact8(1000)), state.BacklogCap)
@@ -1538,7 +1538,7 @@ func (s *ScaleManagerSuite) TestSameTargetAndCapSkipsWrite() {
 	}
 	s.startManager(4, initial)
 
-	s.sm.AddedTasks(1)
+	s.sm.AddedTasks(3)
 	in := waitRecv(s, inputs, "scaler never called")
 	s.Equal([]byte{c500, c500, c500}, in.BacklogCounts, "stored backlog counts must be fed to the scaler")
 

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -440,14 +440,13 @@ func (pm *taskQueuePartitionManagerImpl) signalPartitionScaler(ctx context.Conte
 	if pm.scaleManager == nil {
 		return // only run on root partition
 	}
-	scaleInfo := pm.userDataManager.PartitionScale()
-	effectiveWrite := int(scaleInfo.GetWrite())
-	// if no target is set yet, get effective count from dynamic config (matches client behavior)
-	if effectiveWrite == 0 {
-		effectiveWrite = max(1, pm.config.NumWritePartitions())
-	}
 	estimatedTasksAllPartitions := matching.ParseEstimatedTasksAllPartitions(ctx)
 	if estimatedTasksAllPartitions == 0 {
+		scaleInfo := pm.userDataManager.PartitionScale()
+		effectiveWrite := int(scaleInfo.GetWrite())
+		if effectiveWrite == 0 {
+			effectiveWrite = max(1, pm.config.NumWritePartitions())
+		}
 		estimatedTasksAllPartitions = effectiveWrite
 	}
 	pm.scaleManager.AddedTasks(estimatedTasksAllPartitions)

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -436,7 +436,7 @@ func validatePartitionScaleDrift(
 
 // signalPartitionScaler sends a signal to the partition scaler that a new task has arrived
 // (directly from history, not forwarded).
-func (pm *taskQueuePartitionManagerImpl) signalPartitionScaler() {
+func (pm *taskQueuePartitionManagerImpl) signalPartitionScaler(ctx context.Context) {
 	if pm.scaleManager == nil {
 		return // only run on root partition
 	}
@@ -446,12 +446,11 @@ func (pm *taskQueuePartitionManagerImpl) signalPartitionScaler() {
 	if effectiveWrite == 0 {
 		effectiveWrite = max(1, pm.config.NumWritePartitions())
 	}
-	// we assume that tasks are balanced uniformly across partitions, so if the root has
-	// seen 1 task then all have seen ~1 task, so the whole queue has seen 'effective'
-	// tasks in total.
-	// TODO(dp): this will change when we add non-uniform load balancing. we should eventually
-	// aggregate real stats instead of assuming
-	pm.scaleManager.AddedTasks(effectiveWrite)
+	estimatedTasksAllPartitions := matching.ParseEstimatedTasksAllPartitions(ctx)
+	if estimatedTasksAllPartitions == 0 {
+		estimatedTasksAllPartitions = effectiveWrite
+	}
+	pm.scaleManager.AddedTasks(estimatedTasksAllPartitions)
 }
 
 func (pm *taskQueuePartitionManagerImpl) sendPartitionCountTrailer(ctx context.Context) {
@@ -563,7 +562,7 @@ func (pm *taskQueuePartitionManagerImpl) AddTask(
 		return "", false, err
 	}
 	if params.forwardInfo == nil {
-		pm.signalPartitionScaler()
+		pm.signalPartitionScaler(ctx)
 	}
 
 	var spoolQueue, syncMatchQueue physicalTaskQueueManager
@@ -1023,7 +1022,7 @@ func (pm *taskQueuePartitionManagerImpl) DispatchQueryTask(
 		return nil, err
 	}
 	if request.ForwardInfo == nil {
-		pm.signalPartitionScaler()
+		pm.signalPartitionScaler(ctx)
 	}
 
 	task := newInternalQueryTask(taskID, request)
@@ -1093,7 +1092,7 @@ func (pm *taskQueuePartitionManagerImpl) DispatchNexusTask(
 		return nil, err
 	}
 	if request.ForwardInfo == nil {
-		pm.signalPartitionScaler()
+		pm.signalPartitionScaler(ctx)
 	}
 
 	deadline, _ := ctx.Deadline() // If not set by user, our client will set a default.


### PR DESCRIPTION
## What changed?
- use probability of AddTask to root partition to estimate overall add task rate, instead of assuming uniform distribution
- to enable this, change the AddTask loadbalancing to ensure that there is at least 1% chance of hitting the root, regardless of how much backlog the root has

## Why?
A previous PR changed AddTask load-balancing from uniform random to backlog-aware

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
Changes AddTask computation and AddTask load balancing, but improves the estimation of the former, and we are ok with the tradeoff for the latter


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches AddTask write routing and dynamic partition scaling inputs; behavior changes when backlog-aware routing heavily favors child partitions, though a 1% root floor and fallback estimates limit worst-case drift.
> 
> **Overview**
> Backlog-aware write routing no longer assumes one root add implies uniform load on every partition. The matching client now returns an **estimated tasks across all partitions** when load-balancing picks the **root** partition, sends it on gRPC metadata (`etap`), and the root partition scaler uses that instead of multiplying by write partition count.
> 
> **Write load balancing** enforces at least a **1% chance** of routing to the root (`writePartitionRootProbabilityFloor`) so sampling stays viable when the root backlog is full. When the root is chosen, the estimate is derived from gap-weighted routing (`randomRound(total/gap0)`); non-root picks carry zero estimate. Fallback paths (uniform random, forced partition via test hooks) still return `partitionCount` on root samples.
> 
> **Scale manager** batches and wakes the partition scaler on **estimated** queue-wide task volume (`AddedTasks(estimatedTasksAllPartitions)`), with threshold `batchSize × currentWrite` once write count is known.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ee95df694c22cb1cfd93068ec36e808d84fb5fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->