### PR TITLE
Fail batch operations when Visibility queries time out repeatedly

### DIFF
--- a/service/worker/batcher/activities.go
+++ b/service/worker/batcher/activities.go
@@ -39,6 +39,8 @@ import (
 const (
 	pageSize                         = 1000
 	statusRunningOrPausedQueryFilter = "ExecutionStatus='Running' OR ExecutionStatus='Paused'"
+	// Five activity attempts allow about 105 seconds of retry backoff, plus time spent in each call.
+	maxVisibilityQueryActivityAttempts = 5
 
 	// defaultTaskTimeout bounds how long processing a single task may take so
 	// that one hung operation cannot block the task processor forever.
@@ -141,6 +143,21 @@ func (p *page) done() bool {
 	return p.successCount+p.errorCount == p.length()
 }
 
+func visibilityQueryError(err error, attempt int32) error {
+	var invalidArgErr *serviceerror.InvalidArgument
+	if errors.As(err, &invalidArgErr) {
+		return temporal.NewNonRetryableApplicationError(err.Error(), "InvalidArgument", err)
+	}
+	if attempt >= maxVisibilityQueryActivityAttempts {
+		return temporal.NewNonRetryableApplicationError(
+			fmt.Sprintf("visibility query failed repeatedly after %d activity attempts; failing batch operation: %v", attempt, err),
+			"VisibilityQueryFailed",
+			err,
+		)
+	}
+	return err
+}
+
 // recordCompletedPages records stats for each page that is now fully done and advances the
 // heartbeat resume point to the oldest page that is not yet done.
 func recordCompletedPages(hbd *HeartBeatDetails, resultPage *page) {
@@ -184,11 +201,7 @@ func fetchPage(
 				Query:         config.adjustedQuery,
 			})
 		if err != nil {
-			var invalidArgErr *serviceerror.InvalidArgument
-			if errors.As(err, &invalidArgErr) {
-				return nil, temporal.NewNonRetryableApplicationError(err.Error(), "InvalidArgument", err)
-			}
-			return nil, err
+			return nil, visibilityQueryError(err, activity.GetInfo(ctx).Attempt)
 		}
 
 		targetExecutionInfo = make([]*commonpb.Execution, 0, len(resp.GetExecutions()))
@@ -207,11 +220,7 @@ func fetchPage(
 			Query:         config.adjustedQuery,
 		})
 		if err != nil {
-			var invalidArgErr *serviceerror.InvalidArgument
-			if errors.As(err, &invalidArgErr) {
-				return nil, temporal.NewNonRetryableApplicationError(err.Error(), "InvalidArgument", err)
-			}
-			return nil, err
+			return nil, visibilityQueryError(err, activity.GetInfo(ctx).Attempt)
 		}
 
 		executionInfos = make([]*workflowpb.WorkflowExecutionInfo, 0, len(resp.Executions))
@@ -479,11 +488,7 @@ func (a *activities) BatchActivityWithProtobuf(ctx context.Context, batchParams 
 			if err != nil {
 				metrics.BatcherOperationFailures.With(metricsHandler).Record(1)
 				logger.Error("Failed to get estimate execution count", tag.Error(err))
-				var invalidArgErr *serviceerror.InvalidArgument
-				if errors.As(err, &invalidArgErr) {
-					return HeartBeatDetails{}, temporal.NewNonRetryableApplicationError(err.Error(), "InvalidArgument", err)
-				}
-				return HeartBeatDetails{}, err
+				return HeartBeatDetails{}, visibilityQueryError(err, activity.GetInfo(ctx).Attempt)
 			}
 			estimateCount = count
 		}

--- a/service/worker/batcher/activities_test.go
+++ b/service/worker/batcher/activities_test.go
@@ -55,6 +55,44 @@ func TestActivitiesSuite(t *testing.T) {
 	suite.Run(t, new(activitiesSuite))
 }
 
+func (s *activitiesSuite) TestVisibilityQueryError() {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "service deadline exceeded", err: serviceerror.NewDeadlineExceeded("visibility deadline exceeded")},
+		{name: "context deadline exceeded", err: context.DeadlineExceeded},
+		{name: "service unavailable", err: serviceerror.NewUnavailable("visibility unavailable")},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			for attempt := int32(1); attempt < maxVisibilityQueryActivityAttempts; attempt++ {
+				err := visibilityQueryError(test.err, attempt)
+				s.Equal(test.err, err)
+			}
+
+			err := visibilityQueryError(test.err, maxVisibilityQueryActivityAttempts)
+			var appErr *temporal.ApplicationError
+			s.Require().ErrorAs(err, &appErr)
+			s.True(appErr.NonRetryable())
+			s.Equal("VisibilityQueryFailed", appErr.Type())
+			s.Contains(err.Error(), fmt.Sprintf("visibility query failed repeatedly after %d activity attempts", maxVisibilityQueryActivityAttempts))
+			s.Contains(err.Error(), "failing batch operation")
+		})
+	}
+
+	s.Run("invalid argument", func() {
+		invalidArgumentErr := serviceerror.NewInvalidArgument("invalid visibility query")
+		err := visibilityQueryError(invalidArgumentErr, 1)
+		var appErr *temporal.ApplicationError
+		s.Require().ErrorAs(err, &appErr)
+		s.True(appErr.NonRetryable())
+		s.Equal("InvalidArgument", appErr.Type())
+		s.Contains(err.Error(), "invalid visibility query")
+	})
+}
+
 func (s *activitiesSuite) TestTaskTimeoutContext() {
 	s.Run("no parent deadline applies default timeout", func() {
 		ctx, cancel := taskTimeoutContext(context.Background())


### PR DESCRIPTION
## Summary
- Batch operations query Visibility (`CountWorkflow`/`ListWorkflow`) via an activity whose retry policy has no `MaximumAttempts` or `ScheduleToCloseTimeout`. Previously only `serviceerror.InvalidArgument` was converted to a non-retryable failure (see #cafbc28ef which fixed the malformed-query case); any other error — timeouts, `Unavailable`, etc. — stayed retryable forever, leaving the batch operation stuck in `BATCH_OPERATION_STATE_RUNNING` indefinitely.
- After `maxVisibilityQueryActivityAttempts` (5) attempts, the error is now wrapped as a non-retryable `VisibilityQueryFailed` application error, so the underlying batch workflow fails and `DescribeBatchOperation` correctly reports `BATCH_OPERATION_STATE_FAILED` with a clear message — reusing the exact same terminal-failure mechanism already used for `InvalidArgument`, with no new state/proto changes needed.
- Per-workflow processing (`processSingleTask`/`processTaskWithRetries`) already has its own bounded retry logic and is untouched.

Fixes #11683

## Test plan
- [x] `go build ./...`
- [x] `go test ./service/worker/batcher/...` (97 passed)
- [x] Added `TestVisibilityQueryError` covering: attempts below the threshold stay retryable, the threshold attempt becomes a non-retryable `VisibilityQueryFailed` error with a clear message, and the existing `InvalidArgument` non-retryable behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)