### PR TITLE
Add log capture to TestLogger

### DIFF
--- a/common/testing/testlogger/capture.go
+++ b/common/testing/testlogger/capture.go
@@ -100,6 +100,14 @@ func (c *Capture) Snapshot() []CapturedLog {
 	return records
 }
 
+// Contains reports whether the capture includes a matching log.
+func (c *Capture) Contains(pattern CapturedLogPattern) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return slices.ContainsFunc(c.records, pattern.matches)
+}
+
 // RequireContains fails the test with tag diffs when the capture does not include a matching log.
 func (c *Capture) RequireContains(t TestingT, pattern CapturedLogPattern) {
 	t.Helper()
@@ -129,7 +137,13 @@ func (c *Capture) RequireContains(t TestingT, pattern CapturedLogPattern) {
 		fmt.Fprintf(&failure, "\n\ncandidate %d tag mismatch (-want +got):\n%s", candidateCount, cmp.Diff(expectedTags, actualTags))
 	}
 	if candidateCount == 0 {
-		fmt.Fprintf(&failure, "\n\nno captured log had the expected level and message; captured logs: %+v", records)
+		failure.WriteString("\n\nno captured log had the expected level and message; captured logs:")
+		for _, record := range records {
+			fmt.Fprintf(&failure, "\n- %s %q", record.Level, record.Message)
+			for _, actual := range record.Tags {
+				fmt.Fprintf(&failure, " %s=%s", actual.Key(), formatValue(actual))
+			}
+		}
 	}
 	t.Fatalf("%s", failure.String())
 }

--- a/common/testing/testlogger/capture.go
+++ b/common/testing/testlogger/capture.go
@@ -108,11 +108,6 @@ func (c *Capture) Snapshot() []CapturedLog {
 	return records
 }
 
