### PR TITLE
Converts fmt.Sprintf to static string in nexus link warning

### DIFF
--- a/common/nexus/links.go
+++ b/common/nexus/links.go
@@ -47,7 +47,9 @@ func ConvertNexusLinksToProtoLinks(nexusLinks []nexus.Link, logger log.Logger) [
 			link, err := temporalnexus.ConvertNexusLinkToLinkWorkflow(nexusLink)
 			if err != nil {
 				logger.Warn(
-					fmt.Sprintf("failed to parse link to %q: %s", nexusLink.Type, nexusLink.URL),
+					"failed to convert Nexus link",
+					tag.NewStringTag("nexus-link-type", nexusLink.Type),
+					tag.URL(nexusLink.URL.String()),
 					tag.Error(err),
 				)
 				continue

--- a/common/nexus/links.go
+++ b/common/nexus/links.go
@@ -47,10 +47,10 @@ func ConvertNexusLinksToProtoLinks(nexusLinks []nexus.Link, logger log.Logger) [
 			link, err := temporalnexus.ConvertNexusLinkToLinkWorkflow(nexusLink)
 			if err != nil {
 				logger.Warn(
-					"failed to convert Nexus link",
+					"failed to parse Nexus link",
+					tag.Error(err),
 					tag.NewStringTag("nexus-link-type", nexusLink.Type),
 					tag.URL(nexusLink.URL.String()),
-					tag.Error(err),
 				)
 				continue
 			}

--- a/tests/gethistory_test.go
+++ b/tests/gethistory_test.go
@@ -800,7 +800,7 @@ func (s *GetHistorySuite) TestGetWorkflowExecutionHistory_ContinuationFromAnothe
 	)
 
 	otherNamespace := namespace.Name(testcore.RandomizeStr("other-namespace"))
-	_, err := env.RegisterNamespace(otherNamespace, 1, enumspb.ARCHIVAL_STATE_DISABLED, "", "")
+	_, err := env.RegisterNamespace(s.Context(), otherNamespace, 1, enumspb.ARCHIVAL_STATE_DISABLED, "", "")
 	s.Require().NoError(err)
 
 	startMultiBatchWorkflow(s.Context(), s.Require(), env)
@@ -848,7 +848,7 @@ func (s *RawHistorySuite) TestGetWorkflowExecutionHistoryReverse_ContinuationFro
 	)
 
 	otherNamespace := namespace.Name(testcore.RandomizeStr("other-namespace"))
-	_, err := env.RegisterNamespace(otherNamespace, 1, enumspb.ARCHIVAL_STATE_DISABLED, "", "")
+	_, err := env.RegisterNamespace(s.Context(), otherNamespace, 1, enumspb.ARCHIVAL_STATE_DISABLED, "", "")
 	s.Require().NoError(err)
 
 	startMultiBatchWorkflow(s.Context(), s.Require(), env)


### PR DESCRIPTION
## What changed?
WISOTT

## Why?
Fixes compiler error

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)
