### PR TITLE
Fix scheduler service call timeout

### DIFF
--- a/chasm/lib/scheduler/config.go
+++ b/chasm/lib/scheduler/config.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"context"
 	"time"
 
 	"go.temporal.io/server/chasm"
@@ -114,4 +115,8 @@ func ConfigProvider(dc *dynamicconfig.Collection) *Config {
 			)
 		},
 	}
+}
+
+func (c *Config) serviceCallContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, c.ServiceCallTimeout())
 }

--- a/chasm/lib/scheduler/config_test.go
+++ b/chasm/lib/scheduler/config_test.go
@@ -1,0 +1,50 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestServiceCallContext(t *testing.T) {
+	t.Run("uses configured deadline", func(t *testing.T) {
+		const timeout = time.Second
+		config := &Config{ServiceCallTimeout: func() time.Duration { return timeout }}
+
+		ctx, cancel := config.serviceCallContext(context.Background())
+		defer cancel()
+
+		deadline, ok := ctx.Deadline()
+		require.True(t, ok)
+		require.Greater(t, time.Until(deadline), time.Duration(0))
+		require.LessOrEqual(t, time.Until(deadline), timeout)
+	})
+
+	t.Run("preserves tighter parent deadline", func(t *testing.T) {
+		const parentTimeout = time.Second
+		config := &Config{ServiceCallTimeout: func() time.Duration { return time.Hour }}
+		parentCtx, parentCancel := context.WithTimeout(context.Background(), parentTimeout)
+		defer parentCancel()
+
+		ctx, cancel := config.serviceCallContext(parentCtx)
+		defer cancel()
+
+		deadline, ok := ctx.Deadline()
+		require.True(t, ok)
+		require.Greater(t, time.Until(deadline), time.Duration(0))
+		require.LessOrEqual(t, time.Until(deadline), parentTimeout)
+	})
+
+	t.Run("propagates parent cancellation", func(t *testing.T) {
+		config := &Config{ServiceCallTimeout: func() time.Duration { return time.Hour }}
+		parentCtx, parentCancel := context.WithCancel(context.Background())
+		defer parentCancel()
+		ctx, cancel := config.serviceCallContext(parentCtx)
+		defer cancel()
+
+		parentCancel()
+		require.ErrorIs(t, ctx.Err(), context.Canceled)
+	})
+}

--- a/chasm/lib/scheduler/invoker_execute_task_test.go
+++ b/chasm/lib/scheduler/invoker_execute_task_test.go
@@ -190,6 +190,42 @@ func TestExecuteTask_Basic(t *testing.T) {
 	})
 }
 
+func TestExecuteTask_UsesServiceCallTimeout(t *testing.T) {
+	const serviceCallTimeout = time.Second
+	env := newInvokerExecuteTestEnv(t, func(config *scheduler.Config) {
+		config.ServiceCallTimeout = func() time.Duration { return serviceCallTimeout }
+	})
+	startTime := timestamppb.New(env.TimeSource.Now())
+
+	env.mockFrontendClient.EXPECT().
+		StartWorkflowExecution(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, _ *workflowservice.StartWorkflowExecutionRequest, _ ...grpc.CallOption) (*workflowservice.StartWorkflowExecutionResponse, error) {
+			deadline, ok := ctx.Deadline()
+			require.True(t, ok)
+			require.Greater(t, time.Until(deadline), time.Duration(0))
+			require.LessOrEqual(t, time.Until(deadline), serviceCallTimeout)
+			return &workflowservice.StartWorkflowExecutionResponse{RunId: "run-id"}, nil
+		})
+
+	runExecuteTestCase(t, env, &executeTestCase{
+		InitialBufferedStarts: []*schedulespb.BufferedStart{{
+			NominalTime:   startTime,
+			ActualTime:    startTime,
+			DesiredTime:   startTime,
+			RequestId:     "req1",
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+			Attempt:       1,
+		}},
+		ExpectedBufferedStarts:      1,
+		ExpectedRunningWorkflows:    1,
+		ExpectedTerminateWorkflows:  0,
+		ExpectedCancelWorkflows:     0,
+		ExpectedActionCount:         1,
+		ExpectedOverlapSkipped:      0,
+		ExpectedMissedCatchupWindow: 0,
+	})
+}
+
 func TestExecuteTask_ForwardsVersioningOverride(t *testing.T) {
 	tests := map[string]struct {
 		override *workflowpb.VersioningOverride

--- a/chasm/lib/scheduler/invoker_tasks.go
+++ b/chasm/lib/scheduler/invoker_tasks.go
@@ -700,7 +700,9 @@ func (h *InvokerExecuteTaskHandler) startWorkflow(
 		request.VersioningOverride = requestSpec.VersioningOverride
 	}
 
-	result, err := h.frontendClient.StartWorkflowExecution(ctx, request)
+	callCtx, cancel := h.config.serviceCallContext(ctx)
+	result, err := h.frontendClient.StartWorkflowExecution(callCtx, request)
+	cancel()
 	if err != nil {
 		return err
 	}
@@ -742,7 +744,9 @@ func (h *InvokerExecuteTaskHandler) terminateWorkflow(
 			FirstExecutionRunId: target.RunId,
 		},
 	}
-	_, err := h.historyClient.TerminateWorkflowExecution(ctx, request)
+	callCtx, cancel := h.config.serviceCallContext(ctx)
+	_, err := h.historyClient.TerminateWorkflowExecution(callCtx, request)
+	cancel()
 	return err
 }
 
