### PR TITLE
worker/workerdeployment: bound schedule-to-close on default activity options

### DIFF
--- a/service/worker/workerdeployment/util.go
+++ b/service/worker/workerdeployment/util.go
@@ -124,6 +124,15 @@ var (
 var (
 	defaultActivityOptions = workflow.ActivityOptions{
 		StartToCloseTimeout: 1 * time.Minute,
+		// ScheduleToCloseTimeout bounds a scheduled-but-not-yet-started attempt,
+		// which StartToCloseTimeout alone does not: if an attempt's task is lost
+		// before it starts (e.g. sent to the DLQ because matching was
+		// unreachable), there is otherwise no timer at all to fail it and let
+		// the retry policy advance, so the activity can get stuck in
+		// PENDING_ACTIVITY_STATE_SCHEDULED forever (#11402). 10 minutes gives
+		// ample headroom over the 5-attempt retry budget below for these
+		// short-lived worker-deployment coordination activities.
+		ScheduleToCloseTimeout: 10 * time.Minute,
 		RetryPolicy: &temporal.RetryPolicy{
 			InitialInterval: 100 * time.Millisecond,
 			MaximumAttempts: 5,

--- a/service/worker/workerdeployment/util_test.go
+++ b/service/worker/workerdeployment/util_test.go
@@ -370,6 +370,26 @@ func decodeAndValidateMemo(t *testing.T, filePath, deploymentName, buildID strin
 	require.Equal(t, buildID, result.RoutingConfig.GetCurrentDeploymentVersion().GetBuildId())
 }
 
+// TestDefaultActivityOptionsBoundScheduleToClose is a regression test for
+// #11402: defaultActivityOptions previously set only StartToCloseTimeout,
+// which bounds a *started* attempt but not one that is merely scheduled. If
+// a scheduled attempt's task is lost (e.g. DLQ'd because matching was
+// unreachable), there was no timer to fail it, so the activity (and any
+// Update awaiting it, e.g. RegisterTaskQueueWorker) could get stuck forever
+// with no way for the retry policy to advance. ScheduleToCloseTimeout must
+// be set and must leave enough headroom for the configured retry attempts to
+// actually run under normal conditions.
+func TestDefaultActivityOptionsBoundScheduleToClose(t *testing.T) {
+	t.Parallel()
+	require.Greater(t, defaultActivityOptions.ScheduleToCloseTimeout, time.Duration(0),
+		"ScheduleToCloseTimeout must be set so a lost/never-started attempt eventually times out")
+
+	maxAttempts := time.Duration(defaultActivityOptions.RetryPolicy.MaximumAttempts)
+	minBudget := maxAttempts * defaultActivityOptions.StartToCloseTimeout
+	require.GreaterOrEqual(t, defaultActivityOptions.ScheduleToCloseTimeout, minBudget,
+		"ScheduleToCloseTimeout must leave enough headroom for all retry attempts to run")
+}
+
 func TestIsRetryableUpdateError(t *testing.T) {
 	t.Run("returns true for errUpdateInProgress", func(t *testing.T) {
 		require.True(t, isRetryableUpdateError(errUpdateInProgress))


### PR DESCRIPTION
Fixes #11402

## Problem

`defaultActivityOptions` (`service/worker/workerdeployment/util.go`), used for every coordination activity dispatched by the worker-deployment entity and version workflows (`RegisterWorkerInVersion`, `DeleteWorkerDeploymentVersion`, `SyncWorkerDeploymentVersion`, etc.), set only `StartToCloseTimeout`. That bounds a *started* attempt, but not one that is merely scheduled: if an attempt's task is lost before it starts (e.g. sent to the DLQ because matching was temporarily unreachable), there is no timer of any kind to fail it. The retry policy has nothing to advance past, so the activity can remain `PENDING_ACTIVITY_STATE_SCHEDULED` forever.

The issue's repro traces this precisely for `RegisterTaskQueueWorker`: `RegisterWorkerInVersion`'s first attempt exceeds `StartToCloseTimeout`, the retry's task is DLQ'd, and — with no `ScheduleToStartTimeout`/`ScheduleToCloseTimeout` set — nothing ever fails that retry. The Update stays `ACCEPTED` indefinitely, the worker deployment version ends up permanently half-registered (missing the `activity` task-queue-type row while `workflow` registered fine), and every activity poll for that version is rejected with a misleading `"try again shortly"` until an operator runs a manual `tdbg admin workflow refresh_tasks`. Confirmed unchanged on `main` at the commit the reporter checked.

## Fix

Add `ScheduleToCloseTimeout: 10 * time.Minute` to `defaultActivityOptions`, comfortably above the 5-attempt × 1-minute `StartToCloseTimeout` retry budget these are short, internal coordination activities need under normal conditions. Now a lost/never-started attempt times out deterministically and the calling Update fails, letting the caller's own poll-driven retry loop (already relied on elsewhere in this flow, per the issue's "Expected Behavior") re-drive registration once matching recovers.

Scoped to `defaultActivityOptions` only — the sibling `propagationActivityOptions` in the same file is deliberately "unlimited attempts" for a different reason and is left untouched.

## Testing

- `go build ./service/worker/...` — clean.
- `go vet ./service/worker/workerdeployment/...` — clean.
- `go test ./service/worker/workerdeployment/...` — full package (including `replaytester`) passes; every existing test covering the ~12 call sites sharing `defaultActivityOptions` across `workflow.go`/`version_workflow.go` is unaffected.
- New regression test `TestDefaultActivityOptionsBoundScheduleToClose`: asserts `ScheduleToCloseTimeout` is set and leaves enough headroom for all configured retry attempts, so this can't silently regress to unbounded again.

Release note (bug fix): Fixed a bug where a Worker Deployment coordination activity (e.g. registering a worker's task queue) whose task was lost before being dispatched (for example due to a transient matching-service outage) could remain permanently scheduled and never retried, leaving a worker deployment version stuck half-registered until an operator intervened.