### PR TITLE
add time skipping to (both chasm-based and wf-based) schedules

### DIFF
--- a/chasm/lib/scheduler/invoker_execute_task_test.go
+++ b/chasm/lib/scheduler/invoker_execute_task_test.go
@@ -14,6 +14,7 @@ import (
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/api/historyservicemock/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
 	schedulespb "go.temporal.io/server/api/schedule/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/scheduler"
@@ -23,6 +24,7 @@ import (
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -309,6 +311,68 @@ func TestExecuteTask_DistinctRequestsCanReuseCompletedWorkflowID(t *testing.T) {
 			require.Equal(t, "backfill-run", invoker.BufferedStarts[1].GetRunId())
 		},
 	})
+}
+
+func TestExecuteTask_PropagatesScheduleTimeSkipping(t *testing.T) {
+	tests := []struct {
+		name         string
+		disable      bool
+		expectConfig bool
+	}{
+		{name: "propagates without fast forward", expectConfig: true},
+		{name: "disable propagation", disable: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := newInvokerExecuteTestEnv(t)
+			config := &commonpb.TimeSkippingConfig{
+				Enabled:            true,
+				DisablePropagation: tc.disable,
+				FastForwardConfig: &commonpb.FastForwardConfig{
+					Id:       "schedule-fast-forward",
+					Duration: durationpb.New(5 * time.Hour),
+				},
+			}
+			env.Scheduler.Schedule.TimeSkippingConfig = config
+			env.NodeBackend.HandleGetExecutionInfo = func() *persistencespb.WorkflowExecutionInfo {
+				return &persistencespb.WorkflowExecutionInfo{
+					TimeSkippingInfo: &persistencespb.TimeSkippingInfo{
+						Config:                     config,
+						AccumulatedSkippedDuration: durationpb.New(2 * time.Hour),
+					},
+				}
+			}
+			startTime := timestamppb.New(env.TimeSource.Now())
+
+			env.mockFrontendClient.EXPECT().
+				StartWorkflowExecution(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, request *workflowservice.StartWorkflowExecutionRequest, _ ...grpc.CallOption) (*workflowservice.StartWorkflowExecutionResponse, error) {
+					if tc.expectConfig {
+						require.True(t, request.GetTimeSkippingConfig().GetEnabled())
+						require.Nil(t, request.GetTimeSkippingConfig().GetFastForwardConfig())
+					} else {
+						require.Nil(t, request.GetTimeSkippingConfig())
+					}
+					require.Equal(t, 2*time.Hour, request.GetTimeSkippingStatePropagation().GetInitialSkippedDuration().AsDuration())
+					require.Zero(t, request.GetTimeSkippingStatePropagation().GetInitialSkipCount())
+					return &workflowservice.StartWorkflowExecutionResponse{RunId: "run-id"}, nil
+				})
+
+			runExecuteTestCase(t, env, &executeTestCase{
+				InitialBufferedStarts: []*schedulespb.BufferedStart{{
+					NominalTime:   startTime,
+					ActualTime:    startTime,
+					DesiredTime:   startTime,
+					RequestId:     "request-id",
+					OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+					Attempt:       1,
+				}},
+				ExpectedBufferedStarts:   1,
+				ExpectedRunningWorkflows: 1,
+				ExpectedActionCount:      1,
+			})
+		})
+	}
 }
 
 // Execute is scheduled with an empty buffer.