@@ -761,7 +765,9 @@ func (h *InvokerExecuteTaskHandler) cancelWorkflow(
 			FirstExecutionRunId: target.RunId,
 		},
 	}
-	_, err := h.historyClient.RequestCancelWorkflowExecution(ctx, request)
+	callCtx, cancel := h.config.serviceCallContext(ctx)
+	_, err := h.historyClient.RequestCancelWorkflowExecution(callCtx, request)
+	cancel()
 	return err
 }
 

--- a/chasm/lib/scheduler/scheduler_migrate_task.go
+++ b/chasm/lib/scheduler/scheduler_migrate_task.go
@@ -219,10 +219,12 @@ func (h *SchedulerMigrateToWorkflowTaskHandler) Execute(
 		Priority:                 &commonpb.Priority{},
 	}
 
+	callCtx, cancel := h.config.serviceCallContext(ctx)
 	_, err = h.historyClient.StartWorkflowExecution(
-		ctx,
+		callCtx,
 		common.CreateHistoryStartWorkflowRequest(result.namespaceID, startReq, nil, nil, result.now),
 	)
+	cancel()
 	if err != nil {
 		// Treat already-started as success for idempotency.
 		var alreadyStartedErr *serviceerror.WorkflowExecutionAlreadyStarted

--- a/chasm/lib/scheduler/scheduler_tasks.go
+++ b/chasm/lib/scheduler/scheduler_tasks.go
@@ -247,7 +247,8 @@ func (r *SchedulerCallbacksTaskHandler) watchRunningStart(
 	schedulerRef []byte,
 ) (*watchResult, error) {
 	// Describe the workflow to ensure it exists and is still running.
-	descResp, err := r.historyClient.DescribeWorkflowExecution(ctx, &historyservice.DescribeWorkflowExecutionRequest{
+	callCtx, cancel := r.config.serviceCallContext(ctx)
+	descResp, err := r.historyClient.DescribeWorkflowExecution(callCtx, &historyservice.DescribeWorkflowExecutionRequest{
 		NamespaceId: scheduler.NamespaceId,
 		Request: &workflowservice.DescribeWorkflowExecutionRequest{
 			Namespace: scheduler.Namespace,
@@ -257,6 +258,7 @@ func (r *SchedulerCallbacksTaskHandler) watchRunningStart(
 			},
 		},
 	})
+	cancel()
 	if err != nil {
 		var notFoundErr *serviceerror.NotFound
 		if errors.As(err, &notFoundErr) {
@@ -296,7 +298,8 @@ func (r *SchedulerCallbacksTaskHandler) watchRunningStart(
 		return nil, err
 	}
 
-	_, err = r.frontendClient.StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
+	callCtx, cancel = r.config.serviceCallContext(ctx)
+	_, err = r.frontendClient.StartWorkflowExecution(callCtx, &workflowservice.StartWorkflowExecutionRequest{
 		Namespace:                scheduler.Namespace,
 		WorkflowId:               start.WorkflowId,
 		RequestId:                start.RequestId,
@@ -311,6 +314,7 @@ func (r *SchedulerCallbacksTaskHandler) watchRunningStart(
 			AttachCompletionCallbacks: true,
 		},
 	})
+	cancel()
 	if err != nil {
 		// WorkflowExecutionAlreadyStarted: workflow completed between describe
 		// and this attach call (REJECT_DUPLICATE rejects completed workflows).


### PR DESCRIPTION
## What changed?
Applied `scheduler.serviceCallTimeout` to every outbound CHASM scheduler History/Frontend RPC. The existing task-level timeout remains in place; each call now receives a child context bounded by the configured service-call timeout.

## Why?
The advertised scheduler service-call timeout was previously unused. This restores the documented per-call bound while preserving tighter parent deadlines and cancellation propagation.

## How did you test it?
- [x] covered by existing tests
- [x] added new unit test(s)
- `go test -tags test_dep ./chasm/lib/scheduler`
- `make lint-code`

## Potential risks
The default two-second per-RPC deadline is now effective, so slow calls can fail earlier than the enclosing three-second History task deadline. Existing task retry and acknowledgement behavior handles those errors.