### PR TITLE
Add unit tests for the parent close policy processor workflow and activity

### DIFF
--- a/service/worker/parentclosepolicy/workflow_test.go
+++ b/service/worker/parentclosepolicy/workflow_test.go
@@ -10,7 +10,10 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/api/historyservicemock/v1"
 	"go.temporal.io/server/client"
@@ -168,4 +171,267 @@ func (s *parentClosePolicyWorkflowSuite) TestProcessorActivity_RemoteCluster() {
 
 	_, err := env.ExecuteActivity(ProcessorActivity, request)
 	s.NoError(err)
+}
+
+func (s *parentClosePolicyWorkflowSuite) TestProcessorWorkflow_NoRequest() {
+	env := s.NewTestWorkflowEnvironment()
+	env.SetWorkerOptions(getWorkerOptions(s.processor))
+	env.RegisterWorkflowWithOptions(ProcessorWorkflow, workflow.RegisterOptions{Name: processorWFTypeName})
+	env.RegisterActivityWithOptions(ProcessorActivity, activity.RegisterOptions{Name: processorActivityName})
+
+	activityStarted := false
+	env.SetOnActivityStartedListener(func(*activity.Info, context.Context, converter.EncodedValues) {
+		activityStarted = true
+	})
+
+	env.ExecuteWorkflow(processorWFTypeName)
+
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+	s.False(activityStarted, "no request was signaled, so the processor activity must not be scheduled")
+}
+
+// TestProcessorActivity_NoParentExecution covers the backward compatible behavior: a request
+// without a parent execution must not be scoped to children, otherwise terminate and cancel
+// would fail with a mismatch error.
+func (s *parentClosePolicyWorkflowSuite) TestProcessorActivity_NoParentExecution() {
+	env := s.NewTestActivityEnvironment()
+	env.SetWorkerOptions(getWorkerOptions(s.processor))
+	env.RegisterActivity(ProcessorActivity)
+
+	request := Request{
+		Executions: []RequestDetail{
+			{
+				Namespace:   tests.ChildNamespace.String(),
+				NamespaceID: tests.ChildNamespaceID.String(),
+				WorkflowID:  "child workflowID 1",
+				RunID:       "childworkflow runID 1",
+				Policy:      enumspb.PARENT_CLOSE_POLICY_TERMINATE,
+			},
+		},
+	}
+
+	s.mockHistoryClient.EXPECT().TerminateWorkflowExecution(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(
+			_ context.Context,
+			request *historyservice.TerminateWorkflowExecutionRequest,
+			_ ...grpc.CallOption,
+		) (*historyservice.TerminateWorkflowExecutionResponse, error) {
+			s.False(request.ChildWorkflowOnly)
+			s.Nil(request.ExternalWorkflowExecution)
+			s.Equal(tests.ChildNamespaceID.String(), request.NamespaceId)
+			s.Equal(tests.ChildNamespace.String(), request.TerminateRequest.Namespace)
+			s.Equal("child workflowID 1", request.TerminateRequest.WorkflowExecution.WorkflowId)
+			s.Equal("childworkflow runID 1", request.TerminateRequest.FirstExecutionRunId)
+			s.Equal(processorWFTypeName, request.TerminateRequest.Identity)
+			return &historyservice.TerminateWorkflowExecutionResponse{}, nil
+		},
+	).Times(1)
+
+	_, err := env.ExecuteActivity(ProcessorActivity, request)
+	s.NoError(err)
+}
+
+func (s *parentClosePolicyWorkflowSuite) TestProcessorActivity_ChildWorkflowOnly() {
+	env := s.NewTestActivityEnvironment()
+	env.SetWorkerOptions(getWorkerOptions(s.processor))
+	env.RegisterActivity(ProcessorActivity)
+
+	parentExecution := &commonpb.WorkflowExecution{
+		WorkflowId: "parent workflowID",
+		RunId:      "parent runID",
+	}
+	request := Request{
+		ParentExecution: parentExecution,
+		Executions: []RequestDetail{
+			{
+				Namespace:   tests.ChildNamespace.String(),
+				NamespaceID: tests.ChildNamespaceID.String(),
+				WorkflowID:  "child workflowID 1",
+				RunID:       "childworkflow runID 1",
+				Policy:      enumspb.PARENT_CLOSE_POLICY_REQUEST_CANCEL,
+			},
+		},
+	}
+
+	s.mockHistoryClient.EXPECT().RequestCancelWorkflowExecution(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(
+			_ context.Context,
+			request *historyservice.RequestCancelWorkflowExecutionRequest,
+			_ ...grpc.CallOption,
+		) (*historyservice.RequestCancelWorkflowExecutionResponse, error) {
+			s.True(request.ChildWorkflowOnly)
+			s.Equal(parentExecution.WorkflowId, request.ExternalWorkflowExecution.WorkflowId)
+			s.Equal(parentExecution.RunId, request.ExternalWorkflowExecution.RunId)
+			s.Equal(tests.ChildNamespaceID.String(), request.NamespaceId)
+			s.Equal(tests.ChildNamespace.String(), request.CancelRequest.Namespace)
+			s.Equal("child workflowID 1", request.CancelRequest.WorkflowExecution.WorkflowId)
+			s.Equal("childworkflow runID 1", request.CancelRequest.FirstExecutionRunId)
+			s.Equal(processorWFTypeName, request.CancelRequest.Identity)
+			return &historyservice.RequestCancelWorkflowExecutionResponse{}, nil
+		},
+	).Times(1)
+
+	_, err := env.ExecuteActivity(ProcessorActivity, request)
+	s.NoError(err)
+}
+
+func (s *parentClosePolicyWorkflowSuite) TestProcessorActivity_NamespaceNotFound() {
+	env := s.NewTestActivityEnvironment()
+	env.SetWorkerOptions(getWorkerOptions(s.processor))
+	env.RegisterActivity(ProcessorActivity)
+
+	request := Request{
+		ParentExecution: &commonpb.WorkflowExecution{
+			WorkflowId: "parent workflowID",
+			RunId:      "parent runID",
+		},
+		Executions: []RequestDetail{
+			{
+				Namespace:   tests.ChildNamespace.String(),
+				NamespaceID: tests.ChildNamespaceID.String(),
+				WorkflowID:  "child workflowID 1",
+				RunID:       "childworkflow runID 1",
+				Policy:      enumspb.PARENT_CLOSE_POLICY_TERMINATE,
+			},
+			{
+				Namespace:   tests.ChildNamespace.String(),
+				NamespaceID: tests.ChildNamespaceID.String(),
+				WorkflowID:  "child workflowID 2",
+				RunID:       "childworkflow runID 2",
+				Policy:      enumspb.PARENT_CLOSE_POLICY_TERMINATE,
+			},
+		},
+	}
+
+	// A namespace that is already gone must not fail the rest of the batch.
+	s.mockHistoryClient.EXPECT().TerminateWorkflowExecution(gomock.Any(), gomock.Any()).
+		Return(nil, serviceerror.NewNamespaceNotFound(tests.ChildNamespace.String())).Times(1)
+	s.mockHistoryClient.EXPECT().TerminateWorkflowExecution(gomock.Any(), gomock.Any()).
+		Return(&historyservice.TerminateWorkflowExecutionResponse{}, nil).Times(1)
+
+	_, err := env.ExecuteActivity(ProcessorActivity, request)
+	s.NoError(err)
+}
+
+func (s *parentClosePolicyWorkflowSuite) TestProcessorActivity_UnexpectedErrorFailsActivity() {
+	env := s.NewTestActivityEnvironment()
+	env.SetWorkerOptions(getWorkerOptions(s.processor))
+	env.RegisterActivity(ProcessorActivity)
+
+	request := Request{
+		ParentExecution: &commonpb.WorkflowExecution{
+			WorkflowId: "parent workflowID",
+			RunId:      "parent runID",
+		},
+		Executions: []RequestDetail{
+			{
+				Namespace:   tests.ChildNamespace.String(),
+				NamespaceID: tests.ChildNamespaceID.String(),
+				WorkflowID:  "child workflowID 1",
+				RunID:       "childworkflow runID 1",
+				Policy:      enumspb.PARENT_CLOSE_POLICY_TERMINATE,
+			},
+			{
+				Namespace:   tests.ChildNamespace.String(),
+				NamespaceID: tests.ChildNamespaceID.String(),
+				WorkflowID:  "child workflowID 2",
+				RunID:       "childworkflow runID 2",
+				Policy:      enumspb.PARENT_CLOSE_POLICY_TERMINATE,
+			},
+		},
+	}
+
+	// The activity bails out on the first unexpected error so that the whole batch is retried.
+	s.mockHistoryClient.EXPECT().TerminateWorkflowExecution(gomock.Any(), gomock.Any()).
+		Return(nil, serviceerror.NewInternal("intentional test failure")).Times(1)
+
+	_, err := env.ExecuteActivity(ProcessorActivity, request)
+	s.Error(err)
+	s.ErrorContains(err, "intentional test failure")
+}
+
+func (s *parentClosePolicyWorkflowSuite) TestProcessorActivity_RemoteCluster_OneSignalPerCluster() {
+	env := s.NewTestActivityEnvironment()
+	env.SetWorkerOptions(getWorkerOptions(s.processor))
+	env.RegisterActivity(ProcessorActivity)
+
+	request := Request{
+		ParentExecution: &commonpb.WorkflowExecution{
+			WorkflowId: "parent workflowID",
+			RunId:      "parent runID",
+		},
+		Executions: []RequestDetail{
+			{
+				Namespace:   tests.ChildNamespace.String(),
+				NamespaceID: tests.ChildNamespaceID.String(),
+				WorkflowID:  "child workflowID 1",
+				RunID:       "childworkflow runID 1",
+				Policy:      enumspb.PARENT_CLOSE_POLICY_TERMINATE,
+			},
+			{
+				Namespace:   tests.ChildNamespace.String(),
+				NamespaceID: tests.ChildNamespaceID.String(),
+				WorkflowID:  "child workflowID 2",
+				RunID:       "childworkflow runID 2",
+				Policy:      enumspb.PARENT_CLOSE_POLICY_REQUEST_CANCEL,
+			},
+		},
+	}
+
+	s.mockHistoryClient.EXPECT().TerminateWorkflowExecution(gomock.Any(), gomock.Any()).
+		Return(nil, &serviceerror.NamespaceNotActive{ActiveCluster: "remote cluster 1"}).Times(1)
+	s.mockHistoryClient.EXPECT().RequestCancelWorkflowExecution(gomock.Any(), gomock.Any()).
+		Return(nil, &serviceerror.NamespaceNotActive{ActiveCluster: "remote cluster 1"}).Times(1)
+	// Both executions belong to the same active cluster, so they are forwarded in one signal.
+	s.mockRemoteClient.EXPECT().SignalWithStartWorkflowExecution(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(
+			_ context.Context,
+			request *workflowservice.SignalWithStartWorkflowExecutionRequest,
+			_ ...grpc.CallOption,
+		) (*workflowservice.SignalWithStartWorkflowExecutionResponse, error) {
+			var forwarded Request
+			s.NoError(converter.GetDefaultDataConverter().FromPayloads(request.SignalInput, &forwarded))
+			s.Len(forwarded.Executions, 2)
+			s.Equal("child workflowID 1", forwarded.Executions[0].WorkflowID)
+			s.Equal(enumspb.PARENT_CLOSE_POLICY_TERMINATE, forwarded.Executions[0].Policy)
+			s.Equal("child workflowID 2", forwarded.Executions[1].WorkflowID)
+			s.Equal(enumspb.PARENT_CLOSE_POLICY_REQUEST_CANCEL, forwarded.Executions[1].Policy)
+			return &workflowservice.SignalWithStartWorkflowExecutionResponse{}, nil
+		},
+	).Times(1)
+
+	_, err := env.ExecuteActivity(ProcessorActivity, request)
+	s.NoError(err)
+}
+
+func (s *parentClosePolicyWorkflowSuite) TestProcessorActivity_RemoteCluster_SignalFailure() {
+	env := s.NewTestActivityEnvironment()
+	env.SetWorkerOptions(getWorkerOptions(s.processor))
+	env.RegisterActivity(ProcessorActivity)
+
+	request := Request{
+		ParentExecution: &commonpb.WorkflowExecution{
+			WorkflowId: "parent workflowID",
+			RunId:      "parent runID",
+		},
+		Executions: []RequestDetail{
+			{
+				Namespace:   tests.ChildNamespace.String(),
+				NamespaceID: tests.ChildNamespaceID.String(),
+				WorkflowID:  "child workflowID 1",
+				RunID:       "childworkflow runID 1",
+				Policy:      enumspb.PARENT_CLOSE_POLICY_TERMINATE,
+			},
+		},
+	}
+
+	s.mockHistoryClient.EXPECT().TerminateWorkflowExecution(gomock.Any(), gomock.Any()).
+		Return(nil, &serviceerror.NamespaceNotActive{ActiveCluster: "remote cluster 1"}).Times(1)
+	s.mockRemoteClient.EXPECT().SignalWithStartWorkflowExecution(gomock.Any(), gomock.Any()).
+		Return(nil, serviceerror.NewInternal("intentional test failure")).Times(1)
+
+	_, err := env.ExecuteActivity(ProcessorActivity, request)
+	s.Error(err)
+	s.ErrorContains(err, "intentional test failure")
 }


