### PR TITLE
Unify namespace lifecycle wide event names

### DIFF
--- a/common/namespace/nsreplication/transmission_task_handler_test.go
+++ b/common/namespace/nsreplication/transmission_task_handler_test.go
@@ -19,6 +19,7 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/primitives"
+	"go.temporal.io/server/common/wideevents"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
@@ -170,7 +171,7 @@ func (s *transmissionTaskSuite) TestHandleTransmissionTask_RegisterNamespaceTask
 	)
 	s.Require().NoError(err)
 	s.Require().Len(eventLogger.records, 1)
-	s.Equal("namespace_replication_lifecycle", eventLogger.records[0].EventName())
+	s.Equal(wideevents.NamespaceLifecycleEventName, eventLogger.records[0].EventName())
 	attrs := make(map[string]otellog.Value)
 	eventLogger.records[0].WalkAttributes(func(kv otellog.KeyValue) bool {
 		attrs[kv.Key] = kv.Value

--- a/common/wideevents/namespace_events.go
+++ b/common/wideevents/namespace_events.go
@@ -4,9 +4,8 @@ import "go.opentelemetry.io/otel/log"
 
 // NamespaceLifecycleEventName is the stable event name for the generic, phase-discriminated wide
 // event describing namespace lifecycle activity (failover, configuration, admission, handover,
-// etc.). Namespace replication tasks use NamespaceReplicationLifecyclePayload instead. This package
-// owns only the stable envelope: the set of phase values and the
-// contents of Details are supplied by the emitter.
+// etc.). This package owns only the stable envelope: the set of phase values and the contents of
+// Details are supplied by the emitter.
 const NamespaceLifecycleEventName = "namespace_lifecycle"
 
 // NamespaceLifecyclePayload is the NamespaceLifecycle payload. The identity fields are stable;

--- a/common/wideevents/namespace_replication_events.go
+++ b/common/wideevents/namespace_replication_events.go
@@ -15,7 +15,9 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-const NamespaceReplicationLifecycleEventName = "namespace_replication_lifecycle"
+// NamespaceReplicationLifecycleEventName aliases NamespaceLifecycleEventName for compatibility.
+// TODO: Remove it after callers migrate to NamespaceLifecycleEventName.
+const NamespaceReplicationLifecycleEventName = NamespaceLifecycleEventName
 
 type NamespaceReplicationPhase string
 
@@ -89,12 +91,12 @@ func (defaultNamespaceReplicationTaskEventDataProvider) Extract(
 	}, true
 }
 
-// NamespaceReplicationLifecyclePayload uses the namespace lifecycle envelope while retaining a
-// distinct event name. Replication-specific data is carried in Details.
+// NamespaceReplicationLifecyclePayload uses the namespace lifecycle envelope. Replication-specific
+// data is carried in Details.
 type NamespaceReplicationLifecyclePayload NamespaceLifecyclePayload
 
 func (p NamespaceReplicationLifecyclePayload) EventName() string {
-	return NamespaceReplicationLifecycleEventName
+	return NamespaceLifecycleEventName
 }
 
 func (p NamespaceReplicationLifecyclePayload) Attributes() []log.KeyValue {

--- a/common/wideevents/namespace_replication_events_test.go
+++ b/common/wideevents/namespace_replication_events_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestNamespaceReplicationLifecycleEventName(t *testing.T) {
-	require.Equal(t, "namespace_replication_lifecycle", NamespaceReplicationLifecyclePayload{}.EventName())
+	require.Equal(t, NamespaceLifecycleEventName, NamespaceReplicationLifecyclePayload{}.EventName())
 }
 
 func TestNamespaceReplicationTaskContext(t *testing.T) {
@@ -60,7 +60,7 @@ func TestEmitNamespaceReplicationLifecycle(t *testing.T) {
 	})
 
 	require.Len(t, logger.records, 1)
-	require.Equal(t, NamespaceReplicationLifecycleEventName, logger.records[0].EventName())
+	require.Equal(t, NamespaceLifecycleEventName, logger.records[0].EventName())
 	got := namespaceReplicationRecordValues(logger.records[0])
 	require.Equal(t, map[string]any{
 		"phase":        "dlqed",

--- a/common/wideevents/remote_cluster_events.go
+++ b/common/wideevents/remote_cluster_events.go
@@ -2,19 +2,21 @@ package wideevents
 
 import "go.opentelemetry.io/otel/log"
 
-const RemoteClusterLifecycleEventName = "remote_cluster_lifecycle"
+// RemoteClusterLifecycleEventName aliases NamespaceLifecycleEventName for compatibility.
+// TODO: Remove it after callers migrate to NamespaceLifecycleEventName.
+const RemoteClusterLifecycleEventName = NamespaceLifecycleEventName
 
 const (
 	PhaseRemoteClusterUpsert = "remote_cluster_upsert"
 	PhaseRemoteClusterRemove = "remote_cluster_remove"
 )
 
-// RemoteClusterLifecyclePayload preserves the namespace lifecycle event envelope
-// while using a distinct event name and remote-cluster-specific details.
+// RemoteClusterLifecyclePayload preserves the namespace lifecycle event envelope with
+// remote-cluster-specific details.
 type RemoteClusterLifecyclePayload NamespaceLifecyclePayload
 
 func (p RemoteClusterLifecyclePayload) EventName() string {
-	return RemoteClusterLifecycleEventName
+	return NamespaceLifecycleEventName
 }
 
 func (p RemoteClusterLifecyclePayload) Attributes() []log.KeyValue {

--- a/common/wideevents/remote_cluster_events_test.go
+++ b/common/wideevents/remote_cluster_events_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestRemoteClusterLifecycleEventName(t *testing.T) {
-	require.Equal(t, "remote_cluster_lifecycle", RemoteClusterLifecyclePayload{}.EventName())
+	require.Equal(t, NamespaceLifecycleEventName, RemoteClusterLifecyclePayload{}.EventName())
 }
 
 func TestRemoteClusterLifecycleFieldSetMatchesNamespaceLifecycle(t *testing.T) {

--- a/service/frontend/remote_cluster_lifecycle_events_test.go
+++ b/service/frontend/remote_cluster_lifecycle_events_test.go
@@ -295,7 +295,7 @@ func remoteClusterEventValues(
 ) (map[string]string, map[string]any) {
 	t.Helper()
 	require.Len(t, records, 1)
-	require.Equal(t, wideevents.RemoteClusterLifecycleEventName, records[0].EventName())
+	require.Equal(t, wideevents.NamespaceLifecycleEventName, records[0].EventName())
 	attrs := make(map[string]string)
 	records[0].WalkAttributes(func(kv otellog.KeyValue) bool {
 		attrs[kv.Key] = kv.Value.AsString()


### PR DESCRIPTION
## What changed?

- emit remote cluster and namespace replication lifecycle records under `namespace_lifecycle`
- retain compatibility aliases for specialized event-name constants with TODO cleanup
- update tests and shared envelope documentation

## Why?

Update schema event names to match namespace lifecycle schema which currently exist so they are properly interpreted.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] added new unit test(s)
- [ ] added new functional test(s)