-// Contains reports whether the capture includes a log matching pattern.
-func (c *Capture) Contains(pattern CapturedLogPattern) bool {
-	return slices.ContainsFunc(c.Snapshot(), pattern.matches)
-}
-
 // RequireContains fails the test with tag diffs when the capture does not include a matching log.
 func (c *Capture) RequireContains(t requireTestingT, pattern CapturedLogPattern) {
 	t.Helper()

--- a/common/testing/testlogger/capture.go
+++ b/common/testing/testlogger/capture.go
@@ -1,0 +1,176 @@
+package testlogger
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/google/go-cmp/cmp"
+	"go.temporal.io/server/common/log/tag"
+)
+
+// CapturedLog is a single log call recorded by a Capture.
+type CapturedLog struct {
+	Level   Level
+	Message string
+	Tags    []tag.Tag
+}
+
+// TagValue returns the formatted value of the first tag with the provided key.
+func (r CapturedLog) TagValue(key string) (string, bool) {
+	for _, t := range r.Tags {
+		if t.Key() == key {
+			return formatValue(t), true
+		}
+	}
+	return "", false
+}
+
+// CapturedLogPattern describes a captured log using formatted tag values.
+// Tags must match exactly; AnyTagValue requires a tag without constraining its value.
+type CapturedLogPattern struct {
+	Level   Level
+	Message string
+	Tags    map[string]any
+}
+
+type anyTagValue struct{}
+
+// AnyTagValue matches any formatted value for a tag that must be present.
+var AnyTagValue = &anyTagValue{}
+
+func (p CapturedLogPattern) matches(record CapturedLog) bool {
+	if record.Level != p.Level || record.Message != p.Message || len(record.Tags) != len(p.Tags) {
+		return false
+	}
+
+	matchedTags := make(map[string]struct{}, len(record.Tags))
+	for _, actual := range record.Tags {
+		key := actual.Key()
+		expected, ok := p.Tags[key]
+		if !ok {
+			return false
+		}
+		if _, duplicate := matchedTags[key]; duplicate {
+			return false
+		}
+		matchedTags[key] = struct{}{}
+		if _, anyValue := expected.(*anyTagValue); !anyValue && formatValue(actual) != fmt.Sprint(expected) {
+			return false
+		}
+	}
+	return len(matchedTags) == len(p.Tags)
+}
+
+func (p CapturedLogPattern) formattedTags() map[string]string {
+	formatted := make(map[string]string, len(p.Tags))
+	for key, value := range p.Tags {
+		if _, anyValue := value.(*anyTagValue); anyValue {
+			formatted[key] = "<any>"
+		} else {
+			formatted[key] = fmt.Sprint(value)
+		}
+	}
+	return formatted
+}
+
+type requireTestingT interface {
+	Helper()
+	Fatalf(format string, args ...any)
+}
+
+// Capture is an opt-in recording of TestLogger calls.
+type Capture struct {
+	anyTags map[string]map[string]struct{}
+
+	mu      sync.Mutex
+	records []CapturedLog
+}
+
+func newCapture(anyTags []tag.Tag) *Capture {
+	capture := &Capture{}
+	if len(anyTags) == 0 {
+		return capture
+	}
+	capture.anyTags = make(map[string]map[string]struct{})
+	for _, t := range anyTags {
+		values := capture.anyTags[t.Key()]
+		if values == nil {
+			values = make(map[string]struct{})
+			capture.anyTags[t.Key()] = values
+		}
+		values[formatValue(t)] = struct{}{}
+	}
+	return capture
+}
+
+// Snapshot returns a defensive copy of the captured log calls.
+func (c *Capture) Snapshot() []CapturedLog {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	records := make([]CapturedLog, len(c.records))
+	for i, record := range c.records {
+		records[i] = record
+		records[i].Tags = slices.Clone(record.Tags)
+	}
+	return records
+}
+
+// Contains reports whether the capture includes a log matching pattern.
+func (c *Capture) Contains(pattern CapturedLogPattern) bool {
+	return slices.ContainsFunc(c.Snapshot(), pattern.matches)
+}
+
+// RequireContains fails the test with tag diffs when the capture does not include a matching log.
+func (c *Capture) RequireContains(t requireTestingT, pattern CapturedLogPattern) {
+	t.Helper()
+	records := c.Snapshot()
+	if slices.ContainsFunc(records, pattern.matches) {
+		return
+	}
+
+	var failure strings.Builder
+	fmt.Fprintf(&failure, "captured log pattern not found: level=%s message=%q", pattern.Level, pattern.Message)
+	expectedTags := pattern.formattedTags()
+	candidateCount := 0
+	for _, record := range records {
+		if record.Level != pattern.Level || record.Message != pattern.Message {
+			continue
+		}
+		candidateCount++
+		actualTags := make(map[string]string, len(record.Tags))
+		for _, actual := range record.Tags {
+			key := actual.Key()
+			if _, anyValue := pattern.Tags[key].(*anyTagValue); anyValue {
+				actualTags[key] = "<any>"
+			} else {
+				actualTags[key] = formatValue(actual)
+			}
+		}
+		fmt.Fprintf(&failure, "\n\ncandidate %d tag mismatch (-want +got):\n%s", candidateCount, cmp.Diff(expectedTags, actualTags))
+	}
+	if candidateCount == 0 {
+		fmt.Fprintf(&failure, "\n\nno captured log had the expected level and message; captured logs: %+v", records)
+	}
+	t.Fatalf("%s", failure.String())
+}
+
+func (c *Capture) record(record CapturedLog) {
+	if len(c.anyTags) > 0 {
+		matched := false
+		for _, t := range record.Tags {
+			if _, ok := c.anyTags[t.Key()][formatValue(t)]; ok {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return
+		}
+	}
+	c.mu.Lock()
+	c.records = append(c.records, record)
+	c.mu.Unlock()
+}

--- a/common/testing/testlogger/capture.go
+++ b/common/testing/testlogger/capture.go
@@ -17,16 +17,6 @@ type CapturedLog struct {
 	Tags    []tag.Tag
 }
 
-// TagValue returns the formatted value of the first tag with the provided key.
-func (r CapturedLog) TagValue(key string) (string, bool) {
-	for _, t := range r.Tags {
-		if t.Key() == key {
-			return formatValue(t), true
-		}
-	}
-	return "", false
-}
-
 // CapturedLogPattern describes a captured log using formatted tag values.
 // Tags must match exactly; AnyTagValue requires a tag without constraining its value.
 type CapturedLogPattern struct {
@@ -60,7 +50,7 @@ func (p CapturedLogPattern) matches(record CapturedLog) bool {
 			return false
 		}
 	}
-	return len(matchedTags) == len(p.Tags)
+	return true
 }
 
 func (p CapturedLogPattern) formattedTags() map[string]string {

--- a/common/testing/testlogger/capture.go
+++ b/common/testing/testlogger/capture.go
@@ -18,12 +18,18 @@ type CapturedLog struct {
 }
 
 // CapturedLogPattern describes a captured log using formatted tag values.
-// Tags match a subset of the captured log's tags.
+// Tags match a subset of the captured log's tags; AnyTagValue requires a tag
+// without constraining its value.
 type CapturedLogPattern struct {
 	Level   Level
 	Message string
-	Tags    map[string]string
+	Tags    map[string]any
 }
+
+type anyTagValue struct{}
+
+// AnyTagValue matches any formatted value for a tag that must be present.
+var AnyTagValue = &anyTagValue{}
 
 func (p CapturedLogPattern) matches(record CapturedLog) bool {
 	if record.Level != p.Level || record.Message != p.Message {
@@ -32,12 +38,28 @@ func (p CapturedLogPattern) matches(record CapturedLog) bool {
 
 	for key, expected := range p.Tags {
 		if !slices.ContainsFunc(record.Tags, func(actual tag.Tag) bool {
-			return actual.Key() == key && formatValue(actual) == expected
+			if actual.Key() != key {
+				return false
+			}
+			_, anyValue := expected.(*anyTagValue)
+			return anyValue || formatValue(actual) == fmt.Sprint(expected)
 		}) {
 			return false
 		}
 	}
 	return true
+}
+
+func (p CapturedLogPattern) formattedTags() map[string]string {
+	formatted := make(map[string]string, len(p.Tags))
+	for key, value := range p.Tags {
+		if _, anyValue := value.(*anyTagValue); anyValue {
+			formatted[key] = "<any>"
+		} else {
+			formatted[key] = fmt.Sprint(value)
+		}
+	}
+	return formatted
 }
 
 type captureFilterTag struct {
@@ -88,6 +110,7 @@ func (c *Capture) RequireContains(t TestingT, pattern CapturedLogPattern) {
 
 	var failure strings.Builder
 	fmt.Fprintf(&failure, "captured log pattern not found: level=%s message=%q", pattern.Level, pattern.Message)
+	expectedTags := pattern.formattedTags()
 	candidateCount := 0
 	for _, record := range records {
 		if record.Level != pattern.Level || record.Message != pattern.Message {
@@ -97,11 +120,13 @@ func (c *Capture) RequireContains(t TestingT, pattern CapturedLogPattern) {
 		actualTags := make(map[string]string, len(pattern.Tags))
 		for _, actual := range record.Tags {
 			key := actual.Key()
-			if _, expected := pattern.Tags[key]; expected {
+			if _, anyValue := pattern.Tags[key].(*anyTagValue); anyValue {
+				actualTags[key] = "<any>"
+			} else if _, expected := pattern.Tags[key]; expected {
 				actualTags[key] = formatValue(actual)
 			}
 		}
-		fmt.Fprintf(&failure, "\n\ncandidate %d tag mismatch (-want +got):\n%s", candidateCount, cmp.Diff(pattern.Tags, actualTags))
+		fmt.Fprintf(&failure, "\n\ncandidate %d tag mismatch (-want +got):\n%s", candidateCount, cmp.Diff(expectedTags, actualTags))
 	}
 	if candidateCount == 0 {
 		fmt.Fprintf(&failure, "\n\nno captured log had the expected level and message; captured logs: %+v", records)

--- a/common/testing/testlogger/capture.go
+++ b/common/testing/testlogger/capture.go
@@ -1,12 +1,9 @@
 package testlogger
 
 import (
-	"fmt"
 	"slices"
-	"strings"
 	"sync"
 
-	"github.com/google/go-cmp/cmp"
 	"go.temporal.io/server/common/log/tag"
 )
 
@@ -15,29 +12,6 @@ type CapturedLog struct {
 	Level   Level
 	Message string
 	Tags    []tag.Tag
-}
-
-// CapturedLogPattern describes a captured log using formatted tag values.
-// Tags match a subset of the captured log's tags.
-type CapturedLogPattern struct {
-	Level   Level
-	Message string
-	Tags    map[string]string
-}
-
-func (p CapturedLogPattern) matches(record CapturedLog) bool {
-	if record.Level != p.Level || record.Message != p.Message {
-		return false
-	}
-
-	for key, expected := range p.Tags {
-		if !slices.ContainsFunc(record.Tags, func(actual tag.Tag) bool {
-			return actual.Key() == key && formatValue(actual) == expected
-		}) {
-			return false
-		}
-	}
-	return true
 }
 
 type captureFilterTag struct {
@@ -76,37 +50,6 @@ func (c *Capture) Snapshot() []CapturedLog {
 		records[i].Tags = slices.Clone(record.Tags)
 	}
 	return records
-}
-
-// RequireContains fails the test with tag diffs when the capture does not include a matching log.
-func (c *Capture) RequireContains(t TestingT, pattern CapturedLogPattern) {
-	t.Helper()
-	records := c.Snapshot()
-	if slices.ContainsFunc(records, pattern.matches) {
-		return
-	}
-
-	var failure strings.Builder
-	fmt.Fprintf(&failure, "captured log pattern not found: level=%s message=%q", pattern.Level, pattern.Message)
-	candidateCount := 0
-	for _, record := range records {
-		if record.Level != pattern.Level || record.Message != pattern.Message {
-			continue
-		}
-		candidateCount++
-		actualTags := make(map[string]string, len(pattern.Tags))
-		for _, actual := range record.Tags {
-			key := actual.Key()
-			if _, expected := pattern.Tags[key]; expected {
-				actualTags[key] = formatValue(actual)
-			}
-		}
-		fmt.Fprintf(&failure, "\n\ncandidate %d tag mismatch (-want +got):\n%s", candidateCount, cmp.Diff(pattern.Tags, actualTags))
-	}
-	if candidateCount == 0 {
-		fmt.Fprintf(&failure, "\n\nno captured log had the expected level and message; captured logs: %+v", records)
-	}
-	t.Fatalf("%s", failure.String())
 }
 
 func (c *Capture) record(record CapturedLog) {

--- a/common/testing/testlogger/capture.go
+++ b/common/testing/testlogger/capture.go
@@ -1,9 +1,12 @@
 package testlogger
 
 import (
+	"fmt"
 	"slices"
+	"strings"
 	"sync"
 
+	"github.com/google/go-cmp/cmp"
 	"go.temporal.io/server/common/log/tag"
 )
 
@@ -12,6 +15,29 @@ type CapturedLog struct {
 	Level   Level
 	Message string
 	Tags    []tag.Tag
+}
+
+// CapturedLogPattern describes a captured log using formatted tag values.
+// Tags match a subset of the captured log's tags.
+type CapturedLogPattern struct {
+	Level   Level
+	Message string
+	Tags    map[string]string
+}
+
+func (p CapturedLogPattern) matches(record CapturedLog) bool {
+	if record.Level != p.Level || record.Message != p.Message {
+		return false
+	}
+
+	for key, expected := range p.Tags {
+		if !slices.ContainsFunc(record.Tags, func(actual tag.Tag) bool {
+			return actual.Key() == key && formatValue(actual) == expected
+		}) {
+			return false
+		}
+	}
+	return true
 }
 
 type captureFilterTag struct {
@@ -50,6 +76,37 @@ func (c *Capture) Snapshot() []CapturedLog {
 		records[i].Tags = slices.Clone(record.Tags)
 	}
 	return records
+}
+
+// RequireContains fails the test with tag diffs when the capture does not include a matching log.
+func (c *Capture) RequireContains(t TestingT, pattern CapturedLogPattern) {
+	t.Helper()
+	records := c.Snapshot()
+	if slices.ContainsFunc(records, pattern.matches) {
+		return
+	}
+
+	var failure strings.Builder
+	fmt.Fprintf(&failure, "captured log pattern not found: level=%s message=%q", pattern.Level, pattern.Message)
+	candidateCount := 0
+	for _, record := range records {
+		if record.Level != pattern.Level || record.Message != pattern.Message {
+			continue
+		}
+		candidateCount++
+		actualTags := make(map[string]string, len(pattern.Tags))
+		for _, actual := range record.Tags {
+			key := actual.Key()
+			if _, expected := pattern.Tags[key]; expected {
+				actualTags[key] = formatValue(actual)
+			}
+		}
+		fmt.Fprintf(&failure, "\n\ncandidate %d tag mismatch (-want +got):\n%s", candidateCount, cmp.Diff(pattern.Tags, actualTags))
+	}
+	if candidateCount == 0 {
+		fmt.Fprintf(&failure, "\n\nno captured log had the expected level and message; captured logs: %+v", records)
+	}
+	t.Fatalf("%s", failure.String())
 }
 
 func (c *Capture) record(record CapturedLog) {

--- a/common/testing/testlogger/capture.go
+++ b/common/testing/testlogger/capture.go
@@ -18,61 +18,36 @@ type CapturedLog struct {
 }
 
 // CapturedLogPattern describes a captured log using formatted tag values.
-// Tags must match exactly; AnyTagValue requires a tag without constraining its value.
+// Tags match a subset of the captured log's tags.
 type CapturedLogPattern struct {
 	Level   Level
 	Message string
-	Tags    map[string]any
+	Tags    map[string]string
 }
 
-type anyTagValue struct{}
-
-// AnyTagValue matches any formatted value for a tag that must be present.
-var AnyTagValue = &anyTagValue{}
-
 func (p CapturedLogPattern) matches(record CapturedLog) bool {
-	if record.Level != p.Level || record.Message != p.Message || len(record.Tags) != len(p.Tags) {
+	if record.Level != p.Level || record.Message != p.Message {
 		return false
 	}
 
-	matchedTags := make(map[string]struct{}, len(record.Tags))
-	for _, actual := range record.Tags {
-		key := actual.Key()
-		expected, ok := p.Tags[key]
-		if !ok {
-			return false
-		}
-		if _, duplicate := matchedTags[key]; duplicate {
-			return false
-		}
-		matchedTags[key] = struct{}{}
-		if _, anyValue := expected.(*anyTagValue); !anyValue && formatValue(actual) != fmt.Sprint(expected) {
+	for key, expected := range p.Tags {
+		if !slices.ContainsFunc(record.Tags, func(actual tag.Tag) bool {
+			return actual.Key() == key && formatValue(actual) == expected
+		}) {
 			return false
 		}
 	}
 	return true
 }
 
-func (p CapturedLogPattern) formattedTags() map[string]string {
-	formatted := make(map[string]string, len(p.Tags))
-	for key, value := range p.Tags {
-		if _, anyValue := value.(*anyTagValue); anyValue {
-			formatted[key] = "<any>"
-		} else {
-			formatted[key] = fmt.Sprint(value)
-		}
-	}
-	return formatted
-}
-
-type requireTestingT interface {
-	Helper()
-	Fatalf(format string, args ...any)
+type captureFilterTag struct {
+	key   string
+	value string
 }
 
 // Capture is an opt-in recording of TestLogger calls.
 type Capture struct {
-	anyTags map[string]map[string]struct{}
+	filterTags map[captureFilterTag]struct{}
 
 	mu      sync.Mutex
 	records []CapturedLog
@@ -83,14 +58,9 @@ func newCapture(anyTags []tag.Tag) *Capture {
 	if len(anyTags) == 0 {
 		return capture
 	}
-	capture.anyTags = make(map[string]map[string]struct{})
+	capture.filterTags = make(map[captureFilterTag]struct{}, len(anyTags))
 	for _, t := range anyTags {
-		values := capture.anyTags[t.Key()]
-		if values == nil {
-			values = make(map[string]struct{})
-			capture.anyTags[t.Key()] = values
-		}
-		values[formatValue(t)] = struct{}{}
+		capture.filterTags[captureFilterTag{key: t.Key(), value: formatValue(t)}] = struct{}{}
 	}
 	return capture
 }
@@ -109,7 +79,7 @@ func (c *Capture) Snapshot() []CapturedLog {
 }
 
 // RequireContains fails the test with tag diffs when the capture does not include a matching log.
-func (c *Capture) RequireContains(t requireTestingT, pattern CapturedLogPattern) {
+func (c *Capture) RequireContains(t TestingT, pattern CapturedLogPattern) {
 	t.Helper()
 	records := c.Snapshot()
 	if slices.ContainsFunc(records, pattern.matches) {
@@ -118,23 +88,20 @@ func (c *Capture) RequireContains(t requireTestingT, pattern CapturedLogPattern)
 
 	var failure strings.Builder
 	fmt.Fprintf(&failure, "captured log pattern not found: level=%s message=%q", pattern.Level, pattern.Message)
-	expectedTags := pattern.formattedTags()
 	candidateCount := 0
 	for _, record := range records {
 		if record.Level != pattern.Level || record.Message != pattern.Message {
 			continue
 		}
 		candidateCount++
-		actualTags := make(map[string]string, len(record.Tags))
+		actualTags := make(map[string]string, len(pattern.Tags))
 		for _, actual := range record.Tags {
 			key := actual.Key()
-			if _, anyValue := pattern.Tags[key].(*anyTagValue); anyValue {
-				actualTags[key] = "<any>"
-			} else {
+			if _, expected := pattern.Tags[key]; expected {
 				actualTags[key] = formatValue(actual)
 			}
 		}
-		fmt.Fprintf(&failure, "\n\ncandidate %d tag mismatch (-want +got):\n%s", candidateCount, cmp.Diff(expectedTags, actualTags))
+		fmt.Fprintf(&failure, "\n\ncandidate %d tag mismatch (-want +got):\n%s", candidateCount, cmp.Diff(pattern.Tags, actualTags))
 	}
 	if candidateCount == 0 {
 		fmt.Fprintf(&failure, "\n\nno captured log had the expected level and message; captured logs: %+v", records)
@@ -143,10 +110,10 @@ func (c *Capture) RequireContains(t requireTestingT, pattern CapturedLogPattern)
 }
 
 func (c *Capture) record(record CapturedLog) {
-	if len(c.anyTags) > 0 {
+	if len(c.filterTags) > 0 {
 		matched := false
 		for _, t := range record.Tags {
-			if _, ok := c.anyTags[t.Key()][formatValue(t)]; ok {
+			if _, ok := c.filterTags[captureFilterTag{key: t.Key(), value: formatValue(t)}]; ok {
 				matched = true
 				break
 			}

--- a/common/testing/testlogger/capture.go
+++ b/common/testing/testlogger/capture.go
@@ -100,14 +100,6 @@ func (c *Capture) Snapshot() []CapturedLog {
 	return records
 }
 
-// Contains reports whether the capture includes a matching log.
-func (c *Capture) Contains(pattern CapturedLogPattern) bool {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	return slices.ContainsFunc(c.records, pattern.matches)
-}
-
 // RequireContains fails the test with tag diffs when the capture does not include a matching log.
 func (c *Capture) RequireContains(t TestingT, pattern CapturedLogPattern) {
 	t.Helper()

--- a/common/testing/testlogger/capture_test.go
+++ b/common/testing/testlogger/capture_test.go
@@ -23,6 +23,7 @@ func TestCaptureLifecycle(t *testing.T) {
 	testLogger.Info("info")
 	testLogger.Warn("warn")
 	testLogger.Error("error")
+
 	testLogger.StopCapture(capture)
 	testLogger.Info("after") // won't be captured
 

--- a/common/testing/testlogger/capture_test.go
+++ b/common/testing/testlogger/capture_test.go
@@ -2,7 +2,6 @@ package testlogger_test
 
 import (
 	"errors"
-	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -12,20 +11,6 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/testing/testlogger"
 )
-
-type fatalRecorder struct {
-	testing.TB
-	helperCalled bool
-	message      string
-}
-
-func (r *fatalRecorder) Helper() {
-	r.helperCalled = true
-}
-
-func (r *fatalRecorder) Fatalf(format string, args ...any) {
-	r.message = fmt.Sprintf(format, args...)
-}
 
 func TestCaptureLifecycle(t *testing.T) {
 	t.Parallel()
@@ -104,6 +89,30 @@ func TestCaptureSnapshotIsDefensiveCopy(t *testing.T) {
 	}}, capture.Snapshot())
 }
 
+func TestCaptureContains(t *testing.T) {
+	t.Parallel()
+
+	testLogger := testlogger.NewTestLogger(t, testlogger.FailOnExpectedErrorOnly)
+	capture := testLogger.StartCapture()
+	testLogger.Error("failed", tag.String("operation", "StartOperation"), tag.Time("attempt-start", time.Now()))
+
+	require.True(t, capture.Contains(testlogger.CapturedLogPattern{
+		Level:   testlogger.Error,
+		Message: "failed",
+		Tags: map[string]any{
+			"operation":     "StartOperation",
+			"attempt-start": testlogger.AnyTagValue,
+		},
+	}))
+	require.False(t, capture.Contains(testlogger.CapturedLogPattern{
+		Level:   testlogger.Error,
+		Message: "failed",
+		Tags: map[string]any{
+			"operation": "CancelOperation",
+		},
+	}))
+}
+
 func TestCaptureRequireContains(t *testing.T) {
 	t.Parallel()
 
@@ -121,7 +130,7 @@ func TestCaptureRequireContains(t *testing.T) {
 		},
 	})
 
-	recorder := &fatalRecorder{}
+	recorder := &mockT{T: t}
 	capture.RequireContains(recorder, testlogger.CapturedLogPattern{
 		Level:   testlogger.Error,
 		Message: "failed",
@@ -131,13 +140,14 @@ func TestCaptureRequireContains(t *testing.T) {
 			"error":         "failure",
 		},
 	})
-	require.True(t, recorder.helperCalled)
-	require.Contains(t, recorder.message, "candidate 1 tag mismatch")
-	require.Contains(t, recorder.message, "CancelOperation")
-	require.Contains(t, recorder.message, "StartOperation")
+	failure := recorder.failure.Load()
+	require.NotNil(t, failure)
+	require.Contains(t, *failure, "candidate 1 tag mismatch")
+	require.Contains(t, *failure, "CancelOperation")
+	require.Contains(t, *failure, "StartOperation")
 
 	// A pattern with an extra tag matches nothing.
-	recorder = &fatalRecorder{}
+	recorder = &mockT{T: t}
 	capture.RequireContains(recorder, testlogger.CapturedLogPattern{
 		Level:   testlogger.Error,
 		Message: "failed",
@@ -148,7 +158,19 @@ func TestCaptureRequireContains(t *testing.T) {
 			"unexpected":    "value",
 		},
 	})
-	require.Contains(t, recorder.message, "unexpected")
+	failure = recorder.failure.Load()
+	require.NotNil(t, failure)
+	require.Contains(t, *failure, "unexpected")
+
+	recorder = &mockT{T: t}
+	capture.RequireContains(recorder, testlogger.CapturedLogPattern{
+		Level:   testlogger.Warn,
+		Message: "missing",
+	})
+	failure = recorder.failure.Load()
+	require.NotNil(t, failure)
+	require.Contains(t, *failure, `Error "failed" operation=StartOperation`)
+	require.NotContains(t, *failure, "zapcore")
 }
 
 func TestCaptureRecordsConcurrentDerivedLoggers(t *testing.T) {

--- a/common/testing/testlogger/capture_test.go
+++ b/common/testing/testlogger/capture_test.go
@@ -119,7 +119,7 @@ func TestCaptureRequireContains(t *testing.T) {
 			Level:   testlogger.Error,
 			Message: "failed",
 			Tags: map[string]any{
-				"operation":     "CancelOperation", // does not match!
+				"operation":     "CancelOperation", // mismatch!
 				"attempt-start": testlogger.AnyTagValue,
 				"error":         "failure",
 			},
@@ -143,7 +143,7 @@ func TestCaptureRequireContains(t *testing.T) {
 				"operation":     "StartOperation",
 				"attempt-start": testlogger.AnyTagValue,
 				"error":         "failure",
-				"unexpected":    "value", // does not match!
+				"unexpected":    "value", // extra!
 			},
 		})
 		failure := recorder.failure.Load()
@@ -158,7 +158,7 @@ func TestCaptureRequireContains(t *testing.T) {
 		capture.RequireContains(recorder, testlogger.CapturedLogPattern{
 			Level:   testlogger.Warn,
 			Message: "missing",
-			// missing ... does not match!
+			// missing!
 		})
 		failure := recorder.failure.Load()
 		require.NotNil(t, failure)

--- a/common/testing/testlogger/capture_test.go
+++ b/common/testing/testlogger/capture_test.go
@@ -98,6 +98,8 @@ func TestCaptureRequireContains(t *testing.T) {
 	testLogger.Error("failed", tag.String("operation", "StartOperation"), tag.Time("attempt-start", time.Now()), tag.Error(errors.New("failure")))
 
 	t.Run("matching pattern", func(t *testing.T) {
+		t.Parallel()
+
 		capture.RequireContains(t, testlogger.CapturedLogPattern{
 			Level:   testlogger.Error,
 			Message: "failed",
@@ -110,12 +112,14 @@ func TestCaptureRequireContains(t *testing.T) {
 	})
 
 	t.Run("mismatched tag", func(t *testing.T) {
+		t.Parallel()
+
 		recorder := &mockT{T: t}
 		capture.RequireContains(recorder, testlogger.CapturedLogPattern{
 			Level:   testlogger.Error,
 			Message: "failed",
 			Tags: map[string]any{
-				"operation":     "CancelOperation",
+				"operation":     "CancelOperation", // does not match!
 				"attempt-start": testlogger.AnyTagValue,
 				"error":         "failure",
 			},
@@ -129,6 +133,8 @@ func TestCaptureRequireContains(t *testing.T) {
 
 	// A pattern with an extra tag matches nothing.
 	t.Run("extra tag", func(t *testing.T) {
+		t.Parallel()
+
 		recorder := &mockT{T: t}
 		capture.RequireContains(recorder, testlogger.CapturedLogPattern{
 			Level:   testlogger.Error,
@@ -137,7 +143,7 @@ func TestCaptureRequireContains(t *testing.T) {
 				"operation":     "StartOperation",
 				"attempt-start": testlogger.AnyTagValue,
 				"error":         "failure",
-				"unexpected":    "value",
+				"unexpected":    "value", // does not match!
 			},
 		})
 		failure := recorder.failure.Load()
@@ -146,10 +152,13 @@ func TestCaptureRequireContains(t *testing.T) {
 	})
 
 	t.Run("missing level and message", func(t *testing.T) {
+		t.Parallel()
+
 		recorder := &mockT{T: t}
 		capture.RequireContains(recorder, testlogger.CapturedLogPattern{
 			Level:   testlogger.Warn,
 			Message: "missing",
+			// missing ... does not match!
 		})
 		failure := recorder.failure.Load()
 		require.NotNil(t, failure)

--- a/common/testing/testlogger/capture_test.go
+++ b/common/testing/testlogger/capture_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 type fatalRecorder struct {
+	testing.TB
 	helperCalled bool
 	message      string
 }
@@ -113,10 +114,9 @@ func TestCaptureContains(t *testing.T) {
 	pattern := testlogger.CapturedLogPattern{
 		Level:   testlogger.Error,
 		Message: "failed",
-		Tags: map[string]any{
-			"operation":     "StartOperation",
-			"attempt-start": testlogger.AnyTagValue,
-			"error":         "failure",
+		Tags: map[string]string{
+			"operation": "StartOperation",
+			"error":     "failure",
 		},
 	}
 	capture.RequireContains(t, pattern)
@@ -129,7 +129,7 @@ func TestCaptureContains(t *testing.T) {
 	require.Contains(t, recorder.message, "CancelOperation")
 	require.Contains(t, recorder.message, "StartOperation")
 
-	// A pattern with an extra tag matches nothing, since tag sets must match exactly.
+	// A pattern with an extra tag matches nothing.
 	pattern.Tags["operation"] = "StartOperation"
 	pattern.Tags["unexpected"] = "value"
 	recorder = &fatalRecorder{}

--- a/common/testing/testlogger/capture_test.go
+++ b/common/testing/testlogger/capture_test.go
@@ -104,7 +104,7 @@ func TestCaptureSnapshotIsDefensiveCopy(t *testing.T) {
 	}}, capture.Snapshot())
 }
 
-func TestCaptureContains(t *testing.T) {
+func TestCaptureRequireContains(t *testing.T) {
 	t.Parallel()
 
 	testLogger := testlogger.NewTestLogger(t, testlogger.FailOnExpectedErrorOnly)

--- a/common/testing/testlogger/capture_test.go
+++ b/common/testing/testlogger/capture_test.go
@@ -119,20 +119,22 @@ func TestCaptureContains(t *testing.T) {
 			"error":         "failure",
 		},
 	}
-	require.True(t, capture.Contains(pattern))
 	capture.RequireContains(t, pattern)
 
 	pattern.Tags["operation"] = "CancelOperation"
-	require.False(t, capture.Contains(pattern))
 	recorder := &fatalRecorder{}
 	capture.RequireContains(recorder, pattern)
 	require.True(t, recorder.helperCalled)
 	require.Contains(t, recorder.message, "candidate 1 tag mismatch")
 	require.Contains(t, recorder.message, "CancelOperation")
 	require.Contains(t, recorder.message, "StartOperation")
+
+	// A pattern with an extra tag matches nothing, since tag sets must match exactly.
 	pattern.Tags["operation"] = "StartOperation"
 	pattern.Tags["unexpected"] = "value"
-	require.False(t, capture.Contains(pattern))
+	recorder = &fatalRecorder{}
+	capture.RequireContains(recorder, pattern)
+	require.Contains(t, recorder.message, "unexpected")
 }
 
 func TestCaptureRecordsConcurrentDerivedLoggers(t *testing.T) {

--- a/common/testing/testlogger/capture_test.go
+++ b/common/testing/testlogger/capture_test.go
@@ -1,31 +1,14 @@
 package testlogger_test
 
 import (
-	"errors"
-	"fmt"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/testing/testlogger"
 )
-
-type fatalRecorder struct {
-	testing.TB
-	helperCalled bool
-	message      string
-}
-
-func (r *fatalRecorder) Helper() {
-	r.helperCalled = true
-}
-
-func (r *fatalRecorder) Fatalf(format string, args ...any) {
-	r.message = fmt.Sprintf(format, args...)
-}
 
 func TestCaptureLifecycle(t *testing.T) {
 	t.Parallel()
@@ -102,39 +85,6 @@ func TestCaptureSnapshotIsDefensiveCopy(t *testing.T) {
 		Message: "message",
 		Tags:    []tag.Tag{tag.String("key", "original")},
 	}}, capture.Snapshot())
-}
-
-func TestCaptureContains(t *testing.T) {
-	t.Parallel()
-
-	testLogger := testlogger.NewTestLogger(t, testlogger.FailOnExpectedErrorOnly)
-	capture := testLogger.StartCapture()
-	testLogger.Error("failed", tag.String("operation", "StartOperation"), tag.Time("attempt-start", time.Now()), tag.Error(errors.New("failure")))
-
-	pattern := testlogger.CapturedLogPattern{
-		Level:   testlogger.Error,
-		Message: "failed",
-		Tags: map[string]string{
-			"operation": "StartOperation",
-			"error":     "failure",
-		},
-	}
-	capture.RequireContains(t, pattern)
-
-	pattern.Tags["operation"] = "CancelOperation"
-	recorder := &fatalRecorder{}
-	capture.RequireContains(recorder, pattern)
-	require.True(t, recorder.helperCalled)
-	require.Contains(t, recorder.message, "candidate 1 tag mismatch")
-	require.Contains(t, recorder.message, "CancelOperation")
-	require.Contains(t, recorder.message, "StartOperation")
-
-	// A pattern with an extra tag matches nothing.
-	pattern.Tags["operation"] = "StartOperation"
-	pattern.Tags["unexpected"] = "value"
-	recorder = &fatalRecorder{}
-	capture.RequireContains(recorder, pattern)
-	require.Contains(t, recorder.message, "unexpected")
 }
 
 func TestCaptureRecordsConcurrentDerivedLoggers(t *testing.T) {

--- a/common/testing/testlogger/capture_test.go
+++ b/common/testing/testlogger/capture_test.go
@@ -1,0 +1,162 @@
+package testlogger_test
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/testing/testlogger"
+)
+
+type fatalRecorder struct {
+	helperCalled bool
+	message      string
+}
+
+func (r *fatalRecorder) Helper() {
+	r.helperCalled = true
+}
+
+func (r *fatalRecorder) Fatalf(format string, args ...any) {
+	r.message = fmt.Sprintf(format, args...)
+}
+
+func TestCaptureLifecycle(t *testing.T) {
+	t.Parallel()
+
+	testLogger := testlogger.NewTestLogger(t, testlogger.FailOnExpectedErrorOnly)
+	testLogger.Info("before")
+
+	capture := testLogger.StartCapture()
+	testLogger.Debug("debug", tag.String("key", "value"))
+	testLogger.Info("info")
+	testLogger.Warn("warn")
+	testLogger.Error("error")
+	testLogger.StopCapture(capture)
+	testLogger.Info("after")
+
+	require.Equal(t, []testlogger.CapturedLog{
+		{Level: testlogger.Debug, Message: "debug", Tags: []tag.Tag{tag.String("key", "value")}},
+		{Level: testlogger.Info, Message: "info"},
+		{Level: testlogger.Warn, Message: "warn"},
+		{Level: testlogger.Error, Message: "error"},
+	}, capture.Snapshot())
+}
+
+func TestCaptureSharesStateWithDerivedLoggers(t *testing.T) {
+	t.Parallel()
+
+	testLogger := testlogger.NewTestLogger(t, testlogger.FailOnExpectedErrorOnly)
+	capture := testLogger.StartCapture()
+
+	log.With(testLogger, tag.String("inherited", "value")).Info("with")
+	testLogger.WithTags(tag.String("direct", "value")).Info("with-tags")
+
+	require.Equal(t, []testlogger.CapturedLog{
+		{Level: testlogger.Info, Message: "with", Tags: []tag.Tag{tag.String("inherited", "value")}},
+		{Level: testlogger.Info, Message: "with-tags", Tags: []tag.Tag{tag.String("direct", "value")}},
+	}, capture.Snapshot())
+}
+
+func TestCaptureFiltersIndependently(t *testing.T) {
+	t.Parallel()
+
+	testLogger := testlogger.NewTestLogger(t, testlogger.FailOnExpectedErrorOnly)
+	all := testLogger.StartCapture()
+	matching := testLogger.StartCapture(tag.String("keep", "true"))
+
+	testLogger.Info("excluded")
+	testLogger.Info("included", tag.String("keep", "true"))
+
+	require.Len(t, all.Snapshot(), 2)
+	require.Equal(t, []testlogger.CapturedLog{{
+		Level:   testlogger.Info,
+		Message: "included",
+		Tags:    []tag.Tag{tag.String("keep", "true")},
+	}}, matching.Snapshot())
+}
+
+func TestCaptureSnapshotIsDefensiveCopy(t *testing.T) {
+	t.Parallel()
+
+	testLogger := testlogger.NewTestLogger(t, testlogger.FailOnExpectedErrorOnly)
+	capture := testLogger.StartCapture()
+	tags := []tag.Tag{tag.String("key", "original")}
+
+	testLogger.Info("message", tags...)
+	tags[0] = tag.String("key", "mutated input")
+
+	// mutate the snapshot
+	first := capture.Snapshot()
+	first[0].Message = "mutated snapshot"
+	first[0].Tags[0] = tag.String("key", "mutated snapshot")
+
+	require.Equal(t, []testlogger.CapturedLog{{
+		Level:   testlogger.Info,
+		Message: "message",
+		Tags:    []tag.Tag{tag.String("key", "original")},
+	}}, capture.Snapshot())
+}
+
+func TestCaptureContains(t *testing.T) {
+	t.Parallel()
+
+	testLogger := testlogger.NewTestLogger(t, testlogger.FailOnExpectedErrorOnly)
+	capture := testLogger.StartCapture()
+	testLogger.Error("failed", tag.String("operation", "StartOperation"), tag.Time("attempt-start", time.Now()), tag.Error(errors.New("failure")))
+
+	pattern := testlogger.CapturedLogPattern{
+		Level:   testlogger.Error,
+		Message: "failed",
+		Tags: map[string]any{
+			"operation":     "StartOperation",
+			"attempt-start": testlogger.AnyTagValue,
+			"error":         "failure",
+		},
+	}
+	require.True(t, capture.Contains(pattern))
+	capture.RequireContains(t, pattern)
+
+	pattern.Tags["operation"] = "CancelOperation"
+	require.False(t, capture.Contains(pattern))
+	recorder := &fatalRecorder{}
+	capture.RequireContains(recorder, pattern)
+	require.True(t, recorder.helperCalled)
+	require.Contains(t, recorder.message, "candidate 1 tag mismatch")
+	require.Contains(t, recorder.message, "CancelOperation")
+	require.Contains(t, recorder.message, "StartOperation")
+	pattern.Tags["operation"] = "StartOperation"
+	pattern.Tags["unexpected"] = "value"
+	require.False(t, capture.Contains(pattern))
+}
+
+func TestCaptureRecordsConcurrentDerivedLoggers(t *testing.T) {
+	t.Parallel()
+
+	testLogger := testlogger.NewTestLogger(t, testlogger.FailOnExpectedErrorOnly,
+		testlogger.WrapLogger(log.NewNoopLogger()),
+	)
+	capture := testLogger.StartCapture()
+
+	const (
+		loggerCount   = 10
+		recordsPerLog = 20
+	)
+	var wg sync.WaitGroup
+	for loggerID := range loggerCount {
+		derived := log.With(testLogger, tag.Int("logger-id", loggerID))
+		wg.Go(func() {
+			for range recordsPerLog {
+				derived.Info("concurrent")
+			}
+		})
+	}
+	wg.Wait()
+
+	require.Len(t, capture.Snapshot(), loggerCount*recordsPerLog)
+}

--- a/common/testing/testlogger/capture_test.go
+++ b/common/testing/testlogger/capture_test.go
@@ -16,7 +16,7 @@ func TestCaptureLifecycle(t *testing.T) {
 	t.Parallel()
 
 	testLogger := testlogger.NewTestLogger(t, testlogger.FailOnExpectedErrorOnly)
-	testLogger.Info("before")
+	testLogger.Info("before") // won't be captured
 
 	capture := testLogger.StartCapture()
 	testLogger.Debug("debug", tag.String("key", "value"))
@@ -24,7 +24,7 @@ func TestCaptureLifecycle(t *testing.T) {
 	testLogger.Warn("warn")
 	testLogger.Error("error")
 	testLogger.StopCapture(capture)
-	testLogger.Info("after")
+	testLogger.Info("after") // won't be captured
 
 	require.Equal(t, []testlogger.CapturedLog{
 		{Level: testlogger.Debug, Message: "debug", Tags: []tag.Tag{tag.String("key", "value")}},

--- a/common/testing/testlogger/capture_test.go
+++ b/common/testing/testlogger/capture_test.go
@@ -1,14 +1,31 @@
 package testlogger_test
 
 import (
+	"errors"
+	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/testing/testlogger"
 )
+
+type fatalRecorder struct {
+	testing.TB
+	helperCalled bool
+	message      string
+}
+
+func (r *fatalRecorder) Helper() {
+	r.helperCalled = true
+}
+
+func (r *fatalRecorder) Fatalf(format string, args ...any) {
+	r.message = fmt.Sprintf(format, args...)
+}
 
 func TestCaptureLifecycle(t *testing.T) {
 	t.Parallel()
@@ -85,6 +102,39 @@ func TestCaptureSnapshotIsDefensiveCopy(t *testing.T) {
 		Message: "message",
 		Tags:    []tag.Tag{tag.String("key", "original")},
 	}}, capture.Snapshot())
+}
+
+func TestCaptureContains(t *testing.T) {
+	t.Parallel()
+
+	testLogger := testlogger.NewTestLogger(t, testlogger.FailOnExpectedErrorOnly)
+	capture := testLogger.StartCapture()
+	testLogger.Error("failed", tag.String("operation", "StartOperation"), tag.Time("attempt-start", time.Now()), tag.Error(errors.New("failure")))
+
+	pattern := testlogger.CapturedLogPattern{
+		Level:   testlogger.Error,
+		Message: "failed",
+		Tags: map[string]string{
+			"operation": "StartOperation",
+			"error":     "failure",
+		},
+	}
+	capture.RequireContains(t, pattern)
+
+	pattern.Tags["operation"] = "CancelOperation"
+	recorder := &fatalRecorder{}
+	capture.RequireContains(recorder, pattern)
+	require.True(t, recorder.helperCalled)
+	require.Contains(t, recorder.message, "candidate 1 tag mismatch")
+	require.Contains(t, recorder.message, "CancelOperation")
+	require.Contains(t, recorder.message, "StartOperation")
+
+	// A pattern with an extra tag matches nothing.
+	pattern.Tags["operation"] = "StartOperation"
+	pattern.Tags["unexpected"] = "value"
+	recorder = &fatalRecorder{}
+	capture.RequireContains(recorder, pattern)
+	require.Contains(t, recorder.message, "unexpected")
 }
 
 func TestCaptureRecordsConcurrentDerivedLoggers(t *testing.T) {

--- a/common/testing/testlogger/capture_test.go
+++ b/common/testing/testlogger/capture_test.go
@@ -90,30 +90,6 @@ func TestCaptureSnapshotIsDefensiveCopy(t *testing.T) {
 	}}, capture.Snapshot())
 }
 
-func TestCaptureContains(t *testing.T) {
-	t.Parallel()
-
-	testLogger := testlogger.NewTestLogger(t, testlogger.FailOnExpectedErrorOnly)
-	capture := testLogger.StartCapture()
-	testLogger.Error("failed", tag.String("operation", "StartOperation"), tag.Time("attempt-start", time.Now()))
-
-	require.True(t, capture.Contains(testlogger.CapturedLogPattern{
-		Level:   testlogger.Error,
-		Message: "failed",
-		Tags: map[string]any{
-			"operation":     "StartOperation",
-			"attempt-start": testlogger.AnyTagValue,
-		},
-	}))
-	require.False(t, capture.Contains(testlogger.CapturedLogPattern{
-		Level:   testlogger.Error,
-		Message: "failed",
-		Tags: map[string]any{
-			"operation": "CancelOperation",
-		},
-	}))
-}
-
 func TestCaptureRequireContains(t *testing.T) {
 	t.Parallel()
 
@@ -121,57 +97,65 @@ func TestCaptureRequireContains(t *testing.T) {
 	capture := testLogger.StartCapture()
 	testLogger.Error("failed", tag.String("operation", "StartOperation"), tag.Time("attempt-start", time.Now()), tag.Error(errors.New("failure")))
 
-	capture.RequireContains(t, testlogger.CapturedLogPattern{
-		Level:   testlogger.Error,
-		Message: "failed",
-		Tags: map[string]any{
-			"operation":     "StartOperation",
-			"attempt-start": testlogger.AnyTagValue,
-			"error":         "failure",
-		},
+	t.Run("matching pattern", func(t *testing.T) {
+		capture.RequireContains(t, testlogger.CapturedLogPattern{
+			Level:   testlogger.Error,
+			Message: "failed",
+			Tags: map[string]any{
+				"operation":     "StartOperation",
+				"attempt-start": testlogger.AnyTagValue,
+				"error":         "failure",
+			},
+		})
 	})
 
-	recorder := &mockT{T: t}
-	capture.RequireContains(recorder, testlogger.CapturedLogPattern{
-		Level:   testlogger.Error,
-		Message: "failed",
-		Tags: map[string]any{
-			"operation":     "CancelOperation",
-			"attempt-start": testlogger.AnyTagValue,
-			"error":         "failure",
-		},
+	t.Run("mismatched tag", func(t *testing.T) {
+		recorder := &mockT{T: t}
+		capture.RequireContains(recorder, testlogger.CapturedLogPattern{
+			Level:   testlogger.Error,
+			Message: "failed",
+			Tags: map[string]any{
+				"operation":     "CancelOperation",
+				"attempt-start": testlogger.AnyTagValue,
+				"error":         "failure",
+			},
+		})
+		failure := recorder.failure.Load()
+		require.NotNil(t, failure)
+		require.Contains(t, *failure, "candidate 1 tag mismatch")
+		require.Contains(t, *failure, "CancelOperation")
+		require.Contains(t, *failure, "StartOperation")
 	})
-	failure := recorder.failure.Load()
-	require.NotNil(t, failure)
-	require.Contains(t, *failure, "candidate 1 tag mismatch")
-	require.Contains(t, *failure, "CancelOperation")
-	require.Contains(t, *failure, "StartOperation")
 
 	// A pattern with an extra tag matches nothing.
-	recorder = &mockT{T: t}
-	capture.RequireContains(recorder, testlogger.CapturedLogPattern{
-		Level:   testlogger.Error,
-		Message: "failed",
-		Tags: map[string]any{
-			"operation":     "StartOperation",
-			"attempt-start": testlogger.AnyTagValue,
-			"error":         "failure",
-			"unexpected":    "value",
-		},
+	t.Run("extra tag", func(t *testing.T) {
+		recorder := &mockT{T: t}
+		capture.RequireContains(recorder, testlogger.CapturedLogPattern{
+			Level:   testlogger.Error,
+			Message: "failed",
+			Tags: map[string]any{
+				"operation":     "StartOperation",
+				"attempt-start": testlogger.AnyTagValue,
+				"error":         "failure",
+				"unexpected":    "value",
+			},
+		})
+		failure := recorder.failure.Load()
+		require.NotNil(t, failure)
+		require.Contains(t, *failure, "unexpected")
 	})
-	failure = recorder.failure.Load()
-	require.NotNil(t, failure)
-	require.Contains(t, *failure, "unexpected")
 
-	recorder = &mockT{T: t}
-	capture.RequireContains(recorder, testlogger.CapturedLogPattern{
-		Level:   testlogger.Warn,
-		Message: "missing",
+	t.Run("missing level and message", func(t *testing.T) {
+		recorder := &mockT{T: t}
+		capture.RequireContains(recorder, testlogger.CapturedLogPattern{
+			Level:   testlogger.Warn,
+			Message: "missing",
+		})
+		failure := recorder.failure.Load()
+		require.NotNil(t, failure)
+		require.Contains(t, *failure, `Error "failed" operation=StartOperation`)
+		require.NotContains(t, *failure, "zapcore")
 	})
-	failure = recorder.failure.Load()
-	require.NotNil(t, failure)
-	require.Contains(t, *failure, `Error "failed" operation=StartOperation`)
-	require.NotContains(t, *failure, "zapcore")
 }
 
 func TestCaptureRecordsConcurrentDerivedLoggers(t *testing.T) {

--- a/common/testing/testlogger/capture_test.go
+++ b/common/testing/testlogger/capture_test.go
@@ -111,29 +111,43 @@ func TestCaptureRequireContains(t *testing.T) {
 	capture := testLogger.StartCapture()
 	testLogger.Error("failed", tag.String("operation", "StartOperation"), tag.Time("attempt-start", time.Now()), tag.Error(errors.New("failure")))
 
-	pattern := testlogger.CapturedLogPattern{
+	capture.RequireContains(t, testlogger.CapturedLogPattern{
 		Level:   testlogger.Error,
 		Message: "failed",
-		Tags: map[string]string{
-			"operation": "StartOperation",
-			"error":     "failure",
+		Tags: map[string]any{
+			"operation":     "StartOperation",
+			"attempt-start": testlogger.AnyTagValue,
+			"error":         "failure",
 		},
-	}
-	capture.RequireContains(t, pattern)
+	})
 
-	pattern.Tags["operation"] = "CancelOperation"
 	recorder := &fatalRecorder{}
-	capture.RequireContains(recorder, pattern)
+	capture.RequireContains(recorder, testlogger.CapturedLogPattern{
+		Level:   testlogger.Error,
+		Message: "failed",
+		Tags: map[string]any{
+			"operation":     "CancelOperation",
+			"attempt-start": testlogger.AnyTagValue,
+			"error":         "failure",
+		},
+	})
 	require.True(t, recorder.helperCalled)
 	require.Contains(t, recorder.message, "candidate 1 tag mismatch")
 	require.Contains(t, recorder.message, "CancelOperation")
 	require.Contains(t, recorder.message, "StartOperation")
 
 	// A pattern with an extra tag matches nothing.
-	pattern.Tags["operation"] = "StartOperation"
-	pattern.Tags["unexpected"] = "value"
 	recorder = &fatalRecorder{}
-	capture.RequireContains(recorder, pattern)
+	capture.RequireContains(recorder, testlogger.CapturedLogPattern{
+		Level:   testlogger.Error,
+		Message: "failed",
+		Tags: map[string]any{
+			"operation":     "StartOperation",
+			"attempt-start": testlogger.AnyTagValue,
+			"error":         "failure",
+			"unexpected":    "value",
+		},
+	})
 	require.Contains(t, recorder.message, "unexpected")
 }
 

--- a/common/testing/testlogger/testlogger.go
+++ b/common/testing/testlogger/testlogger.go
@@ -142,6 +142,7 @@ type sharedTestLoggerState struct {
 	mu           struct {
 		sync.RWMutex
 		expectations map[Level]*list.List // Map[Level]List[matcher]
+		captures     map[*Capture]struct{}
 		closed       bool
 	}
 	mode            Mode
@@ -280,6 +281,7 @@ func NewTestLogger(t TestingT, mode Mode, opts ...LoggerOption) *TestLogger {
 		},
 	}
 	tl.state.mu.expectations = make(map[Level]*list.List)
+	tl.state.mu.captures = make(map[*Capture]struct{})
 	tl.state.failOnError.Store(true)
 	tl.state.failOnDPanic.Store(true)
 	tl.state.failOnFatal.Store(true)
@@ -360,6 +362,23 @@ func (tl *TestLogger) Forget(e *Expectation) {
 	tl.state.mu.expectations[e.lvl].Remove(e.e)
 }
 
+// StartCapture starts recording log calls that contain any of the provided exact tags.
+// It records all calls when no tags are provided.
+func (tl *TestLogger) StartCapture(anyTags ...tag.Tag) *Capture {
+	capture := newCapture(anyTags)
+	tl.state.mu.Lock()
+	tl.state.mu.captures[capture] = struct{}{}
+	tl.state.mu.Unlock()
+	return capture
+}
+
+// StopCapture stops recording log calls for capture.
+func (tl *TestLogger) StopCapture(capture *Capture) {
+	tl.state.mu.Lock()
+	delete(tl.state.mu.captures, capture)
+	tl.state.mu.Unlock()
+}
+
 func (tl *TestLogger) shouldFailTest(level Level, msg string, tags []tag.Tag) bool {
 	// Only check expectations if they've been registered for this level.
 	if expectations, found := tl.state.mu.expectations[level]; found {
@@ -397,6 +416,20 @@ func (tl *TestLogger) recordExpectationMatches(level Level, msg string, tags []t
 		if m.Matches(msg, tags) {
 			m.expectation.matches.Add(1)
 		}
+	}
+}
+
+func (tl *TestLogger) recordCaptures(level Level, msg string, tags []tag.Tag) {
+	if len(tl.state.mu.captures) == 0 {
+		return
+	}
+	record := CapturedLog{
+		Level:   level,
+		Message: msg,
+		Tags:    slices.Clone(tags),
+	}
+	for capture := range tl.state.mu.captures {
+		capture.record(record)
 	}
 }
 
@@ -474,6 +507,7 @@ func (tl *TestLogger) DPanic(msg string, tags ...tag.Tag) {
 	}
 	tags = tl.mergeWithLoggerTags(tags)
 	tl.recordExpectationMatches(DPanic, msg, tags)
+	tl.recordCaptures(DPanic, msg, tags)
 	// note, actual panic'ing in wrapped is turned off so we can control.
 	tl.wrapped.DPanic(msg, tags...)
 	if tl.state.failOnDPanic.Load() && tl.shouldFailTest(DPanic, msg, tags) {
@@ -491,6 +525,7 @@ func (tl *TestLogger) Debug(msg string, tags ...tag.Tag) {
 	}
 	tags = tl.mergeWithLoggerTags(tags)
 	tl.recordExpectationMatches(Debug, msg, tags)
+	tl.recordCaptures(Debug, msg, tags)
 	tl.wrapped.Debug(msg, tags...)
 }
 
@@ -503,6 +538,7 @@ func (tl *TestLogger) Error(msg string, tags ...tag.Tag) {
 	}
 	tags = tl.mergeWithLoggerTags(tags)
 	tl.recordExpectationMatches(Error, msg, tags)
+	tl.recordCaptures(Error, msg, tags)
 	if !tl.shouldFailTest(Error, msg, tags) {
 		tl.wrapped.Error(msg, tags...)
 		tl.state.mu.RUnlock()
@@ -529,6 +565,7 @@ func (tl *TestLogger) Fatal(msg string, tags ...tag.Tag) {
 	}
 	tags = tl.mergeWithLoggerTags(tags)
 	tl.recordExpectationMatches(Fatal, msg, tags)
+	tl.recordCaptures(Fatal, msg, tags)
 	tl.state.t.Helper()
 	if tl.state.failOnFatal.Load() && tl.shouldFailTest(Fatal, msg, tags) {
 		tl.failTest(Fatal, msg, tags...)
@@ -552,6 +589,7 @@ func (tl *TestLogger) Info(msg string, tags ...tag.Tag) {
 	}
 	tags = tl.mergeWithLoggerTags(tags)
 	tl.recordExpectationMatches(Info, msg, tags)
+	tl.recordCaptures(Info, msg, tags)
 	tl.wrapped.Info(msg, tags...)
 }
 
@@ -564,6 +602,7 @@ func (tl *TestLogger) Panic(msg string, tags ...tag.Tag) {
 	}
 	tags = tl.mergeWithLoggerTags(tags)
 	tl.recordExpectationMatches(Panic, msg, tags)
+	tl.recordCaptures(Panic, msg, tags)
 	tl.state.t.Helper()
 	// Forcibly fail the test when required as otherwise panics can be caught.
 	if tl.shouldFailTest(Panic, msg, tags) {
@@ -582,6 +621,7 @@ func (tl *TestLogger) Warn(msg string, tags ...tag.Tag) {
 	}
 	tags = tl.mergeWithLoggerTags(tags)
 	tl.recordExpectationMatches(Warn, msg, tags)
+	tl.recordCaptures(Warn, msg, tags)
 	tl.wrapped.Warn(msg, tags...)
 }
 

--- a/common/testing/testlogger/testlogger_test.go
+++ b/common/testing/testlogger/testlogger_test.go
@@ -78,6 +78,8 @@ func assertMatches(t *testing.T, level testlogger.Level, msg string, tags []tag.
 }
 
 func TestTestLogger_ExpectationsMatch(t *testing.T) {
+	t.Parallel()
+
 	for _, level := range []testlogger.Level{testlogger.Error, testlogger.DPanic, testlogger.Panic, testlogger.Fatal} {
 		t.Run(level.String()+" with tags", func(t *testing.T) {
 			assertMatches(t, level, "message with tags", []tag.Tag{tag.String("key", "value")})
@@ -93,6 +95,8 @@ func TestTestLogger_ExpectationsMatch(t *testing.T) {
 }
 
 func TestTestLogger_InfoExpectationMatchCount(t *testing.T) {
+	t.Parallel()
+
 	tl := testlogger.NewTestLogger(t, testlogger.FailOnAnyUnexpectedError)
 	expected := tl.Expect(testlogger.Info, "expected info", tag.String("key", "value"))
 	require.False(t, expected.Matched())
@@ -133,6 +137,8 @@ func assertFails(t *testing.T, level testlogger.Level, msg string, tags []tag.Ta
 }
 
 func TestTestLogger_Uncaught(t *testing.T) {
+	t.Parallel()
+
 	// Non-panicking levels
 	for _, level := range []testlogger.Level{testlogger.Error, testlogger.DPanic} {
 		t.Run(level.String()+" with tags", func(t *testing.T) {
@@ -169,6 +175,8 @@ func TestTestLogger_Uncaught(t *testing.T) {
 // the first failure-worthy log in FailOnAnyUnexpectedError mode and that
 // subsequent failures do not overwrite it (first-failure-wins via CAS).
 func TestTestLogger_Failure_StickyOnAnyUnexpected(t *testing.T) {
+	t.Parallel()
+
 	mt := &mockT{T: t}
 	tl := testlogger.NewTestLogger(mt, testlogger.FailOnAnyUnexpectedError)
 	require.Nil(t, tl.Failure())
@@ -188,6 +196,8 @@ func TestTestLogger_Failure_StickyOnAnyUnexpected(t *testing.T) {
 // FailOnExpectedErrorOnly mode, an Error matching a registered expectation
 // (e.g. tag.FailedAssertion) should mark Failure().
 func TestTestLogger_Failure_OnExpectedMatch(t *testing.T) {
+	t.Parallel()
+
 	mt := &mockT{T: t}
 	tl := testlogger.NewTestLogger(mt, testlogger.FailOnExpectedErrorOnly)
 	tl.Expect(testlogger.Error, ".*", tag.FailedAssertion)
@@ -203,6 +213,8 @@ func TestTestLogger_Failure_OnExpectedMatch(t *testing.T) {
 // TestTestLogger_Failure_NoMatch verifies that FailOnExpectedErrorOnly remains an
 // escape hatch: an Error with no matching expectation does not flip Failure().
 func TestTestLogger_Failure_NoMatch(t *testing.T) {
+	t.Parallel()
+
 	mt := &mockT{T: t}
 	tl := testlogger.NewTestLogger(mt, testlogger.FailOnExpectedErrorOnly)
 	require.Nil(t, tl.Failure())


### PR DESCRIPTION
## What changed

Adds `TestLogger.StartCapture` / `StopCapture` to records log calls and make them queryable.

## Why

We want ability to verify certain logs where emitted to verify observability. See #11689 for first use case.