### PR DESCRIPTION
## What changed?

Added seven test cases to `service/worker/parentclosepolicy/workflow_test.go`.

`ProcessorWorkflow` had no test at all. `ProcessorActivity` had two, both happy paths (`TestProcessorActivity_SameCluster`, `TestProcessorActivity_RemoteCluster`).

New coverage:

| Test | Covers |
|---|---|
| `TestProcessorWorkflow_NoRequest` | workflow completes and schedules no activity when nothing was signaled |
| `TestProcessorActivity_NoParentExecution` | `childWorkflowOnly` is false without a parent execution, plus the full outgoing terminate request |
| `TestProcessorActivity_ChildWorkflowOnly` | `childWorkflowOnly` is true with one, plus the full outgoing cancel request |
| `TestProcessorActivity_NamespaceNotFound` | a gone namespace on one execution does not fail the rest of the batch |
| `TestProcessorActivity_UnexpectedErrorFailsActivity` | an unexpected error aborts the activity so the batch is retried |
| `TestProcessorActivity_RemoteCluster_OneSignalPerCluster` | executions sharing an active cluster are forwarded in one signal, payload decoded and checked |
| `TestProcessorActivity_RemoteCluster_SignalFailure` | a failed signal to a remote cluster is propagated |

No production code changed.

