### PR TITLE
Fix build: tag the Link_Workflow parse warning

### DIFF
--- a/common/nexus/links.go
+++ b/common/nexus/links.go
@@ -47,8 +47,10 @@ func ConvertNexusLinksToProtoLinks(nexusLinks []nexus.Link, logger log.Logger) [
 			link, err := temporalnexus.ConvertNexusLinkToLinkWorkflow(nexusLink)
 			if err != nil {
 				logger.Warn(
-					fmt.Sprintf("failed to parse link to %q: %s", nexusLink.Type, nexusLink.URL),
+					"failed to parse Nexus link",
 					tag.Error(err),
+					tag.NewStringTag("nexus-link-type", nexusLink.Type),
+					tag.URL(nexusLink.URL.String()),
 				)
 				continue
 			}


### PR DESCRIPTION
## main is currently broken

```
common/nexus/links.go:50:6: undefined: fmt
```

`go build ./common/nexus/` fails on `origin/main` as of fc7b395f6.

## Cause

A semantic merge conflict between two PRs that merged around the same time:

- **#11685** removed the `fmt` import from `links.go`, having replaced all three `fmt.Sprintf` message interpolations with log tags.
- **#11274** added a new `Link_Workflow` case that logs via `fmt.Sprintf`.

Neither diff touched the other's lines, so git merged both cleanly and the result does not compile.

## Fix

Convert the new case to the same static-message-plus-tags form as the other three, rather than re-adding the import — that keeps the warning aggregatable in Loki, which is what #11685 was for.

## Testing

`go build ./...`, `go test -tags test_dep ./common/nexus/`, `gofmt`. No remaining `fmt.` references in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)