### PR TITLE
Remove retry stamp dynamic configs

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -220,11 +220,6 @@ in the consistent hash ring used by ringpop. Changing it may cause service disru
 		time.Hour,
 		`Minimum retention duration for local namespaces. This value should only be lowered for testing purposes.`,
 	)
-	EnableActivityRetryStampIncrement = NewGlobalBoolSetting(
-		"system.enableActivityRetryStampIncrement",
-		false,
-		`EnableActivityRetryStampIncrement indicates if activity retry stamp increment is enabled`,
-	)
 	EnableEagerWorkflowStart = NewNamespaceBoolSetting(
 		"system.enableEagerWorkflowStart",
 		true,
@@ -2721,11 +2716,6 @@ the number of children greater than or equal to this threshold`,
 		"history.workflowTaskRetryMaxInterval",
 		time.Minute*10,
 		`WorkflowTaskRetryMaxInterval is the maximum interval added to a workflow task's startToClose timeout for slowing down retry`,
-	)
-	EnableWorkflowTaskStampIncrementOnFailure = NewGlobalBoolSetting(
-		"history.enableWorkflowTaskStampIncrementOnFailure",
-		false,
-		`EnableWorkflowTaskStampIncrementOnFailure controls whether the workflow task stamp is incremented when a workflow task fails and is rescheduled`,
 	)
 	DiscardSpeculativeWorkflowTaskMaximumEventsCount = NewGlobalIntSetting(
 		"history.discardSpeculativeWorkflowTaskMaximumEventsCount",

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -279,7 +279,6 @@ type Config struct {
 	WorkflowTaskHeartbeatTimeout                     dynamicconfig.DurationPropertyFnWithNamespaceFilter
 	WorkflowTaskCriticalAttempts                     dynamicconfig.IntPropertyFn
 	WorkflowTaskRetryMaxInterval                     dynamicconfig.DurationPropertyFn
-	EnableWorkflowTaskStampIncrementOnFailure        dynamicconfig.BoolPropertyFn
 	DiscardSpeculativeWorkflowTaskMaximumEventsCount dynamicconfig.IntPropertyFn
 	EnableDropRepeatedWorkflowTaskFailures           dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	// TODO seankane: Added on 3/10/2026, if this is never used we should remove it at a later date
@@ -394,7 +393,6 @@ type Config struct {
 
 	EnableCrossNamespaceCommands      dynamicconfig.BoolPropertyFn
 	EnableActivityEagerExecution      dynamicconfig.BoolPropertyFnWithNamespaceFilter
-	EnableActivityRetryStampIncrement dynamicconfig.BoolPropertyFn
 	EnableCancelActivityWorkerCommand dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	EnableEagerWorkflowStart          dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	NamespaceCacheRefreshInterval     dynamicconfig.DurationPropertyFn
@@ -720,7 +718,6 @@ func NewConfig(
 		WorkflowTaskHeartbeatTimeout:                     dynamicconfig.WorkflowTaskHeartbeatTimeout.Get(dc),
 		WorkflowTaskCriticalAttempts:                     dynamicconfig.WorkflowTaskCriticalAttempts.Get(dc),
 		WorkflowTaskRetryMaxInterval:                     dynamicconfig.WorkflowTaskRetryMaxInterval.Get(dc),
-		EnableWorkflowTaskStampIncrementOnFailure:        dynamicconfig.EnableWorkflowTaskStampIncrementOnFailure.Get(dc),
 		DiscardSpeculativeWorkflowTaskMaximumEventsCount: dynamicconfig.DiscardSpeculativeWorkflowTaskMaximumEventsCount.Get(dc),
 		EnableDropRepeatedWorkflowTaskFailures:           dynamicconfig.EnableDropRepeatedWorkflowTaskFailures.Get(dc),
 		SendTransientOrSpeculativeWorkflowTaskEvents:     dynamicconfig.SendTransientOrSpeculativeWorkflowTaskEvents.Get(dc),
@@ -800,7 +797,6 @@ func NewConfig(
 
 		EnableCrossNamespaceCommands:      dynamicconfig.EnableCrossNamespaceCommands.Get(dc),
 		EnableActivityEagerExecution:      dynamicconfig.EnableActivityEagerExecution.Get(dc),
-		EnableActivityRetryStampIncrement: dynamicconfig.EnableActivityRetryStampIncrement.Get(dc),
 		EnableCancelActivityWorkerCommand: dynamicconfig.EnableCancelActivityWorkerCommand.Get(dc),
 		EnableEagerWorkflowStart:          dynamicconfig.EnableEagerWorkflowStart.Get(dc),
 		NamespaceCacheRefreshInterval:     dynamicconfig.NamespaceCacheRefreshInterval.Get(dc),

--- a/service/history/timer_queue_standby_task_executor_test.go
+++ b/service/history/timer_queue_standby_task_executor_test.go
@@ -110,7 +110,6 @@ func (s *timerQueueStandbyTaskExecutorSuite) SetupTest() {
 	s.ProtoAssertions = protorequire.New(s.T())
 
 	s.config = tests.NewDynamicConfig()
-	s.config.EnableWorkflowTaskStampIncrementOnFailure = func() bool { return true }
 	s.namespaceEntry = tests.GlobalStandbyNamespaceEntry
 	s.namespaceID = s.namespaceEntry.ID()
 	s.version = s.namespaceEntry.FailoverVersion(namespace.EmptyBusinessID)

--- a/service/history/workflow/activity.go
+++ b/service/history/workflow/activity.go
@@ -62,7 +62,6 @@ func UpdateActivityInfoForRetries(
 	attempt int32,
 	failure *failurepb.Failure,
 	nextScheduledTime *timestamppb.Timestamp,
-	isActivityRetryStampIncrementEnabled bool,
 ) {
 	previousAttempt := ai.Attempt
 	ai.Attempt = attempt
@@ -84,7 +83,7 @@ func UpdateActivityInfoForRetries(
 	ai.ActivityReset = false
 	ai.ResetHeartbeats = false
 
-	if isActivityRetryStampIncrementEnabled && attempt > previousAttempt {
+	if attempt > previousAttempt {
 		ai.Stamp++
 	}
 }

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -6914,9 +6914,7 @@ func (ms *MutableStateImpl) RetryActivity(
 			ClearActivityStartedState(activityInfo)
 			activityInfo.RetryLastFailure = ms.truncateRetryableActivityFailure(activityFailure)
 			activityInfo.Attempt++
-			if ms.config.EnableActivityRetryStampIncrement() {
-				activityInfo.Stamp++
-			}
+			activityInfo.Stamp++
 			return nil
 		}); err != nil {
 			return enumspb.RETRY_STATE_INTERNAL_SERVER_ERROR, err
@@ -7000,7 +6998,6 @@ func (ms *MutableStateImpl) updateActivityInfoForRetries(
 			nextAttempt,
 			ms.truncateRetryableActivityFailure(activityFailure),
 			timestamppb.New(nextScheduledTime),
-			ms.config.EnableActivityRetryStampIncrement(),
 		)
 		return nil
 	})

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -3142,7 +3142,6 @@ func (s *mutableStateSuite) TestRetryWorkflowTask_WithNextRetryDelay() {
 }
 func (s *mutableStateSuite) TestRetryActivity_TruncateRetryableFailure() {
 	s.mockEventsCache.EXPECT().PutEvent(gomock.Any(), gomock.Any()).AnyTimes()
-	s.mockConfig.EnableActivityRetryStampIncrement = dynamicconfig.GetBoolPropertyFn(true)
 
 	// scheduling, starting & completing workflow task is omitted here
 
@@ -3211,7 +3210,6 @@ func (s *mutableStateSuite) TestRetryActivity_TruncateRetryableFailure() {
 
 func (s *mutableStateSuite) TestRetryActivity_PausedIncrementsStamp() {
 	s.mockEventsCache.EXPECT().PutEvent(gomock.Any(), gomock.Any()).AnyTimes()
-	s.mockConfig.EnableActivityRetryStampIncrement = dynamicconfig.GetBoolPropertyFn(true)
 
 	workflowTaskCompletedEventID := int64(4)
 	_, activityInfo, err := s.mutableState.AddActivityTaskScheduledEvent(

--- a/service/history/workflow/workflow_task_state_machine.go
+++ b/service/history/workflow/workflow_task_state_machine.go
@@ -1059,9 +1059,7 @@ func (m *workflowTaskStateMachine) failWorkflowTask(
 		newAttemptsSinceLastSuccess = m.ms.executionInfo.WorkflowTaskAttemptsSinceLastSuccess + 1
 		// Also increment Attempt for transient workflow task tracking
 		newAttempt = m.ms.executionInfo.WorkflowTaskAttempt + 1
-		if m.ms.config.EnableWorkflowTaskStampIncrementOnFailure() {
-			m.ms.executionInfo.WorkflowTaskStamp += 1
-		}
+		m.ms.executionInfo.WorkflowTaskStamp += 1
 	}
 
 	failWorkflowTaskInfo := &historyi.WorkflowTaskInfo{

--- a/tests/xdc/delete_execution_replication_test.go
+++ b/tests/xdc/delete_execution_replication_test.go
@@ -54,10 +54,9 @@ func TestDeleteExecutionReplicationTestSuite(t *testing.T) {
 
 func (s *deleteExecutionReplicationTestSuite) SetupSuite() {
 	s.dynamicConfigOverrides = map[dynamicconfig.Key]any{
-		dynamicconfig.EnableReplicationStream.Key():                   true,
-		dynamicconfig.EnableReplicationTaskBatching.Key():             true,
-		dynamicconfig.EnableSeparateReplicationEnableFlag.Key():       true,
-		dynamicconfig.EnableWorkflowTaskStampIncrementOnFailure.Key(): true,
+		dynamicconfig.EnableReplicationStream.Key():             true,
+		dynamicconfig.EnableReplicationTaskBatching.Key():       true,
+		dynamicconfig.EnableSeparateReplicationEnableFlag.Key(): true,
 	}
 	s.logger = log.NewTestLogger()
 

--- a/tests/xdc/stream_based_replication_test.go
+++ b/tests/xdc/stream_based_replication_test.go
@@ -87,10 +87,9 @@ func TestStreamBasedReplicationTestSuite(t *testing.T) {
 func (s *streamBasedReplicationTestSuite) SetupSuite() {
 	s.controller = gomock.NewController(s.T())
 	s.dynamicConfigOverrides = map[dynamicconfig.Key]any{
-		dynamicconfig.EnableReplicationStream.Key():                   true,
-		dynamicconfig.EnableReplicationTaskBatching.Key():             true,
-		dynamicconfig.EnableWorkflowTaskStampIncrementOnFailure.Key(): true,
-		dynamicconfig.EnableSeparateReplicationEnableFlag.Key():       true,
+		dynamicconfig.EnableReplicationStream.Key():             true,
+		dynamicconfig.EnableReplicationTaskBatching.Key():       true,
+		dynamicconfig.EnableSeparateReplicationEnableFlag.Key(): true,
 	}
 	s.logger = log.NewTestLogger()
 	s.serializer = serialization.NewSerializer()


### PR DESCRIPTION
## What changed?
- Make activity retry stamp increments unconditional.
- Make workflow task failure stamp increments unconditional.
- Remove `system.enableActivityRetryStampIncrement` and `history.enableWorkflowTaskStampIncrementOnFailure`, their history config plumbing, and obsolete test overrides.

## Why?
Both compatibility gates have completed rollout, so they are no longer needed.

This cleans up the flags introduced in #8607 and #8615.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

Commands:
- `go test -tags test_dep ./service/history/workflow ./service/history`
- `go test -tags test_dep ./tests/xdc -run '^$'`
- `make lint-code GOLANGCI_LINT_BASE_REV=origin/main GOLANGCI_LINT_FIX=false`

## Potential risks
The previously gated behavior can no longer be disabled. This is intentional now that both compatibility rollouts are complete.
