### PR TITLE
Fix batch activity unpause visibility query scope

### DIFF
--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -5897,7 +5897,7 @@ func (wh *WorkflowHandler) StartBatchOperation(
 			if err != nil {
 				return nil, err
 			}
-			input.Request = proto.Clone(request).(*workflowservice.StartBatchOperationRequest)
+			input.Request = proto.CloneOf(request)
 			input.Request.VisibilityQuery = unpauseQuery
 		case *batchpb.BatchOperationUnpauseActivities_MatchAll:
 			input.Request.VisibilityQuery = visibilityQuery
@@ -5995,7 +5995,7 @@ func buildUnpauseActivityVisibilityQuery(query string, activityType string) (str
 	activityTypeExpr := &sqlparser.ComparisonExpr{
 		Operator: sqlparser.EqualStr,
 		Left:     &sqlparser.ColName{Name: sqlparser.NewColIdent(sadefs.TemporalPauseInfo)},
-		Right:    sqlparser.NewStrVal([]byte(fmt.Sprintf("property:activityType=%s", activityType))),
+		Right:    sqlparser.NewStrVal(fmt.Appendf(nil, "property:activityType=%s", activityType)),
 	}
 	selectStmt.Where.Expr = &sqlparser.ParenExpr{Expr: selectStmt.Where.Expr}
 	selectStmt.AddWhere(&sqlparser.ParenExpr{Expr: activityTypeExpr})

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -5893,9 +5893,12 @@ func (wh *WorkflowHandler) StartBatchOperation(
 
 		switch a := op.UnpauseActivitiesOperation.GetActivity().(type) {
 		case *batchpb.BatchOperationUnpauseActivities_Type:
-			searchValue := fmt.Sprintf("property:activityType=%s", a.Type)
-			escapedSearchValue := sqlparser.String(sqlparser.NewStrVal([]byte(searchValue)))
-			input.Request.VisibilityQuery = fmt.Sprintf("%s = %s", sadefs.TemporalPauseInfo, escapedSearchValue)
+			unpauseQuery, err := buildUnpauseActivityVisibilityQuery(visibilityQuery, a.Type)
+			if err != nil {
+				return nil, err
+			}
+			input.Request = proto.Clone(request).(*workflowservice.StartBatchOperationRequest)
+			input.Request.VisibilityQuery = unpauseQuery
 		case *batchpb.BatchOperationUnpauseActivities_MatchAll:
 			input.Request.VisibilityQuery = visibilityQuery
 		}
@@ -5968,6 +5971,35 @@ func (wh *WorkflowHandler) StartBatchOperation(
 		return nil, err
 	}
 	return &workflowservice.StartBatchOperationResponse{}, nil
+}
+
+// buildUnpauseActivityVisibilityQuery narrows the caller's scope to workflows containing a
+// paused activity of the requested type. Only the WHERE expression is returned because the batch
+// worker appends its own execution-status filter.
+func buildUnpauseActivityVisibilityQuery(query string, activityType string) (string, error) {
+	if query == "" {
+		return "", nil
+	}
+
+	// Visibility queries are predicate fragments, so wrap the query in a synthetic SELECT to obtain
+	// a WHERE expression. Reject set operations (i.e., UNION) because they do not expose a single WHERE clause to extend.
+	stmt, err := sqlparser.Parse("select * from dummy where " + query)
+	if err != nil {
+		return "", serviceerror.NewInvalidArgumentf("invalid visibility query: %v", err)
+	}
+	selectStmt, ok := stmt.(*sqlparser.Select)
+	if !ok {
+		return "", serviceerror.NewInvalidArgument("invalid visibility query: set operations are not supported")
+	}
+
+	activityTypeExpr := &sqlparser.ComparisonExpr{
+		Operator: sqlparser.EqualStr,
+		Left:     &sqlparser.ColName{Name: sqlparser.NewColIdent(sadefs.TemporalPauseInfo)},
+		Right:    sqlparser.NewStrVal([]byte(fmt.Sprintf("property:activityType=%s", activityType))),
+	}
+	selectStmt.Where.Expr = &sqlparser.ParenExpr{Expr: selectStmt.Where.Expr}
+	selectStmt.AddWhere(&sqlparser.ParenExpr{Expr: activityTypeExpr})
+	return sqlparser.String(selectStmt.Where.Expr), nil
 }
 
 // snakeCaseBatchType maps a batch operation type enum to the canonical string

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -69,6 +69,7 @@ import (
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/persistence/visibility/manager"
+	"go.temporal.io/server/common/persistence/visibility/store/query"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/priorities"
@@ -5974,8 +5975,8 @@ func (wh *WorkflowHandler) StartBatchOperation(
 // buildUnpauseActivityVisibilityQuery narrows the caller's scope to workflows containing a
 // paused activity of the requested type. Only the WHERE expression is returned because the batch
 // worker appends its own execution-status filter.
-func buildUnpauseActivityVisibilityQuery(query string, activityType string) (string, error) {
-	if query == "" {
+func buildUnpauseActivityVisibilityQuery(q string, activityType string) (string, error) {
+	if q == "" {
 		// An empty query means the caller targeted executions explicitly, so there is no scope to
 		// narrow.
 		return "", nil
@@ -5984,7 +5985,7 @@ func buildUnpauseActivityVisibilityQuery(query string, activityType string) (str
 	// Visibility queries are predicate fragments, so wrap the query in a synthetic SELECT to obtain
 	// a WHERE expression. Reject set operations (for example, UNION) because they do not expose a
 	// single WHERE clause to extend.
-	stmt, err := sqlparser.Parse(fmt.Sprintf(sqlquery.QueryTemplate, query))
+	stmt, err := sqlparser.Parse(fmt.Sprintf(sqlquery.QueryTemplate, q))
 	if err != nil {
 		return "", serviceerror.NewInvalidArgumentf("invalid visibility query: %v", err)
 	}
@@ -5995,11 +5996,13 @@ func buildUnpauseActivityVisibilityQuery(query string, activityType string) (str
 
 	activityTypeExpr := &sqlparser.ComparisonExpr{
 		Operator: sqlparser.EqualStr,
-		Left:     &sqlparser.ColName{Name: sqlparser.NewColIdent(sadefs.TemporalPauseInfo)},
+		Left:     query.NewColName(sadefs.TemporalPauseInfo),
 		Right:    sqlparser.NewStrVal(fmt.Appendf(nil, "property:activityType=%s", activityType)),
 	}
-	selectStmt.Where.Expr = &sqlparser.ParenExpr{Expr: selectStmt.Where.Expr}
-	selectStmt.AddWhere(&sqlparser.ParenExpr{Expr: activityTypeExpr})
+	selectStmt.Where.Expr = &sqlparser.AndExpr{
+		Left:  activityTypeExpr,
+		Right: &sqlparser.ParenExpr{Expr: selectStmt.Where.Expr},
+	}
 	return sqlparser.String(selectStmt.Where.Expr), nil
 }
 

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -79,6 +79,7 @@ import (
 	"go.temporal.io/server/common/sdk"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/searchattribute/sadefs"
+	"go.temporal.io/server/common/sqlquery"
 	"go.temporal.io/server/common/tasktoken"
 	"go.temporal.io/server/common/tqid"
 	"go.temporal.io/server/common/util"
@@ -5806,7 +5807,7 @@ func (wh *WorkflowHandler) StartBatchOperation(
 	// Malformed queries (e.g. "()") would otherwise cause the batch activity
 	// to retry indefinitely since the error is not marked non-retryable.
 	if q := request.GetVisibilityQuery(); len(q) > 0 {
-		if _, err := sqlparser.Parse("select * from dummy where " + q); err != nil {
+		if _, err := sqlparser.Parse(fmt.Sprintf(sqlquery.QueryTemplate, q)); err != nil {
 			return nil, serviceerror.NewInvalidArgumentf("invalid visibility query: %v", err)
 		}
 	}
@@ -5891,16 +5892,13 @@ func (wh *WorkflowHandler) StartBatchOperation(
 		input.BatchType = enumspb.BATCH_OPERATION_TYPE_UNPAUSE_ACTIVITY
 		identity = op.UnpauseActivitiesOperation.GetIdentity()
 
-		switch a := op.UnpauseActivitiesOperation.GetActivity().(type) {
-		case *batchpb.BatchOperationUnpauseActivities_Type:
+		if a, ok := op.UnpauseActivitiesOperation.GetActivity().(*batchpb.BatchOperationUnpauseActivities_Type); ok {
 			unpauseQuery, err := buildUnpauseActivityVisibilityQuery(visibilityQuery, a.Type)
 			if err != nil {
 				return nil, err
 			}
 			input.Request = proto.CloneOf(request)
 			input.Request.VisibilityQuery = unpauseQuery
-		case *batchpb.BatchOperationUnpauseActivities_MatchAll:
-			input.Request.VisibilityQuery = visibilityQuery
 		}
 	case *workflowservice.StartBatchOperationRequest_ResetActivitiesOperation:
 		input.BatchType = enumspb.BATCH_OPERATION_TYPE_RESET_ACTIVITY
@@ -5978,12 +5976,15 @@ func (wh *WorkflowHandler) StartBatchOperation(
 // worker appends its own execution-status filter.
 func buildUnpauseActivityVisibilityQuery(query string, activityType string) (string, error) {
 	if query == "" {
+		// An empty query means the caller targeted executions explicitly, so there is no scope to
+		// narrow.
 		return "", nil
 	}
 
 	// Visibility queries are predicate fragments, so wrap the query in a synthetic SELECT to obtain
-	// a WHERE expression. Reject set operations (i.e., UNION) because they do not expose a single WHERE clause to extend.
-	stmt, err := sqlparser.Parse("select * from dummy where " + query)
+	// a WHERE expression. Reject set operations (for example, UNION) because they do not expose a
+	// single WHERE clause to extend.
+	stmt, err := sqlparser.Parse(fmt.Sprintf(sqlquery.QueryTemplate, query))
 	if err != nil {
 		return "", serviceerror.NewInvalidArgumentf("invalid visibility query: %v", err)
 	}

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -2884,19 +2884,19 @@ func TestBuildUnpauseActivityVisibilityQuery(t *testing.T) {
 			name:         "scoped query",
 			query:        "WorkflowType='ScopedWorkflow'",
 			activityType: "ActivityFunc",
-			want:         "(WorkflowType = 'ScopedWorkflow') and (TemporalPauseInfo = 'property:activityType=ActivityFunc')",
+			want:         "TemporalPauseInfo = 'property:activityType=ActivityFunc' and (WorkflowType = 'ScopedWorkflow')",
 		},
 		{
 			name:         "boolean query preserves precedence and escapes activity type",
 			query:        "WorkflowType='ScopedWorkflow' OR WorkflowType='OtherWorkflow'",
 			activityType: "Activity'Func",
-			want:         "(WorkflowType = 'ScopedWorkflow' or WorkflowType = 'OtherWorkflow') and (TemporalPauseInfo = 'property:activityType=Activity\\'Func')",
+			want:         "TemporalPauseInfo = 'property:activityType=Activity\\'Func' and (WorkflowType = 'ScopedWorkflow' or WorkflowType = 'OtherWorkflow')",
 		},
 		{
 			name:         "order by is dropped",
 			query:        "WorkflowType='ScopedWorkflow' ORDER BY StartTime DESC",
 			activityType: "ActivityFunc",
-			want:         "(WorkflowType = 'ScopedWorkflow') and (TemporalPauseInfo = 'property:activityType=ActivityFunc')",
+			want:         "TemporalPauseInfo = 'property:activityType=ActivityFunc' and (WorkflowType = 'ScopedWorkflow')",
 		},
 		{
 			name:         "set operation",
@@ -2947,7 +2947,7 @@ func (s *WorkflowHandlerSuite) TestStartBatchOperation_UnpauseActivitiesPreserve
 					},
 				},
 			},
-			wantQuery: "(WorkflowType = 'ScopedWorkflow') and (TemporalPauseInfo = 'property:activityType=ActivityFunc')",
+			wantQuery: "TemporalPauseInfo = 'property:activityType=ActivityFunc' and (WorkflowType = 'ScopedWorkflow')",
 		},
 		{
 			name: "explicit target",

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -2869,7 +2869,7 @@ func (s *WorkflowHandlerSuite) TestStartBatchOperation_Signal() {
 func TestBuildUnpauseActivityVisibilityQuery(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
+	testCases := []struct {
 		name         string
 		query        string
 		activityType string
@@ -2900,7 +2900,7 @@ func TestBuildUnpauseActivityVisibilityQuery(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -2922,7 +2922,7 @@ func (s *WorkflowHandlerSuite) TestStartBatchOperation_UnpauseActivitiesPreserve
 		BusinessId: uuid.NewString(),
 		RunId:      uuid.NewString(),
 	}
-	tests := []struct {
+	testCases := []struct {
 		name       string
 		request    *workflowservice.StartBatchOperationRequest
 		wantQuery  string
@@ -2960,7 +2960,7 @@ func (s *WorkflowHandlerSuite) TestStartBatchOperation_UnpauseActivitiesPreserve
 		},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range testCases {
 		s.Run(tt.name, func() {
 			namespaceID := namespace.ID(uuid.NewString())
 			wh := s.getWorkflowHandler(s.newConfig())

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -2887,10 +2887,16 @@ func TestBuildUnpauseActivityVisibilityQuery(t *testing.T) {
 			want:         "(WorkflowType = 'ScopedWorkflow') and (TemporalPauseInfo = 'property:activityType=ActivityFunc')",
 		},
 		{
-			name:         "boolean query with ordering and escaped activity type",
-			query:        "WorkflowType='ScopedWorkflow' OR WorkflowType='OtherWorkflow' ORDER BY StartTime DESC",
+			name:         "boolean query preserves precedence and escapes activity type",
+			query:        "WorkflowType='ScopedWorkflow' OR WorkflowType='OtherWorkflow'",
 			activityType: "Activity'Func",
 			want:         "(WorkflowType = 'ScopedWorkflow' or WorkflowType = 'OtherWorkflow') and (TemporalPauseInfo = 'property:activityType=Activity\\'Func')",
+		},
+		{
+			name:         "order by is dropped",
+			query:        "WorkflowType='ScopedWorkflow' ORDER BY StartTime DESC",
+			activityType: "ActivityFunc",
+			want:         "(WorkflowType = 'ScopedWorkflow') and (TemporalPauseInfo = 'property:activityType=ActivityFunc')",
 		},
 		{
 			name:         "set operation",

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -76,6 +76,7 @@ import (
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -2863,6 +2864,134 @@ func (s *WorkflowHandlerSuite) TestStartBatchOperation_Signal() {
 
 	_, err = wh.StartBatchOperation(context.Background(), request)
 	s.NoError(err)
+}
+
+func TestBuildUnpauseActivityVisibilityQuery(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		query        string
+		activityType string
+		want         string
+		wantErr      bool
+	}{
+		{
+			name:         "explicit targets",
+			activityType: "ActivityFunc",
+		},
+		{
+			name:         "scoped query",
+			query:        "WorkflowType='ScopedWorkflow'",
+			activityType: "ActivityFunc",
+			want:         "(WorkflowType = 'ScopedWorkflow') and (TemporalPauseInfo = 'property:activityType=ActivityFunc')",
+		},
+		{
+			name:         "boolean query with ordering and escaped activity type",
+			query:        "WorkflowType='ScopedWorkflow' OR WorkflowType='OtherWorkflow' ORDER BY StartTime DESC",
+			activityType: "Activity'Func",
+			want:         "(WorkflowType = 'ScopedWorkflow' or WorkflowType = 'OtherWorkflow') and (TemporalPauseInfo = 'property:activityType=Activity\\'Func')",
+		},
+		{
+			name:         "set operation",
+			query:        "WorkflowId='test' UNION SELECT * FROM other",
+			activityType: "ActivityFunc",
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := buildUnpauseActivityVisibilityQuery(tt.query, tt.activityType)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func (s *WorkflowHandlerSuite) TestStartBatchOperation_UnpauseActivitiesPreservesTargetScope() {
+	testNamespace := namespace.Name("test-namespace")
+	targetExecution := &commonpb.Execution{
+		Type:       enumspb.EXECUTION_TYPE_WORKFLOW,
+		BusinessId: uuid.NewString(),
+		RunId:      uuid.NewString(),
+	}
+	tests := []struct {
+		name       string
+		request    *workflowservice.StartBatchOperationRequest
+		wantQuery  string
+		wantTarget *commonpb.Execution
+	}{
+		{
+			name: "visibility query",
+			request: &workflowservice.StartBatchOperationRequest{
+				Namespace:       testNamespace.String(),
+				VisibilityQuery: "WorkflowType='ScopedWorkflow'",
+				JobId:           uuid.NewString(),
+				Reason:          "test",
+				Operation: &workflowservice.StartBatchOperationRequest_UnpauseActivitiesOperation{
+					UnpauseActivitiesOperation: &batchpb.BatchOperationUnpauseActivities{
+						Activity: &batchpb.BatchOperationUnpauseActivities_Type{Type: "ActivityFunc"},
+					},
+				},
+			},
+			wantQuery: "(WorkflowType = 'ScopedWorkflow') and (TemporalPauseInfo = 'property:activityType=ActivityFunc')",
+		},
+		{
+			name: "explicit target",
+			request: &workflowservice.StartBatchOperationRequest{
+				Namespace:        testNamespace.String(),
+				TargetExecutions: []*commonpb.Execution{targetExecution},
+				JobId:            uuid.NewString(),
+				Reason:           "test",
+				Operation: &workflowservice.StartBatchOperationRequest_UnpauseActivitiesOperation{
+					UnpauseActivitiesOperation: &batchpb.BatchOperationUnpauseActivities{
+						Activity: &batchpb.BatchOperationUnpauseActivities_Type{Type: "ActivityFunc"},
+					},
+				},
+			},
+			wantTarget: targetExecution,
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			namespaceID := namespace.ID(uuid.NewString())
+			wh := s.getWorkflowHandler(s.newConfig())
+			originalRequest := proto.Clone(tt.request).(*workflowservice.StartBatchOperationRequest)
+			var input batchspb.BatchOperationInput
+
+			s.mockNamespaceCache.EXPECT().GetNamespaceID(gomock.Any()).Return(namespaceID, nil).AnyTimes()
+			s.mockVisibilityMgr.EXPECT().CountWorkflowExecutions(gomock.Any(), gomock.Any()).Return(&manager.CountWorkflowExecutionsResponse{Count: 0}, nil)
+			s.mockHistoryClient.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(
+					_ context.Context,
+					request *historyservice.StartWorkflowExecutionRequest,
+					_ ...grpc.CallOption,
+				) (*historyservice.StartWorkflowExecutionResponse, error) {
+					s.Require().NoError(payloads.Decode(request.StartRequest.Input, &input))
+					return &historyservice.StartWorkflowExecutionResponse{}, nil
+				},
+			)
+
+			_, err := wh.StartBatchOperation(context.Background(), tt.request)
+			s.Require().NoError(err)
+			s.ProtoEqual(originalRequest, tt.request)
+			s.Equal(tt.wantQuery, input.Request.GetVisibilityQuery())
+			if tt.wantTarget == nil {
+				s.Empty(input.Request.GetTargetExecutions())
+			} else {
+				s.Require().Len(input.Request.GetTargetExecutions(), 1)
+				s.ProtoEqual(tt.wantTarget, input.Request.GetTargetExecutions()[0])
+			}
+		})
+	}
 }
 
 func (s *WorkflowHandlerSuite) TestStartBatchOperation_WorkflowExecutions_Signal() {


### PR DESCRIPTION
## What changed?
Preserved the caller-provided visibility scope when starting type-based batch activity unpause operations. The activity-type predicate is now safely combined with the original query.

## Why?
The server previously replaced the caller’s visibility query with the activity-type predicate. This could broaden the batch scope and unpause activities in workflows the caller did not select.

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
Type-based unpause batches now strictly honor the caller’s visibility scope, so they may process fewer workflows than before, but this is the correct design
