### PR TITLE
Cherry-pick #11704 to cloud/v1.32.0-162: return forked branch token from storage layer to OSS

### DIFF
--- a/common/persistence/data_interfaces.go
+++ b/common/persistence/data_interfaces.go
@@ -925,6 +925,12 @@ type (
 	ForkHistoryBranchResponse struct {
 		// branchToken to represent the new branch
 		NewBranchToken []byte
+		// The storage layer might have changed the base branch token. This
+		// response represents the changed base branch token to be used for further
+		// processing in a workflow rebuild operation.
+		// An empty value indicates that the caller's base branch token
+		// is still correct.
+		BaseBranchToken []byte
 	}
 
 	// CompleteForkBranchRequest is used to complete forking
@@ -1165,7 +1171,8 @@ type (
 		// ReadRawHistoryBranch returns history node raw data for a branch ByBatch
 		// NOTE: this API should only be used by 3+DC
 		ReadRawHistoryBranch(ctx context.Context, request *ReadHistoryBranchRequest) (*ReadRawHistoryBranchResponse, error)
-		// ForkHistoryBranch forks a new branch from a old branch
+		// ForkHistoryBranch forks a new branch from an old branch. The response may contain a different/rewritten base token that
+		// should be used for further action.
 		ForkHistoryBranch(ctx context.Context, request *ForkHistoryBranchRequest) (*ForkHistoryBranchResponse, error)
 		// DeleteHistoryBranch removes a branch
 		// If this is the last branch to delete, it will also remove the root node

--- a/service/history/ndc/resetter.go
+++ b/service/history/ndc/resetter.go
@@ -98,7 +98,7 @@ func (r *resetterImpl) resetWorkflow(
 		return nil, err
 	}
 
-	resetBranchToken, err := r.getResetBranchToken(ctx, baseBranchToken, baseLastEventID)
+	resetBranchToken, newBaseBranchToken, err := r.getResetBranchToken(ctx, baseBranchToken, baseLastEventID)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +112,7 @@ func (r *resetterImpl) resetWorkflow(
 			r.workflowID,
 			r.baseRunID,
 		),
-		baseBranchToken,
+		newBaseBranchToken,
 		baseLastEventID,
 		new(baseLastEventVersion),
 		definition.NewWorkflowKey(
@@ -205,7 +205,7 @@ func (r *resetterImpl) getResetBranchToken(
 	ctx context.Context,
 	baseBranchToken []byte,
 	baseLastEventID int64,
-) ([]byte, error) {
+) (newBranchToken []byte, forkedBaseBranchToken []byte, err error) {
 
 	// fork a new history branch
 	shardID := r.shard.GetShardID()
@@ -218,8 +218,13 @@ func (r *resetterImpl) getResetBranchToken(
 		NewRunID:        r.newRunID,
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return resp.NewBranchToken, nil
+	// An empty resp.BaseBranchToken means the storage layer did not rewrite the
+	// token. So it is still valid.
+	if len(resp.BaseBranchToken) == 0 {
+		return resp.NewBranchToken, baseBranchToken, nil
+	}
+	return resp.NewBranchToken, resp.BaseBranchToken, nil
 }

--- a/service/history/ndc/resetter_test.go
+++ b/service/history/ndc/resetter_test.go
@@ -132,6 +132,98 @@ func (s *resetterSuite) TestResetWorkflow_NoError() {
 		ExternalPayloadCount: 56,
 	}
 	newBranchToken := []byte("other random branch token")
+	resurrectedBranchToken := []byte("resurrected branch token")
+
+	s.mockBaseMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{VersionHistories: versionHistories}).AnyTimes()
+
+	mockBaseWorkflowReleaseFnCalled := false
+	mockBaseWorkflowReleaseFn := func(err error) {
+		mockBaseWorkflowReleaseFnCalled = true
+	}
+	mockBaseWorkflow := NewMockWorkflow(s.controller)
+	mockBaseWorkflow.EXPECT().GetMutableState().Return(s.mockBaseMutableState).AnyTimes()
+	mockBaseWorkflow.EXPECT().GetReleaseFn().Return(mockBaseWorkflowReleaseFn)
+
+	s.mockTransactionMgr.EXPECT().LoadWorkflow(
+		ctx,
+		s.namespaceID,
+		s.workflowID,
+		s.baseRunID,
+		chasm.WorkflowArchetypeID,
+	).Return(mockBaseWorkflow, nil)
+
+	s.mockStateBuilder.EXPECT().Rebuild(
+		ctx,
+		now,
+		definition.NewWorkflowKey(
+			s.namespaceID.String(),
+			s.workflowID,
+			s.baseRunID,
+		),
+		resurrectedBranchToken,
+		baseEventID,
+		new(baseVersion),
+		definition.NewWorkflowKey(
+			s.namespaceID.String(),
+			s.workflowID,
+			s.newRunID,
+		),
+		newBranchToken,
+		gomock.Any(),
+	).Return(s.mockRebuiltMutableState, rebuildStats, nil)
+	s.mockRebuiltMutableState.EXPECT().AddHistorySize(rebuildStats.HistorySize)
+	s.mockRebuiltMutableState.EXPECT().AddExternalPayloadSize(rebuildStats.ExternalPayloadSize)
+	s.mockRebuiltMutableState.EXPECT().AddExternalPayloadCount(rebuildStats.ExternalPayloadCount)
+
+	shardID := s.mockShard.GetShardID()
+	s.mockExecManager.EXPECT().ForkHistoryBranch(gomock.Any(), &persistence.ForkHistoryBranchRequest{
+		ForkBranchToken: branchToken,
+		ForkNodeID:      baseEventID + 1,
+		Info:            persistence.BuildHistoryGarbageCleanupInfo(s.namespaceID.String(), s.workflowID, s.newRunID),
+		ShardID:         shardID,
+		NamespaceID:     s.namespaceID.String(),
+		NewRunID:        s.newRunID,
+	}).Return(&persistence.ForkHistoryBranchResponse{NewBranchToken: newBranchToken, BaseBranchToken: resurrectedBranchToken}, nil)
+
+	s.mockRebuiltMutableState.EXPECT().RefreshExpirationTimeoutTask(gomock.Any()).Return(nil)
+
+	rebuiltMutableState, err := s.workflowResetter.resetWorkflow(
+		ctx,
+		now,
+		baseEventID,
+		baseVersion,
+		incomingFirstEventID,
+		incomingVersion,
+	)
+	s.NoError(err)
+	s.Equal(s.mockRebuiltMutableState, rebuiltMutableState)
+	s.True(mockBaseWorkflowReleaseFnCalled)
+}
+
+func (s *resetterSuite) TestResetWorkflow_NoError_BaseBranchToken_Nil() {
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	branchToken := []byte("some random branch token")
+	lastEventID := int64(500)
+	version := int64(123)
+	versionHistory := versionhistory.NewVersionHistory(
+		branchToken,
+		[]*historyspb.VersionHistoryItem{versionhistory.NewVersionHistoryItem(lastEventID, version)},
+	)
+	versionHistories := versionhistory.NewVersionHistories(versionHistory)
+
+	baseEventID := lastEventID - 100
+	baseVersion := version
+	incomingFirstEventID := baseEventID + 12
+	incomingVersion := baseVersion + 3
+
+	rebuildStats := RebuildStats{
+		HistorySize:          9999,
+		ExternalPayloadSize:  1234,
+		ExternalPayloadCount: 56,
+	}
+	newBranchToken := []byte("other random branch token")
 
 	s.mockBaseMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{VersionHistories: versionHistories}).AnyTimes()
 
@@ -182,7 +274,7 @@ func (s *resetterSuite) TestResetWorkflow_NoError() {
 		ShardID:         shardID,
 		NamespaceID:     s.namespaceID.String(),
 		NewRunID:        s.newRunID,
-	}).Return(&persistence.ForkHistoryBranchResponse{NewBranchToken: newBranchToken}, nil)
+	}).Return(&persistence.ForkHistoryBranchResponse{NewBranchToken: newBranchToken, BaseBranchToken: nil}, nil)
 
 	s.mockRebuiltMutableState.EXPECT().RefreshExpirationTimeoutTask(gomock.Any()).Return(nil)
 

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -135,6 +135,10 @@ func (r *workflowResetterImpl) ResetWorkflow(
 
 	var currentWorkflowMutation *persistence.WorkflowMutation
 	var currentWorkflowEventsSeq []*persistence.WorkflowEvents
+	// Every reapply path below deliberately uses the pre-fork baseBranchToken, not the rewritten
+	// token that forkAndGenerateBranchToken returns. A storage layer that rewrites the base token
+	// only guarantees the range below the fork point is readable through it; these reads start at
+	// the fork point and go up, so they must keep the caller's original token.
 	var reapplyEventsFn workflowResetReapplyEventsFn
 	// currentWorkflow is nil only for a reset by explicit runId whose workflow has no current
 	// execution (the current run was deleted while older runs survive). This is exclusive to the
@@ -510,7 +514,7 @@ func (r *workflowResetterImpl) replayResetWorkflow(
 	resetRequestID string,
 ) (Workflow, error) {
 
-	resetBranchToken, err := r.forkAndGenerateBranchToken(
+	resetBranchToken, newBaseBranchToken, err := r.forkAndGenerateBranchToken(
 		ctx,
 		namespaceID,
 		workflowID,
@@ -544,7 +548,7 @@ func (r *workflowResetterImpl) replayResetWorkflow(
 			workflowID,
 			baseRunID,
 		),
-		baseBranchToken,
+		newBaseBranchToken,
 		baseRebuildLastEventID,
 		new(baseRebuildLastEventVersion),
 		definition.NewWorkflowKey(
@@ -677,7 +681,7 @@ func (r *workflowResetterImpl) forkAndGenerateBranchToken(
 	forkBranchToken []byte,
 	forkNodeID int64,
 	resetRunID string,
-) ([]byte, error) {
+) (newBranchToken []byte, forkedBaseBranchToken []byte, err error) {
 	// fork a new history branch
 	shardID := r.shardContext.GetShardID()
 	resp, err := r.executionMgr.ForkHistoryBranch(ctx, &persistence.ForkHistoryBranchRequest{
@@ -689,10 +693,13 @@ func (r *workflowResetterImpl) forkAndGenerateBranchToken(
 		NewRunID:        resetRunID,
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return resp.NewBranchToken, nil
+	if len(resp.BaseBranchToken) == 0 {
+		return resp.NewBranchToken, forkBranchToken, nil
+	}
+	return resp.NewBranchToken, resp.BaseBranchToken, nil
 }
 
 func (r *workflowResetterImpl) terminateWorkflow(

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -374,6 +374,69 @@ func (s *workflowResetterSuite) TestPersistToDB_CurrentExecutionMissing() {
 func (s *workflowResetterSuite) TestReplayResetWorkflow() {
 	ctx := context.Background()
 	baseBranchToken := []byte("some random base branch token")
+	forkedBaseBranchToken := []byte("some random forked base branch token")
+	baseRebuildLastEventID := int64(1233)
+	baseRebuildLastEventVersion := int64(12)
+
+	resetBranchToken := []byte("some random reset branch token")
+	resetRequestID := uuid.NewString()
+	resetStats := RebuildStats{
+		HistorySize:          4411,
+		ExternalPayloadSize:  1234,
+		ExternalPayloadCount: 56,
+	}
+	resetMutableState := historyi.NewMockMutableState(s.controller)
+
+	s.mockExecutionMgr.EXPECT().ForkHistoryBranch(gomock.Any(), gomock.Any()).Return(
+		&persistence.ForkHistoryBranchResponse{NewBranchToken: resetBranchToken, BaseBranchToken: forkedBaseBranchToken}, nil,
+	)
+
+	s.mockStateRebuilder.EXPECT().Rebuild(
+		ctx,
+		gomock.Any(),
+		definition.NewWorkflowKey(
+			s.namespaceID.String(),
+			s.workflowID,
+			s.baseRunID,
+		),
+		forkedBaseBranchToken,
+		baseRebuildLastEventID,
+		new(baseRebuildLastEventVersion),
+		definition.NewWorkflowKey(
+			s.namespaceID.String(),
+			s.workflowID,
+			s.resetRunID,
+		),
+		resetBranchToken,
+		resetRequestID,
+	).Return(resetMutableState, resetStats, nil)
+	resetMutableState.EXPECT().SetBaseWorkflow(
+		s.baseRunID,
+		baseRebuildLastEventID,
+		baseRebuildLastEventVersion,
+	)
+	resetMutableState.EXPECT().AddHistorySize(resetStats.HistorySize)
+	resetMutableState.EXPECT().AddExternalPayloadSize(resetStats.ExternalPayloadSize)
+	resetMutableState.EXPECT().AddExternalPayloadCount(resetStats.ExternalPayloadCount)
+
+	resetWorkflow, err := s.workflowResetter.replayResetWorkflow(
+		ctx,
+		s.namespaceID,
+		s.workflowID,
+		s.baseRunID,
+		baseBranchToken,
+		baseRebuildLastEventID,
+		baseRebuildLastEventVersion,
+		s.resetRunID,
+		resetRequestID,
+	)
+	s.NoError(err)
+	s.Equal(resetMutableState, resetWorkflow.GetMutableState())
+}
+
+func (s *workflowResetterSuite) TestReplayResetWorkflow_EmptyBaseBranchToken() {
+	ctx := context.Background()
+	baseBranchToken := []byte("some random base branch token")
 	baseRebuildLastEventID := int64(1233)
 	baseRebuildLastEventVersion := int64(12)
 
@@ -598,6 +661,31 @@ func (s *workflowResetterSuite) TestFailInflightActivity() {
 
 func (s *workflowResetterSuite) TestGenerateBranchToken() {
 	baseBranchToken := []byte("some random base branch token")
+	resurrectedBaseBranchToken := []byte("some random resurrected new base branch token")
+	baseNodeID := int64(1234)
+
+	resetBranchToken := []byte("some random reset branch token")
+
+	shardID := s.mockShard.GetShardID()
+	s.mockExecutionMgr.EXPECT().ForkHistoryBranch(gomock.Any(), &persistence.ForkHistoryBranchRequest{
+		ForkBranchToken: baseBranchToken,
+		ForkNodeID:      baseNodeID,
+		Info:            persistence.BuildHistoryGarbageCleanupInfo(s.namespaceID.String(), s.workflowID, s.resetRunID),
+		ShardID:         shardID,
+		NamespaceID:     s.namespaceID.String(),
+		NewRunID:        s.resetRunID,
+	}).Return(&persistence.ForkHistoryBranchResponse{NewBranchToken: resetBranchToken, BaseBranchToken: resurrectedBaseBranchToken}, nil)
+
+	newBranchToken, newBaseBranchToken, err := s.workflowResetter.forkAndGenerateBranchToken(
+		context.Background(), s.namespaceID, s.workflowID, baseBranchToken, baseNodeID, s.resetRunID,
+	)
+	s.NoError(err)
+	s.Equal(resetBranchToken, newBranchToken)
+	s.Equal(resurrectedBaseBranchToken, newBaseBranchToken)
+}
+
+func (s *workflowResetterSuite) TestGenerateBranchToken_EmptyBaseBranchToken() {
+	baseBranchToken := []byte("some random base branch token")
 	baseNodeID := int64(1234)
 
 	resetBranchToken := []byte("some random reset branch token")
@@ -612,11 +700,12 @@ func (s *workflowResetterSuite) TestGenerateBranchToken() {
 		NewRunID:        s.resetRunID,
 	}).Return(&persistence.ForkHistoryBranchResponse{NewBranchToken: resetBranchToken}, nil)
 
-	newBranchToken, err := s.workflowResetter.forkAndGenerateBranchToken(
+	newBranchToken, newBaseBranchToken, err := s.workflowResetter.forkAndGenerateBranchToken(
 		context.Background(), s.namespaceID, s.workflowID, baseBranchToken, baseNodeID, s.resetRunID,
 	)
 	s.NoError(err)
 	s.Equal(resetBranchToken, newBranchToken)
+	s.Equal(baseBranchToken, newBaseBranchToken)
 }
 
 func (s *workflowResetterSuite) TestTerminateWorkflow() {


### PR DESCRIPTION
Cherry-pick of #11704 (`6805caea59e35d0611ed96be69641b8d86bff11c`) onto `cloud/v1.32.0-162`. Clean pick — diff is identical to the original.

## What changed?
ForkHistoryBranchResponse now carries BaseBranchToken, and the two reset paths rebuild through it when the store set it. A store that doesn't (Cassandra, SQL) leaves it nil and both call sites fall back to the token the caller already had, so behavior is unchanged everywhere else.

## Why?
ForkHistoryBranch can modify the base branch token in ways the caller may not have visibility into. This PR fixes it so that the changed token is returned to the caller.

Needed on this release branch so the matching saas-temporal cherry-pick (temporalio/saas-temporal#8500) can pin `go.temporal.io/server` to a commit on `cloud/v1.32.0-162` and land on `release/v3.162`.

## How did you test it?
- [x] built
- [x] added new unit test(s) (`go test ./service/history/ndc/...` passes on this branch)
