### PR TITLE
history: bound command types listed in invalid-command-sequence error

### DIFF
--- a/service/history/api/command_attr_validator.go
+++ b/service/history/api/command_attr_validator.go
@@ -643,7 +643,7 @@ func (v *CommandAttrValidator) ValidateCommandSequence(
 		if closeCommand != enumspb.COMMAND_TYPE_UNSPECIFIED {
 			return serviceerror.NewInvalidArgumentf(
 				"invalid command sequence: [%v], command %s must be the last command.",
-				strings.Join(v.commandTypes(commands), ", "), closeCommand.String(),
+				v.commandTypesSummary(commands), closeCommand.String(),
 			)
 		}
 
@@ -677,12 +677,33 @@ func (v *CommandAttrValidator) ValidateCommandSequence(
 	return nil
 }
 
-func (v *CommandAttrValidator) commandTypes(
+// maxCommandTypesInErrorMessage bounds how many command type names are listed
+// in ValidateCommandSequence's error message. Without a bound, a workflow
+// task with a large number of commands (e.g. thousands of RecordMarker
+// commands followed by a misplaced close command) produces an error message
+// long enough to exceed the gRPC/HTTP2 header size limit, causing the
+// connection to be dropped (RST_STREAM) instead of the intended error being
+// returned to the worker.
+const maxCommandTypesInErrorMessage = 50
+
+// commandTypesSummary returns a bounded, comma-separated list of the given
+// commands' types, truncating (with a count of the omitted commands) if
+// there are more than maxCommandTypesInErrorMessage. See its doc comment.
+func (v *CommandAttrValidator) commandTypesSummary(
 	commands []*commandpb.Command,
-) []string {
-	result := make([]string, len(commands))
-	for index, command := range commands {
-		result[index] = command.GetCommandType().String()
+) string {
+	n := len(commands)
+	truncated := n > maxCommandTypesInErrorMessage
+	if truncated {
+		n = maxCommandTypesInErrorMessage
 	}
-	return result
+	types := make([]string, n)
+	for index := 0; index < n; index++ {
+		types[index] = commands[index].GetCommandType().String()
+	}
+	summary := strings.Join(types, ", ")
+	if truncated {
+		summary = fmt.Sprintf("%s, ... (%d more)", summary, len(commands)-n)
+	}
+	return summary
 }

--- a/service/history/api/command_attr_validator_test.go
+++ b/service/history/api/command_attr_validator_test.go
@@ -770,6 +770,31 @@ func (s *commandAttrValidatorSuite) TestValidateCommandSequence_InvalidTerminalC
 	}
 }
 
+// TestValidateCommandSequence_InvalidTerminalCommand_LargeSequence is a
+// regression test for a large command sequence (e.g. thousands of
+// RecordMarker commands) producing an error message long enough to exceed
+// the gRPC/HTTP2 header size limit, causing the connection to be dropped
+// (RST_STREAM) instead of the intended error being returned to the worker
+// (#3284).
+func (s *commandAttrValidatorSuite) TestValidateCommandSequence_InvalidTerminalCommand_LargeSequence() {
+	const numCommands = 5000
+	commands := make([]*commandpb.Command, 0, numCommands+1)
+	commands = append(commands, terminalCommands[0])
+	for i := 0; i < numCommands; i++ {
+		commands = append(commands, &commandpb.Command{CommandType: enumspb.COMMAND_TYPE_RECORD_MARKER})
+	}
+
+	err := s.validator.ValidateCommandSequence(commands)
+	s.Error(err)
+	s.IsType(&serviceerror.InvalidArgument{}, err)
+
+	// The gRPC/HTTP2 default header size limit is 8192 bytes (see #3284);
+	// stay well under that regardless of how many commands were sent so the
+	// error itself is never what breaks the connection.
+	s.Less(len(err.Error()), 4096, "error message must stay bounded regardless of command count")
+	s.Contains(err.Error(), "more)", "message should indicate the list was truncated")
+}
+
 func (s *commandAttrValidatorSuite) TestValidateStartChildExecutionAttributes_InternalTaskQueue() {
 	testCases := []struct {
 		name            string


### PR DESCRIPTION
Fixes #3284

## Problem

`CommandAttrValidator.ValidateCommandSequence` builds its "invalid command sequence" error message by joining the type name of *every* command in the workflow task with `strings.Join`, with no bound. A worker that sends a large number of commands before a misplaced close command (e.g. thousands of `RecordMarker` commands followed by `CompleteWorkflowExecution` in the wrong position) produces an error message long enough to exceed the gRPC/HTTP2 header size limit.

Instead of the worker receiving the intended `INVALID_ARGUMENT` error describing the real problem, the connection is dropped (`RST_STREAM`) or fails with a cryptic header-size exception (`HeaderListSizeException: Header size exceeded max allowed size`), giving the application developer no indication that an incorrect command sequence caused it. Reproduction and root-cause analysis in the issue confirm this against a real SDK-generated oversized command list.

## Fix

`commandTypesSummary` (replacing the unbounded `commandTypes` helper) caps the listed command types at 50 and appends a count of how many were omitted, so the message stays well within header size limits (a few KB at most) regardless of how many commands a worker sends, while still surfacing enough of the sequence for a developer to diagnose the problem.

This is a self-contained, single-call-site fix at the root cause (the message-building logic itself), rather than a workaround on the client/SDK side.

## Testing

- `go build ./service/history/...` — clean.
- `go vet ./service/history/api/...` — clean.
- `go test ./service/history/api/...` — full package passes, including the pre-existing `ValidateCommandSequence` tests (unaffected).
- New regression test `TestValidateCommandSequence_InvalidTerminalCommand_LargeSequence`: builds a 5000-command sequence (mirroring the issue's repro), asserts the resulting error message stays under 4096 bytes (vs. ~145KB unbounded) and indicates truncation — passes.

Release note (bug fix): Fixed a bug where a workflow task with a large number of commands ending in an invalid sequence could cause the gRPC connection to drop (or fail with a cryptic header-size error) instead of returning the intended "invalid command sequence" error.