## Why?

Closes #607.

As the issue notes, a missing `workflow.Context` on the `ExecuteActivity` call once made this workflow fail on every single run, and it was only caught by stress testing. `TestProcessorWorkflow_NoRequest` executes the workflow function through the SDK test environment, so that class of wiring break surfaces in unit tests instead.

The `childWorkflowOnly` assertions are the other piece worth locking down. The flag is deliberately false when `ParentExecution` is unset, for backward compatibility — scoping to children in that case makes terminate and cancel fail with a mismatch error. That reasoning lives in a comment today and nothing enforced it.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

```
go test -v -run TestParentClosePolicyWorkflowSuite ./service/worker/parentclosepolicy/
--- PASS: TestParentClosePolicyWorkflowSuite (0.11s)   9 cases, 7 new
ok      go.temporal.io/server/service/worker/parentclosepolicy  1.768s

go build ./service/worker/...   OK
go vet ./service/worker/...     OK
```

## Known gap

The signal driven iteration of `ProcessorWorkflow` is not reachable from the SDK test environment. `registerDelayedCallback` with a zero delay posts onto the callback channel ahead of `workflowDef.Execute`, so `env.signalHandler` is still nil when the signal fires; and because the workflow drains with `ReceiveAsync` and exits, any nonzero delay arrives after it has already completed. The root workflow has no start delay hook to open that window either.

So the workflow level test covers the drain empty path, and the signal carrying path is covered through the activity directly. Reproducing the full signal-then-process loop needs a functional test against a real server — worth doing, but a bigger change than this one. Flagging it in case a maintainer knows a trick I missed.

## Potential risks

Test-only change, no production code touched.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZ77zQt5SjbxQnmRHxsm88
