### PR TITLE
POC: add time skipping to (both chasm-based and wf-based) schedules

### DIFF
--- a/chasm/chasmtest/test_engine.go
+++ b/chasm/chasmtest/test_engine.go
@@ -536,6 +536,7 @@ func (e *Engine) newExecution(key chasm.ExecutionKey) *execution {
 	)
 
 	backend := &chasm.MockNodeBackend{
+		HandleNow: e.timeSource.Now,
 		// NextTransitionCount is the count the in-flight transaction will commit as.
 		HandleNextTransitionCount: func() int64 {
 			bsMu.Lock()
@@ -589,7 +590,6 @@ func (e *Engine) newExecution(key chasm.ExecutionKey) *execution {
 		backend: backend,
 		node: chasm.NewEmptyTree(
 			e.registry,
-			e.timeSource,
 			backend,
 			chasm.DefaultPathEncoder,
 			e.logger,

--- a/chasm/context.go
+++ b/chasm/context.go
@@ -283,6 +283,10 @@ func (c *mutableCtx) withValue(key any, value any) Context {
 	}
 }
 
+func (c *mutableCtx) SetTimeSkippingConfig(config *commonpb.TimeSkippingConfig) {
+	c.root.backend.SetTimeSkippingConfig(config)
+}
+
 // ContextWithValue returns a new Context with the given key-value pair added.
 // Added key-value pairs will be accessible via the Value() method on the returned Context,
 // and the behavior of the key-value pair is the same as context.Context.WithValue().

--- a/chasm/context.go
+++ b/chasm/context.go
@@ -28,6 +28,8 @@ type Context interface {
 	ExecutionKey() ExecutionKey
 	// ExecutionInfo returns metadata information about the execution.
 	ExecutionInfo() ExecutionInfo
+	// GetTimeSkippingInfo returns a detached API snapshot of the execution's virtual-time state.
+	GetTimeSkippingInfo() *commonpb.TimeSkippingInfo
 	// GetTimeSkippingPropagateState returns the time-skipping configuration and
 	// state to propagate to a new, independent execution that shares this execution's virtual clock.
 	GetTimeSkippingPropagateState() (*commonpb.TimeSkippingConfig, *commonpb.TimeSkippingStatePropagation)
@@ -198,6 +200,10 @@ func (c *immutableCtx) ExecutionInfo() ExecutionInfo {
 		ApproximateStateSize: c.root.backend.GetApproximatePersistedSize(),
 		CloseTime:            closeTime,
 	}
+}
+
+func (c *immutableCtx) GetTimeSkippingInfo() *commonpb.TimeSkippingInfo {
+	return timeSkippingInfoFromPersistence(c.root.backend.GetExecutionInfo().GetTimeSkippingInfo(), c.now)
 }
 
 func (c *immutableCtx) GetTimeSkippingPropagateState() (

--- a/chasm/context.go
+++ b/chasm/context.go
@@ -28,6 +28,9 @@ type Context interface {
 	ExecutionKey() ExecutionKey
 	// ExecutionInfo returns metadata information about the execution.
 	ExecutionInfo() ExecutionInfo
+	// GetTimeSkippingPropagateState returns the time-skipping configuration and
+	// state to propagate to a new, independent execution that shares this execution's virtual clock.
+	GetTimeSkippingPropagateState() (*commonpb.TimeSkippingConfig, *commonpb.TimeSkippingStatePropagation)
 	// Logger returns a logger tagged with execution key and other chasm framework internal information.
 	Logger() log.Logger
 	// NamespaceEntry returns the namespace entry for the execution.
@@ -85,6 +88,7 @@ type EndpointRegistry interface {
 
 type MutableContext interface {
 	Context
+	TimeSkippingConfigurator
 
 	// AddTask adds a task to be emitted as part of the current transaction.
 	// The task is associated with the given component and will be invoked via the registered handler for the given task
@@ -194,6 +198,13 @@ func (c *immutableCtx) ExecutionInfo() ExecutionInfo {
 		ApproximateStateSize: c.root.backend.GetApproximatePersistedSize(),
 		CloseTime:            closeTime,
 	}
+}
+
+func (c *immutableCtx) GetTimeSkippingPropagateState() (
+	*commonpb.TimeSkippingConfig,
+	*commonpb.TimeSkippingStatePropagation,
+) {
+	return PropagateTimeSkippingToOtherExecution(c.root.backend.GetExecutionInfo().GetTimeSkippingInfo())
 }
 
 func (c *immutableCtx) Logger() log.Logger {

--- a/chasm/context_mock.go
+++ b/chasm/context_mock.go
@@ -187,6 +187,7 @@ type MockMutableContext struct {
 	Tasks                   []MockTask
 	LinksByRequest          map[Component]map[string][]*commonpb.Link
 	UserMetadataByComponent map[Component]*sdkpb.UserMetadata
+	TimeSkippingConfig      *commonpb.TimeSkippingConfig
 }
 
 func (c *MockMutableContext) AddTask(component Component, attributes TaskAttributes, payload any) {
@@ -229,6 +230,12 @@ func (c *MockMutableContext) withValue(key any, value any) Context {
 		MockContext: *ContextWithValue(&c.MockContext, key, value),
 		Tasks:       slices.Clone(c.Tasks),
 	}
+}
+
+func (c *MockMutableContext) SetTimeSkippingConfig(config *commonpb.TimeSkippingConfig) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.TimeSkippingConfig = config
 }
 
 type MockTask struct {

--- a/chasm/context_mock.go
+++ b/chasm/context_mock.go
@@ -36,6 +36,7 @@ type MockContext struct {
 	HandleLinks                         func(component Component) []*commonpb.Link
 	HandleRequestLinks                  func(component Component, requestID string) ([]*commonpb.Link, error)
 	HandleUserMetadata                  func(component Component) *sdkpb.UserMetadata
+	HandleGetTimeSkippingInfo           func() *commonpb.TimeSkippingInfo
 	HandleGetTimeSkippingPropagateState func() (*commonpb.TimeSkippingConfig, *commonpb.TimeSkippingStatePropagation)
 
 	// GoCtx is the underlying context.Context used for context value lookups.
@@ -77,6 +78,13 @@ func (c *MockContext) GetTimeSkippingPropagateState() (
 		return nil, nil
 	}
 	return c.HandleGetTimeSkippingPropagateState()
+}
+
+func (c *MockContext) GetTimeSkippingInfo() *commonpb.TimeSkippingInfo {
+	if c.HandleGetTimeSkippingInfo == nil {
+		return nil
+	}
+	return c.HandleGetTimeSkippingInfo()
 }
 
 func (c *MockContext) RequestHeader(key string) string {
@@ -186,6 +194,7 @@ func (c *MockContext) withValue(key any, value any) Context {
 		HandleLinks:                         c.HandleLinks,
 		HandleRequestLinks:                  c.HandleRequestLinks,
 		HandleUserMetadata:                  c.HandleUserMetadata,
+		HandleGetTimeSkippingInfo:           c.HandleGetTimeSkippingInfo,
 		HandleGetTimeSkippingPropagateState: c.HandleGetTimeSkippingPropagateState,
 	}
 }

--- a/chasm/context_mock.go
+++ b/chasm/context_mock.go
@@ -23,19 +23,20 @@ var _ MutableContext = (*MockMutableContext)(nil)
 
 // MockContext is a mock implementation of [Context].
 type MockContext struct {
-	HandleExecutionKey         func() ExecutionKey
-	HandleNow                  func(component Component) time.Time
-	HandleRef                  func(component Component) ([]byte, error)
-	HandleExecutionCloseTime   func() time.Time
-	HandleStateTransitionCount func() int64
-	HandleExecutionInfo        func() ExecutionInfo
-	HandleLibrary              func(name string) (Library, bool)
-	HandleNamespaceEntry       func() *namespace.Namespace
-	HandleEndpointByName       func(string) (*persistencespb.NexusEndpointEntry, error)
-	HandleMetricsHandler       func() metrics.Handler
-	HandleLinks                func(component Component) []*commonpb.Link
-	HandleRequestLinks         func(component Component, requestID string) ([]*commonpb.Link, error)
-	HandleUserMetadata         func(component Component) *sdkpb.UserMetadata
+	HandleExecutionKey                  func() ExecutionKey
+	HandleNow                           func(component Component) time.Time
+	HandleRef                           func(component Component) ([]byte, error)
+	HandleExecutionCloseTime            func() time.Time
+	HandleStateTransitionCount          func() int64
+	HandleExecutionInfo                 func() ExecutionInfo
+	HandleLibrary                       func(name string) (Library, bool)
+	HandleNamespaceEntry                func() *namespace.Namespace
+	HandleEndpointByName                func(string) (*persistencespb.NexusEndpointEntry, error)
+	HandleMetricsHandler                func() metrics.Handler
+	HandleLinks                         func(component Component) []*commonpb.Link
+	HandleRequestLinks                  func(component Component, requestID string) ([]*commonpb.Link, error)
+	HandleUserMetadata                  func(component Component) *sdkpb.UserMetadata
+	HandleGetTimeSkippingPropagateState func() (*commonpb.TimeSkippingConfig, *commonpb.TimeSkippingStatePropagation)
 
 	// GoCtx is the underlying context.Context used for context value lookups.
 	// Any values set on it will be available via the CHASM mock context's Value method,
@@ -66,6 +67,16 @@ func (c *MockContext) goContext() context.Context {
 		c.GoCtx = context.Background()
 	}
 	return c.GoCtx
+}
+
+func (c *MockContext) GetTimeSkippingPropagateState() (
+	*commonpb.TimeSkippingConfig,
+	*commonpb.TimeSkippingStatePropagation,
+) {
+	if c.HandleGetTimeSkippingPropagateState == nil {
+		return nil, nil
+	}
+	return c.HandleGetTimeSkippingPropagateState()
 }
 
 func (c *MockContext) RequestHeader(key string) string {
@@ -164,17 +175,18 @@ func (c *MockContext) UserMetadata(component Component) *sdkpb.UserMetadata {
 
 func (c *MockContext) withValue(key any, value any) Context {
 	return &MockContext{
-		HandleExecutionKey:   c.HandleExecutionKey,
-		HandleNow:            c.HandleNow,
-		HandleRef:            c.HandleRef,
-		HandleExecutionInfo:  c.HandleExecutionInfo,
-		HandleMetricsHandler: c.HandleMetricsHandler,
-		GoCtx:                context.WithValue(c.goContext(), key, value),
-		HandleNamespaceEntry: c.HandleNamespaceEntry,
-		HandleEndpointByName: c.HandleEndpointByName,
-		HandleLinks:          c.HandleLinks,
-		HandleRequestLinks:   c.HandleRequestLinks,
-		HandleUserMetadata:   c.HandleUserMetadata,
+		HandleExecutionKey:                  c.HandleExecutionKey,
+		HandleNow:                           c.HandleNow,
+		HandleRef:                           c.HandleRef,
+		HandleExecutionInfo:                 c.HandleExecutionInfo,
+		HandleMetricsHandler:                c.HandleMetricsHandler,
+		GoCtx:                               context.WithValue(c.goContext(), key, value),
+		HandleNamespaceEntry:                c.HandleNamespaceEntry,
+		HandleEndpointByName:                c.HandleEndpointByName,
+		HandleLinks:                         c.HandleLinks,
+		HandleRequestLinks:                  c.HandleRequestLinks,
+		HandleUserMetadata:                  c.HandleUserMetadata,
+		HandleGetTimeSkippingPropagateState: c.HandleGetTimeSkippingPropagateState,
 	}
 }
 

--- a/chasm/field_test.go
+++ b/chasm/field_test.go
@@ -143,7 +143,6 @@ func (s *fieldSuite) newTestTree(
 	if len(serializedNodes) == 0 {
 		return NewEmptyTree(
 			s.registry,
-			s.timeSource,
 			s.nodeBackend,
 			s.nodePathEncoder,
 			s.logger,
@@ -153,7 +152,6 @@ func (s *fieldSuite) newTestTree(
 	return NewTreeFromDB(
 		serializedNodes,
 		s.registry,
-		s.timeSource,
 		s.nodeBackend,
 		s.nodePathEncoder,
 		s.logger,
@@ -165,7 +163,6 @@ func (s *fieldSuite) newTestTree(
 func (s *fieldSuite) setupComponentWithTree(rootComponent *TestComponent) (*Node, MutableContext, error) {
 	rootNode := NewEmptyTree(
 		s.registry,
-		s.timeSource,
 		s.nodeBackend,
 		s.nodePathEncoder,
 		s.logger,

--- a/chasm/lib/callback/tasks_test.go
+++ b/chasm/lib/callback/tasks_test.go
@@ -555,7 +555,7 @@ func TestExecuteInvocationTaskChasm_Outcomes(t *testing.T) {
 			require.NoError(t, err)
 
 			nodeBackend := &chasm.MockNodeBackend{}
-			root := chasm.NewEmptyTree(chasmRegistry, timeSource, nodeBackend, chasm.DefaultPathEncoder, logger, metricsHandler)
+			root := chasm.NewEmptyTree(chasmRegistry, nodeBackend, chasm.DefaultPathEncoder, logger, metricsHandler)
 
 			// Create headers
 			headers := nexus.Header{}

--- a/chasm/lib/nexusoperation/operation_tasks_test.go
+++ b/chasm/lib/nexusoperation/operation_tasks_test.go
@@ -116,7 +116,7 @@ func newInvocationTaskTestEnv(
 		},
 	}
 
-	root := chasm.NewEmptyTree(registry, timeSource, nodeBackend, chasm.DefaultPathEncoder, logger, metrics.NoopMetricsHandler)
+	root := chasm.NewEmptyTree(registry, nodeBackend, chasm.DefaultPathEncoder, logger, metrics.NoopMetricsHandler)
 	ctx := chasm.NewMutableContext(context.Background(), root)
 	require.NoError(t, root.SetRootComponent(&mockStoreComponent{
 		invocationData: invocationData,

--- a/chasm/lib/nexusoperation/operation_test.go
+++ b/chasm/lib/nexusoperation/operation_test.go
@@ -437,7 +437,7 @@ func TestOperation_BuildExecutionInfo_ReturnsIsolatedSearchAttributes(t *testing
 			return &persistencespb.VersionedTransition{NamespaceFailoverVersion: 1, TransitionCount: 1}
 		},
 	}
-	root := chasm.NewEmptyTree(registry, timeSource, nodeBackend, chasm.DefaultPathEncoder, logger, metrics.NoopMetricsHandler)
+	root := chasm.NewEmptyTree(registry, nodeBackend, chasm.DefaultPathEncoder, logger, metrics.NoopMetricsHandler)
 	ctx := chasm.NewMutableContext(context.Background(), root)
 
 	op := NewOperation(&nexusoperationpb.OperationState{Status: nexusoperationpb.OPERATION_STATUS_STARTED})

--- a/chasm/lib/scheduler/helper_test.go
+++ b/chasm/lib/scheduler/helper_test.go
@@ -374,6 +374,7 @@ func newTestEnv(t *testing.T, opts ...testEnvOption) *testEnv {
 
 	tv := testvars.New(t)
 	nodeBackend := &chasm.MockNodeBackend{
+		HandleNow:                 timeSource.Now,
 		HandleNextTransitionCount: func() int64 { return 2 },
 		HandleGetCurrentVersion:   func() int64 { return 1 },
 		HandleGetWorkflowKey:      tv.Any().WorkflowKey,
@@ -387,7 +388,7 @@ func newTestEnv(t *testing.T, opts ...testEnvOption) *testEnv {
 		},
 	}
 
-	node := chasm.NewEmptyTree(registry, timeSource, nodeBackend, nodePathEncoder, logger, metrics.NoopMetricsHandler)
+	node := chasm.NewEmptyTree(registry, nodeBackend, nodePathEncoder, logger, metrics.NoopMetricsHandler)
 	ctx := chasm.NewMutableContext(context.Background(), node)
 	sched, err := scheduler.NewScheduler(ctx, namespace, namespaceID, scheduleID, defaultSchedule(), nil)
 	if err != nil {
@@ -525,6 +526,7 @@ func setupTestInfra(t *testing.T, specProcessor scheduler.SpecProcessor) *testIn
 	timeSource.Update(time.Now())
 
 	tv := testvars.New(t)
+	nodeBackend.HandleNow = timeSource.Now
 	nodeBackend.HandleNextTransitionCount = func() int64 { return 2 }
 	nodeBackend.HandleGetCurrentVersion = func() int64 { return 1 }
 	nodeBackend.HandleGetWorkflowKey = tv.Any().WorkflowKey
@@ -537,7 +539,7 @@ func setupTestInfra(t *testing.T, specProcessor scheduler.SpecProcessor) *testIn
 		}
 	}
 
-	node := chasm.NewEmptyTree(registry, timeSource, nodeBackend, nodePathEncoder, logger, metrics.NoopMetricsHandler)
+	node := chasm.NewEmptyTree(registry, nodeBackend, nodePathEncoder, logger, metrics.NoopMetricsHandler)
 	return &testInfra{
 		node:        node,
 		nodeBackend: nodeBackend,

--- a/chasm/lib/scheduler/invoker_execute_task_test.go
+++ b/chasm/lib/scheduler/invoker_execute_task_test.go
@@ -15,6 +15,7 @@ import (
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/api/historyservicemock/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
 	schedulespb "go.temporal.io/server/api/schedule/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/chasmtest"
@@ -26,6 +27,7 @@ import (
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -475,6 +477,68 @@ func TestExecuteTask_UsesBufferedOverlapPolicy(t *testing.T) {
 			require.Equal(t, enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ALL, invoker.BufferedStarts[0].GetOverlapPolicy())
 		},
 	})
+}
+
+func TestExecuteTask_PropagatesScheduleTimeSkipping(t *testing.T) {
+	tests := []struct {
+		name         string
+		disable      bool
+		expectConfig bool
+	}{
+		{name: "propagates without fast forward", expectConfig: true},
+		{name: "disable propagation", disable: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := newInvokerExecuteTestEnv(t)
+			config := &commonpb.TimeSkippingConfig{
+				Enabled:            true,
+				DisablePropagation: tc.disable,
+				FastForwardConfig: &commonpb.FastForwardConfig{
+					Id:       "schedule-fast-forward",
+					Duration: durationpb.New(5 * time.Hour),
+				},
+			}
+			env.Scheduler.Schedule.TimeSkippingConfig = config
+			env.NodeBackend.HandleGetExecutionInfo = func() *persistencespb.WorkflowExecutionInfo {
+				return &persistencespb.WorkflowExecutionInfo{
+					TimeSkippingInfo: &persistencespb.TimeSkippingInfo{
+						Config:                     config,
+						AccumulatedSkippedDuration: durationpb.New(2 * time.Hour),
+					},
+				}
+			}
+			startTime := timestamppb.New(env.TimeSource.Now())
+
+			env.mockFrontendClient.EXPECT().
+				StartWorkflowExecution(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, request *workflowservice.StartWorkflowExecutionRequest, _ ...grpc.CallOption) (*workflowservice.StartWorkflowExecutionResponse, error) {
+					if tc.expectConfig {
+						require.True(t, request.GetTimeSkippingConfig().GetEnabled())
+						require.Nil(t, request.GetTimeSkippingConfig().GetFastForwardConfig())
+					} else {
+						require.Nil(t, request.GetTimeSkippingConfig())
+					}
+					require.Equal(t, 2*time.Hour, request.GetTimeSkippingStatePropagation().GetInitialSkippedDuration().AsDuration())
+					require.Zero(t, request.GetTimeSkippingStatePropagation().GetInitialSkipCount())
+					return &workflowservice.StartWorkflowExecutionResponse{RunId: "run-id"}, nil
+				})
+
+			runExecuteTestCase(t, env, &executeTestCase{
+				InitialBufferedStarts: []*schedulespb.BufferedStart{{
+					NominalTime:   startTime,
+					ActualTime:    startTime,
+					DesiredTime:   startTime,
+					RequestId:     "request-id",
+					OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ALL,
+					Attempt:       1,
+				}},
+				ExpectedBufferedStarts:   1,
+				ExpectedRunningWorkflows: 1,
+				ExpectedActionCount:      1,
+			})
+		})
+	}
 }
 
 // Execute is scheduled with an empty buffer.

--- a/chasm/lib/scheduler/invoker_execute_task_test.go
+++ b/chasm/lib/scheduler/invoker_execute_task_test.go
@@ -331,6 +331,37 @@ func TestRecordExecuteResult_AllowAllRecentActionsBounded(t *testing.T) {
 	require.Len(t, env.Scheduler.ListInfo(ctx).GetRecentActions(), 5)
 }
 
+func TestExecuteTask_StartTimeUsesFrameworkClock(t *testing.T) {
+	env := newInvokerExecuteTestEnv(t)
+	frameworkNow := env.TimeSource.Now().Add(24 * time.Hour)
+	env.TimeSource.Update(frameworkNow)
+	env.Scheduler.Schedule.State.Paused = true
+
+	startTime := timestamppb.New(frameworkNow)
+	env.mockFrontendClient.EXPECT().
+		StartWorkflowExecution(gomock.Any(), gomock.Any()).
+		Return(&workflowservice.StartWorkflowExecutionResponse{RunId: "run-id"}, nil)
+
+	runExecuteTestCase(t, env, &executeTestCase{
+		InitialBufferedStarts: []*schedulespb.BufferedStart{{
+			NominalTime:   startTime,
+			ActualTime:    startTime,
+			DesiredTime:   startTime,
+			RequestId:     "req1",
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+			Attempt:       1,
+		}},
+		ExpectedBufferedStarts:   0,
+		ExpectedRunningWorkflows: 0,
+		ExpectedActionCount:      1,
+		ValidateInvoker: func(t *testing.T, _ *scheduler.Invoker, env *invokerExecuteTestEnv) {
+			recentActions := env.Scheduler.Info.GetRecentActions()
+			require.Len(t, recentActions, 1)
+			require.True(t, frameworkNow.Equal(recentActions[0].GetActualTime().AsTime()))
+		},
+	})
+}
+
 func TestExecuteTask_ForwardsVersioningOverride(t *testing.T) {
 	tests := map[string]struct {
 		override *workflowpb.VersioningOverride

--- a/chasm/lib/scheduler/invoker_tasks.go
+++ b/chasm/lib/scheduler/invoker_tasks.go
@@ -175,6 +175,8 @@ func (h *InvokerExecuteTaskHandler) Execute(
 	var scheduler *Scheduler
 	var lastCompletionState *schedulerpb.LastCompletionResult
 	var schedulerRef []byte
+	var timeSkippingConfig *commonpb.TimeSkippingConfig
+	var timeSkippingStatePropagation *commonpb.TimeSkippingStatePropagation
 	var now time.Time
 
 	// Read and deep copy returned components, since we'll continue to access them
@@ -196,6 +198,8 @@ func (h *InvokerExecuteTaskHandler) Execute(
 
 			lcs := s.LastCompletionResult.Get(ctx)
 			lastCompletionState = common.CloneProto(lcs)
+			timeSkippingConfig, timeSkippingStatePropagation =
+				ctx.GetTimeSkippingPropagateState()
 
 			// Capture the scheduler's component ref so a per-start completion callback (carrying that
 			// start's request ID in its token) can be built outside the MS lock.
@@ -233,7 +237,18 @@ func (h *InvokerExecuteTaskHandler) Execute(
 	ictx := h.newInvokerTaskHandlerContext(ctx, scheduler)
 	result = result.Append(h.terminateWorkflows(ictx, logger, metricsHandler, scheduler, invoker.GetTerminateWorkflows()))
 	result = result.Append(h.cancelWorkflows(ictx, logger, metricsHandler, scheduler, invoker.GetCancelWorkflows()))
-	result = result.Append(h.startWorkflows(ictx, logger, metricsHandler, scheduler, invoker, lastCompletionState, schedulerRef, now))
+	result = result.Append(h.startWorkflows(
+		ictx,
+		logger,
+		metricsHandler,
+		scheduler,
+		invoker,
+		lastCompletionState,
+		schedulerRef,
+		timeSkippingConfig,
+		timeSkippingStatePropagation,
+		now,
+	))
 
 	// Record action results on the Invoker (internal state), as well as the
 	// Scheduler (user-facing metrics).
@@ -364,6 +379,8 @@ func (h *InvokerExecuteTaskHandler) startWorkflows(
 	invoker *Invoker,
 	lastCompletionState *schedulerpb.LastCompletionResult,
 	schedulerRef []byte,
+	timeSkippingConfig *commonpb.TimeSkippingConfig,
+	timeSkippingStatePropagation *commonpb.TimeSkippingStatePropagation,
 	now time.Time,
 ) (result executeResult) {
 	metricsWithTag := metricsHandler.WithTags(
@@ -387,7 +404,16 @@ func (h *InvokerExecuteTaskHandler) startWorkflows(
 		// Run all starts concurrently.
 		newCtx := ctx.Clone()
 		wg.Go(func() {
-			err := h.startWorkflow(newCtx, metricsHandler, scheduler, start, lastCompletionState, schedulerRef)
+			err := h.startWorkflow(
+				newCtx,
+				metricsHandler,
+				scheduler,
+				start,
+				lastCompletionState,
+				schedulerRef,
+				timeSkippingConfig,
+				timeSkippingStatePropagation,
+			)
 
 			resultMutex.Lock()
 			defer resultMutex.Unlock()
@@ -637,6 +663,8 @@ func (h *InvokerExecuteTaskHandler) startWorkflow(
 	start *schedulespb.BufferedStart,
 	lastCompletionState *schedulerpb.LastCompletionResult,
 	schedulerRef []byte,
+	timeSkippingConfig *commonpb.TimeSkippingConfig,
+	timeSkippingStatePropagation *commonpb.TimeSkippingStatePropagation,
 ) error {
 	requestSpec := scheduler.GetSchedule().GetAction().GetStartWorkflow()
 
@@ -679,25 +707,27 @@ func (h *InvokerExecuteTaskHandler) startWorkflow(
 		return err
 	}
 	request := &workflowservice.StartWorkflowExecutionRequest{
-		CompletionCallbacks:      []*commonpb.Callback{callback},
-		Header:                   requestSpec.Header,
-		Identity:                 scheduler.identity(),
-		Input:                    requestSpec.Input,
-		Memo:                     requestSpec.Memo,
-		Namespace:                scheduler.Namespace,
-		RequestId:                start.RequestId,
-		RetryPolicy:              requestSpec.RetryPolicy,
-		SearchAttributes:         scheduler.startWorkflowSearchAttributes(start.NominalTime.AsTime()),
-		TaskQueue:                requestSpec.TaskQueue,
-		UserMetadata:             requestSpec.UserMetadata,
-		WorkflowExecutionTimeout: requestSpec.WorkflowExecutionTimeout,
-		WorkflowId:               start.WorkflowId,
-		WorkflowIdReusePolicy:    reusePolicy,
-		WorkflowRunTimeout:       requestSpec.WorkflowRunTimeout,
-		WorkflowTaskTimeout:      requestSpec.WorkflowTaskTimeout,
-		WorkflowType:             requestSpec.WorkflowType,
-		Priority:                 requestSpec.Priority,
-		ContinuedFailure:         continuedFailure,
+		CompletionCallbacks:          []*commonpb.Callback{callback},
+		Header:                       requestSpec.Header,
+		Identity:                     scheduler.identity(),
+		Input:                        requestSpec.Input,
+		Memo:                         requestSpec.Memo,
+		Namespace:                    scheduler.Namespace,
+		RequestId:                    start.RequestId,
+		RetryPolicy:                  requestSpec.RetryPolicy,
+		SearchAttributes:             scheduler.startWorkflowSearchAttributes(start.NominalTime.AsTime()),
+		TaskQueue:                    requestSpec.TaskQueue,
+		UserMetadata:                 requestSpec.UserMetadata,
+		WorkflowExecutionTimeout:     requestSpec.WorkflowExecutionTimeout,
+		WorkflowId:                   start.WorkflowId,
+		WorkflowIdReusePolicy:        reusePolicy,
+		WorkflowRunTimeout:           requestSpec.WorkflowRunTimeout,
+		WorkflowTaskTimeout:          requestSpec.WorkflowTaskTimeout,
+		WorkflowType:                 requestSpec.WorkflowType,
+		Priority:                     requestSpec.Priority,
+		TimeSkippingConfig:           timeSkippingConfig,
+		TimeSkippingStatePropagation: timeSkippingStatePropagation,
+		ContinuedFailure:             continuedFailure,
 		LastCompletionResult: &commonpb.Payloads{
 			Payloads: lcr,
 		},

--- a/chasm/lib/scheduler/invoker_tasks.go
+++ b/chasm/lib/scheduler/invoker_tasks.go
@@ -411,6 +411,7 @@ func (h *InvokerExecuteTaskHandler) startWorkflows(
 				start,
 				lastCompletionState,
 				schedulerRef,
+				now,
 				timeSkippingConfig,
 				timeSkippingStatePropagation,
 			)
@@ -663,6 +664,7 @@ func (h *InvokerExecuteTaskHandler) startWorkflow(
 	start *schedulespb.BufferedStart,
 	lastCompletionState *schedulerpb.LastCompletionResult,
 	schedulerRef []byte,
+	actualStartTime time.Time,
 	timeSkippingConfig *commonpb.TimeSkippingConfig,
 	timeSkippingStatePropagation *commonpb.TimeSkippingStatePropagation,
 ) error {
@@ -740,8 +742,6 @@ func (h *InvokerExecuteTaskHandler) startWorkflow(
 	if err != nil {
 		return err
 	}
-	actualStartTime := time.Now()
-
 	// Set metadata on the cloned start. The clone was created in startWorkflows
 	// before spawning this goroutine, and will be copied back to the Invoker's
 	// BufferedStarts in recordExecuteResult.

--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -844,6 +844,7 @@ func (s *Scheduler) Describe(
 
 	executionInfo := ctx.ExecutionInfo()
 	info.StateSizeBytes = int64(executionInfo.ApproximateStateSize)
+	info.TimeSkippingInfo = ctx.GetTimeSkippingInfo()
 
 	return &schedulerpb.DescribeScheduleResponse{
 		FrontendResponse: &workflowservice.DescribeScheduleResponse{

--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -66,6 +66,7 @@ type Scheduler struct {
 var (
 	_ (chasm.VisibilitySearchAttributesProvider) = (*Scheduler)(nil)
 	_ (chasm.VisibilityMemoProvider)             = (*Scheduler)(nil)
+	_ (chasm.TimeSkippingRuntimeGate)            = (*Scheduler)(nil)
 )
 
 const (
@@ -152,6 +153,7 @@ func NewScheduler(
 		EventLog:             chasm.NewComponentField(ctx, NewEventLog(ctx)),
 	}
 	sched.setNullableFields()
+	ctx.SetTimeSkippingConfig(input.GetTimeSkippingConfig())
 	sched.Info.CreateTime = timestamppb.New(ctx.Now(sched))
 	sched.applyPausePatch(ctx, patch)
 
@@ -320,6 +322,7 @@ func CreateSchedulerFromMigration(
 		EventLog:             chasm.NewComponentField(ctx, NewEventLog(ctx)),
 	}
 	sched.setNullableFields()
+	ctx.SetTimeSkippingConfig(sched.Schedule.GetTimeSkippingConfig())
 
 	// These components won't start with any tasks, as stale running workflow entries
 	// can cause immediate computation after migration to drop actions due to overlap
@@ -355,6 +358,31 @@ func (s *Scheduler) LifecycleState(ctx chasm.Context) chasm.LifecycleState {
 	}
 
 	return chasm.LifecycleStateRunning
+}
+
+// IsExecutionSkippable reports whether the scheduler has no internal work that
+// must complete before its virtual clock advances to the next timer.
+func (s *Scheduler) IsExecutionSkippable(ctx chasm.Context) bool {
+	if s.Sentinel || s.Closed || s.WorkflowMigration != nil || s.Schedule.GetState().GetPaused() || s.hasMoreBackfills() {
+		return false
+	}
+	lastProcessedTime := s.Generator.Get(ctx).GetLastProcessedTime()
+	if lastProcessedTime == nil || lastProcessedTime.AsTime().Before(s.Info.GetUpdateTime().AsTime()) {
+		return false
+	}
+
+	invoker := s.Invoker.Get(ctx)
+	if len(invoker.GetCancelWorkflows()) > 0 || len(invoker.GetTerminateWorkflows()) > 0 {
+		return false
+	}
+	for _, start := range invoker.GetBufferedStarts() {
+		// Running workflows are external to the scheduler execution and do not
+		// block its clock; overlap policy handles them at the next scheduled tick.
+		if start.GetRunId() == "" && start.GetCompleted() == nil {
+			return false
+		}
+	}
+	return true
 }
 
 func (s *Scheduler) ContextMetadata(_ chasm.Context) map[string]string {
@@ -1002,6 +1030,7 @@ func (s *Scheduler) Update(
 
 	s.Schedule = req.FrontendRequest.Schedule
 	s.setNullableFields()
+	ctx.SetTimeSkippingConfig(s.Schedule.GetTimeSkippingConfig())
 
 	s.Info.UpdateTime = timestamppb.New(ctx.Now(s))
 	s.updateConflictToken()

--- a/chasm/lib/scheduler/scheduler_test.go
+++ b/chasm/lib/scheduler/scheduler_test.go
@@ -113,6 +113,97 @@ func TestCreateScheduler_InitialPauseState(t *testing.T) {
 	}
 }
 
+func TestTimeSkippingConfigWiring(t *testing.T) {
+	ctx := &chasm.MockMutableContext{}
+	initialConfig := &commonpb.TimeSkippingConfig{
+		Enabled: true,
+		FastForwardConfig: &commonpb.FastForwardConfig{
+			Id:       "initial",
+			Duration: durationpb.New(5 * time.Hour),
+		},
+	}
+	input := defaultSchedule()
+	input.TimeSkippingConfig = initialConfig
+
+	sched, err := scheduler.NewScheduler(ctx, namespace, namespaceID, scheduleID, input, nil)
+	require.NoError(t, err)
+	protorequire.ProtoEqual(t, initialConfig, ctx.TimeSkippingConfig)
+
+	updatedConfig := &commonpb.TimeSkippingConfig{
+		Enabled: true,
+		FastForwardConfig: &commonpb.FastForwardConfig{
+			Id:       "updated",
+			Duration: durationpb.New(6 * time.Hour),
+		},
+	}
+	updated := defaultSchedule()
+	updated.TimeSkippingConfig = updatedConfig
+	_, err = sched.Update(ctx, &schedulerpb.UpdateScheduleRequest{
+		FrontendRequest: &workflowservice.UpdateScheduleRequest{Schedule: updated},
+	})
+	require.NoError(t, err)
+	protorequire.ProtoEqual(t, updatedConfig, ctx.TimeSkippingConfig)
+}
+
+func TestIsExecutionSkippable(t *testing.T) {
+	markGeneratorReady := func(sched *scheduler.Scheduler, ctx chasm.MutableContext) {
+		sched.Generator.Get(ctx).LastProcessedTime = timestamppb.New(ctx.Now(sched))
+	}
+
+	t.Run("pending generator task after update", func(t *testing.T) {
+		sched, ctx, _ := setupSchedulerForTest(t)
+		sched.Info.UpdateTime = timestamppb.New(sched.Generator.Get(ctx).GetLastProcessedTime().AsTime().Add(time.Second))
+		require.False(t, sched.IsExecutionSkippable(ctx))
+	})
+
+	t.Run("idle", func(t *testing.T) {
+		sched, ctx, _ := setupSchedulerForTest(t)
+		markGeneratorReady(sched, ctx)
+		require.True(t, sched.IsExecutionSkippable(ctx))
+	})
+
+	t.Run("running and completed workflows do not block scheduler time", func(t *testing.T) {
+		sched, ctx, _ := setupSchedulerForTest(t)
+		markGeneratorReady(sched, ctx)
+		sched.Invoker.Get(ctx).BufferedStarts = []*schedulespb.BufferedStart{
+			{RequestId: "running", RunId: "run-id"},
+			{RequestId: "completed", RunId: "completed-run-id", Completed: &schedulespb.CompletedResult{}},
+		}
+		require.True(t, sched.IsExecutionSkippable(ctx))
+	})
+
+	tests := []struct {
+		name  string
+		block func(*scheduler.Scheduler, chasm.MutableContext)
+	}{
+		{name: "paused", block: func(s *scheduler.Scheduler, _ chasm.MutableContext) { s.Schedule.State.Paused = true }},
+		{name: "closed", block: func(s *scheduler.Scheduler, _ chasm.MutableContext) { s.Closed = true }},
+		{name: "migration", block: func(s *scheduler.Scheduler, _ chasm.MutableContext) {
+			s.WorkflowMigration = &schedulerpb.WorkflowMigrationState{}
+		}},
+		{name: "backfill", block: func(s *scheduler.Scheduler, ctx chasm.MutableContext) {
+			s.Backfillers["pending"] = chasm.NewComponentField(ctx, &scheduler.Backfiller{})
+		}},
+		{name: "pending start", block: func(s *scheduler.Scheduler, ctx chasm.MutableContext) {
+			s.Invoker.Get(ctx).BufferedStarts = []*schedulespb.BufferedStart{{RequestId: "pending"}}
+		}},
+		{name: "cancel", block: func(s *scheduler.Scheduler, ctx chasm.MutableContext) {
+			s.Invoker.Get(ctx).CancelWorkflows = []*commonpb.WorkflowExecution{{WorkflowId: "wf"}}
+		}},
+		{name: "terminate", block: func(s *scheduler.Scheduler, ctx chasm.MutableContext) {
+			s.Invoker.Get(ctx).TerminateWorkflows = []*commonpb.WorkflowExecution{{WorkflowId: "wf"}}
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sched, ctx, _ := setupSchedulerForTest(t)
+			markGeneratorReady(sched, ctx)
+			tc.block(sched, ctx)
+			require.False(t, sched.IsExecutionSkippable(ctx))
+		})
+	}
+}
+
 // TestListInfo_RecentActionsCapped verifies that the ScheduleListInfo memo
 // hard-caps RecentActions. recentActions() includes running starts, which
 // aren't bounded by completed-action retention, so without the cap the

--- a/chasm/node_backend_mock.go
+++ b/chasm/node_backend_mock.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
@@ -22,24 +23,27 @@ var _ NodeBackend = (*MockNodeBackend)(nil)
 // fields (thread-safe).
 type MockNodeBackend struct {
 	// Optional function overrides. If nil, methods return zero-values.
-	HandleGetExecutionState           func() *persistencespb.WorkflowExecutionState
-	HandleGetExecutionInfo            func() *persistencespb.WorkflowExecutionInfo
-	HandleGetCurrentVersion           func() int64
-	HandleNextTransitionCount         func() int64
-	HandleGetApproximatePersistedSize func() int
-	HandleChasmSkipPersistenceEnabled func() bool
-	HandleCurrentVersionedTransition  func() *persistencespb.VersionedTransition
-	HandleGetWorkflowKey              func() definition.WorkflowKey
-	HandleUpdateWorkflowStateStatus   func(state enumsspb.WorkflowExecutionState, status enumspb.WorkflowExecutionStatus) (bool, error)
-	HandleIsWorkflow                  func() bool
-	HandleGetNexusCompletion          func(ctx context.Context, requestID string) (nexusrpc.CompleteOperationOptions, error)
-	HandleGetNexusUpdateCompletion    func(ctx context.Context, updateID string, requestID string) (nexusrpc.CompleteOperationOptions, error)
-	HandleAddHistoryEvent             func(t enumspb.EventType, setAttributes func(*historypb.HistoryEvent)) *historypb.HistoryEvent
-	HandleLoadHistoryEvent            func(ctx context.Context, token []byte) (*historypb.HistoryEvent, error)
-	HandleGenerateEventLoadToken      func(event *historypb.HistoryEvent) ([]byte, error)
-	HandleHasAnyBufferedEvent         func(filter func(*historypb.HistoryEvent) bool) bool
-	HandleGetNamespaceEntry           func() *namespace.Namespace
-	HandleEndpointRegistry            func() EndpointRegistry
+	HandleGetExecutionState            func() *persistencespb.WorkflowExecutionState
+	HandleGetExecutionInfo             func() *persistencespb.WorkflowExecutionInfo
+	HandleGetCurrentVersion            func() int64
+	HandleNextTransitionCount          func() int64
+	HandleGetApproximatePersistedSize  func() int
+	HandleChasmSkipPersistenceEnabled  func() bool
+	HandleCurrentVersionedTransition   func() *persistencespb.VersionedTransition
+	HandleGetWorkflowKey               func() definition.WorkflowKey
+	HandleUpdateWorkflowStateStatus    func(state enumsspb.WorkflowExecutionState, status enumspb.WorkflowExecutionStatus) (bool, error)
+	HandleIsWorkflow                   func() bool
+	HandleGetNexusCompletion           func(ctx context.Context, requestID string) (nexusrpc.CompleteOperationOptions, error)
+	HandleGetNexusUpdateCompletion     func(ctx context.Context, updateID string, requestID string) (nexusrpc.CompleteOperationOptions, error)
+	HandleAddHistoryEvent              func(t enumspb.EventType, setAttributes func(*historypb.HistoryEvent)) *historypb.HistoryEvent
+	HandleLoadHistoryEvent             func(ctx context.Context, token []byte) (*historypb.HistoryEvent, error)
+	HandleGenerateEventLoadToken       func(event *historypb.HistoryEvent) ([]byte, error)
+	HandleHasAnyBufferedEvent          func(filter func(*historypb.HistoryEvent) bool) bool
+	HandleGetNamespaceEntry            func() *namespace.Namespace
+	HandleEndpointRegistry             func() EndpointRegistry
+	HandleSetTimeSkippingConfig        func(config *commonpb.TimeSkippingConfig)
+	HandleNow                          func() time.Time
+	HandleRecordTimeSkippingTransition func(transition *TimeSkippingTransition)
 
 	// Recorded calls (protected by mu).
 	mu                  sync.Mutex
@@ -238,6 +242,25 @@ func (m *MockNodeBackend) EndpointRegistry() EndpointRegistry {
 		return m.HandleEndpointRegistry()
 	}
 	return nil
+}
+
+func (m *MockNodeBackend) SetTimeSkippingConfig(config *commonpb.TimeSkippingConfig) {
+	if m.HandleSetTimeSkippingConfig != nil {
+		m.HandleSetTimeSkippingConfig(config)
+	}
+}
+
+func (m *MockNodeBackend) Now() time.Time {
+	if m.HandleNow != nil {
+		return m.HandleNow()
+	}
+	return time.Time{}
+}
+
+func (m *MockNodeBackend) RecordTimeSkippingTransition(transition *TimeSkippingTransition) {
+	if m.HandleRecordTimeSkippingTransition != nil {
+		m.HandleRecordTimeSkippingTransition(transition)
+	}
 }
 
 func (m *MockNodeBackend) GetNexusUpdateCompletion(

--- a/chasm/skip_persistence_test.go
+++ b/chasm/skip_persistence_test.go
@@ -24,7 +24,6 @@ func (s *nodeSuite) newSkipPersistenceTestTree(
 	if len(serializedNodes) == 0 {
 		return NewEmptyTree(
 			s.registry,
-			s.timeSource,
 			s.nodeBackend,
 			s.nodePathEncoder,
 			s.logger,
@@ -35,7 +34,6 @@ func (s *nodeSuite) newSkipPersistenceTestTree(
 	root, err := NewTreeFromDB(
 		serializedNodes,
 		s.registry,
-		s.timeSource,
 		s.nodeBackend,
 		s.nodePathEncoder,
 		s.logger,

--- a/chasm/test_component_test.go
+++ b/chasm/test_component_test.go
@@ -64,6 +64,13 @@ type (
 		SubComponent2Data *protoMessageType
 	}
 
+	TestTimeSkippingImplComponent struct {
+		UnimplementedComponent
+
+		ComponentData        *protoMessageType
+		isExecutionSkippable bool
+	}
+
 	TestSubComponent interface {
 		GetData() string
 	}
@@ -82,6 +89,8 @@ var (
 	_ VisibilitySearchAttributesProvider = (*TestComponent)(nil)
 	_ VisibilityMemoProvider             = (*TestComponent)(nil)
 	_ RootComponent                      = (*TestComponent)(nil)
+	_ RootComponent                      = (*TestTimeSkippingImplComponent)(nil)
+	_ TimeSkippingRuntimeGate            = (*TestTimeSkippingImplComponent)(nil)
 )
 
 func (tc *TestComponent) LifecycleState(_ Context) LifecycleState {
@@ -180,6 +189,26 @@ func (tsc11 *TestSubComponent11) LifecycleState(_ Context) LifecycleState {
 
 func (tsc2 *TestSubComponent2) LifecycleState(_ Context) LifecycleState {
 	return LifecycleStateRunning
+}
+
+func (gc *TestTimeSkippingImplComponent) LifecycleState(_ Context) LifecycleState {
+	return LifecycleStateRunning
+}
+
+func (gc *TestTimeSkippingImplComponent) ContextMetadata(_ Context) map[string]string {
+	return nil
+}
+
+func (gc *TestTimeSkippingImplComponent) Terminate(
+	_ MutableContext,
+	_ TerminateComponentRequest,
+) (TerminateComponentResponse, error) {
+	return TerminateComponentResponse{}, nil
+}
+
+// IsExecutionSkippable implements the TimeSkippingRuntimeGate interface.
+func (gc *TestTimeSkippingImplComponent) IsExecutionSkippable(_ Context) bool {
+	return gc.isExecutionSkippable
 }
 
 func setTestComponentFields(c *TestComponent, backend *MockNodeBackend) {

--- a/chasm/test_library_test.go
+++ b/chasm/test_library_test.go
@@ -48,6 +48,7 @@ func (l *TestLibrary) Components() []*RegistrableComponent {
 			WithBusinessIDAlias("TestBusinessId"),
 			WithSearchAttributes(TestComponentStartTimeSearchAttribute),
 		),
+		NewRegistrableComponent[*TestTimeSkippingImplComponent](testTimeSkippingComponentName),
 		NewRegistrableComponent[*TestSubComponent1](testSubComponent1Name),
 		NewRegistrableComponent[*TestSubComponent11](testSubComponent11Name),
 		NewRegistrableComponent[*TestSubComponent2](testSubComponent2Name),

--- a/chasm/test_var_test.go
+++ b/chasm/test_var_test.go
@@ -1,11 +1,12 @@
 package chasm
 
 const (
-	testLibraryName        = "TestLibrary"
-	testComponentName      = "test_component"
-	testSubComponent1Name  = "test_sub_component_1"
-	testSubComponent11Name = "test_sub_component_11"
-	testSubComponent2Name  = "test_sub_component_2"
+	testLibraryName               = "TestLibrary"
+	testComponentName             = "test_component"
+	testTimeSkippingComponentName = "test_timeskipping_component"
+	testSubComponent1Name         = "test_sub_component_1"
+	testSubComponent11Name        = "test_sub_component_11"
+	testSubComponent2Name         = "test_sub_component_2"
 
 	testSideEffectTaskName            = "test_side_effect_task"
 	testDiscardableSideEffectTaskName = "test_discardable_side_effect_task"

--- a/chasm/timeskipping.go
+++ b/chasm/timeskipping.go
@@ -5,6 +5,8 @@ import (
 
 	commonpb "go.temporal.io/api/common/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 // =============================================================================
@@ -36,6 +38,32 @@ type TimeSkippingRuntimeGate interface {
 	//     cause timeout and the worker may not have a chance to finish its work.
 	//   3. other execution-specific preconditions, as needed.
 	IsExecutionSkippable(ctx Context) bool
+}
+
+// PropagateTimeSkippingToOtherExecution snapshots time-skipping state for a new, independent
+// execution that shares the source execution's virtual clock, such as a child workflow or a
+// workflow started by a schedule.
+func PropagateTimeSkippingToOtherExecution(
+	tsi *persistencespb.TimeSkippingInfo,
+) (*commonpb.TimeSkippingConfig, *commonpb.TimeSkippingStatePropagation) {
+	if tsi == nil {
+		return nil, nil
+	}
+
+	var statePropagation *commonpb.TimeSkippingStatePropagation
+	if accumulated := tsi.GetAccumulatedSkippedDuration().AsDuration(); accumulated > 0 {
+		statePropagation = &commonpb.TimeSkippingStatePropagation{
+			InitialSkippedDuration: durationpb.New(accumulated),
+		}
+	}
+
+	config := tsi.GetConfig()
+	if config == nil || config.GetDisablePropagation() {
+		return nil, statePropagation
+	}
+	propagatedConfig := common.CloneProto(config)
+	propagatedConfig.FastForwardConfig = nil
+	return propagatedConfig, statePropagation
 }
 
 // =============================================================================

--- a/chasm/timeskipping.go
+++ b/chasm/timeskipping.go
@@ -7,6 +7,7 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // =============================================================================
@@ -64,6 +65,29 @@ func PropagateTimeSkippingToOtherExecution(
 	propagatedConfig := common.CloneProto(config)
 	propagatedConfig.FastForwardConfig = nil
 	return propagatedConfig, statePropagation
+}
+
+func timeSkippingInfoFromPersistence(
+	tsi *persistencespb.TimeSkippingInfo,
+	currentTime time.Time,
+) *commonpb.TimeSkippingInfo {
+	if tsi == nil {
+		return nil
+	}
+
+	info := &commonpb.TimeSkippingInfo{
+		CurrentTime:     timestamppb.New(currentTime),
+		EffectiveConfig: common.CloneProto(tsi.GetConfig()),
+	}
+	if ff := tsi.GetFastForwardInfo(); ff != nil {
+		info.FastForwardInfo = &commonpb.TimeSkippingFastForwardInfo{
+			TargetTime:          common.CloneProto(ff.GetTargetTime()),
+			HasCompleted:        ff.GetHasReached(),
+			FastForwardId:       tsi.GetConfig().GetFastForwardConfig().GetId(),
+			FastForwardDuration: common.CloneProto(tsi.GetConfig().GetFastForwardConfig().GetDuration()),
+		}
+	}
+	return info
 }
 
 // =============================================================================

--- a/chasm/timeskipping.go
+++ b/chasm/timeskipping.go
@@ -1,0 +1,121 @@
+package chasm
+
+import (
+	"time"
+
+	commonpb "go.temporal.io/api/common/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+)
+
+// =============================================================================
+// Time Skipping CHASM Contract
+// =============================================================================
+// This contract is between the CHASM framework and a root component, split along the
+// configuration / runtime axis:
+//
+//   - TimeSkippingConfigurator (PROVIDED BY the framework, CALLED BY the component) is the
+//     configuration-time surface. It is embedded in MutableContext and lets the component opt in /
+//     adjust the config via SetTimeSkippingConfig.
+//   - TimeSkippingRuntimeGate (component-implemented, MANDATORY) is the runtime surface the framework
+//     consults each transaction to decide whether the execution is idle enough to skip. The framework
+//     consults only the root component for this interface.
+
+type TimeSkippingConfigurator interface {
+	// SetTimeSkippingConfig sets the execution's time-skipping config: the first call establishes it,
+	// later calls update it in place (preserving the accumulated skipped duration).
+	SetTimeSkippingConfig(config *commonpb.TimeSkippingConfig)
+}
+
+type TimeSkippingRuntimeGate interface {
+	// IsExecutionSkippable reports whether the execution may have its virtual clock fast-forwarded right
+	// now. The framework skips no time while it returns false.
+	//
+	// A recommended implementation composes:
+	//   1. status check: if the execution is not paused nor completed, time may not need to skip.
+	//   2. in-flight work check: if the execution has in-flight work, skip to next timer task may
+	//     cause timeout and the worker may not have a chance to finish its work.
+	//   3. other execution-specific preconditions, as needed.
+	IsExecutionSkippable(ctx Context) bool
+}
+
+// =============================================================================
+// Time Skipping Data Structure
+// =============================================================================
+
+type TimeSkippingTransition struct {
+	CurrentTime time.Time
+	// targetTime is intentionally private: it may only be written through TrackEarliestFutureTime
+	// and GateByFastForward, both of which reject any candidate before CurrentTime. That guarantee
+	// is what keeps GetSkippedDuration from ever going negative. Read it via GetTargetTime.
+	targetTime               time.Time
+	DisabledAfterFastForward bool
+}
+
+// NewTimeSkippingTransition creates a new time-skipping transition with the current time.
+// Methods provided by this data structure cannot be used without a current time.
+//
+// todo@time-skipping: the methods will be used by CHASM so keep as public.
+func NewTimeSkippingTransition(currentTime time.Time) *TimeSkippingTransition {
+	return &TimeSkippingTransition{CurrentTime: currentTime}
+}
+
+// IsValid reports whether the transition is worth applying: a real skip target, or a bare disable
+// signal. Nil-safe. A transition without a current time is never valid — every meaningful field is
+// derived relative to the current time, so without it there is nothing to apply.
+func (t *TimeSkippingTransition) IsValid() bool {
+	return t != nil && !t.CurrentTime.IsZero() && (!t.targetTime.IsZero() || t.DisabledAfterFastForward)
+}
+
+// GetTargetTime returns the earliest tracked skip target, or the zero time when none has been set.
+// Nil-safe. This is the only way to read the target: it is written exclusively through
+// TrackEarliestFutureTime and GateByFastForward, which never accept a time before CurrentTime.
+func (t *TimeSkippingTransition) GetTargetTime() time.Time {
+	if t == nil {
+		return time.Time{}
+	}
+	return t.targetTime
+}
+
+func (t *TimeSkippingTransition) TrackEarliestFutureTime(candidate time.Time) {
+	if t == nil || t.CurrentTime.IsZero() || candidate.IsZero() || candidate.Before(t.CurrentTime) {
+		return
+	}
+	if t.targetTime.IsZero() || candidate.Before(t.targetTime) {
+		t.targetTime = candidate
+	}
+}
+
+func (t *TimeSkippingTransition) GateByFastForward(ff *persistencespb.FastForwardInfo) {
+	if t == nil || t.CurrentTime.IsZero() {
+		return
+	}
+	if ff == nil || ff.GetHasReached() || ff.GetTargetTime() == nil ||
+		ff.GetTargetTime().AsTime().IsZero() {
+		return
+	}
+	ffTargetTime := ff.GetTargetTime().AsTime()
+	if !ffTargetTime.After(t.CurrentTime) {
+		t.targetTime = time.Time{}
+		t.DisabledAfterFastForward = true
+		return
+	}
+
+	// If a real candidate is scheduled strictly before the fast-forward target, we skip to
+	// that and the fast-forward budget is not yet exhausted — leave time skipping enabled.
+	if !t.targetTime.IsZero() && t.targetTime.Before(ffTargetTime) {
+		return
+	}
+	// Otherwise the fast-forward target is the earliest target: skip to it and disable time
+	// skipping — the budget is reached.
+	// This is what lets the budget cap a chain of runs: a run with no earlier candidate
+	// consumes the remaining budget by skipping to the fast-forward and disabling.
+	t.targetTime = ffTargetTime
+	t.DisabledAfterFastForward = true
+}
+
+func (t *TimeSkippingTransition) GetSkippedDuration() time.Duration {
+	if t == nil || t.CurrentTime.IsZero() || t.targetTime.IsZero() {
+		return 0
+	}
+	return t.targetTime.Sub(t.CurrentTime)
+}

--- a/chasm/timeskipping_test.go
+++ b/chasm/timeskipping_test.go
@@ -1,0 +1,205 @@
+package chasm
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// TestTimeSkippingTransition covers the pure timeSkippingTransition data structure:
+// its constructor, validity check, earliest-future-time tracking, and fast-forward
+// gating. It needs no mutable state, so it is a plain test rather than a suite method.
+func TestTimeSkippingTransition(t *testing.T) {
+	t.Parallel()
+	base := time.Date(2027, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	t.Run("New sets only the current time", func(t *testing.T) {
+		tr := NewTimeSkippingTransition(base)
+		require.Equal(t, base, tr.CurrentTime)
+		require.True(t, tr.GetTargetTime().IsZero())
+		require.False(t, tr.DisabledAfterFastForward)
+		require.False(t, tr.IsValid(), "a transition with no target and no disable signal is invalid")
+	})
+	// Invariant 1: every method is nil-safe — on a nil receiver, and (for GateByFastForward)
+	// on a nil/absent fast-forward argument.
+	t.Run("nil safe", func(t *testing.T) {
+		var nilTr *TimeSkippingTransition
+		require.False(t, nilTr.IsValid(), "nil transition is never valid")
+		require.NotPanics(t, func() { nilTr.TrackEarliestFutureTime(base.Add(time.Hour)) })
+		require.NotPanics(t, func() {
+			nilTr.GateByFastForward(&persistencespb.FastForwardInfo{TargetTime: timestamppb.New(base.Add(time.Hour))})
+		})
+
+		// A nil or empty fast-forward must be a no-op, not a spurious disable. A nil proto
+		// timestamp's AsTime() is the Unix epoch (not the Go zero time), so this guards against
+		// treating "no fast-forward" as a past target.
+		tr := NewTimeSkippingTransition(base)
+		require.NotPanics(t, func() { tr.GateByFastForward(nil) })
+		tr.GateByFastForward(nil)
+		require.True(t, tr.GetTargetTime().IsZero())
+		require.False(t, tr.DisabledAfterFastForward)
+
+		tr.GateByFastForward(&persistencespb.FastForwardInfo{}) // non-nil ff, nil target time
+		require.True(t, tr.GetTargetTime().IsZero())
+		require.False(t, tr.DisabledAfterFastForward)
+		require.False(t, tr.IsValid())
+	})
+
+	// Invariant 2: TrackEarliestFutureTime keeps the earliest strictly-trackable future time
+	// and ignores anything that is not a usable future skip target.
+	t.Run("earliest future time", func(t *testing.T) {
+		t.Run("ignores zero and past candidates", func(t *testing.T) {
+			tr := NewTimeSkippingTransition(base)
+			tr.TrackEarliestFutureTime(time.Time{})          // zero candidate
+			tr.TrackEarliestFutureTime(base.Add(-time.Hour)) // past candidate
+			require.True(t, tr.GetTargetTime().IsZero())
+		})
+
+		t.Run("keeps the earliest of several future candidates", func(t *testing.T) {
+			tr := NewTimeSkippingTransition(base)
+			tr.TrackEarliestFutureTime(base.Add(3 * time.Hour))
+			require.Equal(t, base.Add(3*time.Hour), tr.GetTargetTime())
+
+			tr.TrackEarliestFutureTime(base.Add(time.Hour)) // earlier wins
+			require.Equal(t, base.Add(time.Hour), tr.GetTargetTime())
+
+			tr.TrackEarliestFutureTime(base.Add(2 * time.Hour)) // later is ignored
+			require.Equal(t, base.Add(time.Hour), tr.GetTargetTime())
+		})
+
+		t.Run("accepts a candidate equal to the current time", func(t *testing.T) {
+			tr := NewTimeSkippingTransition(base)
+			tr.TrackEarliestFutureTime(base)
+			require.Equal(t, base, tr.GetTargetTime())
+		})
+	})
+
+	// Invariant 3: the fast-forward target is taken — and disables time skipping — exactly when
+	// it is the earliest target (nothing earlier tracked). When a real candidate is earlier the
+	// fast-forward is not reached and skipping stays enabled. An absent/reached/zero fast-forward
+	// is a no-op.
+	t.Run("fast-forward fallback and gating", func(t *testing.T) {
+		t.Run("taken as the target and disables when nothing earlier exists", func(t *testing.T) {
+			tr := NewTimeSkippingTransition(base)
+			tr.GateByFastForward(&persistencespb.FastForwardInfo{TargetTime: timestamppb.New(base.Add(time.Hour))})
+			require.True(t, base.Add(time.Hour).Equal(tr.GetTargetTime()))
+			require.True(t, tr.DisabledAfterFastForward)
+			require.True(t, tr.IsValid())
+		})
+
+		t.Run("an earlier tracked target wins over a later fast-forward", func(t *testing.T) {
+			tr := NewTimeSkippingTransition(base)
+			tr.TrackEarliestFutureTime(base.Add(time.Hour))
+			tr.GateByFastForward(&persistencespb.FastForwardInfo{TargetTime: timestamppb.New(base.Add(3 * time.Hour))})
+			require.Equal(t, base.Add(time.Hour), tr.GetTargetTime())
+			require.False(t, tr.DisabledAfterFastForward)
+		})
+
+		t.Run("an earlier fast-forward wins over a later tracked target and disables", func(t *testing.T) {
+			tr := NewTimeSkippingTransition(base)
+			tr.TrackEarliestFutureTime(base.Add(3 * time.Hour))
+			tr.GateByFastForward(&persistencespb.FastForwardInfo{TargetTime: timestamppb.New(base.Add(time.Hour))})
+			require.True(t, base.Add(time.Hour).Equal(tr.GetTargetTime()))
+			require.True(t, tr.DisabledAfterFastForward)
+		})
+
+		t.Run("ignores an already-reached fast-forward", func(t *testing.T) {
+			tr := NewTimeSkippingTransition(base)
+			tr.GateByFastForward(&persistencespb.FastForwardInfo{
+				HasReached: true,
+				TargetTime: timestamppb.New(base.Add(time.Hour)),
+			})
+			require.True(t, tr.GetTargetTime().IsZero())
+			require.False(t, tr.DisabledAfterFastForward)
+		})
+
+		t.Run("ignores a zero-valued target time", func(t *testing.T) {
+			tr := NewTimeSkippingTransition(base)
+			tr.GateByFastForward(&persistencespb.FastForwardInfo{TargetTime: timestamppb.New(time.Time{})})
+			require.True(t, tr.GetTargetTime().IsZero())
+			require.False(t, tr.DisabledAfterFastForward)
+		})
+
+		t.Run("target equal to current disables as a bare signal", func(t *testing.T) {
+			tr := NewTimeSkippingTransition(base)
+			tr.GateByFastForward(&persistencespb.FastForwardInfo{TargetTime: timestamppb.New(base)})
+			require.True(t, tr.GetTargetTime().IsZero())
+			require.True(t, tr.DisabledAfterFastForward)
+			require.True(t, tr.IsValid())
+		})
+
+		t.Run("past target disables as a bare signal", func(t *testing.T) {
+			tr := NewTimeSkippingTransition(base)
+			tr.GateByFastForward(&persistencespb.FastForwardInfo{TargetTime: timestamppb.New(base.Add(-time.Hour))})
+			require.True(t, tr.GetTargetTime().IsZero(), "a past target is not a future skip target")
+			require.True(t, tr.DisabledAfterFastForward)
+			require.True(t, tr.IsValid())
+		})
+	})
+
+	// Invariant 4: without a current time the transition is always invalid and no setter can
+	// make it valid — every field is relative to the current time.
+	t.Run("no current time always invalid", func(t *testing.T) {
+		t.Run("a directly-set target is still invalid", func(t *testing.T) {
+			tr := &TimeSkippingTransition{targetTime: base.Add(time.Hour)}
+			require.False(t, tr.IsValid())
+		})
+
+		t.Run("a directly-set disable signal is still invalid", func(t *testing.T) {
+			tr := &TimeSkippingTransition{DisabledAfterFastForward: true}
+			require.False(t, tr.IsValid())
+		})
+
+		t.Run("setters are no-ops without a current time", func(t *testing.T) {
+			tr := &TimeSkippingTransition{}
+			tr.TrackEarliestFutureTime(base)
+			tr.GateByFastForward(&persistencespb.FastForwardInfo{TargetTime: timestamppb.New(base.Add(time.Hour))})
+			require.True(t, tr.GetTargetTime().IsZero())
+			require.False(t, tr.DisabledAfterFastForward)
+			require.False(t, tr.IsValid())
+		})
+	})
+
+	// Invariant 5: GetSkippedDuration is the gap from current to target time, and is zero whenever
+	// there is nothing to skip — a nil receiver, no current time, or no target time.
+	t.Run("skipped duration", func(t *testing.T) {
+		t.Run("nil receiver is zero", func(t *testing.T) {
+			var nilTr *TimeSkippingTransition
+			require.Zero(t, nilTr.GetSkippedDuration())
+		})
+
+		t.Run("no current time is zero", func(t *testing.T) {
+			tr := &TimeSkippingTransition{targetTime: base.Add(time.Hour)}
+			require.Zero(t, tr.GetSkippedDuration())
+		})
+
+		t.Run("no target time is zero", func(t *testing.T) {
+			tr := NewTimeSkippingTransition(base)
+			require.Zero(t, tr.GetSkippedDuration())
+		})
+
+		t.Run("target after current is the gap", func(t *testing.T) {
+			tr := NewTimeSkippingTransition(base)
+			tr.TrackEarliestFutureTime(base.Add(90 * time.Minute))
+			require.Equal(t, 90*time.Minute, tr.GetSkippedDuration())
+		})
+
+		t.Run("target equal to current is zero", func(t *testing.T) {
+			tr := NewTimeSkippingTransition(base)
+			tr.TrackEarliestFutureTime(base)
+			require.Zero(t, tr.GetSkippedDuration())
+		})
+
+		t.Run("a past candidate leaves no target and is zero", func(t *testing.T) {
+			// TrackEarliestFutureTime rejects a past candidate, so the target stays unset and
+			// there is nothing to skip — the duration is zero, never negative.
+			tr := NewTimeSkippingTransition(base)
+			tr.TrackEarliestFutureTime(base.Add(-time.Hour))
+			require.True(t, tr.GetTargetTime().IsZero())
+			require.Zero(t, tr.GetSkippedDuration())
+		})
+	})
+}

--- a/chasm/timeskipping_test.go
+++ b/chasm/timeskipping_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -56,6 +57,45 @@ func TestPropagateTimeSkippingToOtherExecution(t *testing.T) {
 		require.Nil(t, config)
 		require.Equal(t, time.Hour, state.GetInitialSkippedDuration().AsDuration())
 	})
+}
+
+func TestTimeSkippingInfoFromPersistence(t *testing.T) {
+	t.Parallel()
+
+	currentTime := time.Date(2027, 1, 1, 12, 0, 0, 0, time.UTC)
+	require.Nil(t, timeSkippingInfoFromPersistence(nil, currentTime))
+
+	config := &commonpb.TimeSkippingConfig{
+		Enabled: true,
+		FastForwardConfig: &commonpb.FastForwardConfig{
+			Id:       "fast-forward-id",
+			Duration: durationpb.New(5 * time.Hour),
+		},
+	}
+	targetTime := currentTime.Add(5 * time.Hour)
+	persistenceInfo := &persistencespb.TimeSkippingInfo{
+		Config: config,
+		FastForwardInfo: &persistencespb.FastForwardInfo{
+			TargetTime: timestamppb.New(targetTime),
+			HasReached: true,
+		},
+	}
+	info := timeSkippingInfoFromPersistence(persistenceInfo, currentTime)
+
+	require.Equal(t, currentTime, info.GetCurrentTime().AsTime())
+	require.True(t, proto.Equal(config, info.GetEffectiveConfig()))
+	require.NotSame(t, config, info.GetEffectiveConfig())
+	require.Equal(t, targetTime, info.GetFastForwardInfo().GetTargetTime().AsTime())
+	require.True(t, info.GetFastForwardInfo().GetHasCompleted())
+	require.Equal(t, "fast-forward-id", info.GetFastForwardInfo().GetFastForwardId())
+	require.Equal(t, 5*time.Hour, info.GetFastForwardInfo().GetFastForwardDuration().AsDuration())
+
+	info.EffectiveConfig.Enabled = false
+	info.FastForwardInfo.TargetTime.Seconds = 0
+	info.FastForwardInfo.FastForwardDuration.Seconds = 0
+	require.True(t, persistenceInfo.GetConfig().GetEnabled())
+	require.Equal(t, targetTime, persistenceInfo.GetFastForwardInfo().GetTargetTime().AsTime())
+	require.Equal(t, 5*time.Hour, persistenceInfo.GetConfig().GetFastForwardConfig().GetDuration().AsDuration())
 }
 
 // TestTimeSkippingTransition covers the pure timeSkippingTransition data structure:

--- a/chasm/timeskipping_test.go
+++ b/chasm/timeskipping_test.go
@@ -5,9 +5,58 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+func TestPropagateTimeSkippingToOtherExecution(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil", func(t *testing.T) {
+		config, state := PropagateTimeSkippingToOtherExecution(nil)
+		require.Nil(t, config)
+		require.Nil(t, state)
+	})
+
+	t.Run("config and virtual time", func(t *testing.T) {
+		sourceConfig := &commonpb.TimeSkippingConfig{
+			Enabled:             true,
+			MaxSessionSkipCount: 7,
+			FastForwardConfig: &commonpb.FastForwardConfig{
+				Id:       "source-fast-forward",
+				Duration: durationpb.New(5 * time.Hour),
+			},
+		}
+		config, state := PropagateTimeSkippingToOtherExecution(&persistencespb.TimeSkippingInfo{
+			Config:                     sourceConfig,
+			AccumulatedSkippedDuration: durationpb.New(2 * time.Hour),
+		})
+
+		require.True(t, config.GetEnabled())
+		require.Equal(t, int32(7), config.GetMaxSessionSkipCount())
+		require.Nil(t, config.GetFastForwardConfig())
+		require.Equal(t, 2*time.Hour, state.GetInitialSkippedDuration().AsDuration())
+		require.Zero(t, state.GetInitialSkipCount())
+
+		config.Enabled = false
+		require.True(t, sourceConfig.GetEnabled(), "propagated config must be cloned")
+	})
+
+	t.Run("disable propagation only suppresses config", func(t *testing.T) {
+		config, state := PropagateTimeSkippingToOtherExecution(&persistencespb.TimeSkippingInfo{
+			Config: &commonpb.TimeSkippingConfig{
+				Enabled:            true,
+				DisablePropagation: true,
+			},
+			AccumulatedSkippedDuration: durationpb.New(time.Hour),
+		})
+
+		require.Nil(t, config)
+		require.Equal(t, time.Hour, state.GetInitialSkippedDuration().AsDuration())
+	})
+}
 
 // TestTimeSkippingTransition covers the pure timeSkippingTransition data structure:
 // its constructor, validity check, earliest-future-time tracking, and fast-forward

--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -20,7 +20,6 @@ import (
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common"
-	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
@@ -143,7 +142,6 @@ type (
 	// nodeBase is a set of dependencies and states shared by all nodes in a CHASM tree.
 	nodeBase struct {
 		registry       *Registry
-		timeSource     clock.TimeSource
 		backend        NodeBackend
 		pathEncoder    NodePathEncoder
 		logger         log.Logger
@@ -235,6 +233,9 @@ type (
 			requestID string,
 		) (nexusrpc.CompleteOperationOptions, error)
 		EndpointRegistry() EndpointRegistry
+		Now() time.Time
+		SetTimeSkippingConfig(config *commonpb.TimeSkippingConfig)
+		RecordTimeSkippingTransition(transition *TimeSkippingTransition)
 	}
 
 	// NodePathEncoder is an interface for encoding and decoding node paths.
@@ -260,20 +261,19 @@ type (
 func NewTreeFromDB(
 	serializedNodes map[string]*persistencespb.ChasmNode, // This is coming from MS map[nodePath]ChasmNode.
 	registry *Registry,
-	timeSource clock.TimeSource,
 	backend NodeBackend,
 	pathEncoder NodePathEncoder,
 	logger log.Logger,
 	metricsHandler metrics.Handler,
 ) (*Node, error) {
 	if len(serializedNodes) == 0 {
-		root := NewEmptyTree(registry, timeSource, backend, pathEncoder, logger, metricsHandler)
+		root := NewEmptyTree(registry, backend, pathEncoder, logger, metricsHandler)
 		// NewEmptyTree initializes the serializedNode to an empty component node,
 		root.serializedNode.Metadata.GetComponentAttributes().TypeId = WorkflowArchetypeID
 		return root, nil
 	}
 
-	root := newTreeHelper(registry, timeSource, backend, pathEncoder, logger, metricsHandler)
+	root := newTreeHelper(registry, backend, pathEncoder, logger, metricsHandler)
 	for encodedPath, serializedNode := range serializedNodes {
 		nodePath, err := pathEncoder.Decode(encodedPath)
 		if err != nil {
@@ -291,13 +291,12 @@ func NewTreeFromDB(
 // NewEmptyTree creates a new empty in-memory CHASM tree.
 func NewEmptyTree(
 	registry *Registry,
-	timeSource clock.TimeSource,
 	backend NodeBackend,
 	pathEncoder NodePathEncoder,
 	logger log.Logger,
 	metricsHandler metrics.Handler,
 ) *Node {
-	root := newTreeHelper(registry, timeSource, backend, pathEncoder, logger, metricsHandler)
+	root := newTreeHelper(registry, backend, pathEncoder, logger, metricsHandler)
 
 	// If serializedNodes is empty, it means that this new tree.
 	// Initialize empty serializedNode.
@@ -313,7 +312,6 @@ func NewEmptyTree(
 
 func newTreeHelper(
 	registry *Registry,
-	timeSource clock.TimeSource,
 	backend NodeBackend,
 	pathEncoder NodePathEncoder,
 	logger log.Logger,
@@ -321,7 +319,6 @@ func newTreeHelper(
 ) *Node {
 	base := &nodeBase{
 		registry:       registry,
-		timeSource:     timeSource,
 		backend:        backend,
 		pathEncoder:    pathEncoder,
 		logger:         logger,
@@ -1663,7 +1660,7 @@ func (n *Node) Now(
 	_ Component,
 ) time.Time {
 	// TODO: Now() could be different for components after we support Pause for CHASM components.
-	return n.timeSource.Now()
+	return n.backend.Now()
 }
 
 // AddTask implements the CHASM MutableContext interface
@@ -1733,6 +1730,10 @@ func (n *Node) CloseTransaction() (NodesMutation, error) {
 	}
 
 	if err := n.closeTransactionApplyPendingComponentMetadata(); err != nil {
+		return NodesMutation{}, err
+	}
+
+	if err := n.closeTransactionHandleTimeSkipping(immutableContext); err != nil {
 		return NodesMutation{}, err
 	}
 
@@ -3869,4 +3870,125 @@ func makeValidationFn(
 // serializer while preserving deterministic proto3 bytes for byte comparisons.
 func encodeChasmBlob(m proto.Message) (*commonpb.DataBlob, error) {
 	return serialization.Encode(m, serialization.WithDeterministicProto3)
+}
+
+func (n *Node) closeTransactionHandleTimeSkipping(immutableContext Context) error {
+	if n.parent != nil {
+		n.logger.Warn("time skipping handler called on non-root component is no-op")
+		return nil
+	}
+	if n.ArchetypeID() == WorkflowArchetypeID {
+		return nil
+	}
+
+	// conf check
+	tsi := n.backend.GetExecutionInfo().GetTimeSkippingInfo()
+	if !tsi.GetConfig().GetEnabled() {
+		return nil
+	}
+
+	// todo@feiyang: how to check that the current cluster is active cluster
+	// and this closeTransaction state change logic should only happen in active cluster
+	rootComponent, err := n.Component(immutableContext, ComponentRef{})
+	if err != nil {
+		return err
+	}
+	tsRoot, ok := rootComponent.(TimeSkippingRuntimeGate)
+	if !ok {
+		n.logger.Error(
+			"root component does not implement TimeSkippingRuntimeGate when executions have turned on time skipping",
+			tag.Error(fmt.Errorf("type: %s", reflect.TypeOf(rootComponent).Name())))
+		return serviceerror.NewInternal("time skipping is not enabled for current execution type")
+	}
+
+	// runtime check
+	if !tsRoot.IsExecutionSkippable(immutableContext) {
+		return nil
+	}
+	transition := n.defaultFindNextTargetTime()
+	if !transition.IsValid() {
+		return nil
+	}
+
+	// state change
+	n.backend.RecordTimeSkippingTransition(transition)
+	return n.regenerateTimerTasksForTimeSkipping()
+}
+
+func (n *Node) regenerateTimerTasksForTimeSkipping() error {
+	archetypeID := n.ArchetypeID()
+	var firstPureTask *persistencespb.ChasmComponentAttributes_Task
+	var firstPureTaskNode *Node
+
+	for nodePath, node := range n.andAllChildren() {
+		componentAttr := node.serializedNode.GetMetadata().GetComponentAttributes()
+		if componentAttr == nil {
+			continue
+		}
+
+		for _, sideEffectTask := range componentAttr.GetSideEffectTasks() {
+			if taskCategory(sideEffectTask) != tasks.CategoryTimer {
+				continue
+			}
+			sideEffectTask.PhysicalTaskStatus = physicalTaskStatusNone
+			node.closeTransactionGeneratePhysicalSideEffectTask(sideEffectTask, nodePath, archetypeID)
+		}
+
+		// Find the earliest pure task in the entire tree. Pure tasks are sorted
+		// by scheduled time, so pureTasks[0] is the earliest for this component.
+		pureTasks := componentAttr.GetPureTasks()
+		if len(pureTasks) == 0 {
+			continue
+		}
+
+		if firstPureTask == nil || comparePureTasks(pureTasks[0], firstPureTask) < 0 {
+			firstPureTask = pureTasks[0]
+			firstPureTaskNode = node
+		}
+	}
+
+	if firstPureTask != nil {
+		// Pure tasks are represented by a single physical task, so we only need to
+		// regenerate that one. The earliest pure task is already
+		// physicalTaskStatusCreated from a prior transaction, and
+		// closeTransactionGeneratePhysicalPureTask short-circuits on that status.
+		// Reset it so backend.AddTask re-converts the fire time for the skipped time.
+		firstPureTask.PhysicalTaskStatus = physicalTaskStatusNone
+	}
+	return n.closeTransactionGeneratePhysicalPureTask(firstPureTask, firstPureTaskNode, archetypeID)
+}
+
+// defaultFindNextTargetTime finds the earliest timer task from both pure tasks and side-effect tasks
+// as the target time for time skipping, and conditionally adjusts the target time with the fast-forward time if set.
+// this method doesn't validate tasks and is assumed to be called after invalidate tasks are deleted
+func (n *Node) defaultFindNextTargetTime() *TimeSkippingTransition {
+	transition := NewTimeSkippingTransition(n.Now(nil))
+	now := transition.CurrentTime
+	for _, node := range n.andAllChildren() {
+		componentAttr := node.serializedNode.GetMetadata().GetComponentAttributes()
+		if componentAttr == nil {
+			continue
+		}
+		for _, taskList := range [][]*persistencespb.ChasmComponentAttributes_Task{
+			componentAttr.GetPureTasks(),
+			componentAttr.GetSideEffectTasks(),
+		} {
+			for _, task := range taskList {
+				if taskCategory(task) != tasks.CategoryTimer {
+					continue
+				}
+				scheduledTime := task.GetScheduledTime().AsTime()
+				if !scheduledTime.After(now) {
+					continue
+				}
+				transition.TrackEarliestFutureTime(scheduledTime)
+			}
+		}
+	}
+	tsi := n.backend.GetExecutionInfo().GetTimeSkippingInfo()
+	ff := tsi.GetFastForwardInfo()
+	if ff != nil && !ff.HasReached {
+		transition.GateByFastForward(ff)
+	}
+	return transition
 }

--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -72,6 +72,7 @@ func (s *nodeSuite) SetupTest() {
 	s.NoError(err)
 
 	s.timeSource = clock.NewEventTimeSource()
+	s.nodeBackend.HandleNow = s.timeSource.Now
 	s.nodePathEncoder = &testNodePathEncoder{}
 }
 
@@ -223,7 +224,7 @@ func (s *nodeSuite) TestSerializeNode_ClearSubDataField() {
 }
 
 func (s *nodeSuite) TestSetRootComponent_SetsArchetypeID() {
-	rootNode := NewEmptyTree(s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
+	rootNode := NewEmptyTree(s.registry, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
 	s.Equal(WorkflowArchetypeID, rootNode.ArchetypeID())
 	rootComponent := &TestComponent{
 		MSPointer: NewMSPointer(s.nodeBackend),
@@ -1159,7 +1160,6 @@ func (s *nodeSuite) TestApplyMutation_InvalidatesHydratedMapAncestors() {
 		target, err := NewTreeFromDB(
 			common.CloneProtoMap(persistedNodes),
 			s.registry,
-			s.timeSource,
 			s.nodeBackend,
 			s.nodePathEncoder,
 			s.logger,
@@ -3716,7 +3716,6 @@ func (e *testNodePathEncoder) Decode(
 func (s *nodeSuite) nodeBase() *nodeBase {
 	return &nodeBase{
 		registry:    s.registry,
-		timeSource:  s.timeSource,
 		backend:     s.nodeBackend,
 		pathEncoder: s.nodePathEncoder,
 
@@ -4632,9 +4631,9 @@ func (s *nodeSuite) newTestTree(
 ) (*Node, error) {
 	s.nodeBackend.HandleChasmSkipPersistenceEnabled = func() bool { return true }
 	if len(serializedNodes) == 0 {
-		return NewEmptyTree(s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler), nil
+		return NewEmptyTree(s.registry, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler), nil
 	}
-	return NewTreeFromDB(serializedNodes, s.registry, s.timeSource, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
+	return NewTreeFromDB(serializedNodes, s.registry, s.nodeBackend, s.nodePathEncoder, s.logger, s.metricsHandler)
 }
 
 func (s *nodeSuite) emptyDataBlob() *commonpb.DataBlob {
@@ -5306,4 +5305,446 @@ func (s *nodeSuite) TestCloseTransaction_SingletonTask_InvalidNewTask_DoesNotDis
 	s.Len(rootAttr.SideEffectTasks, 1, "invalid new task must not displace existing singleton")
 	s.Equal(firstTask.VersionedTransition, rootAttr.SideEffectTasks[0].VersionedTransition,
 		"existing task must be unchanged")
+}
+
+// TestCloseTransactionHandleTimeSkipping covers the framework-level guard rails of the root-only
+// close-transaction hook: it must be panic-safe and non-erroring for executions without time
+// skipping, a no-op on non-root nodes, and it must surface an internal error only when the config
+// says time skipping is on but the root component does not implement TimeSkippingRuntimeGate.
+func (s *nodeSuite) TestCloseTransactionHandleTimeSkipping() {
+	baseTime := time.Date(2027, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	// executionInfo installs a GetExecutionInfo stub returning the given time-skipping info.
+	executionInfo := func(tsi *persistencespb.TimeSkippingInfo) {
+		s.nodeBackend.HandleGetExecutionInfo = func() *persistencespb.WorkflowExecutionInfo {
+			return &persistencespb.WorkflowExecutionInfo{TimeSkippingInfo: tsi}
+		}
+	}
+
+	// timerTask builds a future timer-category task scheduled at baseTime+offset.
+	timerTask := func(offset time.Duration, typeID uint32, tvOffset int64) *persistencespb.ChasmComponentAttributes_Task {
+		return &persistencespb.ChasmComponentAttributes_Task{
+			TypeId:                    typeID,
+			ScheduledTime:             timestamppb.New(baseTime.Add(offset)),
+			VersionedTransition:       &persistencespb.VersionedTransition{TransitionCount: 1},
+			VersionedTransitionOffset: tvOffset,
+			PhysicalTaskStatus:        physicalTaskStatusNone,
+		}
+	}
+
+	// gateRoot builds a root whose component implements TimeSkippingRuntimeGate (returning the
+	// given skippable value), carries two side-effect and three pure future timer tasks as skip
+	// targets, and has time skipping enabled in its config. The in-memory SetRootComponent path
+	// preserves the unmanaged skippable flag so IsExecutionSkippable is deterministic.
+	gateRoot := func(skippable bool) *Node {
+		s.nodeBackend = &MockNodeBackend{}
+		s.nodeBackend.HandleNow = s.timeSource.Now
+		s.nodeBackend.HandleNextTransitionCount = func() int64 { return 1 }
+		s.nodeBackend.HandleGetCurrentVersion = func() int64 { return 1 }
+		s.timeSource.Update(baseTime)
+
+		var nilSerializedNodes map[string]*persistencespb.ChasmNode
+		root, err := s.newTestTree(nilSerializedNodes)
+		s.NoError(err)
+		s.NoError(root.SetRootComponent(&TestTimeSkippingImplComponent{
+			ComponentData:        &protoMessageType{CreateRequestId: "gate"},
+			isExecutionSkippable: skippable,
+		}))
+
+		attrs := root.serializedNode.Metadata.GetComponentAttributes()
+		attrs.SideEffectTasks = []*persistencespb.ChasmComponentAttributes_Task{
+			timerTask(2*time.Hour, testSideEffectTaskTypeID, 1),
+			timerTask(4*time.Hour, testSideEffectTaskTypeID, 2),
+		}
+		attrs.PureTasks = []*persistencespb.ChasmComponentAttributes_Task{
+			timerTask(time.Hour, testPureTaskTypeID, 3), // earliest overall
+			timerTask(3*time.Hour, testPureTaskTypeID, 4),
+			timerTask(5*time.Hour, testPureTaskTypeID, 5),
+		}
+		executionInfo(&persistencespb.TimeSkippingInfo{Config: &commonpb.TimeSkippingConfig{Enabled: true}})
+		return root
+	}
+
+	// TestComponent (the root of testComponentTree) does not implement TimeSkippingRuntimeGate,
+	// which is exactly what the "gate not implemented" cases below rely on.
+
+	s.Run("NilTimeSkippingInfoIsSafeNoOp", func() {
+		s.nodeBackend = &MockNodeBackend{}
+		// default GetExecutionInfo returns an empty WorkflowExecutionInfo => nil TimeSkippingInfo
+		root := s.testComponentTree()
+
+		var err error
+		s.NotPanics(func() {
+			err = root.closeTransactionHandleTimeSkipping(NewContext(context.Background(), root))
+		})
+		s.NoError(err, "an execution without time-skipping info must be a safe no-op")
+	})
+
+	s.Run("NonRootNodeIsNoOp", func() {
+		s.nodeBackend = &MockNodeBackend{}
+		s.nodeBackend.HandleNow = s.timeSource.Now
+		s.timeSource.Update(time.Date(2027, 1, 1, 12, 0, 0, 0, time.UTC))
+		root, err := s.newTestTree(map[string]*persistencespb.ChasmNode{
+			"": {
+				Metadata: &persistencespb.ChasmNodeMetadata{
+					InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 1},
+					LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 1},
+					Attributes: &persistencespb.ChasmNodeMetadata_ComponentAttributes{
+						ComponentAttributes: &persistencespb.ChasmComponentAttributes{TypeId: testComponentTypeID},
+					},
+				},
+			},
+			"SubComponent1": {
+				Metadata: &persistencespb.ChasmNodeMetadata{
+					InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 1},
+					LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 1},
+					Attributes: &persistencespb.ChasmNodeMetadata_ComponentAttributes{
+						ComponentAttributes: &persistencespb.ChasmComponentAttributes{TypeId: testSubComponent1TypeID},
+					},
+				},
+			},
+		})
+		s.NoError(err)
+		child := root.children["SubComponent1"]
+		s.Require().NotNil(child)
+		s.Require().NotNil(child.parent, "must exercise a genuinely non-root node")
+
+		// A non-root node is a benign no-op: it logs a warning (not an error) and returns nil.
+		// The FailOnAnyUnexpectedError logger also asserts that no error-level log is emitted.
+		var closeErr error
+		s.NotPanics(func() {
+			closeErr = child.closeTransactionHandleTimeSkipping(NewContext(context.Background(), child))
+		})
+		s.NoError(closeErr)
+	})
+
+	s.Run("ConfigDisabledAndGateNotImplemented_NoError", func() {
+		s.nodeBackend = &MockNodeBackend{}
+		executionInfo(&persistencespb.TimeSkippingInfo{
+			Config: &commonpb.TimeSkippingConfig{Enabled: false},
+		})
+		root := s.testComponentTree()
+
+		// Config disabled short-circuits before the gate check, so the missing
+		// TimeSkippingRuntimeGate on TestComponent must not surface as an error.
+		err := root.closeTransactionHandleTimeSkipping(NewContext(context.Background(), root))
+		s.NoError(err)
+	})
+
+	s.Run("ConfigEnabledAndGateNotImplemented_InternalError", func() {
+		s.nodeBackend = &MockNodeBackend{}
+		executionInfo(&persistencespb.TimeSkippingInfo{
+			Config: &commonpb.TimeSkippingConfig{Enabled: true},
+		})
+		root := s.testComponentTree()
+
+		tl, ok := s.logger.(*testlogger.TestLogger)
+		s.Require().True(ok)
+		tl.Expect(testlogger.Error, "does not implement TimeSkippingRuntimeGate")
+
+		err := root.closeTransactionHandleTimeSkipping(NewContext(context.Background(), root))
+		s.Require().Error(err, "enabled config with no gate implementation is a misconfiguration")
+		var internalErr *serviceerror.Internal
+		s.ErrorAs(err, &internalErr, "the error must be an internal service error")
+	})
+
+	s.Run("GateNotSkippable_NoStateChange", func() {
+		root := gateRoot(false)
+		var recorded *TimeSkippingTransition
+		s.nodeBackend.HandleRecordTimeSkippingTransition = func(tr *TimeSkippingTransition) { recorded = tr }
+
+		err := root.closeTransactionHandleTimeSkipping(NewContext(context.Background(), root))
+		s.NoError(err)
+		s.Nil(recorded, "a gate that reports not-skippable must not record a transition")
+		s.Equal(0, s.nodeBackend.NumTasksAdded(), "no timer tasks are regenerated when skipping is gated out")
+	})
+
+	s.Run("GateSkippable_RecordsTransitionAndRegeneratesTasks", func() {
+		root := gateRoot(true)
+		var recorded *TimeSkippingTransition
+		s.nodeBackend.HandleRecordTimeSkippingTransition = func(tr *TimeSkippingTransition) { recorded = tr }
+
+		err := root.closeTransactionHandleTimeSkipping(NewContext(context.Background(), root))
+		s.NoError(err)
+		s.Require().NotNil(recorded, "a skippable execution with a future timer must record a transition")
+		s.True(recorded.IsValid())
+		s.True(baseTime.Add(time.Hour).Equal(recorded.GetTargetTime()), "skips to the earliest future timer task")
+		// Two side-effect timer tasks are each regenerated, plus the single earliest pure task
+		// (only one physical pure task is generated regardless of pure-task count) => 3 total.
+		s.Equal(3, s.nodeBackend.NumTasksAdded(), "two side-effect tasks and the earliest pure task are regenerated")
+		s.Equal(baseTime.Add(time.Hour).UTC(), s.nodeBackend.LastDeletePureTaskCall(),
+			"pure-task deletion is anchored at the earliest pure scheduled time")
+	})
+}
+
+// TestDefaultFindNextTargetTime covers the earliest-future-timer selection across the whole tree:
+// non-timer and past tasks are ignored, the earliest future timer wins, and an active fast-forward
+// caps (and disables) the skip when it is the earliest target.
+func (s *nodeSuite) TestDefaultFindNextTargetTime() {
+	baseTime := time.Date(2027, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	// timerTask builds a timer-category task (non-visibility type, no destination, future
+	// scheduled time). transferTask builds an immediate/transfer task (no scheduled time) that
+	// must never be treated as a skip target.
+	timerTask := func(offset time.Duration) *persistencespb.ChasmComponentAttributes_Task {
+		return &persistencespb.ChasmComponentAttributes_Task{
+			TypeId:              testSideEffectTaskTypeID,
+			ScheduledTime:       timestamppb.New(baseTime.Add(offset)),
+			VersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 1},
+		}
+	}
+	transferTask := func() *persistencespb.ChasmComponentAttributes_Task {
+		return &persistencespb.ChasmComponentAttributes_Task{
+			TypeId:              testSideEffectTaskTypeID,
+			VersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 1},
+		}
+	}
+
+	// buildRoot builds a single-root tree carrying the given side-effect and pure tasks, on a
+	// fresh backend with the clock pinned to baseTime.
+	buildRoot := func(sideEffect, pure []*persistencespb.ChasmComponentAttributes_Task) *Node {
+		s.nodeBackend = &MockNodeBackend{}
+		s.nodeBackend.HandleNow = s.timeSource.Now
+		s.timeSource.Update(baseTime)
+		root, err := s.newTestTree(map[string]*persistencespb.ChasmNode{
+			"": {
+				Metadata: &persistencespb.ChasmNodeMetadata{
+					InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 1},
+					LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 1},
+					Attributes: &persistencespb.ChasmNodeMetadata_ComponentAttributes{
+						ComponentAttributes: &persistencespb.ChasmComponentAttributes{
+							TypeId:          testComponentTypeID,
+							SideEffectTasks: sideEffect,
+							PureTasks:       pure,
+						},
+					},
+				},
+			},
+		})
+		s.NoError(err)
+		return root
+	}
+
+	s.Run("NoTasksInvalidTransition", func() {
+		root := buildRoot(nil, nil)
+		tr := root.defaultFindNextTargetTime()
+		s.Require().NotNil(tr)
+		s.Equal(baseTime, tr.CurrentTime)
+		s.True(tr.GetTargetTime().IsZero())
+		s.False(tr.IsValid())
+	})
+
+	s.Run("EarliestFutureTaskWins", func() {
+		root := buildRoot(
+			[]*persistencespb.ChasmComponentAttributes_Task{timerTask(2 * time.Hour)},
+			[]*persistencespb.ChasmComponentAttributes_Task{timerTask(time.Hour), transferTask()},
+		)
+		tr := root.defaultFindNextTargetTime()
+		s.Require().NotNil(tr)
+		s.True(tr.IsValid())
+		s.Equal(baseTime.Add(time.Hour), tr.GetTargetTime(), "the earliest future timer across all task lists wins")
+		s.False(tr.DisabledAfterFastForward)
+	})
+
+	s.Run("PastAndNonTimerTasksIgnored", func() {
+		root := buildRoot(
+			[]*persistencespb.ChasmComponentAttributes_Task{timerTask(-time.Hour), transferTask()},
+			[]*persistencespb.ChasmComponentAttributes_Task{timerTask(3 * time.Hour)},
+		)
+		tr := root.defaultFindNextTargetTime()
+		s.Require().NotNil(tr)
+		s.Equal(baseTime.Add(3*time.Hour), tr.GetTargetTime(),
+			"past timers and non-timer (transfer) tasks must not be skip targets")
+	})
+
+	s.Run("EarlierFastForwardCapsAndDisables", func() {
+		root := buildRoot(nil, []*persistencespb.ChasmComponentAttributes_Task{timerTask(3 * time.Hour), transferTask()})
+		s.nodeBackend.HandleGetExecutionInfo = func() *persistencespb.WorkflowExecutionInfo {
+			return &persistencespb.WorkflowExecutionInfo{
+				TimeSkippingInfo: &persistencespb.TimeSkippingInfo{
+					FastForwardInfo: &persistencespb.FastForwardInfo{
+						TargetTime: timestamppb.New(baseTime.Add(time.Hour)),
+						HasReached: false,
+					},
+				},
+			}
+		}
+		tr := root.defaultFindNextTargetTime()
+		s.Require().NotNil(tr)
+		s.True(baseTime.Add(time.Hour).Equal(tr.GetTargetTime()),
+			"an earlier fast-forward caps the skip below the later timer")
+		s.True(tr.DisabledAfterFastForward, "reaching the fast-forward target disables time skipping")
+	})
+}
+
+// TestRegenerateTimerTasksForTimeSkipping verifies task regeneration: every timer side-effect task
+// is re-created (non-timer ones are skipped), only the single earliest pure task across the tree
+// gets a physical pure task, and pure-task deletion is anchored at the earliest scheduled time (or
+// the maximum key when there are no pure tasks).
+func (s *nodeSuite) TestRegenerateTimerTasksForTimeSkipping() {
+	baseTime := time.Date(2027, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	s.Run("RegeneratesSideEffectTimersAndEarliestPureTask", func() {
+		s.nodeBackend = &MockNodeBackend{}
+		s.nodeBackend.HandleNow = s.timeSource.Now
+		s.timeSource.Update(baseTime)
+
+		root, err := s.newTestTree(map[string]*persistencespb.ChasmNode{
+			"": {
+				Metadata: &persistencespb.ChasmNodeMetadata{
+					InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 1},
+					LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 1},
+					Attributes: &persistencespb.ChasmNodeMetadata_ComponentAttributes{
+						ComponentAttributes: &persistencespb.ChasmComponentAttributes{
+							TypeId: testComponentTypeID,
+							SideEffectTasks: []*persistencespb.ChasmComponentAttributes_Task{
+								{ // timer side-effect task, already-created status must be reset & regenerated
+									TypeId:                    testSideEffectTaskTypeID,
+									ScheduledTime:             timestamppb.New(baseTime.Add(2 * time.Hour)),
+									VersionedTransition:       &persistencespb.VersionedTransition{TransitionCount: 1},
+									VersionedTransitionOffset: 1,
+									PhysicalTaskStatus:        physicalTaskStatusCreated,
+								},
+								{ // transfer (no scheduled time) task: not a timer, must be skipped
+									TypeId:                    testSideEffectTaskTypeID,
+									VersionedTransition:       &persistencespb.VersionedTransition{TransitionCount: 1},
+									VersionedTransitionOffset: 2,
+									PhysicalTaskStatus:        physicalTaskStatusCreated,
+								},
+							},
+							PureTasks: []*persistencespb.ChasmComponentAttributes_Task{
+								{ // later pure task on the root
+									TypeId:                    testPureTaskTypeID,
+									ScheduledTime:             timestamppb.New(baseTime.Add(2 * time.Hour)),
+									VersionedTransition:       &persistencespb.VersionedTransition{TransitionCount: 1},
+									VersionedTransitionOffset: 3,
+									PhysicalTaskStatus:        physicalTaskStatusCreated,
+								},
+							},
+						},
+					},
+				},
+			},
+			"SubComponent1": {
+				Metadata: &persistencespb.ChasmNodeMetadata{
+					InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 1},
+					LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 1},
+					Attributes: &persistencespb.ChasmNodeMetadata_ComponentAttributes{
+						ComponentAttributes: &persistencespb.ChasmComponentAttributes{
+							TypeId: testSubComponent1TypeID,
+							PureTasks: []*persistencespb.ChasmComponentAttributes_Task{
+								{ // earliest pure task across the tree
+									TypeId:                    testPureTaskTypeID,
+									ScheduledTime:             timestamppb.New(baseTime.Add(time.Hour)),
+									VersionedTransition:       &persistencespb.VersionedTransition{TransitionCount: 1},
+									VersionedTransitionOffset: 1,
+									PhysicalTaskStatus:        physicalTaskStatusNone,
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+		s.NoError(err)
+
+		s.NoError(root.regenerateTimerTasksForTimeSkipping())
+
+		// One physical task for the timer side-effect task + one for the single earliest pure task.
+		s.Equal(2, s.nodeBackend.NumTasksAdded())
+		s.Equal(baseTime.Add(time.Hour).UTC(), s.nodeBackend.LastDeletePureTaskCall(),
+			"pure-task deletion is anchored at the earliest pure scheduled time")
+
+		rootAttrs := root.serializedNode.Metadata.GetComponentAttributes()
+		s.Equal(physicalTaskStatusCreated, rootAttrs.SideEffectTasks[0].PhysicalTaskStatus,
+			"the timer side-effect task must be regenerated")
+		s.Equal(physicalTaskStatusCreated, rootAttrs.SideEffectTasks[1].PhysicalTaskStatus,
+			"the non-timer side-effect task is untouched and keeps its created status")
+		s.Equal(physicalTaskStatusCreated, rootAttrs.PureTasks[0].PhysicalTaskStatus,
+			"a non-earliest pure task is left untouched and not regenerated")
+
+		childAttrs := root.children["SubComponent1"].serializedNode.Metadata.GetComponentAttributes()
+		s.Equal(physicalTaskStatusCreated, childAttrs.PureTasks[0].PhysicalTaskStatus,
+			"the earliest pure task gets a physical task")
+	})
+
+	s.Run("NoPureTasksDeletesWithMaximumKey", func() {
+		s.nodeBackend = &MockNodeBackend{}
+		s.nodeBackend.HandleNow = s.timeSource.Now
+		s.timeSource.Update(baseTime)
+
+		root, err := s.newTestTree(map[string]*persistencespb.ChasmNode{
+			"": {
+				Metadata: &persistencespb.ChasmNodeMetadata{
+					InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 1},
+					LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 1},
+					Attributes: &persistencespb.ChasmNodeMetadata_ComponentAttributes{
+						ComponentAttributes: &persistencespb.ChasmComponentAttributes{
+							TypeId: testComponentTypeID,
+							SideEffectTasks: []*persistencespb.ChasmComponentAttributes_Task{
+								{
+									TypeId:                    testSideEffectTaskTypeID,
+									ScheduledTime:             timestamppb.New(baseTime.Add(time.Hour)),
+									VersionedTransition:       &persistencespb.VersionedTransition{TransitionCount: 1},
+									VersionedTransitionOffset: 1,
+									PhysicalTaskStatus:        physicalTaskStatusNone,
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+		s.NoError(err)
+
+		s.NoError(root.regenerateTimerTasksForTimeSkipping())
+
+		s.Equal(1, s.nodeBackend.NumTasksAdded(), "only the side-effect timer task is regenerated")
+		s.Equal(tasks.MaximumKey.FireTime, s.nodeBackend.LastDeletePureTaskCall(),
+			"with no pure tasks, deletion sweeps up to the maximum key")
+	})
+
+	s.Run("RegeneratesAlreadyCreatedEarliestPureTask", func() {
+		// The earliest pure task already carries physicalTaskStatusCreated from a prior
+		// transaction. Regeneration must reset it so closeTransactionGeneratePhysicalPureTask
+		// does not short-circuit and instead re-adds the physical task at the skipped time.
+		s.nodeBackend = &MockNodeBackend{}
+		s.nodeBackend.HandleNow = s.timeSource.Now
+		s.timeSource.Update(baseTime)
+
+		root, err := s.newTestTree(map[string]*persistencespb.ChasmNode{
+			"": {
+				Metadata: &persistencespb.ChasmNodeMetadata{
+					InitialVersionedTransition:    &persistencespb.VersionedTransition{TransitionCount: 1},
+					LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 1},
+					Attributes: &persistencespb.ChasmNodeMetadata_ComponentAttributes{
+						ComponentAttributes: &persistencespb.ChasmComponentAttributes{
+							TypeId: testComponentTypeID,
+							PureTasks: []*persistencespb.ChasmComponentAttributes_Task{
+								{
+									TypeId:                    testPureTaskTypeID,
+									ScheduledTime:             timestamppb.New(baseTime.Add(time.Hour)),
+									VersionedTransition:       &persistencespb.VersionedTransition{TransitionCount: 1},
+									VersionedTransitionOffset: 1,
+									PhysicalTaskStatus:        physicalTaskStatusCreated,
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+		s.NoError(err)
+
+		s.NoError(root.regenerateTimerTasksForTimeSkipping())
+
+		s.Equal(1, s.nodeBackend.NumTasksAdded(),
+			"the already-created earliest pure task is reset and regenerated, not short-circuited")
+		s.Equal(baseTime.Add(time.Hour).UTC(), s.nodeBackend.LastDeletePureTaskCall(),
+			"pure-task deletion is anchored at the earliest pure scheduled time")
+
+		rootAttrs := root.serializedNode.Metadata.GetComponentAttributes()
+		s.Equal(physicalTaskStatusCreated, rootAttrs.PureTasks[0].PhysicalTaskStatus,
+			"the regenerated earliest pure task ends up created again")
+	})
 }

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -3711,6 +3711,11 @@ WorkerActivitiesPerSecond, MaxConcurrentActivityTaskPollers.
 		false,
 		`WorkflowTimeSkippingEnabled is a "feature enable" flag. When enabled it allows clients to skip time in executions.`,
 	)
+	ScheduleTimeSkippingEnabled = NewNamespaceBoolSetting(
+		"frontend.ScheduleTimeSkippingEnabled",
+		false,
+		`ScheduleTimeSkippingEnabled is a namespace-level feature flag that allows time skipping for schedules.`,
+	)
 	WorkflowTimeSkippingMaxSkipPerSession = NewNamespaceIntSetting(
 		"frontend.WorkflowTimeSkippingMaxSkipPerSession",
 		200,

--- a/common/util.go
+++ b/common/util.go
@@ -568,16 +568,17 @@ func CreateHistoryStartWorkflowRequest(
 		startRequest = CloneProto(startRequest)
 	}
 	histRequest := &historyservice.StartWorkflowExecutionRequest{
-		NamespaceId:              namespaceID,
-		StartRequest:             startRequest,
-		ContinueAsNewInitiator:   enumspb.CONTINUE_AS_NEW_INITIATOR_UNSPECIFIED,
-		Attempt:                  1,
-		ParentExecutionInfo:      parentExecutionInfo,
-		FirstWorkflowTaskBackoff: durationpb.New(backoff.GetBackoffForNextScheduleNonNegative(startRequest.GetCronSchedule(), now, now)),
-		ContinuedFailure:         startRequest.ContinuedFailure,
-		LastCompletionResult:     startRequest.LastCompletionResult,
-		RootExecutionInfo:        rootExecutionInfo,
-		VersioningOverride:       startRequest.GetVersioningOverride(),
+		NamespaceId:                  namespaceID,
+		StartRequest:                 startRequest,
+		ContinueAsNewInitiator:       enumspb.CONTINUE_AS_NEW_INITIATOR_UNSPECIFIED,
+		Attempt:                      1,
+		ParentExecutionInfo:          parentExecutionInfo,
+		FirstWorkflowTaskBackoff:     durationpb.New(backoff.GetBackoffForNextScheduleNonNegative(startRequest.GetCronSchedule(), now, now)),
+		ContinuedFailure:             startRequest.ContinuedFailure,
+		LastCompletionResult:         startRequest.LastCompletionResult,
+		RootExecutionInfo:            rootExecutionInfo,
+		VersioningOverride:           startRequest.GetVersioningOverride(),
+		TimeSkippingStatePropagation: startRequest.GetTimeSkippingStatePropagation(),
 	}
 	startRequest.ContinuedFailure = nil
 	startRequest.LastCompletionResult = nil

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
 	historypb "go.temporal.io/api/history/v1"
@@ -21,6 +22,7 @@ import (
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"google.golang.org/protobuf/testing/protopack"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 func TestIsContextDeadlineExceededErr(t *testing.T) {
@@ -647,4 +649,25 @@ func TestCreateHistoryStartWorkflowRequestPayloads(t *testing.T) {
 
 	// ensure the original request object is unmodified
 	require.Equal(t, startRequestClone, startRequest)
+}
+
+func TestCreateHistoryStartWorkflowRequestTimeSkippingStatePropagation(t *testing.T) {
+	state := &commonpb.TimeSkippingStatePropagation{
+		InitialSkippedDuration: durationpb.New(2 * time.Hour),
+	}
+	startRequest := &workflowservice.StartWorkflowExecutionRequest{
+		Namespace:                    uuid.NewString(),
+		WorkflowId:                   uuid.NewString(),
+		TimeSkippingStatePropagation: state,
+	}
+
+	historyRequest := CreateHistoryStartWorkflowRequest(
+		startRequest.Namespace,
+		startRequest,
+		nil,
+		nil,
+		time.Now(),
+	)
+
+	require.Equal(t, state, historyRequest.GetTimeSkippingStatePropagation())
 }

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.44.0
-	go.temporal.io/api v1.63.5
+	go.temporal.io/api v1.63.6-0.20260823202248-4fc68e4a3223
 	go.temporal.io/auto-scaled-workers v0.0.0-20260811170210-91f6fe1d10ab
 	go.temporal.io/sdk v1.44.0
 	go.uber.org/fx v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -479,8 +479,6 @@ go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0 h1:R
 go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0/go.mod h1:I89cynRj8y+383o7tEQVg2SVA6SRgDVIouWPUVXjx0U=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0 h1:CQvJSldHRUN6Z8jsUeYv8J0lXRvygALXIzsmAeCcZE0=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0/go.mod h1:xSQ+mEfJe/GjK1LXEyVOoSI1N9JV9ZI923X5kup43W4=
-go.temporal.io/api v1.63.5 h1:c11+kPYHkXXL3UiShPdbMD+xtvqGsbTibUA9ypmiCa4=
-go.temporal.io/api v1.63.5/go.mod h1:SrlW2JMwVlDP4nRWSNznUFqnSHd+YeMDS1BkYo63HCQ=
 go.temporal.io/api v1.63.6-0.20260823202248-4fc68e4a3223 h1:EIombLH8gEmJZAqq//2oL7akW5PI4DJ6N59FhUrJtt0=
 go.temporal.io/api v1.63.6-0.20260823202248-4fc68e4a3223/go.mod h1:SrlW2JMwVlDP4nRWSNznUFqnSHd+YeMDS1BkYo63HCQ=
 go.temporal.io/auto-scaled-workers v0.0.0-20260811170210-91f6fe1d10ab h1:99wXW0317BBi49d6xgMdA0EZtvA+xbBUWV4HsTEGEcg=

--- a/go.sum
+++ b/go.sum
@@ -481,6 +481,8 @@ go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0 h1:CQvJSldHRUN
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0/go.mod h1:xSQ+mEfJe/GjK1LXEyVOoSI1N9JV9ZI923X5kup43W4=
 go.temporal.io/api v1.63.5 h1:c11+kPYHkXXL3UiShPdbMD+xtvqGsbTibUA9ypmiCa4=
 go.temporal.io/api v1.63.5/go.mod h1:SrlW2JMwVlDP4nRWSNznUFqnSHd+YeMDS1BkYo63HCQ=
+go.temporal.io/api v1.63.6-0.20260823202248-4fc68e4a3223 h1:EIombLH8gEmJZAqq//2oL7akW5PI4DJ6N59FhUrJtt0=
+go.temporal.io/api v1.63.6-0.20260823202248-4fc68e4a3223/go.mod h1:SrlW2JMwVlDP4nRWSNznUFqnSHd+YeMDS1BkYo63HCQ=
 go.temporal.io/auto-scaled-workers v0.0.0-20260811170210-91f6fe1d10ab h1:99wXW0317BBi49d6xgMdA0EZtvA+xbBUWV4HsTEGEcg=
 go.temporal.io/auto-scaled-workers v0.0.0-20260811170210-91f6fe1d10ab/go.mod h1:hhHijO9XRPIkAflLJJHix61M9FzbRPqk8fSydkcLkqw=
 go.temporal.io/sdk v1.44.0 h1:suitPDukX74rW3/N1FqvEbZTZVJJsxMKhv0KMa/j7pU=

--- a/service/frontend/errors.go
+++ b/service/frontend/errors.go
@@ -116,5 +116,6 @@ var (
 	errListHistoryTasksNotAllowed = serviceerror.NewPermissionDenied("ListHistoryTasks feature is disabled on this cluster.", "")
 
 	errWorkflowTimeSkippingNotEnabled  = serviceerror.NewUnimplemented("The Time-Skipping feature is not enabled for namespace.")
+	errScheduleTimeSkippingNotEnabled  = serviceerror.NewUnimplemented("Schedule time skipping is not enabled for namespace.")
 	errTimeSkippingFastForwardIDNotSet = serviceerror.NewInvalidArgument("Time skipping config invalid: fast_forward_id must be set")
 )

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -248,6 +248,7 @@ type Config struct {
 	PollerAutoscalingAutoEnroll             dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	WorkflowPauseEnabled                    dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	WorkflowTimeSkippingEnabled             dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	ScheduleTimeSkippingEnabled             dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	WorkflowTimeSkippingMaxSkipPerSession   dynamicconfig.IntPropertyFnWithNamespaceFilter
 	StandaloneNexusOperationsEnabled        dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	EnableWorkflowTaskCompletionPagination  dynamicconfig.BoolPropertyFnWithNamespaceFilter
@@ -438,6 +439,7 @@ func NewConfig(
 		PollerAutoscalingAutoEnroll:             dynamicconfig.PollerAutoscalingAutoEnroll.Get(dc),
 		WorkflowPauseEnabled:                    dynamicconfig.WorkflowPauseEnabled.Get(dc),
 		WorkflowTimeSkippingEnabled:             dynamicconfig.WorkflowTimeSkippingEnabled.Get(dc),
+		ScheduleTimeSkippingEnabled:             dynamicconfig.ScheduleTimeSkippingEnabled.Get(dc),
 		WorkflowTimeSkippingMaxSkipPerSession:   dynamicconfig.WorkflowTimeSkippingMaxSkipPerSession.Get(dc),
 		StandaloneNexusOperationsEnabled:        chasmnexus.Enabled.Get(dc),
 		EnableWorkflowTaskCompletionPagination:  dynamicconfig.EnableWorkflowTaskCompletionPagination.Get(dc),

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -4611,6 +4611,7 @@ func (wh *WorkflowHandler) describeScheduleWorkflow(ctx context.Context, request
 		return nil, serviceerror.NewInternalf("describe schedule: %v", err)
 	}
 	// Search attributes in the Action are already in external ("aliased") form. Do not alias them here.
+	queryResponse.Info.TimeSkippingInfo = describeResponse.GetWorkflowExtendedInfo().GetTimeSkippingInfo()
 
 	// for all running workflows started by the schedule, we should check that they're still running
 	origLen := len(queryResponse.Info.RunningWorkflows)

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -3781,6 +3781,7 @@ func (wh *WorkflowHandler) createScheduleWorkflow(
 		Memo:                     request.Memo,
 		SearchAttributes:         sa,
 		Priority:                 &commonpb.Priority{}, // ie default priority
+		TimeSkippingConfig:       request.Schedule.GetTimeSkippingConfig(),
 	}
 	_, err = wh.historyClient.StartWorkflowExecution(
 		ctx,
@@ -4867,6 +4868,21 @@ func (wh *WorkflowHandler) updateScheduleWorkflow(
 			Input:             inputPayloads,
 			Identity:          request.Identity,
 			RequestId:         request.RequestId,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	_, err = wh.historyClient.UpdateWorkflowExecutionOptions(ctx, &historyservice.UpdateWorkflowExecutionOptionsRequest{
+		NamespaceId: namespaceID.String(),
+		UpdateRequest: &workflowservice.UpdateWorkflowExecutionOptionsRequest{
+			Namespace:         request.Namespace,
+			WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: workflowID},
+			WorkflowExecutionOptions: &workflowpb.WorkflowExecutionOptions{
+				TimeSkippingConfig: request.Schedule.GetTimeSkippingConfig(),
+			},
+			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"time_skipping_config"}},
+			Identity:   request.Identity,
 		},
 	})
 	if err != nil {

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -113,6 +113,7 @@ const (
 	maxReasonLength              = 1000 // Maximum length for the reason field in RateLimitUpdate configurations.
 	defaultUserTerminateReason   = "terminated by user via frontend"
 	defaultUserTerminateIdentity = "frontend-service"
+	maxScheduleFastForward       = 365 * 24 * time.Hour
 )
 
 type (
@@ -706,6 +707,8 @@ func (wh *WorkflowHandler) prepareStartWorkflowRequest(
 		return nil, err
 	}
 
+	// TODO(time-skipping): Accept TimeSkippingStatePropagation only from trusted server callers such as
+	// schedules starting workflows; external clients must not be allowed to set this internal field.
 	if err := wh.validateAndPopulateTimeSkippingConfig(request.GetTimeSkippingConfig(), namespaceName); err != nil {
 		return nil, err
 	}
@@ -742,6 +745,35 @@ func (wh *WorkflowHandler) validateAndPopulateTimeSkippingConfig(
 			return serviceerror.NewInvalidArgument("time_skipping_config: cannot set fast_forward when enabled is false")
 		}
 		return nil
+	}
+	return nil
+}
+
+func (wh *WorkflowHandler) validateAndPopulateScheduleTimeSkippingConfig(
+	schedule *schedulepb.Schedule,
+	ns namespace.Name,
+) error {
+	config := schedule.GetTimeSkippingConfig()
+	if config == nil {
+		return nil
+	}
+	if !wh.config.ScheduleTimeSkippingEnabled(ns.String()) {
+		return errScheduleTimeSkippingNotEnabled
+	}
+	if err := wh.validateAndPopulateTimeSkippingConfig(config, ns); err != nil {
+		return err
+	}
+	if !config.GetEnabled() {
+		return nil
+	}
+	fastForward := config.GetFastForwardConfig()
+	if fastForward == nil {
+		return serviceerror.NewInvalidArgument(
+			"schedule time_skipping_config: fast_forward_config is required when enabled")
+	}
+	if fastForward.GetDuration().AsDuration() > maxScheduleFastForward {
+		return serviceerror.NewInvalidArgument(
+			"schedule time_skipping_config: fast_forward duration cannot exceed 365 days")
 	}
 	return nil
 }
@@ -3908,6 +3940,9 @@ func (wh *WorkflowHandler) CreateSchedule(
 	if err != nil {
 		return nil, err
 	}
+	if err = wh.validateAndPopulateScheduleTimeSkippingConfig(request.Schedule, namespaceName); err != nil {
+		return nil, err
+	}
 
 	if err = wh.validateStartWorkflowArgsForSchedule(namespaceName, request.GetSchedule().GetAction().GetStartWorkflow()); err != nil {
 		return nil, err
@@ -4721,6 +4756,9 @@ func (wh *WorkflowHandler) UpdateSchedule(
 	}
 	err := wh.canonicalizeScheduleSpec(request.Schedule, namespaceName.String())
 	if err != nil {
+		return nil, err
+	}
+	if err = wh.validateAndPopulateScheduleTimeSkippingConfig(request.Schedule, namespaceName); err != nil {
 		return nil, err
 	}
 

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -3948,6 +3948,50 @@ func (s *WorkflowHandlerSuite) TestValidateTimeSkippingConfig() {
 	s.Require().Equal(int32(999), tsc.GetMaxSessionSkipCount())
 }
 
+func (s *WorkflowHandlerSuite) TestValidateScheduleTimeSkippingConfig() {
+	config := s.newConfig()
+	config.WorkflowTimeSkippingEnabled = dc.GetBoolPropertyFnFilteredByNamespace(true)
+	config.ScheduleTimeSkippingEnabled = dc.GetBoolPropertyFnFilteredByNamespace(false)
+	wh := s.getWorkflowHandler(config)
+	s.Require().ErrorIs(
+		wh.validateAndPopulateScheduleTimeSkippingConfig(
+			&schedulepb.Schedule{TimeSkippingConfig: &commonpb.TimeSkippingConfig{Enabled: true}},
+			s.testNamespace,
+		),
+		errScheduleTimeSkippingNotEnabled,
+	)
+
+	config.ScheduleTimeSkippingEnabled = dc.GetBoolPropertyFnFilteredByNamespace(true)
+	wh = s.getWorkflowHandler(config)
+
+	testCases := []struct {
+		name    string
+		config  *commonpb.TimeSkippingConfig
+		wantErr bool
+	}{
+		{name: "unset"},
+		{name: "disabled", config: &commonpb.TimeSkippingConfig{Enabled: false}},
+		{name: "enabled without fast forward", config: &commonpb.TimeSkippingConfig{Enabled: true}, wantErr: true},
+		{name: "one year", config: &commonpb.TimeSkippingConfig{Enabled: true, FastForwardConfig: &commonpb.FastForwardConfig{
+			Id: "one-year", Duration: durationpb.New(365 * 24 * time.Hour),
+		}}},
+		{name: "over one year", config: &commonpb.TimeSkippingConfig{Enabled: true, FastForwardConfig: &commonpb.FastForwardConfig{
+			Id: "over-one-year", Duration: durationpb.New(365*24*time.Hour + time.Second),
+		}}, wantErr: true},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			err := wh.validateAndPopulateScheduleTimeSkippingConfig(
+				&schedulepb.Schedule{TimeSkippingConfig: tc.config}, s.testNamespace)
+			if tc.wantErr {
+				s.Require().Error(err)
+			} else {
+				s.Require().NoError(err)
+			}
+		})
+	}
+}
+
 func (s *WorkflowHandlerSuite) TestPollWorkflowExecutionTimeSkipping() {
 	validExecution := &commonpb.WorkflowExecution{WorkflowId: "wf-id"}
 	newReq := func(fastForwardID string) *workflowservice.PollWorkflowExecutionTimeSkippingRequest {

--- a/service/history/timer_queue_active_task_executor_test.go
+++ b/service/history/timer_queue_active_task_executor_test.go
@@ -2044,6 +2044,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestExecuteChasmPureTimerTask_Execut
 		WorkflowId: tests.WorkflowKey.WorkflowID,
 		RunId:      tests.WorkflowKey.RunID,
 	}
+	virtualNow := s.now.Add(5 * time.Hour)
 
 	// Mock the CHASM tree and execute interface.
 	mockEach := &chasm.MockNodePureTask{
@@ -2052,7 +2053,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestExecuteChasmPureTimerTask_Execut
 		},
 	}
 	chasmTree := historyi.NewMockChasmTree(s.controller)
-	chasmTree.EXPECT().EachPureTask(gomock.Any(), gomock.Any()).
+	chasmTree.EXPECT().EachPureTask(virtualNow, gomock.Any()).
 		Times(1).Do(
 		func(_ time.Time, callback func(executor chasm.NodePureTask, taskAttributes chasm.TaskAttributes, task any) (bool, error)) error {
 			_, err := callback(mockEach, chasm.TaskAttributes{}, nil)
@@ -2071,7 +2072,7 @@ func (s *timerQueueActiveTaskExecutorSuite) TestExecuteChasmPureTimerTask_Execut
 		&persistencespb.WorkflowExecutionState{Status: enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING},
 	).AnyTimes()
 	ms.EXPECT().ChasmTree().Return(chasmTree).AnyTimes()
-	ms.EXPECT().Now().Return(s.now).AnyTimes()
+	ms.EXPECT().Now().Return(virtualNow).AnyTimes()
 
 	// Add a valid timer task.
 	timerTask := &tasks.ChasmTaskPure{

--- a/service/history/timer_queue_task_executor_base.go
+++ b/service/history/timer_queue_task_executor_base.go
@@ -18,7 +18,6 @@ import (
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/resource"
-	"go.temporal.io/server/common/util"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/deletemanager"
@@ -275,13 +274,10 @@ func (t *timerQueueTaskExecutorBase) executeChasmPureTimers(
 		return errNoChasmTree
 	}
 
-	// Because the persistence layer can lose precision on the task compared to the
-	// physical task stored in the queue, we take the max of both here. Time is also
-	// truncated to a common (millisecond) precision later on.
-	//
-	// See also queues.IsTimeExpired.
-	// TODO@time-skipping: hasn's supported time skipping for CHASM system yet
-	referenceTime := util.MaxTime(t.Now(), task.GetKey().FireTime)
+	// CHASM task timestamps and mutable-state time share the virtual frame. The
+	// queue task's fire time has already been converted back to wall-clock time,
+	// so comparing it here would miss timers made due by a time skip.
+	referenceTime := ms.Now()
 
 	return tree.EachPureTask(referenceTime, callback)
 }

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -6461,7 +6461,7 @@ func (ms *MutableStateImpl) AddStartChildWorkflowExecutionInitiatedEvent(
 	if err := ms.checkMutability(opTag); err != nil {
 		return nil, nil, err
 	}
-	childTSC, childTSStateProp := propagateTimeSkippingToOtherExecution(ms.GetExecutionInfo().GetTimeSkippingInfo())
+	childTSC, childTSStateProp := chasm.PropagateTimeSkippingToOtherExecution(ms.GetExecutionInfo().GetTimeSkippingInfo())
 	event, batchID := ms.hBuilder.AddStartChildWorkflowExecutionInitiatedEvent(
 		workflowTaskCompletedEventID,
 		command,

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -429,7 +429,6 @@ func NewMutableState(
 	if s.config.EnableChasm(namespaceName) {
 		s.chasmTree = chasm.NewEmptyTree(
 			shard.ChasmRegistry(),
-			shard.GetTimeSource(),
 			s,
 			chasm.DefaultPathEncoder,
 			logger,
@@ -588,7 +587,6 @@ func NewMutableStateFromDB(
 		mutableState.chasmTree, err = chasm.NewTreeFromDB(
 			dbRecord.ChasmNodes,
 			shard.ChasmRegistry(),
-			shard.GetTimeSource(),
 			mutableState,
 			chasm.DefaultPathEncoder,
 			mutableState.logger, // this logger is tagged with execution key.

--- a/service/history/workflow/timeskipping.go
+++ b/service/history/workflow/timeskipping.go
@@ -9,6 +9,7 @@ import (
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/serviceerror"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/log/tag"
@@ -55,6 +56,14 @@ func (ms *MutableStateImpl) updateTimeSkippingInfo(
 	tsi.SessionSkipCount = 0
 	ms.applyFastForward(nil)
 	ms.timeSkippingInfoUpdated = true
+}
+
+func (ms *MutableStateImpl) SetTimeSkippingConfig(config *commonpb.TimeSkippingConfig) {
+	if ms.executionInfo.GetTimeSkippingInfo() == nil {
+		ms.initTimeSkippingInfo(config, nil)
+	} else {
+		ms.updateTimeSkippingInfo(config)
+	}
 }
 
 // applyFastForward (re)computes the FastForwardInfo using the new TimeSkippingConfig (TSC) and propagated time-skippingstates.
@@ -440,8 +449,8 @@ func (ms *MutableStateImpl) isWorkflowSkippable() bool {
 // findNextSkipTarget finds the next skip target from the pending timers, activity-retries,
 // workflow backoff timers, and workflow execution timeout, etc that those are skippable and scheduled in the future
 // it should only be called after isWorkflowSkippable returns true
-func (ms *MutableStateImpl) findNextSkipTarget() *timeSkippingTransition {
-	transition := NewTimeSkippingTransition(ms.Now())
+func (ms *MutableStateImpl) findNextSkipTarget() *chasm.TimeSkippingTransition {
+	transition := chasm.NewTimeSkippingTransition(ms.Now())
 	for _, timerInfo := range ms.GetPendingTimerInfos() {
 		transition.TrackEarliestFutureTime(timerInfo.ExpiryTime.AsTime())
 	}
@@ -515,7 +524,7 @@ func (ms *MutableStateImpl) closeTransactionHandleWorkflowTimeSkipping(
 		}
 		// 3. state change.
 		_, err := ms.AddWorkflowExecutionTimeSkippingTransitionedEvent(
-			ctx, transition.TargetTime, transition.DisabledAfterFastForward)
+			ctx, transition.GetTargetTime(), transition.DisabledAfterFastForward)
 		if err != nil {
 			ms.logger.Error("failed to add workflow execution time skipping transitioned event", tag.Error(err))
 			return false
@@ -593,4 +602,32 @@ func (ms *MutableStateImpl) closeTransactionRegenTimerTasksForWorkflowTimeSkippi
 	default:
 		return serviceerror.NewInternalf("unknown transaction policy: %v", transactionPolicy)
 	}
+}
+
+func (ms *MutableStateImpl) RecordTimeSkippingTransition(transition *chasm.TimeSkippingTransition) {
+	if ms.IsWorkflow() || !transition.IsValid() {
+		return
+	}
+
+	tsi := ms.executionInfo.GetTimeSkippingInfo()
+	if tsi == nil {
+		return
+	}
+
+	if !transition.GetTargetTime().IsZero() {
+		tsi.AccumulatedSkippedDuration = durationpb.New(
+			ms.accumulatedSkippedDuration() + transition.GetSkippedDuration())
+	}
+	if transition.DisabledAfterFastForward && tsi.GetFastForwardInfo() != nil {
+		reachedFFInfo := tsi.GetFastForwardInfo()
+		reachedFFInfo.HasReached = true
+		ms.setAndStampFastForwardInfo(reachedFFInfo)
+		tsi.Config.Enabled = false
+	}
+
+	tsi.SessionSkipCount++
+	if tsi.SessionSkipCount >= tsi.GetConfig().GetMaxSessionSkipCount() && tsi.GetConfig().GetEnabled() {
+		tsi.Config.Enabled = false
+	}
+	ms.timeSkippingInfoUpdated = true
 }

--- a/service/history/workflow/timeskipping.go
+++ b/service/history/workflow/timeskipping.go
@@ -161,38 +161,6 @@ func propagateTimeSkippingToNextRun(
 	return newTSC, stateProp
 }
 
-// propagateTimeSkippingToOtherExecution snapshots the current execution's time skipping into another
-// execution (e.g. a child workflow), which shares the current execution's virtual clock. Two rules:
-//  1. State: nothing propagates except virtual time.
-//  2. Config: everything propagates except the fast-forward config, and the whole config can be
-//     suppressed by DisablePropagation.
-func propagateTimeSkippingToOtherExecution(
-	tsi *persistencespb.TimeSkippingInfo,
-) (*commonpb.TimeSkippingConfig, *commonpb.TimeSkippingStatePropagation) {
-	if tsi == nil {
-		return nil, nil
-	}
-	tsc := tsi.GetConfig()
-	accum := NewTimeSkippingInfoUtil(tsi).GetAccumulatedSkippedDuration()
-
-	var stateProp *commonpb.TimeSkippingStatePropagation
-	if accum > 0 {
-		stateProp = &commonpb.TimeSkippingStatePropagation{
-			InitialSkippedDuration: durationpb.New(accum),
-			InitialSkipCount:       0,
-		}
-	}
-
-	if tsc == nil || tsc.GetDisablePropagation() {
-		return nil, stateProp
-	}
-
-	// Propagate the whole config except the per-execution fast-forward.
-	newTSC := common.CloneProto(tsc)
-	newTSC.FastForwardConfig = nil
-	return newTSC, stateProp
-}
-
 // =============================================================================
 // Time Skipping Runtime Time Impacts
 // =============================================================================

--- a/service/history/workflow/timeskipping_test.go
+++ b/service/history/workflow/timeskipping_test.go
@@ -184,7 +184,7 @@ func (s *mutableStateSuite) TestPropagateTimeSkippingToNextRun() {
 
 	s.Run("DisablePropagationFlag_PreservedInChainOfRuns", func() {
 		// Chain-of-runs clones the full config, so DisablePropagation is preserved. Contrast with
-		// propagateTimeSkippingToOtherExecution, which never carries the flag onto a child config.
+		// chasm.PropagateTimeSkippingToOtherExecution, which never carries the flag onto a child config.
 		tsi := &persistencespb.TimeSkippingInfo{
 			Config: &commonpb.TimeSkippingConfig{
 				Enabled:             true,
@@ -221,7 +221,7 @@ func (s *mutableStateSuite) TestPropagateTimeSkippingToOtherExecution() {
 	}
 
 	s.Run("NilTimeSkippingInfo_PropagatesNothing", func() {
-		tsc, propagatedState := propagateTimeSkippingToOtherExecution(nil)
+		tsc, propagatedState := chasm.PropagateTimeSkippingToOtherExecution(nil)
 		s.Nil(tsc)
 		s.Nil(propagatedState)
 		s.requireInitNoPanic(tsc, propagatedState)
@@ -229,7 +229,7 @@ func (s *mutableStateSuite) TestPropagateTimeSkippingToOtherExecution() {
 
 	s.Run("FullState_PropagatesConfigAndVirtualTime", func() {
 		tsi := newTSI()
-		tsc, propagatedState := propagateTimeSkippingToOtherExecution(tsi)
+		tsc, propagatedState := chasm.PropagateTimeSkippingToOtherExecution(tsi)
 		s.Require().NotNil(tsc)
 		s.True(tsc.GetEnabled())
 		// no fast-forward
@@ -245,7 +245,7 @@ func (s *mutableStateSuite) TestPropagateTimeSkippingToOtherExecution() {
 
 	s.Run("FastForward_NeverPropagatedToChild", func() {
 		tsi := newTSI() // enabled parent carrying an active, unreached fast-forward
-		tsc, propagatedState := propagateTimeSkippingToOtherExecution(tsi)
+		tsc, propagatedState := chasm.PropagateTimeSkippingToOtherExecution(tsi)
 		s.Require().NotNil(tsc)
 		s.Nil(tsc.GetFastForwardConfig(), "child never inherits the fast-forward config")
 		s.Require().NotNil(propagatedState)
@@ -258,7 +258,7 @@ func (s *mutableStateSuite) TestPropagateTimeSkippingToOtherExecution() {
 		// Config only propagates when !DisablePropagation, so the flag is structurally always
 		// false on a propagated child config -- there is nothing to carry down the tree.
 		tsi := newTSI()
-		tsc, propagatedState := propagateTimeSkippingToOtherExecution(tsi)
+		tsc, propagatedState := chasm.PropagateTimeSkippingToOtherExecution(tsi)
 		s.Require().NotNil(tsc)
 		s.False(tsc.GetDisablePropagation())
 		s.requireInitNoPanic(tsc, propagatedState)
@@ -267,7 +267,7 @@ func (s *mutableStateSuite) TestPropagateTimeSkippingToOtherExecution() {
 	s.Run("DisablePropagationSet_NoConfigPropagated", func() {
 		tsi := newTSI()
 		tsi.Config.DisablePropagation = true
-		tsc, propagatedState := propagateTimeSkippingToOtherExecution(tsi)
+		tsc, propagatedState := chasm.PropagateTimeSkippingToOtherExecution(tsi)
 		s.Nil(tsc)
 		s.Require().NotNil(propagatedState)
 		s.Equal(accumSkip, propagatedState.GetInitialSkippedDuration().AsDuration())
@@ -279,7 +279,7 @@ func (s *mutableStateSuite) TestPropagateTimeSkippingToOtherExecution() {
 	s.Run("NilConfig_PropagatesVirtualTime", func() {
 		tsi := newTSI()
 		tsi.Config = nil
-		tsc, propagatedState := propagateTimeSkippingToOtherExecution(tsi)
+		tsc, propagatedState := chasm.PropagateTimeSkippingToOtherExecution(tsi)
 		s.Nil(tsc)
 		s.Require().NotNil(propagatedState)
 		s.Equal(int32(0), propagatedState.GetInitialSkipCount())
@@ -292,7 +292,7 @@ func (s *mutableStateSuite) TestPropagateTimeSkippingToOtherExecution() {
 	s.Run("DisabledParentConfig_PropagatesDisabledConfig", func() {
 		tsi := newTSI()
 		tsi.Config.Enabled = false
-		tsc, propagatedState := propagateTimeSkippingToOtherExecution(tsi)
+		tsc, propagatedState := chasm.PropagateTimeSkippingToOtherExecution(tsi)
 		// enabled is copied through: a disabled-but-propagating parent hands the child a disabled config.
 		s.Require().NotNil(tsc)
 		s.False(tsc.GetEnabled())
@@ -309,7 +309,7 @@ func (s *mutableStateSuite) TestPropagateTimeSkippingToOtherExecution() {
 	s.Run("ZeroAccumulatedSkip_ConfigButNilState", func() {
 		tsi := newTSI()
 		tsi.AccumulatedSkippedDuration = nil
-		tsc, propagatedState := propagateTimeSkippingToOtherExecution(tsi)
+		tsc, propagatedState := chasm.PropagateTimeSkippingToOtherExecution(tsi)
 		s.Require().NotNil(tsc, "an enabled config still propagates with no accumulated skip")
 		s.True(tsc.GetEnabled())
 		s.Nil(propagatedState, "no accumulated skip -> no state to propagate")

--- a/service/history/workflow/timeskipping_test.go
+++ b/service/history/workflow/timeskipping_test.go
@@ -11,6 +11,7 @@ import (
 	historypb "go.temporal.io/api/history/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/activity"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/clock"
@@ -1004,7 +1005,7 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 	s.Run("NilTimeSkippingInfo_NoPanic", func() {
 		resetMS()
 		s.mutableState.executionInfo.TimeSkippingInfo = nil
-		var tr *timeSkippingTransition
+		var tr *chasm.TimeSkippingTransition
 		s.NotPanics(func() { tr = s.mutableState.findNextSkipTarget() })
 		s.Nil(tr, "nil TimeSkippingInfo with no candidates yields no transition")
 	})
@@ -1032,7 +1033,7 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 
 		tr := s.mutableState.findNextSkipTarget()
 		s.Require().NotNil(tr)
-		s.Equal(t1, tr.TargetTime)
+		s.Equal(t1, tr.GetTargetTime())
 		s.False(tr.DisabledAfterFastForward)
 	})
 
@@ -1043,7 +1044,7 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 
 		tr := s.mutableState.findNextSkipTarget()
 		s.Require().NotNil(tr)
-		s.Equal(baseTime.Add(2*time.Hour), tr.TargetTime)
+		s.Equal(baseTime.Add(2*time.Hour), tr.GetTargetTime())
 	})
 
 	s.Run("UserTimerAndEarlierFastForward_TargetIsFastForward", func() {
@@ -1054,7 +1055,7 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 
 		tr := s.mutableState.findNextSkipTarget()
 		s.Require().NotNil(tr)
-		s.Equal(fastForwardTarget, tr.TargetTime)
+		s.Equal(fastForwardTarget, tr.GetTargetTime())
 		// The fast-forward is the earliest target (earlier than the timer), so skipping to it
 		// consumes the budget and disables time skipping on this transition.
 		s.True(tr.DisabledAfterFastForward)
@@ -1071,7 +1072,7 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 
 		tr := s.mutableState.findNextSkipTarget()
 		s.Require().NotNil(tr)
-		s.Equal(execTime, tr.TargetTime)
+		s.Equal(execTime, tr.GetTargetTime())
 		s.False(tr.DisabledAfterFastForward)
 	})
 
@@ -1114,7 +1115,7 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 
 		tr := s.mutableState.findNextSkipTarget()
 		s.Require().NotNil(tr)
-		s.Equal(schedTime, tr.TargetTime)
+		s.Equal(schedTime, tr.GetTargetTime())
 		s.False(tr.DisabledAfterFastForward)
 	})
 
@@ -1133,7 +1134,7 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 
 		tr := s.mutableState.findNextSkipTarget()
 		s.Require().NotNil(tr)
-		s.Equal(early, tr.TargetTime)
+		s.Equal(early, tr.GetTargetTime())
 	})
 
 	s.Run("ActivityBackoffAndEarlierTimer_TargetIsTimer", func() {
@@ -1147,7 +1148,7 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 
 		tr := s.mutableState.findNextSkipTarget()
 		s.Require().NotNil(tr)
-		s.Equal(timerTime, tr.TargetTime)
+		s.Equal(timerTime, tr.GetTargetTime())
 	})
 
 	s.Run("RunTimeout_IsTarget", func() {
@@ -1157,7 +1158,7 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 
 		tr := s.mutableState.findNextSkipTarget()
 		s.Require().NotNil(tr)
-		s.Equal(runTimeout, tr.TargetTime)
+		s.Equal(runTimeout, tr.GetTargetTime())
 	})
 
 	s.Run("ExecutionTimeout_IsTarget", func() {
@@ -1167,7 +1168,7 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 
 		tr := s.mutableState.findNextSkipTarget()
 		s.Require().NotNil(tr)
-		s.Equal(execTimeout, tr.TargetTime)
+		s.Equal(execTimeout, tr.GetTargetTime())
 	})
 
 	s.Run("RunAndExecutionTimeout_EarliestWins", func() {
@@ -1178,7 +1179,7 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 
 		tr := s.mutableState.findNextSkipTarget()
 		s.Require().NotNil(tr)
-		s.Equal(runTimeout, tr.TargetTime, "the earlier run timeout must win")
+		s.Equal(runTimeout, tr.GetTargetTime(), "the earlier run timeout must win")
 	})
 
 	s.Run("ExpiredTimeouts_NotTargets", func() {
@@ -1197,7 +1198,7 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 
 		tr := s.mutableState.findNextSkipTarget()
 		s.Require().NotNil(tr)
-		s.Equal(runTimeout, tr.TargetTime, "skip is bounded by the earlier run timeout")
+		s.Equal(runTimeout, tr.GetTargetTime(), "skip is bounded by the earlier run timeout")
 		s.False(tr.DisabledAfterFastForward, "fast-forward not reached: it was not the chosen target")
 	})
 
@@ -1209,7 +1210,7 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 
 		tr := s.mutableState.findNextSkipTarget()
 		s.Require().NotNil(tr)
-		s.Equal(fastForwardTarget, tr.TargetTime)
+		s.Equal(fastForwardTarget, tr.GetTargetTime())
 		s.True(tr.DisabledAfterFastForward, "fast-forward is the earliest target: skipping to it disables time skipping")
 	})
 
@@ -1221,7 +1222,7 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 
 		tr := s.mutableState.findNextSkipTarget()
 		s.Require().NotNil(tr)
-		s.Equal(execTimeout, tr.TargetTime, "skip is bounded by the earlier execution timeout")
+		s.Equal(execTimeout, tr.GetTargetTime(), "skip is bounded by the earlier execution timeout")
 		s.False(tr.DisabledAfterFastForward)
 	})
 
@@ -1235,7 +1236,7 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 
 		tr := s.mutableState.findNextSkipTarget()
 		s.Require().NotNil(tr)
-		s.Equal(fastForwardTarget, tr.TargetTime, "a zero-valued timeout must not cap the skip")
+		s.Equal(fastForwardTarget, tr.GetTargetTime(), "a zero-valued timeout must not cap the skip")
 		// The fast-forward is the only (and therefore earliest) target, so it is reached and
 		// time skipping is disabled.
 		s.True(tr.DisabledAfterFastForward)
@@ -1249,7 +1250,7 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 
 		tr := s.mutableState.findNextSkipTarget()
 		s.Require().NotNil(tr)
-		s.True(tr.TargetTime.IsZero())
+		s.True(tr.GetTargetTime().IsZero())
 		s.True(tr.DisabledAfterFastForward)
 	})
 }

--- a/service/worker/scheduler/activities.go
+++ b/service/worker/scheduler/activities.go
@@ -16,6 +16,7 @@ import (
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/server/api/historyservice/v1"
 	schedulespb "go.temporal.io/server/api/schedule/v1"
+	"go.temporal.io/server/chasm"
 	schedulerpb "go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -68,6 +69,9 @@ func (a *activities) StartWorkflow(ctx context.Context, req *schedulespb.StartWo
 	if err := a.waitForRateLimiterPermission(req); err != nil {
 		return nil, err
 	}
+	if err := a.populateTimeSkippingPropagation(ctx, req.Request); err != nil {
+		return nil, err
+	}
 
 	req.Request.Namespace = a.namespace.String()
 
@@ -84,6 +88,38 @@ func (a *activities) StartWorkflow(ctx context.Context, req *schedulespb.StartWo
 		RunId:         res.RunId,
 		RealStartTime: timestamppb.New(now),
 	}, nil
+}
+
+func (a *activities) populateTimeSkippingPropagation(
+	ctx context.Context,
+	request *workflowservice.StartWorkflowExecutionRequest,
+) error {
+	activityInfo := activity.GetInfo(ctx)
+	response, err := a.HistoryClient.DescribeMutableState(ctx, &historyservice.DescribeMutableStateRequest{
+		NamespaceId: a.namespaceID.String(),
+		Execution: &commonpb.WorkflowExecution{
+			WorkflowId: activityInfo.WorkflowExecution.ID,
+			RunId:      activityInfo.WorkflowExecution.RunID,
+		},
+		SkipForceReload: true,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to load scheduler time-skipping state: %w", err)
+	}
+
+	mutableState := response.GetCacheMutableState()
+	if mutableState == nil {
+		mutableState = response.GetDatabaseMutableState()
+	}
+	timeSkippingInfo := mutableState.GetExecutionInfo().GetTimeSkippingInfo()
+	if timeSkippingInfo == nil {
+		request.TimeSkippingConfig = nil
+		request.TimeSkippingStatePropagation = nil
+		return nil
+	}
+	request.TimeSkippingConfig, request.TimeSkippingStatePropagation =
+		chasm.PropagateTimeSkippingToOtherExecution(timeSkippingInfo)
+	return nil
 }
 
 func (a *activities) waitForRateLimiterPermission(req *schedulespb.StartWorkflowRequest) error {

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -1530,6 +1530,7 @@ func (s *scheduler) startWorkflow(
 			ContinuedFailure:         continuedFailure,
 			UserMetadata:             newWorkflow.UserMetadata,
 			Priority:                 newWorkflow.Priority,
+			TimeSkippingConfig:       s.Schedule.GetTimeSkippingConfig(),
 		},
 	}
 	for {

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -420,7 +420,6 @@ func TestScheduleCHASM(t *testing.T) {
 	t.Run("TestUpdateScheduleMemoOnly", func(t *testing.T) { t.Parallel(); testUpdateScheduleMemoOnly(t, newContext) })
 	t.Run("TestStateSizeBytesReported", func(t *testing.T) { t.Parallel(); testStateSizeBytesReported(t, newContext) })
 	t.Run("TestBufferOverrunDropsActions", func(t *testing.T) { t.Parallel(); testBufferOverrunDropsActions(t, newContext) })
-	t.Run("TestTimeSkippingFastForward", func(t *testing.T) { t.Parallel(); testScheduleTimeSkippingFastForward(t, newContext) })
 	t.Run("TestDescribeCatchupWindowAfterCreateAndUpdate", func(t *testing.T) {
 		t.Parallel()
 		testDescribeCatchupWindowAfterCreateAndUpdate(t)
@@ -450,9 +449,46 @@ func TestScheduleCHASM(t *testing.T) {
 	})
 }
 
-func testScheduleTimeSkippingFastForward(t *testing.T, newContext contextFactory) {
-	opts := append(
-		scheduleCommonOpts(t),
+type scheduleTimeSkippingResult struct {
+	startedWorkflows             int32
+	verifiedVirtualTimeWorkflows int
+}
+
+func TestScheduleTimeSkipping(t *testing.T) {
+	t.Parallel()
+
+	results := make(map[string]scheduleTimeSkippingResult, 2)
+	for _, backend := range []struct {
+		name       string
+		newContext contextFactory
+		opts       []testcore.TestOption
+	}{
+		{name: "CHASM-V2", newContext: chasmContextFactory},
+		{
+			name:       "Workflow-V1",
+			newContext: v1ContextFactory,
+			opts:       []testcore.TestOption{testcore.WithWorkerService("V1 scheduler")},
+		},
+	} {
+		t.Run(backend.name, func(t *testing.T) {
+			results[backend.name] = testScheduleTimeSkipping(t, backend.newContext, backend.opts...)
+		})
+	}
+
+	if len(results) == 2 && !t.Failed() {
+		require.Equal(t, results["CHASM-V2"], results["Workflow-V1"],
+			"schedule time skipping should behave identically across backends")
+	}
+}
+
+func testScheduleTimeSkipping(
+	t *testing.T,
+	newContext contextFactory,
+	additionalOpts ...testcore.TestOption,
+) scheduleTimeSkippingResult {
+	opts := append(scheduleCommonOpts(t), additionalOpts...)
+	opts = append(
+		opts,
 		testcore.WithDynamicConfig(dynamicconfig.WorkflowTimeSkippingEnabled, true),
 		testcore.WithDynamicConfig(dynamicconfig.ScheduleTimeSkippingEnabled, true),
 	)
@@ -512,6 +548,10 @@ func testScheduleTimeSkippingFastForward(t *testing.T, newContext contextFactory
 		})
 		return err == nil && len(describe.GetInfo().GetRecentActions()) >= 2
 	}, time.Minute, pollInterval)
+	scheduleTimeSkippingInfo := describe.GetInfo().GetTimeSkippingInfo()
+	require.NotNil(t, scheduleTimeSkippingInfo)
+	require.True(t, scheduleTimeSkippingInfo.GetFastForwardInfo().GetHasCompleted())
+	require.Greater(t, time.Until(scheduleTimeSkippingInfo.GetCurrentTime().AsTime()), 30*time.Minute)
 
 	seenRunIDs := make(map[string]struct{}, 2)
 	for _, action := range describe.GetInfo().GetRecentActions()[:2] {
@@ -532,9 +572,14 @@ func testScheduleTimeSkippingFastForward(t *testing.T, newContext contextFactory
 		require.NoError(t, err)
 		timeSkippingInfo := workflowDescription.GetWorkflowExtendedInfo().GetTimeSkippingInfo()
 		require.NotNil(t, timeSkippingInfo)
-		require.True(t, timeSkippingInfo.GetEffectiveConfig().GetEnabled())
+		require.NotNil(t, timeSkippingInfo.GetEffectiveConfig())
 		require.Nil(t, timeSkippingInfo.GetEffectiveConfig().GetFastForwardConfig())
 		require.Greater(t, timeSkippingInfo.GetCurrentTime().AsTime().Sub(wallTime), 30*time.Minute)
+	}
+
+	return scheduleTimeSkippingResult{
+		startedWorkflows:             runs.Load(),
+		verifiedVirtualTimeWorkflows: len(seenRunIDs),
 	}
 }
 
@@ -604,7 +649,6 @@ func TestScheduleV1(t *testing.T) {
 	t.Run("TestCreatesCHASMSentinel", func(t *testing.T) { t.Parallel(); testCreatesCHASMSentinel(t, newContext) })
 	t.Run("TestSkipsCHASMSentinelWhenDisabled", func(t *testing.T) { t.Parallel(); testSkipsCHASMSentinelWhenDisabled(t, newContext) })
 	t.Run("TestUpdateScheduleMemoRejected", func(t *testing.T) { t.Parallel(); testUpdateScheduleMemoRejected(t, newContext) })
-	t.Run("TestTimeSkippingFastForward", func(t *testing.T) { t.Parallel(); testScheduleTimeSkippingFastForward(t, newContext) })
 }
 
 func runSharedScheduleTests(t *testing.T, newContext contextFactory) {

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -420,6 +420,7 @@ func TestScheduleCHASM(t *testing.T) {
 	t.Run("TestUpdateScheduleMemoOnly", func(t *testing.T) { t.Parallel(); testUpdateScheduleMemoOnly(t, newContext) })
 	t.Run("TestStateSizeBytesReported", func(t *testing.T) { t.Parallel(); testStateSizeBytesReported(t, newContext) })
 	t.Run("TestBufferOverrunDropsActions", func(t *testing.T) { t.Parallel(); testBufferOverrunDropsActions(t, newContext) })
+	t.Run("TestTimeSkippingFastForward", func(t *testing.T) { t.Parallel(); testScheduleTimeSkippingFastForward(t) })
 	t.Run("TestDescribeCatchupWindowAfterCreateAndUpdate", func(t *testing.T) {
 		t.Parallel()
 		testDescribeCatchupWindowAfterCreateAndUpdate(t)
@@ -447,6 +448,94 @@ func TestScheduleCHASM(t *testing.T) {
 		t.Parallel()
 		testPauseOnFailureIgnoresCancelTerminate(t, newContext, stopByTerminate)
 	})
+}
+
+func testScheduleTimeSkippingFastForward(t *testing.T) {
+	opts := append(
+		scheduleCommonOpts(t),
+		testcore.WithDynamicConfig(dynamicconfig.WorkflowTimeSkippingEnabled, true),
+		testcore.WithDynamicConfig(dynamicconfig.ScheduleTimeSkippingEnabled, true),
+	)
+	s := newScheduleEnv(t, opts...)
+	ctx := chasmContextFactory(testcontext.For(t))
+
+	sid := testcore.RandomizeStr("sched-time-skipping")
+	wid := testcore.RandomizeStr("sched-time-skipping-wf")
+	wt := testcore.RandomizeStr("sched-time-skipping-wt")
+	var runs atomic.Int32
+	registerCountingWorkflow(s, wt, &runs)
+
+	now := time.Now().UTC()
+	schedule := &schedulepb.Schedule{
+		Spec: &schedulepb.ScheduleSpec{
+			Interval: []*schedulepb.IntervalSpec{{
+				Interval: durationpb.New(time.Hour),
+				Phase:    durationpb.New(now.Sub(now.Truncate(time.Hour))),
+			}},
+		},
+		Action: startWorkflowAction(s, wid, wt),
+		Policies: &schedulepb.SchedulePolicies{
+			OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+		},
+		State: &schedulepb.ScheduleState{Paused: true},
+	}
+	createSchedule(ctx, t, s, sid, schedule)
+
+	schedule.State.Paused = false
+	schedule.TimeSkippingConfig = &commonpb.TimeSkippingConfig{
+		Enabled: true,
+		FastForwardConfig: &commonpb.FastForwardConfig{
+			Id:       uuid.NewString(),
+			Duration: durationpb.New(5*time.Hour + 30*time.Minute),
+		},
+	}
+	_, err := s.FrontendClient().UpdateSchedule(ctx, &workflowservice.UpdateScheduleRequest{
+		Namespace:  s.Namespace().String(),
+		ScheduleId: sid,
+		Schedule:   schedule,
+		Identity:   "test",
+		RequestId:  uuid.NewString(),
+	})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return runs.Load() >= 5
+	}, time.Minute, pollInterval)
+	require.Equal(t, int32(5), runs.Load())
+
+	var describe *workflowservice.DescribeScheduleResponse
+	require.Eventually(t, func() bool {
+		var err error
+		describe, err = s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  s.Namespace().String(),
+			ScheduleId: sid,
+		})
+		return err == nil && len(describe.GetInfo().GetRecentActions()) >= 2
+	}, time.Minute, pollInterval)
+
+	seenRunIDs := make(map[string]struct{}, 2)
+	for _, action := range describe.GetInfo().GetRecentActions()[:2] {
+		execution := action.GetStartWorkflowResult()
+		require.NotEmpty(t, execution.GetWorkflowId())
+		require.NotEmpty(t, execution.GetRunId())
+		require.NotContains(t, seenRunIDs, execution.GetRunId())
+		seenRunIDs[execution.GetRunId()] = struct{}{}
+
+		wallTime := time.Now()
+		workflowDescription, err := s.FrontendClient().DescribeWorkflowExecution(
+			ctx,
+			&workflowservice.DescribeWorkflowExecutionRequest{
+				Namespace: s.Namespace().String(),
+				Execution: execution,
+			},
+		)
+		require.NoError(t, err)
+		timeSkippingInfo := workflowDescription.GetWorkflowExtendedInfo().GetTimeSkippingInfo()
+		require.NotNil(t, timeSkippingInfo)
+		require.True(t, timeSkippingInfo.GetEffectiveConfig().GetEnabled())
+		require.Nil(t, timeSkippingInfo.GetEffectiveConfig().GetFastForwardConfig())
+		require.Greater(t, timeSkippingInfo.GetCurrentTime().AsTime().Sub(wallTime), 30*time.Minute)
+	}
 }
 
 func testDescribeCatchupWindowAfterCreateAndUpdate(t *testing.T) {

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -420,7 +420,7 @@ func TestScheduleCHASM(t *testing.T) {
 	t.Run("TestUpdateScheduleMemoOnly", func(t *testing.T) { t.Parallel(); testUpdateScheduleMemoOnly(t, newContext) })
 	t.Run("TestStateSizeBytesReported", func(t *testing.T) { t.Parallel(); testStateSizeBytesReported(t, newContext) })
 	t.Run("TestBufferOverrunDropsActions", func(t *testing.T) { t.Parallel(); testBufferOverrunDropsActions(t, newContext) })
-	t.Run("TestTimeSkippingFastForward", func(t *testing.T) { t.Parallel(); testScheduleTimeSkippingFastForward(t) })
+	t.Run("TestTimeSkippingFastForward", func(t *testing.T) { t.Parallel(); testScheduleTimeSkippingFastForward(t, newContext) })
 	t.Run("TestDescribeCatchupWindowAfterCreateAndUpdate", func(t *testing.T) {
 		t.Parallel()
 		testDescribeCatchupWindowAfterCreateAndUpdate(t)
@@ -450,14 +450,14 @@ func TestScheduleCHASM(t *testing.T) {
 	})
 }
 
-func testScheduleTimeSkippingFastForward(t *testing.T) {
+func testScheduleTimeSkippingFastForward(t *testing.T, newContext contextFactory) {
 	opts := append(
 		scheduleCommonOpts(t),
 		testcore.WithDynamicConfig(dynamicconfig.WorkflowTimeSkippingEnabled, true),
 		testcore.WithDynamicConfig(dynamicconfig.ScheduleTimeSkippingEnabled, true),
 	)
 	s := newScheduleEnv(t, opts...)
-	ctx := chasmContextFactory(testcontext.For(t))
+	ctx := newContext(testcontext.For(t))
 
 	sid := testcore.RandomizeStr("sched-time-skipping")
 	wid := testcore.RandomizeStr("sched-time-skipping-wf")
@@ -604,6 +604,7 @@ func TestScheduleV1(t *testing.T) {
 	t.Run("TestCreatesCHASMSentinel", func(t *testing.T) { t.Parallel(); testCreatesCHASMSentinel(t, newContext) })
 	t.Run("TestSkipsCHASMSentinelWhenDisabled", func(t *testing.T) { t.Parallel(); testSkipsCHASMSentinelWhenDisabled(t, newContext) })
 	t.Run("TestUpdateScheduleMemoRejected", func(t *testing.T) { t.Parallel(); testUpdateScheduleMemoRejected(t, newContext) })
+	t.Run("TestTimeSkippingFastForward", func(t *testing.T) { t.Parallel(); testScheduleTimeSkippingFastForward(t, newContext) })
 }
 
 func runSharedScheduleTests(t *testing.T, newContext contextFactory) {


### PR DESCRIPTION
## What changed?
add time skipping to schedules (CHASM-based and workflow-based)

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)