### PR TITLE
fix: preserve explicit MaximumAttempts=0 (unlimited) from dynamic config overrides

### DIFF
--- a/chasm/lib/activity/validator.go
+++ b/chasm/lib/activity/validator.go
@@ -144,6 +144,11 @@ func validateActivityRetryPolicy(
 		return nil
 	}
 	defaultActivityRetrySettings := getDefaultActivityRetrySettings(namespaceName.String())
+	// Don't override explicit MaximumAttempts=0 (unlimited).
+	// Proto3 int32 can't distinguish "unset" from "explicitly set to 0".
+	if defaultActivityRetrySettings.MaximumAttempts != 0 {
+		defaultActivityRetrySettings.MaximumAttempts = 0
+	}
 	retrypolicy.EnsureDefaults(retryPolicy, defaultActivityRetrySettings)
 	return retrypolicy.Validate(retryPolicy)
 }

--- a/chasm/lib/workflow/validator.go
+++ b/chasm/lib/workflow/validator.go
@@ -90,7 +90,13 @@ func (v *RequestValidator) ValidateRetryPolicy(namespaceName string, retryPolicy
 		return nil
 	}
 
-	retrypolicy.EnsureDefaults(retryPolicy, v.config.defaultWorkflowRetrySettings(namespaceName))
+	defaultSettings := v.config.defaultWorkflowRetrySettings(namespaceName)
+	// Don't override explicit MaximumAttempts=0 (unlimited).
+	// Proto3 int32 can't distinguish "unset" from "explicitly set to 0".
+	if defaultSettings.MaximumAttempts != 0 {
+		defaultSettings.MaximumAttempts = 0
+	}
+	retrypolicy.EnsureDefaults(retryPolicy, defaultSettings)
 	return retrypolicy.Validate(retryPolicy)
 }
 

--- a/service/history/api/command_attr_validator.go
+++ b/service/history/api/command_attr_validator.go
@@ -563,6 +563,14 @@ func (v *CommandAttrValidator) validateActivityRetryPolicy(
 		return nil
 	}
 	defaultActivityRetrySettings := v.getDefaultActivityRetrySettings(namespaceName.String())
+	// Don't override explicit MaximumAttempts=0 (unlimited).
+	// Proto3 int32 can't distinguish "unset" from "explicitly set to 0",
+	// so preserve the caller's value when the dynamic config has a non-zero default.
+	// The dynamic config docs say it applies "where the user has not specified an
+	// explicit RetryPolicy" — by the time we reach here, the user has.
+	if defaultActivityRetrySettings.MaximumAttempts != 0 {
+		defaultActivityRetrySettings.MaximumAttempts = 0
+	}
 	retrypolicy.EnsureDefaults(retryPolicy, defaultActivityRetrySettings)
 	return retrypolicy.Validate(retryPolicy)
 }
@@ -578,6 +586,11 @@ func (v *CommandAttrValidator) validateWorkflowRetryPolicy(
 
 	// Otherwise, for any unset fields on the retry policy, set with defaults
 	defaultWorkflowRetrySettings := v.getDefaultWorkflowRetrySettings(namespaceName.String())
+	// Don't override explicit MaximumAttempts=0 (unlimited).
+	// Proto3 int32 can't distinguish "unset" from "explicitly set to 0".
+	if defaultWorkflowRetrySettings.MaximumAttempts != 0 {
+		defaultWorkflowRetrySettings.MaximumAttempts = 0
+	}
 	retrypolicy.EnsureDefaults(retryPolicy, defaultWorkflowRetrySettings)
 	return retrypolicy.Validate(retryPolicy)
 }


### PR DESCRIPTION
## What changed

When a user provides an explicit `RetryPolicy` with `maximum_attempts=0` (unlimited
retries), the server's `defaultActivityRetryPolicy` dynamic config overwrites it
with a non-zero default. Proto3 `int32` can't distinguish "unset" from "explicit 0",
so the server treats `0` as "unset" and applies the dynamic config value.

## Root cause

The `RetryPolicy.maximum_attempts` field is a proto3 `int32` without field presence
(`optional` keyword). On the wire, `0` and "not set" are identical. The server's
`EnsureDefaults` function checks `GetMaximumAttempts() == 0` and overwrites with
the dynamic config value.

## Fix

For explicit user policies (non-nil), zero out the dynamic config's `MaximumAttempts`
before calling `EnsureDefaults`. This ensures the user's explicit `0` (unlimited) is
preserved. The nil→empty→defaults path (used when the user removes their retry
policy entirely) still applies the dynamic config's `MaximumAttempts`.

The dynamic config docs say: "DefaultActivityRetryPolicy represents the out-of-box
retry policy for activities where the user has not specified an explicit RetryPolicy".
This fix aligns the implementation with the documented intent.

## Files changed

- `service/history/api/command_attr_validator.go` — validateActivityRetryPolicy, validateWorkflowRetryPolicy
- `chasm/lib/activity/validator.go` — validateActivityRetryPolicy
- `chasm/lib/workflow/validator.go` — ValidateRetryPolicy
- `common/dynamicconfig/constants.go` — doc comment update

## Related issue

Closes #11721

Signed-off-by: waterWang <672684719@qq.com>