### PR TITLE
Check SQL refresh throttle before discarding the connection pool

### DIFF
--- a/common/persistence/sql/sqlplugin/db_handle.go
+++ b/common/persistence/sql/sqlplugin/db_handle.go
@@ -79,16 +79,9 @@ func (h *DatabaseHandle) reconnect(force bool) *sqlx.DB {
 	}
 
 	prevConn := h.db.Load()
-	if prevConn != nil {
-		if !force {
-			// Another goroutine already reconnected
-			return prevConn
-		}
-
-		h.db.Store(nil)
-		// Store `nil` to prevent other goroutines from slamming the now-unusable database with
-		// transactions we know will fail
-		go prevConn.Close()
+	if prevConn != nil && !force {
+		// Another goroutine already reconnected
+		return prevConn
 	}
 
 	metrics.PersistenceSessionRefreshAttempts.With(h.metrics).Record(1)
@@ -96,11 +89,20 @@ func (h *DatabaseHandle) reconnect(force bool) *sqlx.DB {
 	now := h.timeSource.Now()
 	lastRefresh := h.lastRefresh
 	if now.Sub(lastRefresh) < sessionRefreshMinInternal {
+		// Throttled, so there will be no replacement pool. Keep the current one installed
+		// rather than leaving the handle with no database at all.
 		h.logger.Warn("sql handle: did not refresh database connection pool because the last refresh was too close",
 			tag.Duration("min_refresh_interval_seconds", sessionRefreshMinInternal))
 		handler := h.metrics.WithTags(metrics.FailureTag("throttle"))
 		metrics.PersistenceSessionRefreshFailures.With(handler).Record(1)
 		return nil
+	}
+
+	if prevConn != nil {
+		h.db.Store(nil)
+		// Store `nil` to prevent other goroutines from slamming the now-unusable database with
+		// transactions we know will fail
+		go prevConn.Close()
 	}
 
 	h.lastRefresh = now

--- a/common/persistence/sql/sqlplugin/db_handle_test.go
+++ b/common/persistence/sql/sqlplugin/db_handle_test.go
@@ -1,12 +1,14 @@
 package sqlplugin
 
 import (
+	"database/sql"
 	"errors"
 	"testing"
 	"time"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
@@ -53,3 +55,38 @@ func TestDatabaseHandleReconnect(t *testing.T) {
 }
 
 var errTest = errors.New("test")
+
+// TestDatabaseHandleThrottledForcedReconnectKeepsPool asserts that a forced reconnect that the
+// refresh throttle rejects leaves the existing pool installed on the handle. A rejected refresh
+// creates no replacement pool, so discarding the current one leaves the handle with no database
+// at all until the throttle window elapses.
+func TestDatabaseHandleThrottledForcedReconnectKeepsPool(t *testing.T) {
+	t.Parallel()
+
+	connectAttempts := 0
+	connectFunc := func() (*sqlx.DB, error) {
+		connectAttempts++
+		return sqlx.NewDb(sql.OpenDB(&fakeConnector{}), "fake"), nil
+	}
+	needsRefreshFunc := func(error) bool { return false }
+
+	fakeTimeSource := clock.NewEventTimeSource().Update(time.Now())
+	dbHandle := NewDatabaseHandle(DbKindUnknown, connectFunc, needsRefreshFunc, log.NewNoopLogger(), metrics.NoopMetricsHandler, fakeTimeSource)
+	defer dbHandle.Close()
+
+	require.Equal(t, 1, connectAttempts)
+	require.NotNil(t, dbHandle.db.Load())
+
+	// Outside the throttle window a forced reconnect replaces the pool.
+	fakeTimeSource.Advance(sessionRefreshMinInternal + time.Millisecond)
+	p2 := dbHandle.reconnect(true)
+	require.NotNil(t, p2)
+	require.Equal(t, 2, connectAttempts)
+	require.Same(t, p2, dbHandle.db.Load())
+
+	// Inside the throttle window the refresh is rejected, so the pool must be left alone.
+	fakeTimeSource.Advance(sessionRefreshMinInternal / 2)
+	dbHandle.reconnect(true)
+	require.Equal(t, 2, connectAttempts, "throttled refresh must not open a new pool")
+	require.Same(t, p2, dbHandle.db.Load(), "throttled refresh must not discard the current pool")
+}


### PR DESCRIPTION
## What changed?

Check the SQL session refresh throttle before discarding the current connection pool.

Previously, a forced refresh cleared and closed the active pool before checking whether the refresh was throttled. If throttled, no replacement pool was created and the database handle was temporarily left without a connection pool.

The current pool is now preserved when the refresh is rejected by the throttle.

## Why?

This addresses the refresh-ordering failure mode described in #11691.

It does not address stale errors from an older connection pool triggering refresh of a newer pool; that requires separate generation-aware handling.

## How did you test it?

- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

Added a deterministic regression test using the existing fake clock and SQL connector. The test verifies that a throttled forced reconnect:

- does not create another pool
- keeps the currently installed pool intact

Validated with:

`go test ./common/persistence/sql/sqlplugin/... -count=1`

`go test -race ./common/persistence/sql/sqlplugin/ -run 'TestDatabaseHandle' -count=1`

`go vet ./common/persistence/sql/sqlplugin/`