### PR TITLE
Fix build break

### DIFF
--- a/common/nexus/links.go
+++ b/common/nexus/links.go
@@ -1,8 +1,6 @@
 package nexus
 
 import (
-	"fmt"
-
 	"github.com/nexus-rpc/sdk-go/nexus"
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/temporalnexus"
@@ -49,7 +47,9 @@ func ConvertNexusLinksToProtoLinks(nexusLinks []nexus.Link, logger log.Logger) [
 			link, err := temporalnexus.ConvertNexusLinkToLinkWorkflow(nexusLink)
 			if err != nil {
 				logger.Warn(
-					fmt.Sprintf("failed to parse link to %q: %s", nexusLink.Type, nexusLink.URL),
+					"failed to parse link",
+					tag.NewStringTag("nexus-link-type", nexusLink.Type),
+					tag.URL(nexusLink.URL.String()),
 					tag.Error(err),
 				)
 				continue

--- a/common/nexus/links.go
+++ b/common/nexus/links.go
@@ -1,6 +1,8 @@
 package nexus
 
 import (
+	"fmt"
+
 	"github.com/nexus-rpc/sdk-go/nexus"
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/temporalnexus"

--- a/tests/gethistory_test.go
+++ b/tests/gethistory_test.go
@@ -789,6 +789,7 @@ func startMultiBatchWorkflow(
 func (s *GetHistorySuite) TestGetWorkflowExecutionHistory_ContinuationFromAnotherNamespace(
 	enableTransitionHistory bool,
 ) {
+	ctx := s.Context()
 	// A single-shard cluster so both namespaces map to the same history shard. On SQL backends
 	// shard_id is part of the history_node primary key, so without this the replay would be
 	// rejected for the wrong reason; on Cassandra it is not part of the key at all.
@@ -800,7 +801,7 @@ func (s *GetHistorySuite) TestGetWorkflowExecutionHistory_ContinuationFromAnothe
 	)
 
 	otherNamespace := namespace.Name(testcore.RandomizeStr("other-namespace"))
-	_, err := env.RegisterNamespace(otherNamespace, 1, enumspb.ARCHIVAL_STATE_DISABLED, "", "")
+	_, err := env.RegisterNamespace(ctx, otherNamespace, 1, enumspb.ARCHIVAL_STATE_DISABLED, "", "")
 	s.Require().NoError(err)
 
 	startMultiBatchWorkflow(s.Context(), s.Require(), env)
@@ -841,6 +842,7 @@ func (s *GetHistorySuite) TestGetWorkflowExecutionHistory_ContinuationFromAnothe
 }
 
 func (s *RawHistorySuite) TestGetWorkflowExecutionHistoryReverse_ContinuationFromAnotherNamespace() {
+	ctx := s.Context()
 	env := s.newTestEnv(
 		testcore.WithHistoryShardCount(1),
 		// Shadow mode reports the mismatch but still serves the page.
@@ -848,7 +850,7 @@ func (s *RawHistorySuite) TestGetWorkflowExecutionHistoryReverse_ContinuationFro
 	)
 
 	otherNamespace := namespace.Name(testcore.RandomizeStr("other-namespace"))
-	_, err := env.RegisterNamespace(otherNamespace, 1, enumspb.ARCHIVAL_STATE_DISABLED, "", "")
+	_, err := env.RegisterNamespace(ctx, otherNamespace, 1, enumspb.ARCHIVAL_STATE_DISABLED, "", "")
 	s.Require().NoError(err)
 
 	startMultiBatchWorkflow(s.Context(), s.Require(), env)


### PR DESCRIPTION
## What changed?

Fixes a build error, seemingly introduced when multiple changes were merged automatically after approval.

## Why?

Because a broken build stops the flow of spice. And the spice must flow.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

None. But there might be other issues, I'm curious to see if there are any other issues flagged by CI/CD.
