### PR TITLE
Tag replicator errors by replication task type

### DIFF
--- a/service/worker/replicator/replication_message_processor.go
+++ b/service/worker/replicator/replication_message_processor.go
@@ -218,7 +218,7 @@ func (p *replicationMessageProcessor) handleReplicationTasks() {
 		}, policy, isTransientRetryableError)
 
 		if err != nil {
-			metrics.ReplicatorFailures.With(p.metricsHandler).Record(1)
+			metrics.ReplicatorFailures.With(p.metricsHandler).Record(1, metrics.ReplicationTaskTypeTag(task.TaskType))
 			p.logger.Error("Failed to apply replication tasks", tag.Error(err))
 
 			dlqErr := backoff.ThrottleRetry(func() error {

--- a/service/worker/replicator/replication_message_processor_test.go
+++ b/service/worker/replicator/replication_message_processor_test.go
@@ -21,6 +21,7 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/membership"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/metrics/metricstest"
 	"go.temporal.io/server/common/namespace/nsreplication"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/wideevents"
@@ -153,6 +154,9 @@ func TestHandleNamespaceReplicationTaskCountsRetries(t *testing.T) {
 
 func TestHandleNamespaceReplicationTaskEmitsDLQed(t *testing.T) {
 	p, task, executor, queue, eventLogger := newReplicationEventTestProcessor(t, true, 1)
+	metricsHandler := metricstest.NewCaptureHandler()
+	capture := metricsHandler.StartCapture()
+	p.metricsHandler = metricsHandler
 	executor.EXPECT().Execute(gomock.Any(), task.GetNamespaceTaskAttributes()).Return(serviceerror.NewInvalidArgument("bad task"))
 	queue.EXPECT().PublishToDLQ(gomock.Any(), task).Return(nil)
 
@@ -162,6 +166,10 @@ func TestHandleNamespaceReplicationTaskEmitsDLQed(t *testing.T) {
 	require.InDelta(t, float64(1), dlqed["attempt_count"], 0)
 	require.Equal(t, "bad task", dlqed["error"])
 	require.NotContains(t, dlqed, "persistence_request")
+	recordings := capture.Snapshot()[metrics.ReplicatorFailures.Name()]
+	require.Len(t, recordings, 1)
+	taskTypeTag := metrics.ReplicationTaskTypeTag(task.TaskType)
+	require.Equal(t, taskTypeTag.Value, recordings[0].Tags[taskTypeTag.Key])
 }
 
 func TestHandleNamespaceReplicationTaskEventsDisabled(t *testing.T) {


### PR DESCRIPTION
## What changed?

`replicator_errors` now records the existing `replication_task_type` metric dimension when a namespace replication processor exhausts its task-application retries. This distinguishes values such as `NamespaceTask` and `TaskQueueUserData` without introducing a new metric.

A unit test verifies that the failure counter carries the task type from the failed replication task.

## Why?

This is a prerequisite for splitting task queue user data (`TaskQueueUserData`) failures from namespace metadata replication (`NamespaceTask`) alerts. Today both task kinds feed `replicator_errors` under `NamespaceReplicationTask` and are indistinguishable, so TQUD failures can be reported as namespace replication poison pills.

This PR only adds the server metric label. Alert definitions will be updated separately after the label is available in deployed server versions.

## How did you test it?

- [x] built
- [x] covered by existing tests
- [x] added unit tests
- [ ] added new functional test(s)

Manual two-cluster XDC E2E using `development-cluster-a.yaml` and `development-cluster-b.yaml`:

- A namespace replication conflict exported `replicationTaskType="NamespaceTask"`.
- A TQUD apply failure exported `replicationTaskType="TaskQueueUserData"`.
