### PR TITLE
Add worker.historyScannerRPS to tune the history scavenger independently

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -3500,6 +3500,14 @@ because executions scanner support for SQL is not yet implemented.`,
 		`HistoryScannerVerifyRetention indicates if the history scavenger should verify data retention.
 When enabled, the scavenger will delete completed workflow execution data that are older than the namespace retention period plus worker.executionDataDurationBuffer.`,
 	)
+	HistoryScannerRPS = NewGlobalIntSetting(
+		"worker.historyScannerRPS",
+		0,
+		`HistoryScannerRPS is the maximum rate of persistence calls from the history scavenger.
+The history scavenger issues heavy scan and delete calls, so it can be worth throttling it
+independently of the rest of worker.Scanner. When set to 0 (the default) the history scavenger
+falls back to worker.scannerPersistenceMaxQPS.`,
+	)
 	EnableBatcherNamespace = NewNamespaceBoolSetting(
 		"worker.enableNamespaceBatcher",
 		true,

--- a/service/worker/scanner/history/scavenger.go
+++ b/service/worker/scanner/history/scavenger.go
@@ -84,7 +84,7 @@ const (
 func NewScavenger(
 	numShards int32,
 	db persistence.ExecutionManager,
-	rps int,
+	rps dynamicconfig.IntPropertyFn,
 	client historyservice.HistoryServiceClient,
 	adminClient adminservice.AdminServiceClient,
 	registry namespace.Registry,
@@ -103,7 +103,7 @@ func NewScavenger(
 		adminClient: adminClient,
 		registry:    registry,
 		rateLimiter: quotas.NewDefaultOutgoingRateLimiter(
-			func() float64 { return float64(rps) },
+			func() float64 { return float64(rps()) },
 		),
 		historyDataMinAge:           historyDataMinAge,
 		executionDataDurationBuffer: executionDataDurationBuffer,

--- a/service/worker/scanner/history/scavenger_test.go
+++ b/service/worker/scanner/history/scavenger_test.go
@@ -94,7 +94,7 @@ func (s *ScavengerTestSuite) createTestScavenger(
 	s.scavenger = NewScavenger(
 		s.numShards,
 		s.mockExecutionManager,
-		rps,
+		dynamicconfig.GetIntPropertyFn(rps),
 		s.mockHistoryClient,
 		s.mockAdminClient,
 		s.mockRegistry,

--- a/service/worker/scanner/scanner.go
+++ b/service/worker/scanner/scanner.go
@@ -57,6 +57,9 @@ type (
 		HistoryScannerDataMinAge dynamicconfig.DurationPropertyFn
 		// HistoryScannerVerifyRetention indicates if the history scavenger to do retention verification
 		HistoryScannerVerifyRetention dynamicconfig.BoolPropertyFn
+		// HistoryScannerRPS is the max rate of persistence calls made by the history scavenger.
+		// When it is not set (0 or negative), PersistenceMaxQPS is used instead.
+		HistoryScannerRPS dynamicconfig.IntPropertyFn
 		// ExecutionScannerPerHostQPS the max rate of calls to scan execution data per host
 		ExecutionScannerPerHostQPS dynamicconfig.IntPropertyFn
 		// ExecutionScannerPerShardQPS the max rate of calls to scan execution data per shard

--- a/service/worker/scanner/workflow.go
+++ b/service/worker/scanner/workflow.go
@@ -9,6 +9,7 @@ import (
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/service/worker/scanner/executions"
 	"go.temporal.io/server/service/worker/scanner/history"
@@ -110,7 +111,7 @@ func HistoryScavengerActivity(
 ) (history.ScavengerHeartbeatDetails, error) {
 
 	ctx := activityCtx.Value(scannerContextKey).(scannerContext)
-	rps := ctx.cfg.PersistenceMaxQPS()
+	rps := historyScavengerRPS(ctx.cfg)
 	numShards := ctx.cfg.Persistence.NumHistoryShards
 
 	hbd := history.ScavengerHeartbeatDetails{}
@@ -136,6 +137,19 @@ func HistoryScavengerActivity(
 		ctx.serializer,
 	)
 	return scavenger.Run(activityCtx)
+}
+
+// historyScavengerRPS returns the rate limit to apply to the history scavenger's
+// persistence calls. HistoryScannerRPS takes precedence, so that the scavenger can be
+// throttled without throttling the rest of the scanner; when it is not set the scavenger
+// falls back to the scanner wide PersistenceMaxQPS.
+func historyScavengerRPS(cfg *Config) dynamicconfig.IntPropertyFn {
+	return func() int {
+		if rps := cfg.HistoryScannerRPS(); rps > 0 {
+			return rps
+		}
+		return cfg.PersistenceMaxQPS()
+	}
 }
 
 // TaskQueueScavengerActivity is the activity that runs task queue scavenger

--- a/service/worker/scanner/workflow_test.go
+++ b/service/worker/scanner/workflow_test.go
@@ -11,6 +11,7 @@ import (
 	"go.temporal.io/sdk/testsuite"
 	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
+	"go.temporal.io/server/common/dynamicconfig"
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/resourcetest"
@@ -44,6 +45,28 @@ func (s *scannerWorkflowTestSuite) TestWorkflow() {
 	env.OnActivity(taskQueueScavengerActivityName, mock.Anything).Return(nil)
 	env.ExecuteWorkflow(tqScannerWFTypeName)
 	s.True(env.IsWorkflowCompleted())
+}
+
+func (s *scannerWorkflowTestSuite) TestHistoryScavengerRPS_FallsBackToPersistenceMaxQPS() {
+	cfg := &Config{
+		PersistenceMaxQPS: dynamicconfig.GetIntPropertyFn(100),
+		HistoryScannerRPS: dynamicconfig.GetIntPropertyFn(0),
+	}
+	s.Equal(100, historyScavengerRPS(cfg)())
+}
+
+func (s *scannerWorkflowTestSuite) TestHistoryScavengerRPS_OverridesPersistenceMaxQPS() {
+	historyScannerRPS := 0
+	cfg := &Config{
+		PersistenceMaxQPS: dynamicconfig.GetIntPropertyFn(100),
+		HistoryScannerRPS: func() int { return historyScannerRPS },
+	}
+	rps := historyScavengerRPS(cfg)
+	s.Equal(100, rps())
+
+	// The scavenger activity is long running, so the override has to be picked up while it runs.
+	historyScannerRPS = 5
+	s.Equal(5, rps())
 }
 
 func (s *scannerWorkflowTestSuite) TestScavengerActivity() {

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -215,6 +215,7 @@ func NewConfig(
 			ExecutionsScannerEnabled:                dynamicconfig.ExecutionsScannerEnabled.Get(dc),
 			HistoryScannerDataMinAge:                dynamicconfig.HistoryScannerDataMinAge.Get(dc),
 			HistoryScannerVerifyRetention:           dynamicconfig.HistoryScannerVerifyRetention.Get(dc),
+			HistoryScannerRPS:                       dynamicconfig.HistoryScannerRPS.Get(dc),
 			ExecutionScannerPerHostQPS:              dynamicconfig.ExecutionScannerPerHostQPS.Get(dc),
 			ExecutionScannerPerShardQPS:             dynamicconfig.ExecutionScannerPerShardQPS.Get(dc),
 			ExecutionDataDurationBuffer:             dynamicconfig.ExecutionDataDurationBuffer.Get(dc),


### PR DESCRIPTION
## What changed?

Added a new dynamic config setting `worker.historyScannerRPS` that rate limits the history scavenger's persistence calls independently of the rest of `worker.Scanner`.

- `worker.historyScannerRPS` (global int, default `0`). When `> 0` it is used; when `0` the scavenger falls back to `worker.scannerPersistenceMaxQPS`, so existing deployments see no behavior change.
- `history.NewScavenger` now takes a `dynamicconfig.IntPropertyFn` instead of a static `int`.

## Why?

Closes #7625.

The history scavenger's rate limit came from `worker.scannerPersistenceMaxQPS`, so the only lever an operator had for its heavy scan and delete traffic also throttled every other scanner persistence call. As reported in the issue, self-hosted clusters see their persistence store saturate on the 12 hourly scavenger cron, and the only mitigation was lowering the cluster wide limit — giving up throughput outside the cleanup window to fix a problem inside it.

The scavengers were also inconsistent here: the executions scanner already has its own per-shard QPS setting, the history scanner had none.

On the property fn change: the scavenger activity has an effectively infinite `StartToCloseTimeout`, and `quotas.NewDefaultOutgoingRateLimiter` refreshes its rate periodically. Passing a property fn instead of an `int` means the limit can be retuned while a run is in flight, rather than only taking effect at the next cron start — which is what you want when you are reacting to a live incident. This matches how `executions.NewScavenger` already consumes `ExecutionScannerPerShardQPS`.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

Two new cases in `service/worker/scanner/workflow_test.go` cover the fallback to `PersistenceMaxQPS` and the override being picked up mid-run.

```
go build ./...                                                   OK
go test ./service/worker/scanner/... ./common/dynamicconfig/...   ok (8 packages)
go vet ./service/worker/...                                       OK
```

Note: `service/worker/migration` `TestActivitiesSuite` fails on this checkout, but it fails identically on a clean `main` — unrelated to this change.

## Potential risks

`history.NewScavenger`'s signature changed. It has one non-test caller in this repo (`HistoryScavengerActivity`), updated here, but it is an exported function so any out-of-tree caller would need the same one-line change.

The default of `0` preserves today's behavior exactly, so the risk of the new setting itself is limited to clusters that opt in.

## Not addressed

The issue also floats making the scavenger's cron schedule configurable. I left that out: changing the schedule of an already-running cron workflow needs its own restart handling, and it reads as a separate change. Happy to follow up if wanted.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZ77zQt5SjbxQnmRHxsm88