--- a/chasm/lib/scheduler/invoker_tasks.go
+++ b/chasm/lib/scheduler/invoker_tasks.go
@@ -174,6 +174,8 @@ func (h *InvokerExecuteTaskHandler) Execute(
 	var scheduler *Scheduler
 	var lastCompletionState *schedulerpb.LastCompletionResult
 	var schedulerRef []byte
+	var timeSkippingConfig *commonpb.TimeSkippingConfig
+	var timeSkippingStatePropagation *commonpb.TimeSkippingStatePropagation
 	var now time.Time
 
 	// Read and deep copy returned components, since we'll continue to access them
@@ -195,6 +197,8 @@ func (h *InvokerExecuteTaskHandler) Execute(
 
 			lcs := s.LastCompletionResult.Get(ctx)
 			lastCompletionState = common.CloneProto(lcs)
+			timeSkippingConfig, timeSkippingStatePropagation =
+				ctx.GetTimeSkippingPropagateState()
 
 			// Capture the scheduler's component ref so a per-start completion callback (carrying that
 			// start's request ID in its token) can be built outside the MS lock.
@@ -232,7 +236,18 @@ func (h *InvokerExecuteTaskHandler) Execute(
 	ictx := h.newInvokerTaskHandlerContext(ctx, scheduler)
 	result = result.Append(h.terminateWorkflows(ictx, logger, metricsHandler, scheduler, invoker.GetTerminateWorkflows()))
 	result = result.Append(h.cancelWorkflows(ictx, logger, metricsHandler, scheduler, invoker.GetCancelWorkflows()))
-	result = result.Append(h.startWorkflows(ictx, logger, metricsHandler, scheduler, invoker, lastCompletionState, schedulerRef, now))
+	result = result.Append(h.startWorkflows(
+		ictx,
+		logger,
+		metricsHandler,
+		scheduler,
+		invoker,
+		lastCompletionState,
+		schedulerRef,
+		timeSkippingConfig,
+		timeSkippingStatePropagation,
+		now,
+	))
 
 	// Record action results on the Invoker (internal state), as well as the
 	// Scheduler (user-facing metrics).
@@ -362,6 +377,8 @@ func (h *InvokerExecuteTaskHandler) startWorkflows(
 	invoker *Invoker,
 	lastCompletionState *schedulerpb.LastCompletionResult,
 	schedulerRef []byte,
+	timeSkippingConfig *commonpb.TimeSkippingConfig,
+	timeSkippingStatePropagation *commonpb.TimeSkippingStatePropagation,
 	now time.Time,
 ) (result executeResult) {
 	metricsWithTag := metricsHandler.WithTags(
@@ -385,7 +402,16 @@ func (h *InvokerExecuteTaskHandler) startWorkflows(
 		// Run all starts concurrently.
 		newCtx := ctx.Clone()
 		wg.Go(func() {
-			err := h.startWorkflow(newCtx, metricsHandler, scheduler, start, lastCompletionState, schedulerRef)
+			err := h.startWorkflow(
+				newCtx,
+				metricsHandler,
+				scheduler,
+				start,
+				lastCompletionState,
+				schedulerRef,
+				timeSkippingConfig,
+				timeSkippingStatePropagation,
+			)
 
 			resultMutex.Lock()
 			defer resultMutex.Unlock()
@@ -635,6 +661,8 @@ func (h *InvokerExecuteTaskHandler) startWorkflow(
 	start *schedulespb.BufferedStart,
 	lastCompletionState *schedulerpb.LastCompletionResult,
 	schedulerRef []byte,
+	timeSkippingConfig *commonpb.TimeSkippingConfig,
+	timeSkippingStatePropagation *commonpb.TimeSkippingStatePropagation,
 ) error {
 	requestSpec := scheduler.GetSchedule().GetAction().GetStartWorkflow()
 
@@ -673,25 +701,27 @@ func (h *InvokerExecuteTaskHandler) startWorkflow(
 		return err
 	}
 	request := &workflowservice.StartWorkflowExecutionRequest{
-		CompletionCallbacks:      []*commonpb.Callback{callback},
-		Header:                   requestSpec.Header,
-		Identity:                 scheduler.identity(),
-		Input:                    requestSpec.Input,
-		Memo:                     requestSpec.Memo,
-		Namespace:                scheduler.Namespace,
-		RequestId:                start.RequestId,
-		RetryPolicy:              requestSpec.RetryPolicy,
-		SearchAttributes:         scheduler.startWorkflowSearchAttributes(start.NominalTime.AsTime()),
-		TaskQueue:                requestSpec.TaskQueue,
-		UserMetadata:             requestSpec.UserMetadata,
-		WorkflowExecutionTimeout: requestSpec.WorkflowExecutionTimeout,
-		WorkflowId:               start.WorkflowId,
-		WorkflowIdReusePolicy:    reusePolicy,
-		WorkflowRunTimeout:       requestSpec.WorkflowRunTimeout,
-		WorkflowTaskTimeout:      requestSpec.WorkflowTaskTimeout,
-		WorkflowType:             requestSpec.WorkflowType,
-		Priority:                 requestSpec.Priority,
-		ContinuedFailure:         lastCompletionState.Failure,
+		CompletionCallbacks:          []*commonpb.Callback{callback},
+		Header:                       requestSpec.Header,
+		Identity:                     scheduler.identity(),
+		Input:                        requestSpec.Input,
+		Memo:                         requestSpec.Memo,
+		Namespace:                    scheduler.Namespace,
+		RequestId:                    start.RequestId,
+		RetryPolicy:                  requestSpec.RetryPolicy,
+		SearchAttributes:             scheduler.startWorkflowSearchAttributes(start.NominalTime.AsTime()),
+		TaskQueue:                    requestSpec.TaskQueue,
+		UserMetadata:                 requestSpec.UserMetadata,
+		WorkflowExecutionTimeout:     requestSpec.WorkflowExecutionTimeout,
+		WorkflowId:                   start.WorkflowId,
+		WorkflowIdReusePolicy:        reusePolicy,
+		WorkflowRunTimeout:           requestSpec.WorkflowRunTimeout,
+		WorkflowTaskTimeout:          requestSpec.WorkflowTaskTimeout,
+		WorkflowType:                 requestSpec.WorkflowType,
+		Priority:                     requestSpec.Priority,
+		TimeSkippingConfig:           timeSkippingConfig,
+		TimeSkippingStatePropagation: timeSkippingStatePropagation,
+		ContinuedFailure:             lastCompletionState.Failure,
 		LastCompletionResult: &commonpb.Payloads{
 			Payloads: lcr,
 		},

--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -65,6 +65,7 @@ type Scheduler struct {
 var (
 	_ (chasm.VisibilitySearchAttributesProvider) = (*Scheduler)(nil)
 	_ (chasm.VisibilityMemoProvider)             = (*Scheduler)(nil)
+	_ (chasm.TimeSkippingRuntimeGate)            = (*Scheduler)(nil)
 )
 
 var (
@@ -146,6 +147,7 @@ func NewScheduler(
 		EventLog:             chasm.NewComponentField(ctx, NewEventLog(ctx)),
 	}
 	sched.setNullableFields()
+	ctx.SetTimeSkippingConfig(input.GetTimeSkippingConfig())
 	sched.Info.CreateTime = timestamppb.New(ctx.Now(sched))
 	sched.applyPausePatch(ctx, patch)
 
@@ -314,6 +316,7 @@ func CreateSchedulerFromMigration(
 		EventLog:             chasm.NewComponentField(ctx, NewEventLog(ctx)),
 	}
 	sched.setNullableFields()
+	ctx.SetTimeSkippingConfig(sched.Schedule.GetTimeSkippingConfig())
 
 	// These components won't start with any tasks, as stale running workflow entries
 	// can cause immediate computation after migration to drop actions due to overlap
@@ -349,6 +352,31 @@ func (s *Scheduler) LifecycleState(ctx chasm.Context) chasm.LifecycleState {
 	}
 
 	return chasm.LifecycleStateRunning
+}
+
+// IsExecutionSkippable reports whether the scheduler has no internal work that
+// must complete before its virtual clock advances to the next timer.
+func (s *Scheduler) IsExecutionSkippable(ctx chasm.Context) bool {
+	if s.Sentinel || s.Closed || s.WorkflowMigration != nil || s.Schedule.GetState().GetPaused() || s.hasMoreBackfills() {
+		return false
+	}
+	lastProcessedTime := s.Generator.Get(ctx).GetLastProcessedTime()
+	if lastProcessedTime == nil || lastProcessedTime.AsTime().Before(s.Info.GetUpdateTime().AsTime()) {
+		return false
+	}
+
+	invoker := s.Invoker.Get(ctx)
+	if len(invoker.GetCancelWorkflows()) > 0 || len(invoker.GetTerminateWorkflows()) > 0 {
+		return false
+	}
+	for _, start := range invoker.GetBufferedStarts() {
+		// Running workflows are external to the scheduler execution and do not
+		// block its clock; overlap policy handles them at the next scheduled tick.
+		if start.GetRunId() == "" && start.GetCompleted() == nil {
+			return false
+		}
+	}
+	return true
 }
 
 func (s *Scheduler) ContextMetadata(_ chasm.Context) map[string]string {
@@ -929,6 +957,7 @@ func (s *Scheduler) Update(
 
 	s.Schedule = req.FrontendRequest.Schedule
 	s.setNullableFields()
+	ctx.SetTimeSkippingConfig(s.Schedule.GetTimeSkippingConfig())
 
 	s.Info.UpdateTime = timestamppb.New(ctx.Now(s))
 	s.updateConflictToken()

--- a/chasm/lib/scheduler/scheduler_test.go
+++ b/chasm/lib/scheduler/scheduler_test.go
@@ -113,6 +113,97 @@ func TestCreateScheduler_InitialPauseState(t *testing.T) {
 	}
 }
 
+func TestTimeSkippingConfigWiring(t *testing.T) {
+	ctx := &chasm.MockMutableContext{}
+	initialConfig := &commonpb.TimeSkippingConfig{
+		Enabled: true,
+		FastForwardConfig: &commonpb.FastForwardConfig{
+			Id:       "initial",
+			Duration: durationpb.New(5 * time.Hour),
+		},
+	}
+	input := defaultSchedule()
+	input.TimeSkippingConfig = initialConfig
+
+	sched, err := scheduler.NewScheduler(ctx, namespace, namespaceID, scheduleID, input, nil)
+	require.NoError(t, err)
+	protorequire.ProtoEqual(t, initialConfig, ctx.TimeSkippingConfig)
+
+	updatedConfig := &commonpb.TimeSkippingConfig{
+		Enabled: true,
+		FastForwardConfig: &commonpb.FastForwardConfig{
+			Id:       "updated",
+			Duration: durationpb.New(6 * time.Hour),
+		},
+	}
+	updated := defaultSchedule()
+	updated.TimeSkippingConfig = updatedConfig
+	_, err = sched.Update(ctx, &schedulerpb.UpdateScheduleRequest{
+		FrontendRequest: &workflowservice.UpdateScheduleRequest{Schedule: updated},
+	})
+	require.NoError(t, err)
+	protorequire.ProtoEqual(t, updatedConfig, ctx.TimeSkippingConfig)
+}
+
+func TestIsExecutionSkippable(t *testing.T) {
+	markGeneratorReady := func(sched *scheduler.Scheduler, ctx chasm.MutableContext) {
+		sched.Generator.Get(ctx).LastProcessedTime = timestamppb.New(ctx.Now(sched))
+	}
+
+	t.Run("pending generator task after update", func(t *testing.T) {
+		sched, ctx, _ := setupSchedulerForTest(t)
+		sched.Info.UpdateTime = timestamppb.New(sched.Generator.Get(ctx).GetLastProcessedTime().AsTime().Add(time.Second))
+		require.False(t, sched.IsExecutionSkippable(ctx))
+	})
+
+	t.Run("idle", func(t *testing.T) {
+		sched, ctx, _ := setupSchedulerForTest(t)
+		markGeneratorReady(sched, ctx)
+		require.True(t, sched.IsExecutionSkippable(ctx))
+	})
+
+	t.Run("running and completed workflows do not block scheduler time", func(t *testing.T) {
+		sched, ctx, _ := setupSchedulerForTest(t)
+		markGeneratorReady(sched, ctx)
+		sched.Invoker.Get(ctx).BufferedStarts = []*schedulespb.BufferedStart{
+			{RequestId: "running", RunId: "run-id"},
+			{RequestId: "completed", RunId: "completed-run-id", Completed: &schedulespb.CompletedResult{}},
+		}
+		require.True(t, sched.IsExecutionSkippable(ctx))
+	})
+
+	tests := []struct {
+		name  string
+		block func(*scheduler.Scheduler, chasm.MutableContext)
+	}{
+		{name: "paused", block: func(s *scheduler.Scheduler, _ chasm.MutableContext) { s.Schedule.State.Paused = true }},
+		{name: "closed", block: func(s *scheduler.Scheduler, _ chasm.MutableContext) { s.Closed = true }},
+		{name: "migration", block: func(s *scheduler.Scheduler, _ chasm.MutableContext) {
+			s.WorkflowMigration = &schedulerpb.WorkflowMigrationState{}
+		}},
+		{name: "backfill", block: func(s *scheduler.Scheduler, ctx chasm.MutableContext) {
+			s.Backfillers["pending"] = chasm.NewComponentField(ctx, &scheduler.Backfiller{})
+		}},
+		{name: "pending start", block: func(s *scheduler.Scheduler, ctx chasm.MutableContext) {
+			s.Invoker.Get(ctx).BufferedStarts = []*schedulespb.BufferedStart{{RequestId: "pending"}}
+		}},
+		{name: "cancel", block: func(s *scheduler.Scheduler, ctx chasm.MutableContext) {
+			s.Invoker.Get(ctx).CancelWorkflows = []*commonpb.WorkflowExecution{{WorkflowId: "wf"}}
+		}},
+		{name: "terminate", block: func(s *scheduler.Scheduler, ctx chasm.MutableContext) {
+			s.Invoker.Get(ctx).TerminateWorkflows = []*commonpb.WorkflowExecution{{WorkflowId: "wf"}}
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sched, ctx, _ := setupSchedulerForTest(t)
+			markGeneratorReady(sched, ctx)
+			tc.block(sched, ctx)
+			require.False(t, sched.IsExecutionSkippable(ctx))
+		})
+	}
+}
+
 // TestListInfo_RecentActionsCapped verifies that the ScheduleListInfo memo
 // hard-caps RecentActions. recentActions() includes running starts, which
 // aren't bounded by completed-action retention, so without the cap the

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -3711,6 +3711,11 @@ WorkerActivitiesPerSecond, MaxConcurrentActivityTaskPollers.
 		false,
 		`WorkflowTimeSkippingEnabled is a "feature enable" flag. When enabled it allows clients to skip time in executions.`,
 	)
+	ScheduleTimeSkippingEnabled = NewNamespaceBoolSetting(
+		"frontend.ScheduleTimeSkippingEnabled",
+		false,
+		`ScheduleTimeSkippingEnabled is a namespace-level feature flag that allows time skipping for schedules.`,
+	)
 	WorkflowTimeSkippingMaxSkipPerSession = NewNamespaceIntSetting(
 		"frontend.WorkflowTimeSkippingMaxSkipPerSession",
 		200,

--- a/common/util.go
+++ b/common/util.go
@@ -568,16 +568,17 @@ func CreateHistoryStartWorkflowRequest(
 		startRequest = CloneProto(startRequest)
 	}
 	histRequest := &historyservice.StartWorkflowExecutionRequest{
-		NamespaceId:              namespaceID,
-		StartRequest:             startRequest,
-		ContinueAsNewInitiator:   enumspb.CONTINUE_AS_NEW_INITIATOR_UNSPECIFIED,
-		Attempt:                  1,
-		ParentExecutionInfo:      parentExecutionInfo,
-		FirstWorkflowTaskBackoff: durationpb.New(backoff.GetBackoffForNextScheduleNonNegative(startRequest.GetCronSchedule(), now, now)),
-		ContinuedFailure:         startRequest.ContinuedFailure,
-		LastCompletionResult:     startRequest.LastCompletionResult,
-		RootExecutionInfo:        rootExecutionInfo,
-		VersioningOverride:       startRequest.GetVersioningOverride(),
+		NamespaceId:                  namespaceID,
+		StartRequest:                 startRequest,
+		ContinueAsNewInitiator:       enumspb.CONTINUE_AS_NEW_INITIATOR_UNSPECIFIED,
+		Attempt:                      1,
+		ParentExecutionInfo:          parentExecutionInfo,
+		FirstWorkflowTaskBackoff:     durationpb.New(backoff.GetBackoffForNextScheduleNonNegative(startRequest.GetCronSchedule(), now, now)),
+		ContinuedFailure:             startRequest.ContinuedFailure,
+		LastCompletionResult:         startRequest.LastCompletionResult,
+		RootExecutionInfo:            rootExecutionInfo,
+		VersioningOverride:           startRequest.GetVersioningOverride(),
+		TimeSkippingStatePropagation: startRequest.GetTimeSkippingStatePropagation(),
 	}
 	startRequest.ContinuedFailure = nil
 	startRequest.LastCompletionResult = nil

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
 	historypb "go.temporal.io/api/history/v1"
@@ -21,6 +22,7 @@ import (
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"google.golang.org/protobuf/testing/protopack"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 func TestIsContextDeadlineExceededErr(t *testing.T) {
@@ -647,4 +649,25 @@ func TestCreateHistoryStartWorkflowRequestPayloads(t *testing.T) {
 
 	// ensure the original request object is unmodified
 	require.Equal(t, startRequestClone, startRequest)
+}
+
+func TestCreateHistoryStartWorkflowRequestTimeSkippingStatePropagation(t *testing.T) {
+	state := &commonpb.TimeSkippingStatePropagation{
+		InitialSkippedDuration: durationpb.New(2 * time.Hour),
+	}
+	startRequest := &workflowservice.StartWorkflowExecutionRequest{
+		Namespace:                    uuid.NewString(),
+		WorkflowId:                   uuid.NewString(),
+		TimeSkippingStatePropagation: state,
+	}
+
+	historyRequest := CreateHistoryStartWorkflowRequest(
+		startRequest.Namespace,
+		startRequest,
+		nil,
+		nil,
+		time.Now(),
+	)
+
+	require.Equal(t, state, historyRequest.GetTimeSkippingStatePropagation())
 }

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.44.0
-	go.temporal.io/api v1.63.5
+	go.temporal.io/api v1.63.6-0.20260823202248-4fc68e4a3223
 	go.temporal.io/auto-scaled-workers v0.0.0-20260811170210-91f6fe1d10ab
 	go.temporal.io/sdk v1.44.0
 	go.uber.org/fx v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -479,8 +479,6 @@ go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0 h1:R
 go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0/go.mod h1:I89cynRj8y+383o7tEQVg2SVA6SRgDVIouWPUVXjx0U=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0 h1:CQvJSldHRUN6Z8jsUeYv8J0lXRvygALXIzsmAeCcZE0=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0/go.mod h1:xSQ+mEfJe/GjK1LXEyVOoSI1N9JV9ZI923X5kup43W4=
-go.temporal.io/api v1.63.5 h1:c11+kPYHkXXL3UiShPdbMD+xtvqGsbTibUA9ypmiCa4=
-go.temporal.io/api v1.63.5/go.mod h1:SrlW2JMwVlDP4nRWSNznUFqnSHd+YeMDS1BkYo63HCQ=
 go.temporal.io/api v1.63.6-0.20260823202248-4fc68e4a3223 h1:EIombLH8gEmJZAqq//2oL7akW5PI4DJ6N59FhUrJtt0=
 go.temporal.io/api v1.63.6-0.20260823202248-4fc68e4a3223/go.mod h1:SrlW2JMwVlDP4nRWSNznUFqnSHd+YeMDS1BkYo63HCQ=
 go.temporal.io/auto-scaled-workers v0.0.0-20260811170210-91f6fe1d10ab h1:99wXW0317BBi49d6xgMdA0EZtvA+xbBUWV4HsTEGEcg=

--- a/go.sum
+++ b/go.sum
@@ -481,6 +481,8 @@ go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0 h1:CQvJSldHRUN
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0/go.mod h1:xSQ+mEfJe/GjK1LXEyVOoSI1N9JV9ZI923X5kup43W4=
 go.temporal.io/api v1.63.5 h1:c11+kPYHkXXL3UiShPdbMD+xtvqGsbTibUA9ypmiCa4=
 go.temporal.io/api v1.63.5/go.mod h1:SrlW2JMwVlDP4nRWSNznUFqnSHd+YeMDS1BkYo63HCQ=
+go.temporal.io/api v1.63.6-0.20260823202248-4fc68e4a3223 h1:EIombLH8gEmJZAqq//2oL7akW5PI4DJ6N59FhUrJtt0=
+go.temporal.io/api v1.63.6-0.20260823202248-4fc68e4a3223/go.mod h1:SrlW2JMwVlDP4nRWSNznUFqnSHd+YeMDS1BkYo63HCQ=
 go.temporal.io/auto-scaled-workers v0.0.0-20260811170210-91f6fe1d10ab h1:99wXW0317BBi49d6xgMdA0EZtvA+xbBUWV4HsTEGEcg=
 go.temporal.io/auto-scaled-workers v0.0.0-20260811170210-91f6fe1d10ab/go.mod h1:hhHijO9XRPIkAflLJJHix61M9FzbRPqk8fSydkcLkqw=
 go.temporal.io/sdk v1.44.0 h1:suitPDukX74rW3/N1FqvEbZTZVJJsxMKhv0KMa/j7pU=

--- a/service/frontend/errors.go
+++ b/service/frontend/errors.go
@@ -116,5 +116,6 @@ var (
 	errListHistoryTasksNotAllowed = serviceerror.NewPermissionDenied("ListHistoryTasks feature is disabled on this cluster.", "")
 
 	errWorkflowTimeSkippingNotEnabled  = serviceerror.NewUnimplemented("The Time-Skipping feature is not enabled for namespace.")
+	errScheduleTimeSkippingNotEnabled  = serviceerror.NewUnimplemented("Schedule time skipping is not enabled for namespace.")
 	errTimeSkippingFastForwardIDNotSet = serviceerror.NewInvalidArgument("Time skipping config invalid: fast_forward_id must be set")
 )

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -247,6 +247,7 @@ type Config struct {
 	PollerAutoscalingAutoEnroll             dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	WorkflowPauseEnabled                    dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	WorkflowTimeSkippingEnabled             dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	ScheduleTimeSkippingEnabled             dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	WorkflowTimeSkippingMaxSkipPerSession   dynamicconfig.IntPropertyFnWithNamespaceFilter
 	StandaloneNexusOperationsEnabled        dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	EnableWorkflowTaskCompletionPagination  dynamicconfig.BoolPropertyFnWithNamespaceFilter
@@ -437,6 +438,7 @@ func NewConfig(
 		PollerAutoscalingAutoEnroll:             dynamicconfig.PollerAutoscalingAutoEnroll.Get(dc),
 		WorkflowPauseEnabled:                    dynamicconfig.WorkflowPauseEnabled.Get(dc),
 		WorkflowTimeSkippingEnabled:             dynamicconfig.WorkflowTimeSkippingEnabled.Get(dc),
+		ScheduleTimeSkippingEnabled:             dynamicconfig.ScheduleTimeSkippingEnabled.Get(dc),
 		WorkflowTimeSkippingMaxSkipPerSession:   dynamicconfig.WorkflowTimeSkippingMaxSkipPerSession.Get(dc),
 		StandaloneNexusOperationsEnabled:        chasmnexus.Enabled.Get(dc),
 		EnableWorkflowTaskCompletionPagination:  dynamicconfig.EnableWorkflowTaskCompletionPagination.Get(dc),

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -3751,6 +3751,7 @@ func (wh *WorkflowHandler) createScheduleWorkflow(
 		Memo:                     request.Memo,
 		SearchAttributes:         sa,
 		Priority:                 &commonpb.Priority{}, // ie default priority
+		TimeSkippingConfig:       request.Schedule.GetTimeSkippingConfig(),
 	}
 	_, err = wh.historyClient.StartWorkflowExecution(
 		ctx,
@@ -4841,6 +4842,21 @@ func (wh *WorkflowHandler) updateScheduleWorkflow(
 			Input:             inputPayloads,
 			Identity:          request.Identity,
 			RequestId:         request.RequestId,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	_, err = wh.historyClient.UpdateWorkflowExecutionOptions(ctx, &historyservice.UpdateWorkflowExecutionOptionsRequest{
+		NamespaceId: namespaceID.String(),
+		UpdateRequest: &workflowservice.UpdateWorkflowExecutionOptionsRequest{
+			Namespace:         request.Namespace,
+			WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: workflowID},
+			WorkflowExecutionOptions: &workflowpb.WorkflowExecutionOptions{
+				TimeSkippingConfig: request.Schedule.GetTimeSkippingConfig(),
+			},
+			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config"}},
+			Identity:   request.Identity,
 		},
 	})
 	if err != nil {

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -111,6 +111,7 @@ const (
 	maxReasonLength              = 1000 // Maximum length for the reason field in RateLimitUpdate configurations.
 	defaultUserTerminateReason   = "terminated by user via frontend"
 	defaultUserTerminateIdentity = "frontend-service"
+	maxScheduleFastForward       = 365 * 24 * time.Hour
 )
 
 type (
@@ -704,6 +705,8 @@ func (wh *WorkflowHandler) prepareStartWorkflowRequest(
 		return nil, err
 	}
 
+	// TODO(time-skipping): Accept TimeSkippingStatePropagation only from trusted server callers such as
+	// schedules starting workflows; external clients must not be allowed to set this internal field.
 	if err := wh.validateAndPopulateTimeSkippingConfig(request.GetTimeSkippingConfig(), namespaceName); err != nil {
 		return nil, err
 	}
@@ -740,6 +743,35 @@ func (wh *WorkflowHandler) validateAndPopulateTimeSkippingConfig(
 			return serviceerror.NewInvalidArgument("time_skipping_config: cannot set fast_forward when enabled is false")
 		}
 		return nil
+	}
+	return nil
+}
+
+func (wh *WorkflowHandler) validateAndPopulateScheduleTimeSkippingConfig(
+	schedule *schedulepb.Schedule,
+	ns namespace.Name,
+) error {
+	config := schedule.GetTimeSkippingConfig()
+	if config == nil {
+		return nil
+	}
+	if !wh.config.ScheduleTimeSkippingEnabled(ns.String()) {
+		return errScheduleTimeSkippingNotEnabled
+	}
+	if err := wh.validateAndPopulateTimeSkippingConfig(config, ns); err != nil {
+		return err
+	}
+	if !config.GetEnabled() {
+		return nil
+	}
+	fastForward := config.GetFastForwardConfig()
+	if fastForward == nil {
+		return serviceerror.NewInvalidArgument(
+			"schedule time_skipping_config: fast_forward_config is required when enabled")
+	}
+	if fastForward.GetDuration().AsDuration() > maxScheduleFastForward {
+		return serviceerror.NewInvalidArgument(
+			"schedule time_skipping_config: fast_forward duration cannot exceed 365 days")
 	}
 	return nil
 }
@@ -3880,6 +3912,9 @@ func (wh *WorkflowHandler) CreateSchedule(
 	if err != nil {
 		return nil, err
 	}
+	if err = wh.validateAndPopulateScheduleTimeSkippingConfig(request.Schedule, namespaceName); err != nil {
+		return nil, err
+	}
 
 	if err = wh.validateStartWorkflowArgsForSchedule(namespaceName, request.GetSchedule().GetAction().GetStartWorkflow()); err != nil {
 		return nil, err
@@ -4695,6 +4730,9 @@ func (wh *WorkflowHandler) UpdateSchedule(
 	}
 	err := wh.canonicalizeScheduleSpec(request.Schedule, namespaceName.String())
 	if err != nil {
+		return nil, err
+	}
+	if err = wh.validateAndPopulateScheduleTimeSkippingConfig(request.Schedule, namespaceName); err != nil {
 		return nil, err
 	}
 

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -3817,6 +3817,50 @@ func (s *WorkflowHandlerSuite) TestValidateTimeSkippingConfig() {
 	s.Require().Equal(int32(999), tsc.GetMaxSessionSkipCount())
 }
 
+func (s *WorkflowHandlerSuite) TestValidateScheduleTimeSkippingConfig() {
+	config := s.newConfig()
+	config.WorkflowTimeSkippingEnabled = dc.GetBoolPropertyFnFilteredByNamespace(true)
+	config.ScheduleTimeSkippingEnabled = dc.GetBoolPropertyFnFilteredByNamespace(false)
+	wh := s.getWorkflowHandler(config)
+	s.Require().ErrorIs(
+		wh.validateAndPopulateScheduleTimeSkippingConfig(
+			&schedulepb.Schedule{TimeSkippingConfig: &commonpb.TimeSkippingConfig{Enabled: true}},
+			s.testNamespace,
+		),
+		errScheduleTimeSkippingNotEnabled,
+	)
+
+	config.ScheduleTimeSkippingEnabled = dc.GetBoolPropertyFnFilteredByNamespace(true)
+	wh = s.getWorkflowHandler(config)
+
+	testCases := []struct {
+		name    string
+		config  *commonpb.TimeSkippingConfig
+		wantErr bool
+	}{
+		{name: "unset"},
+		{name: "disabled", config: &commonpb.TimeSkippingConfig{Enabled: false}},
+		{name: "enabled without fast forward", config: &commonpb.TimeSkippingConfig{Enabled: true}, wantErr: true},
+		{name: "one year", config: &commonpb.TimeSkippingConfig{Enabled: true, FastForwardConfig: &commonpb.FastForwardConfig{
+			Id: "one-year", Duration: durationpb.New(365 * 24 * time.Hour),
+		}}},
+		{name: "over one year", config: &commonpb.TimeSkippingConfig{Enabled: true, FastForwardConfig: &commonpb.FastForwardConfig{
+			Id: "over-one-year", Duration: durationpb.New(365*24*time.Hour + time.Second),
+		}}, wantErr: true},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			err := wh.validateAndPopulateScheduleTimeSkippingConfig(
+				&schedulepb.Schedule{TimeSkippingConfig: tc.config}, s.testNamespace)
+			if tc.wantErr {
+				s.Require().Error(err)
+			} else {
+				s.Require().NoError(err)
+			}
+		})
+	}
+}
+
 func (s *WorkflowHandlerSuite) TestPollWorkflowExecutionTimeSkipping() {
 	validExecution := &commonpb.WorkflowExecution{WorkflowId: "wf-id"}
 	newReq := func(fastForwardID string) *workflowservice.PollWorkflowExecutionTimeSkippingRequest {

--- a/service/history/timer_queue_active_task_executor_test.go
+++ b/service/history/timer_queue_active_task_executor_test.go
@@ -2044,6 +2044,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestExecuteChasmPureTimerTask_Execut
 		WorkflowId: tests.WorkflowKey.WorkflowID,
 		RunId:      tests.WorkflowKey.RunID,
 	}
+	virtualNow := s.now.Add(5 * time.Hour)
 
 	// Mock the CHASM tree and execute interface.
 	mockEach := &chasm.MockNodePureTask{
@@ -2052,7 +2053,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestExecuteChasmPureTimerTask_Execut
 		},
 	}
 	chasmTree := historyi.NewMockChasmTree(s.controller)
-	chasmTree.EXPECT().EachPureTask(gomock.Any(), gomock.Any()).
+	chasmTree.EXPECT().EachPureTask(virtualNow, gomock.Any()).
 		Times(1).Do(
 		func(_ time.Time, callback func(executor chasm.NodePureTask, taskAttributes chasm.TaskAttributes, task any) (bool, error)) error {
 			_, err := callback(mockEach, chasm.TaskAttributes{}, nil)
@@ -2071,7 +2072,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestExecuteChasmPureTimerTask_Execut
 		&persistencespb.WorkflowExecutionState{Status: enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING},
 	).AnyTimes()
 	ms.EXPECT().ChasmTree().Return(chasmTree).AnyTimes()
-	ms.EXPECT().Now().Return(s.now).AnyTimes()
+	ms.EXPECT().Now().Return(virtualNow).AnyTimes()
 
 	// Add a valid timer task.
 	timerTask := &tasks.ChasmTaskPure{

--- a/service/history/timer_queue_task_executor_base.go
+++ b/service/history/timer_queue_task_executor_base.go
@@ -18,7 +18,6 @@ import (
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/resource"
-	"go.temporal.io/server/common/util"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/deletemanager"
@@ -275,13 +274,10 @@ func (t *timerQueueTaskExecutorBase) executeChasmPureTimers(
 		return errNoChasmTree
 	}
 
-	// Because the persistence layer can lose precision on the task compared to the
-	// physical task stored in the queue, we take the max of both here. Time is also
-	// truncated to a common (millisecond) precision later on.
-	//
-	// See also queues.IsTimeExpired.
-	// TODO@time-skipping: hasn's supported time skipping for CHASM system yet
-	referenceTime := util.MaxTime(t.Now(), task.GetKey().FireTime)
+	// CHASM task timestamps and mutable-state time share the virtual frame. The
+	// queue task's fire time has already been converted back to wall-clock time,
+	// so comparing it here would miss timers made due by a time skip.
+	referenceTime := ms.Now()
 
 	return tree.EachPureTask(referenceTime, callback)
 }

--- a/service/worker/scheduler/activities.go
+++ b/service/worker/scheduler/activities.go
@@ -16,6 +16,7 @@ import (
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/server/api/historyservice/v1"
 	schedulespb "go.temporal.io/server/api/schedule/v1"
+	"go.temporal.io/server/chasm"
 	schedulerpb "go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -68,6 +69,9 @@ func (a *activities) StartWorkflow(ctx context.Context, req *schedulespb.StartWo
 	if err := a.waitForRateLimiterPermission(req); err != nil {
 		return nil, err
 	}
+	if err := a.populateTimeSkippingPropagation(ctx, req.Request); err != nil {
+		return nil, err
+	}
 
 	req.Request.Namespace = a.namespace.String()
 
@@ -84,6 +88,38 @@ func (a *activities) StartWorkflow(ctx context.Context, req *schedulespb.StartWo
 		RunId:         res.RunId,
 		RealStartTime: timestamppb.New(now),
 	}, nil
+}
+
+func (a *activities) populateTimeSkippingPropagation(
+	ctx context.Context,
+	request *workflowservice.StartWorkflowExecutionRequest,
+) error {
+	activityInfo := activity.GetInfo(ctx)
+	response, err := a.HistoryClient.DescribeMutableState(ctx, &historyservice.DescribeMutableStateRequest{
+		NamespaceId: a.namespaceID.String(),
+		Execution: &commonpb.WorkflowExecution{
+			WorkflowId: activityInfo.WorkflowExecution.ID,
+			RunId:      activityInfo.WorkflowExecution.RunID,
+		},
+		SkipForceReload: true,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to load scheduler time-skipping state: %w", err)
+	}
+
+	mutableState := response.GetCacheMutableState()
+	if mutableState == nil {
+		mutableState = response.GetDatabaseMutableState()
+	}
+	timeSkippingInfo := mutableState.GetExecutionInfo().GetTimeSkippingInfo()
+	if timeSkippingInfo == nil {
+		request.TimeSkippingConfig = nil
+		request.TimeSkippingStatePropagation = nil
+		return nil
+	}
+	request.TimeSkippingConfig, request.TimeSkippingStatePropagation =
+		chasm.PropagateTimeSkippingToOtherExecution(timeSkippingInfo)
+	return nil
 }
 
 func (a *activities) waitForRateLimiterPermission(req *schedulespb.StartWorkflowRequest) error {

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -1530,6 +1530,7 @@ func (s *scheduler) startWorkflow(
 			ContinuedFailure:         continuedFailure,
 			UserMetadata:             newWorkflow.UserMetadata,
 			Priority:                 newWorkflow.Priority,
+			TimeSkippingConfig:       s.Schedule.GetTimeSkippingConfig(),
 		},
 	}
 	for {

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -420,7 +420,6 @@ func TestScheduleCHASM(t *testing.T) {
 	t.Run("TestUpdateScheduleMemoOnly", func(t *testing.T) { t.Parallel(); testUpdateScheduleMemoOnly(t, newContext) })
 	t.Run("TestStateSizeBytesReported", func(t *testing.T) { t.Parallel(); testStateSizeBytesReported(t, newContext) })
 	t.Run("TestBufferOverrunDropsActions", func(t *testing.T) { t.Parallel(); testBufferOverrunDropsActions(t, newContext) })
-	t.Run("TestTimeSkippingFastForward", func(t *testing.T) { t.Parallel(); testScheduleTimeSkippingFastForward(t, newContext) })
 	t.Run("TestDescribeCatchupWindowAfterCreateAndUpdate", func(t *testing.T) {
 		t.Parallel()
 		testDescribeCatchupWindowAfterCreateAndUpdate(t)
@@ -450,9 +449,46 @@ func TestScheduleCHASM(t *testing.T) {
 	})
 }
 
-func testScheduleTimeSkippingFastForward(t *testing.T, newContext contextFactory) {
-	opts := append(
-		scheduleCommonOpts(t),
+type scheduleTimeSkippingResult struct {
+	startedWorkflows             int32
+	verifiedVirtualTimeWorkflows int
+}
+
+func TestScheduleTimeSkipping(t *testing.T) {
+	t.Parallel()
+
+	results := make(map[string]scheduleTimeSkippingResult, 2)
+	for _, backend := range []struct {
+		name       string
+		newContext contextFactory
+		opts       []testcore.TestOption
+	}{
+		{name: "CHASM-V2", newContext: chasmContextFactory},
+		{
+			name:       "Workflow-V1",
+			newContext: v1ContextFactory,
+			opts:       []testcore.TestOption{testcore.WithWorkerService("V1 scheduler")},
+		},
+	} {
+		t.Run(backend.name, func(t *testing.T) {
+			results[backend.name] = testScheduleTimeSkipping(t, backend.newContext, backend.opts...)
+		})
+	}
+
+	if len(results) == 2 && !t.Failed() {
+		require.Equal(t, results["CHASM-V2"], results["Workflow-V1"],
+			"schedule time skipping should behave identically across backends")
+	}
+}
+
+func testScheduleTimeSkipping(
+	t *testing.T,
+	newContext contextFactory,
+	additionalOpts ...testcore.TestOption,
+) scheduleTimeSkippingResult {
+	opts := append(scheduleCommonOpts(t), additionalOpts...)
+	opts = append(
+		opts,
 		testcore.WithDynamicConfig(dynamicconfig.WorkflowTimeSkippingEnabled, true),
 		testcore.WithDynamicConfig(dynamicconfig.ScheduleTimeSkippingEnabled, true),
 	)
@@ -536,6 +572,11 @@ func testScheduleTimeSkippingFastForward(t *testing.T, newContext contextFactory
 		require.Nil(t, timeSkippingInfo.GetEffectiveConfig().GetFastForwardConfig())
 		require.Greater(t, timeSkippingInfo.GetCurrentTime().AsTime().Sub(wallTime), 30*time.Minute)
 	}
+
+	return scheduleTimeSkippingResult{
+		startedWorkflows:             runs.Load(),
+		verifiedVirtualTimeWorkflows: len(seenRunIDs),
+	}
 }
 
 func testDescribeCatchupWindowAfterCreateAndUpdate(t *testing.T) {
@@ -604,7 +645,6 @@ func TestScheduleV1(t *testing.T) {
 	t.Run("TestCreatesCHASMSentinel", func(t *testing.T) { t.Parallel(); testCreatesCHASMSentinel(t, newContext) })
 	t.Run("TestSkipsCHASMSentinelWhenDisabled", func(t *testing.T) { t.Parallel(); testSkipsCHASMSentinelWhenDisabled(t, newContext) })
 	t.Run("TestUpdateScheduleMemoRejected", func(t *testing.T) { t.Parallel(); testUpdateScheduleMemoRejected(t, newContext) })
-	t.Run("TestTimeSkippingFastForward", func(t *testing.T) { t.Parallel(); testScheduleTimeSkippingFastForward(t, newContext) })
 }
 
 func runSharedScheduleTests(t *testing.T, newContext contextFactory) {

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -420,6 +420,7 @@ func TestScheduleCHASM(t *testing.T) {
 	t.Run("TestUpdateScheduleMemoOnly", func(t *testing.T) { t.Parallel(); testUpdateScheduleMemoOnly(t, newContext) })
 	t.Run("TestStateSizeBytesReported", func(t *testing.T) { t.Parallel(); testStateSizeBytesReported(t, newContext) })
 	t.Run("TestBufferOverrunDropsActions", func(t *testing.T) { t.Parallel(); testBufferOverrunDropsActions(t, newContext) })
+	t.Run("TestTimeSkippingFastForward", func(t *testing.T) { t.Parallel(); testScheduleTimeSkippingFastForward(t) })
 	t.Run("TestDescribeCatchupWindowAfterCreateAndUpdate", func(t *testing.T) {
 		t.Parallel()
 		testDescribeCatchupWindowAfterCreateAndUpdate(t)
@@ -447,6 +448,94 @@ func TestScheduleCHASM(t *testing.T) {
 		t.Parallel()
 		testPauseOnFailureIgnoresCancelTerminate(t, newContext, stopByTerminate)
 	})
+}
+
+func testScheduleTimeSkippingFastForward(t *testing.T) {
+	opts := append(
+		scheduleCommonOpts(t),
+		testcore.WithDynamicConfig(dynamicconfig.WorkflowTimeSkippingEnabled, true),
+		testcore.WithDynamicConfig(dynamicconfig.ScheduleTimeSkippingEnabled, true),
+	)
+	s := newScheduleEnv(t, opts...)
+	ctx := chasmContextFactory(testcontext.For(t))
+
+	sid := testcore.RandomizeStr("sched-time-skipping")
+	wid := testcore.RandomizeStr("sched-time-skipping-wf")
+	wt := testcore.RandomizeStr("sched-time-skipping-wt")
+	var runs atomic.Int32
+	registerCountingWorkflow(s, wt, &runs)
+
+	now := time.Now().UTC()
+	schedule := &schedulepb.Schedule{
+		Spec: &schedulepb.ScheduleSpec{
+			Interval: []*schedulepb.IntervalSpec{{
+				Interval: durationpb.New(time.Hour),
+				Phase:    durationpb.New(now.Sub(now.Truncate(time.Hour))),
+			}},
+		},
+		Action: startWorkflowAction(s, wid, wt),
+		Policies: &schedulepb.SchedulePolicies{
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+		},
+		State: &schedulepb.ScheduleState{Paused: true},
+	}
+	createSchedule(ctx, t, s, sid, schedule)
+
+	schedule.State.Paused = false
+	schedule.TimeSkippingConfig = &commonpb.TimeSkippingConfig{
+		Enabled: true,
+		FastForwardConfig: &commonpb.FastForwardConfig{
+			Id:       uuid.NewString(),
+			Duration: durationpb.New(5*time.Hour + 30*time.Minute),
+		},
+	}
+	_, err := s.FrontendClient().UpdateSchedule(ctx, &workflowservice.UpdateScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+		Schedule:   schedule,
+		Identity:   "test",
+		RequestId:  uuid.NewString(),
+	})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return runs.Load() >= 5
+	}, time.Minute, pollInterval)
+	require.Equal(t, int32(5), runs.Load())
+
+	var describe *workflowservice.DescribeScheduleResponse
+	require.Eventually(t, func() bool {
+		var err error
+		describe, err = s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  s.Namespace().String(),
+			ScheduleId: sid,
+		})
+		return err == nil && len(describe.GetInfo().GetRecentActions()) >= 2
+	}, time.Minute, pollInterval)
+
+	seenRunIDs := make(map[string]struct{}, 2)
+	for _, action := range describe.GetInfo().GetRecentActions()[:2] {
+		execution := action.GetStartWorkflowResult()
+		require.NotEmpty(t, execution.GetWorkflowId())
+		require.NotEmpty(t, execution.GetRunId())
+		require.NotContains(t, seenRunIDs, execution.GetRunId())
+		seenRunIDs[execution.GetRunId()] = struct{}{}
+
+		wallTime := time.Now()
+		workflowDescription, err := s.FrontendClient().DescribeWorkflowExecution(
+			ctx,
+			&workflowservice.DescribeWorkflowExecutionRequest{
+				Namespace: s.Namespace().String(),
+				Execution: execution,
+			},
+		)
+		require.NoError(t, err)
+		timeSkippingInfo := workflowDescription.GetWorkflowExtendedInfo().GetTimeSkippingInfo()
+		require.NotNil(t, timeSkippingInfo)
+		require.True(t, timeSkippingInfo.GetEffectiveConfig().GetEnabled())
+		require.Nil(t, timeSkippingInfo.GetEffectiveConfig().GetFastForwardConfig())
+		require.Greater(t, timeSkippingInfo.GetCurrentTime().AsTime().Sub(wallTime), 30*time.Minute)
+	}
 }
 
 func testDescribeCatchupWindowAfterCreateAndUpdate(t *testing.T) {

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -420,7 +420,7 @@ func TestScheduleCHASM(t *testing.T) {
 	t.Run("TestUpdateScheduleMemoOnly", func(t *testing.T) { t.Parallel(); testUpdateScheduleMemoOnly(t, newContext) })
 	t.Run("TestStateSizeBytesReported", func(t *testing.T) { t.Parallel(); testStateSizeBytesReported(t, newContext) })
 	t.Run("TestBufferOverrunDropsActions", func(t *testing.T) { t.Parallel(); testBufferOverrunDropsActions(t, newContext) })
-	t.Run("TestTimeSkippingFastForward", func(t *testing.T) { t.Parallel(); testScheduleTimeSkippingFastForward(t) })
+	t.Run("TestTimeSkippingFastForward", func(t *testing.T) { t.Parallel(); testScheduleTimeSkippingFastForward(t, newContext) })
 	t.Run("TestDescribeCatchupWindowAfterCreateAndUpdate", func(t *testing.T) {
 		t.Parallel()
 		testDescribeCatchupWindowAfterCreateAndUpdate(t)
@@ -450,14 +450,14 @@ func TestScheduleCHASM(t *testing.T) {
 	})
 }
 
-func testScheduleTimeSkippingFastForward(t *testing.T) {
+func testScheduleTimeSkippingFastForward(t *testing.T, newContext contextFactory) {
 	opts := append(
 		scheduleCommonOpts(t),
 		testcore.WithDynamicConfig(dynamicconfig.WorkflowTimeSkippingEnabled, true),
 		testcore.WithDynamicConfig(dynamicconfig.ScheduleTimeSkippingEnabled, true),
 	)
 	s := newScheduleEnv(t, opts...)
-	ctx := chasmContextFactory(testcontext.For(t))
+	ctx := newContext(testcontext.For(t))
 
 	sid := testcore.RandomizeStr("sched-time-skipping")
 	wid := testcore.RandomizeStr("sched-time-skipping-wf")
@@ -604,6 +604,7 @@ func TestScheduleV1(t *testing.T) {
 	t.Run("TestCreatesCHASMSentinel", func(t *testing.T) { t.Parallel(); testCreatesCHASMSentinel(t, newContext) })
 	t.Run("TestSkipsCHASMSentinelWhenDisabled", func(t *testing.T) { t.Parallel(); testSkipsCHASMSentinelWhenDisabled(t, newContext) })
 	t.Run("TestUpdateScheduleMemoRejected", func(t *testing.T) { t.Parallel(); testUpdateScheduleMemoRejected(t, newContext) })
+	t.Run("TestTimeSkippingFastForward", func(t *testing.T) { t.Parallel(); testScheduleTimeSkippingFastForward(t, newContext) })
 }
 
 func runSharedScheduleTests(t *testing.T, newContext contextFactory) {


### PR DESCRIPTION
## What changed?
add time skipping to schedules (CHASM-based and workflow-based)

## Stack
- Depends on #10934.
- Supersedes #11741.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)