### PR TITLE
WIP: Enforce target namespace blob size limit on Nexus failure/cancel completions

### DIFF
--- a/service/frontend/nexus_completion_http_handler.go
+++ b/service/frontend/nexus_completion_http_handler.go
@@ -222,28 +222,15 @@ func (h *nexusCompletionHandler) CompleteOperation(ctx context.Context, r *nexus
 
 	var successPayload *commonpb.Payload
 	var failure *failurepb.Failure
-	failureTruncated := false
+	var failureTruncated bool
 	switch r.State { // nolint:exhaustive
 	case nexus.OperationStateFailed, nexus.OperationStateCanceled:
-		nexusFailure := nexusrpc.UnwrapFailure(r.Error.OriginalFailure)
-		failure, err = commonnexus.NexusFailureToTemporalFailure(*nexusFailure)
+		failure, failureTruncated, err = h.resolveFailureForCompletion(
+			r, targetNamespaceID, targetBusinessID, targetRunID, blobSizeLimitError, blobSizeLimitWarn, rCtx.metricsHandler,
+		)
 		if err != nil {
 			logger.Error("cannot convert nexus failure from completion request", tag.Error(err))
 			return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid failure content")
-		}
-		if err := common.CheckEventBlobSizeLimit(
-			failure.Size(),
-			min(blobSizeLimitWarn, blobSizeLimitError),
-			blobSizeLimitError,
-			targetNamespaceID,
-			targetBusinessID,
-			targetRunID,
-			rCtx.metricsHandler,
-			h.ThrottledLogger,
-			nexusCompletionMethodName,
-		); err != nil {
-			failure = truncateOversizedFailure(failure, blobSizeLimitError, blobSizeLimitWarn)
-			failureTruncated = true
 		}
 	case nexus.OperationStateSucceeded:
 		var result *commonpb.Payload
@@ -286,6 +273,38 @@ func (h *nexusCompletionHandler) CompleteOperation(ctx context.Context, r *nexus
 		return commonnexus.ConvertGRPCError(err, true)
 	}
 	return commonnexus.ConvertGRPCError(err, false)
+}
+
+// resolveFailureForCompletion converts a failed/canceled completion's failure to its canonical Temporal
+// form and truncates it if it exceeds blobSizeLimitError, returning the failure to persist and whether it
+// was truncated.
+func (h *nexusCompletionHandler) resolveFailureForCompletion(
+	r *nexusrpc.CompletionRequest,
+	targetNamespaceID, targetBusinessID, targetRunID string,
+	blobSizeLimitError, blobSizeLimitWarn int,
+	metricsHandler metrics.Handler,
+) (*failurepb.Failure, bool, error) {
+	// Temporal->Temporal calls transmit the real failure as the wrapper OperationError's cause.
+	// Unwrap it so the caller sees the handler's original error rather than the generic wrapper.
+	nexusFailure := nexusrpc.UnwrapFailure(r.Error.OriginalFailure)
+	failure, err := commonnexus.NexusFailureToTemporalFailure(*nexusFailure)
+	if err != nil {
+		return nil, false, err
+	}
+	if err := common.CheckEventBlobSizeLimit(
+		failure.Size(),
+		min(blobSizeLimitWarn, blobSizeLimitError),
+		blobSizeLimitError,
+		targetNamespaceID,
+		targetBusinessID,
+		targetRunID,
+		metricsHandler,
+		h.ThrottledLogger,
+		nexusCompletionMethodName,
+	); err != nil {
+		return truncateOversizedFailure(failure, blobSizeLimitError, blobSizeLimitWarn), true, nil
+	}
+	return failure, false, nil
 }
 
 // completeOperation dispatches the completion to the framework named by its
@@ -367,6 +386,11 @@ func truncateOversizedFailure(failure *failurepb.Failure, blobSizeLimitError, bl
 		return failure
 	}
 	wrapper := commonfailure.NewServerFailure(common.FailureReasonFailureExceedsLimit, true)
+	if failure.GetCanceledFailureInfo() != nil {
+		// CHASM derives canceled vs. failed from the top-level CanceledFailureInfo alone (it has no
+		// separate state field), so this must survive truncation.
+		wrapper.FailureInfo = &failurepb.Failure_CanceledFailureInfo{CanceledFailureInfo: &failurepb.CanceledFailureInfo{}}
+	}
 	budget := min(blobSizeLimitWarn, blobSizeLimitError)
 	// Leave room for the wrapper itself plus the tag/length prefix embedding the cause adds.
 	const causeEmbeddingOverhead = 8

--- a/service/frontend/nexus_completion_http_handler.go
+++ b/service/frontend/nexus_completion_http_handler.go
@@ -291,6 +291,9 @@ func (h *nexusCompletionHandler) resolveFailureForCompletion(
 	if err != nil {
 		return nil, false, err
 	}
+	// CheckEventBlobSizeLimit only enforces errorLimit once actualSize also exceeds warnLimit, so
+	// without clamping warnLimit to at most errorLimit, a namespace misconfigured this way would
+	// let the oversized failure through unenforced instead of truncating it.
 	if err := common.CheckEventBlobSizeLimit(
 		failure.Size(),
 		min(blobSizeLimitWarn, blobSizeLimitError),

--- a/service/frontend/nexus_completion_http_handler.go
+++ b/service/frontend/nexus_completion_http_handler.go
@@ -48,6 +48,7 @@ type nexusCompletionHandler struct {
 	ClusterMetadata                      cluster.Metadata
 	NamespaceRegistry                    namespace.Registry
 	Logger                               log.Logger
+	ThrottledLogger                      log.Logger
 	MetricsHandler                       metrics.Handler
 	Config                               *Config
 	CallbackTokenGenerator               *commonnexus.CallbackTokenGenerator
@@ -74,6 +75,7 @@ func newNexusCompletionHandler(
 	clusterMetadata cluster.Metadata,
 	namespaceRegistry namespace.Registry,
 	logger log.Logger,
+	throttledLogger log.ThrottledLogger,
 	metricsHandler metrics.Handler,
 	serviceConfig *Config,
 	callbackTokenGenerator *commonnexus.CallbackTokenGenerator,
@@ -93,6 +95,7 @@ func newNexusCompletionHandler(
 		ClusterMetadata:                      clusterMetadata,
 		NamespaceRegistry:                    namespaceRegistry,
 		Logger:                               logger,
+		ThrottledLogger:                      throttledLogger,
 		MetricsHandler:                       metricsHandler,
 		Config:                               serviceConfig,
 		CallbackTokenGenerator:               callbackTokenGenerator,
@@ -218,9 +221,30 @@ func (h *nexusCompletionHandler) CompleteOperation(ctx context.Context, r *nexus
 	blobSizeLimitWarn := h.Config.BlobSizeLimitWarn(ns.Name().String())
 
 	var successPayload *commonpb.Payload
+	var failure *failurepb.Failure
+	failureTruncated := false
 	switch r.State { // nolint:exhaustive
 	case nexus.OperationStateFailed, nexus.OperationStateCanceled:
-		// The failure is validated and converted per framework in completeOperation.
+		nexusFailure := nexusrpc.UnwrapFailure(r.Error.OriginalFailure)
+		failure, err = commonnexus.NexusFailureToTemporalFailure(*nexusFailure)
+		if err != nil {
+			logger.Error("cannot convert nexus failure from completion request", tag.Error(err))
+			return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid failure content")
+		}
+		if err := common.CheckEventBlobSizeLimit(
+			failure.Size(),
+			min(blobSizeLimitWarn, blobSizeLimitError),
+			blobSizeLimitError,
+			targetNamespaceID,
+			targetBusinessID,
+			targetRunID,
+			rCtx.metricsHandler,
+			h.ThrottledLogger,
+			nexusCompletionMethodName,
+		); err != nil {
+			failure = truncateOversizedFailure(failure, blobSizeLimitError, blobSizeLimitWarn)
+			failureTruncated = true
+		}
 	case nexus.OperationStateSucceeded:
 		var result *commonpb.Payload
 		if err := r.Result.Consume(&result); err != nil {
@@ -243,11 +267,11 @@ func (h *nexusCompletionHandler) CompleteOperation(ctx context.Context, r *nexus
 		logger,
 		completion,
 		successPayload,
+		failure,
+		failureTruncated,
 		r,
 		links,
 		h.Config.EnableChasm(ns.Name().String()),
-		blobSizeLimitError,
-		blobSizeLimitWarn,
 	)
 	if err == nil {
 		return nil
@@ -272,18 +296,18 @@ func (h *nexusCompletionHandler) completeOperation(
 	logger log.Logger,
 	completion *tokenspb.NexusOperationCompletion,
 	successPayload *commonpb.Payload,
+	failure *failurepb.Failure,
+	failureTruncated bool,
 	req *nexusrpc.CompletionRequest,
 	links []*commonpb.Link,
 	chasmEnabled bool,
-	blobSizeLimitError int,
-	blobSizeLimitWarn int,
 ) error {
 	isChasm := len(completion.GetComponentRef()) > 0
 	var err error
 	if isChasm {
-		err = h.completeChasmOperation(ctx, logger, completion, successPayload, req, links, blobSizeLimitError, blobSizeLimitWarn)
+		err = h.completeChasmOperation(ctx, logger, completion, successPayload, failure, req, links)
 	} else {
-		err = h.completeHSMOperation(ctx, logger, completion, successPayload, req, links, blobSizeLimitError, blobSizeLimitWarn)
+		err = h.completeHSMOperation(ctx, logger, completion, successPayload, failure, failureTruncated, req, links)
 	}
 	if _, notFound := errors.AsType[*serviceerror.NotFound](err); !notFound || completion.GetRequestId() == "" {
 		return err
@@ -303,9 +327,9 @@ func (h *nexusCompletionHandler) completeOperation(
 	}
 	var fallbackErr error
 	if isChasm {
-		fallbackErr = h.completeHSMOperation(ctx, logger, converted, successPayload, req, links, blobSizeLimitError, blobSizeLimitWarn)
+		fallbackErr = h.completeHSMOperation(ctx, logger, converted, successPayload, failure, failureTruncated, req, links)
 	} else {
-		fallbackErr = h.completeChasmOperation(ctx, logger, converted, successPayload, req, links, blobSizeLimitError, blobSizeLimitWarn)
+		fallbackErr = h.completeChasmOperation(ctx, logger, converted, successPayload, failure, req, links)
 	}
 	// If the fallback also reports NotFound, the operation is gone in both frameworks.
 	// Return the error from the initial attempt.
@@ -338,11 +362,10 @@ func convertCompletionToOtherFramework(completion *tokenspb.NexusOperationComple
 // truncateOversizedFailure returns a truncated Failure if larger than blobSizeLimitError, otherwise
 // returns failure unchanged. Guarantees the result fits within blobSizeLimitError, provided
 // blobSizeLimitError is at least the size of a bare ServerFailure marker with no cause.
-func truncateOversizedFailure(logger log.Logger, failure *failurepb.Failure, blobSizeLimitError, blobSizeLimitWarn int) *failurepb.Failure {
+func truncateOversizedFailure(failure *failurepb.Failure, blobSizeLimitError, blobSizeLimitWarn int) *failurepb.Failure {
 	if failure.Size() <= blobSizeLimitError {
 		return failure
 	}
-	logger.Error("failure size exceeds error limit for Nexus CompleteOperation request")
 	wrapper := commonfailure.NewServerFailure(common.FailureReasonFailureExceedsLimit, true)
 	budget := min(blobSizeLimitWarn, blobSizeLimitError)
 	// Leave room for the wrapper itself plus the tag/length prefix embedding the cause adds.
@@ -361,10 +384,10 @@ func (h *nexusCompletionHandler) completeHSMOperation(
 	logger log.Logger,
 	completion *tokenspb.NexusOperationCompletion,
 	successPayload *commonpb.Payload,
+	failure *failurepb.Failure,
+	failureTruncated bool,
 	req *nexusrpc.CompletionRequest,
 	links []*commonpb.Link,
-	blobSizeLimitError int,
-	blobSizeLimitWarn int,
 ) error {
 	hr := &historyservice.CompleteNexusOperationRequest{
 		Completion:     completion,
@@ -376,23 +399,17 @@ func (h *nexusCompletionHandler) completeHSMOperation(
 
 	switch req.State { // nolint:exhaustive
 	case nexus.OperationStateFailed, nexus.OperationStateCanceled:
-		// Enforce the size limit against the canonical Temporal failure, not the raw wire format, so the
-		// limit doesn't vary with encoding overhead.
-		nexusFailure := nexusrpc.UnwrapFailure(req.Error.OriginalFailure)
-		temporalFailure, err := commonnexus.NexusFailureToTemporalFailure(*nexusFailure)
-		if err != nil {
-			logger.Error("cannot convert nexus failure from completion request", tag.Error(err))
-			return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid failure content")
-		}
-		truncated := truncateOversizedFailure(logger, temporalFailure, blobSizeLimitError, blobSizeLimitWarn)
-		truncatedNexusFailure, err := commonnexus.TemporalFailureToNexusFailure(truncated)
-		if err != nil {
-			// Should be unreachable: truncated is a well-formed failure we just constructed.
-			logger.Error("cannot convert truncated failure back to nexus failure", tag.Error(err))
-			return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error")
+		failureToSend := *req.Error.OriginalFailure
+		if failureTruncated {
+			var err error
+			failureToSend, err = commonnexus.TemporalFailureToNexusFailure(failure)
+			if err != nil {
+				logger.Error("cannot convert truncated failure back to nexus failure", tag.Error(err))
+				return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error")
+			}
 		}
 		hr.Outcome = &historyservice.CompleteNexusOperationRequest_Failure{
-			Failure: commonnexus.NexusFailureToProtoFailure(truncatedNexusFailure),
+			Failure: commonnexus.NexusFailureToProtoFailure(failureToSend),
 		}
 	case nexus.OperationStateSucceeded:
 		hr.Outcome = &historyservice.CompleteNexusOperationRequest_Success{
@@ -412,10 +429,9 @@ func (h *nexusCompletionHandler) completeChasmOperation(
 	logger log.Logger,
 	completion *tokenspb.NexusOperationCompletion,
 	successPayload *commonpb.Payload,
+	failure *failurepb.Failure,
 	req *nexusrpc.CompletionRequest,
 	links []*commonpb.Link,
-	blobSizeLimitError int,
-	blobSizeLimitWarn int,
 ) error {
 	hr := &historyservice.CompleteNexusOperationChasmRequest{
 		Completion: &tokenspb.NexusOperationCompletion{
@@ -434,16 +450,6 @@ func (h *nexusCompletionHandler) completeChasmOperation(
 
 	switch req.State { // nolint:exhaustive
 	case nexus.OperationStateFailed, nexus.OperationStateCanceled:
-		// Temporal->Temporal calls transmit the real failure as the wrapper OperationError's cause.
-		// Unwrap it so the caller sees the handler's original error (message, type, details, and
-		// canceled/terminated info) rather than the generic wrapper.
-		nexusFailure := nexusrpc.UnwrapFailure(req.Error.OriginalFailure)
-		failure, err := commonnexus.NexusFailureToTemporalFailure(*nexusFailure)
-		if err != nil {
-			logger.Error("cannot convert nexus failure from completion request", tag.Error(err))
-			return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid failure content")
-		}
-		failure = truncateOversizedFailure(logger, failure, blobSizeLimitError, blobSizeLimitWarn)
 		hr.Outcome = &historyservice.CompleteNexusOperationChasmRequest_Failure{
 			Failure: failure,
 		}

--- a/service/frontend/nexus_completion_http_handler.go
+++ b/service/frontend/nexus_completion_http_handler.go
@@ -15,12 +15,14 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/nexus-rpc/sdk-go/nexus"
 	commonpb "go.temporal.io/api/common/v1"
+	failurepb "go.temporal.io/api/failure/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/api/historyservice/v1"
 	tokenspb "go.temporal.io/server/api/token/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/authorization"
 	"go.temporal.io/server/common/cluster"
+	commonfailure "go.temporal.io/server/common/failure"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
@@ -212,18 +214,20 @@ func (h *nexusCompletionHandler) CompleteOperation(ctx context.Context, r *nexus
 	}
 
 	links := commonnexus.ConvertNexusLinksToProtoLinks(r.Links, logger)
+	blobSizeLimitError := h.Config.BlobSizeLimitError(ns.Name().String())
+	blobSizeLimitWarn := h.Config.BlobSizeLimitWarn(ns.Name().String())
 
 	var successPayload *commonpb.Payload
 	switch r.State { // nolint:exhaustive
 	case nexus.OperationStateFailed, nexus.OperationStateCanceled:
-		// no validation needed
+		// The failure is validated and converted per framework in completeOperation.
 	case nexus.OperationStateSucceeded:
 		var result *commonpb.Payload
 		if err := r.Result.Consume(&result); err != nil {
 			logger.Error("cannot deserialize payload from completion result", tag.Error(err))
 			return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid result content")
 		}
-		if result.Size() > h.Config.BlobSizeLimitError(ns.Name().String()) {
+		if result.Size() > blobSizeLimitError {
 			logger.Error("payload size exceeds error limit for Nexus CompleteOperation request")
 			return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "result exceeds size limit")
 		}
@@ -234,7 +238,17 @@ func (h *nexusCompletionHandler) CompleteOperation(ctx context.Context, r *nexus
 		return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid completion state")
 	}
 
-	err = h.completeOperation(ctx, logger, completion, successPayload, r, links, h.Config.EnableChasm(ns.Name().String()))
+	err = h.completeOperation(
+		ctx,
+		logger,
+		completion,
+		successPayload,
+		r,
+		links,
+		h.Config.EnableChasm(ns.Name().String()),
+		blobSizeLimitError,
+		blobSizeLimitWarn,
+	)
 	if err == nil {
 		return nil
 	}
@@ -261,13 +275,15 @@ func (h *nexusCompletionHandler) completeOperation(
 	req *nexusrpc.CompletionRequest,
 	links []*commonpb.Link,
 	chasmEnabled bool,
+	blobSizeLimitError int,
+	blobSizeLimitWarn int,
 ) error {
 	isChasm := len(completion.GetComponentRef()) > 0
 	var err error
 	if isChasm {
-		err = h.completeChasmOperation(ctx, logger, completion, successPayload, req, links)
+		err = h.completeChasmOperation(ctx, logger, completion, successPayload, req, links, blobSizeLimitError, blobSizeLimitWarn)
 	} else {
-		err = h.completeHSMOperation(ctx, completion, successPayload, req, links)
+		err = h.completeHSMOperation(ctx, logger, completion, successPayload, req, links, blobSizeLimitError, blobSizeLimitWarn)
 	}
 	if _, notFound := errors.AsType[*serviceerror.NotFound](err); !notFound || completion.GetRequestId() == "" {
 		return err
@@ -287,9 +303,9 @@ func (h *nexusCompletionHandler) completeOperation(
 	}
 	var fallbackErr error
 	if isChasm {
-		fallbackErr = h.completeHSMOperation(ctx, converted, successPayload, req, links)
+		fallbackErr = h.completeHSMOperation(ctx, logger, converted, successPayload, req, links, blobSizeLimitError, blobSizeLimitWarn)
 	} else {
-		fallbackErr = h.completeChasmOperation(ctx, logger, converted, successPayload, req, links)
+		fallbackErr = h.completeChasmOperation(ctx, logger, converted, successPayload, req, links, blobSizeLimitError, blobSizeLimitWarn)
 	}
 	// If the fallback also reports NotFound, the operation is gone in both frameworks.
 	// Return the error from the initial attempt.
@@ -319,12 +335,36 @@ func convertCompletionToOtherFramework(completion *tokenspb.NexusOperationComple
 	return nexusworkflowref.HSMRefToCHASMRef(completion)
 }
 
+// truncateOversizedFailure returns a truncated Failure if larger than blobSizeLimitError, otherwise
+// returns failure unchanged. Guarantees the result fits within blobSizeLimitError, provided
+// blobSizeLimitError is at least the size of a bare ServerFailure marker with no cause.
+func truncateOversizedFailure(logger log.Logger, failure *failurepb.Failure, blobSizeLimitError, blobSizeLimitWarn int) *failurepb.Failure {
+	if failure.Size() <= blobSizeLimitError {
+		return failure
+	}
+	logger.Error("failure size exceeds error limit for Nexus CompleteOperation request")
+	wrapper := commonfailure.NewServerFailure(common.FailureReasonFailureExceedsLimit, true)
+	budget := min(blobSizeLimitWarn, blobSizeLimitError)
+	// Leave room for the wrapper itself plus the tag/length prefix embedding the cause adds.
+	const causeEmbeddingOverhead = 8
+	budget = max(budget-wrapper.Size()-causeEmbeddingOverhead, 0)
+	// Retain a truncated cause when it fits; otherwise send the size-limit marker.
+	wrapper.Cause = commonfailure.Truncate(failure, budget)
+	if wrapper.Size() > blobSizeLimitError {
+		wrapper.Cause = nil
+	}
+	return wrapper
+}
+
 func (h *nexusCompletionHandler) completeHSMOperation(
 	ctx context.Context,
+	logger log.Logger,
 	completion *tokenspb.NexusOperationCompletion,
 	successPayload *commonpb.Payload,
 	req *nexusrpc.CompletionRequest,
 	links []*commonpb.Link,
+	blobSizeLimitError int,
+	blobSizeLimitWarn int,
 ) error {
 	hr := &historyservice.CompleteNexusOperationRequest{
 		Completion:     completion,
@@ -336,8 +376,23 @@ func (h *nexusCompletionHandler) completeHSMOperation(
 
 	switch req.State { // nolint:exhaustive
 	case nexus.OperationStateFailed, nexus.OperationStateCanceled:
+		// Enforce the size limit against the canonical Temporal failure, not the raw wire format, so the
+		// limit doesn't vary with encoding overhead.
+		nexusFailure := nexusrpc.UnwrapFailure(req.Error.OriginalFailure)
+		temporalFailure, err := commonnexus.NexusFailureToTemporalFailure(*nexusFailure)
+		if err != nil {
+			logger.Error("cannot convert nexus failure from completion request", tag.Error(err))
+			return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid failure content")
+		}
+		truncated := truncateOversizedFailure(logger, temporalFailure, blobSizeLimitError, blobSizeLimitWarn)
+		truncatedNexusFailure, err := commonnexus.TemporalFailureToNexusFailure(truncated)
+		if err != nil {
+			// Should be unreachable: truncated is a well-formed failure we just constructed.
+			logger.Error("cannot convert truncated failure back to nexus failure", tag.Error(err))
+			return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error")
+		}
 		hr.Outcome = &historyservice.CompleteNexusOperationRequest_Failure{
-			Failure: commonnexus.NexusFailureToProtoFailure(*req.Error.OriginalFailure),
+			Failure: commonnexus.NexusFailureToProtoFailure(truncatedNexusFailure),
 		}
 	case nexus.OperationStateSucceeded:
 		hr.Outcome = &historyservice.CompleteNexusOperationRequest_Success{
@@ -359,6 +414,8 @@ func (h *nexusCompletionHandler) completeChasmOperation(
 	successPayload *commonpb.Payload,
 	req *nexusrpc.CompletionRequest,
 	links []*commonpb.Link,
+	blobSizeLimitError int,
+	blobSizeLimitWarn int,
 ) error {
 	hr := &historyservice.CompleteNexusOperationChasmRequest{
 		Completion: &tokenspb.NexusOperationCompletion{
@@ -386,6 +443,7 @@ func (h *nexusCompletionHandler) completeChasmOperation(
 			logger.Error("cannot convert nexus failure from completion request", tag.Error(err))
 			return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "invalid failure content")
 		}
+		failure = truncateOversizedFailure(logger, failure, blobSizeLimitError, blobSizeLimitWarn)
 		hr.Outcome = &historyservice.CompleteNexusOperationChasmRequest_Failure{
 			Failure: failure,
 		}

--- a/service/frontend/nexus_completion_http_handler_test.go
+++ b/service/frontend/nexus_completion_http_handler_test.go
@@ -2,22 +2,28 @@ package frontend
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/nexus-rpc/sdk-go/nexus"
 	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
+	failurepb "go.temporal.io/api/failure/v1"
+	nexuspb "go.temporal.io/api/nexus/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/api/historyservicemock/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	tokenspb "go.temporal.io/server/api/token/v1"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/log"
+	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/nexus/nexusrpc"
 	"go.temporal.io/server/components/nexusoperations"
 	"go.temporal.io/server/nexusworkflowref"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
 )
 
 const convTestRequestID = "request-id"
@@ -192,12 +198,191 @@ func TestCompleteOperation_FrameworkFallback(t *testing.T) {
 			h := &nexusCompletionHandler{HistoryClient: client}
 			req := &nexusrpc.CompletionRequest{State: nexus.OperationStateSucceeded, OperationToken: "operation-token"}
 
-			err := h.completeOperation(context.Background(), log.NewNoopLogger(), tc.token(t), &commonpb.Payload{}, req, nil, !tc.chasmDisabled)
+			err := h.completeOperation(context.Background(), log.NewNoopLogger(), tc.token(t), &commonpb.Payload{}, req, nil, !tc.chasmDisabled, 0, 0)
 			if tc.wantErr != nil {
 				require.ErrorIs(t, err, tc.wantErr)
 			} else {
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+func decodeCanonicalFailure(t *testing.T, wireFailure *nexuspb.Failure) *failurepb.Failure {
+	t.Helper()
+	nf := commonnexus.ProtoFailureToNexusFailure(wireFailure)
+	canonical, err := commonnexus.NexusFailureToTemporalFailure(nf)
+	require.NoError(t, err)
+	return canonical
+}
+
+func wrappedTemporalFailure(t *testing.T, cause *failurepb.Failure) *nexus.Failure {
+	t.Helper()
+	nf, err := commonnexus.TemporalFailureToNexusFailure(cause)
+	require.NoError(t, err)
+	return &nexus.Failure{
+		Message:  "nexus operation completed unsuccessfully",
+		Metadata: map[string]string{"unwrap-error": "true"},
+		Cause:    &nf,
+	}
+}
+
+// completeHSMAndCaptureFailure returns the HSM failure sent to History.
+func completeHSMAndCaptureFailure(
+	t *testing.T,
+	state nexus.OperationState,
+	originalFailure *nexus.Failure,
+	blobSizeLimitError, blobSizeLimitWarn int,
+) *nexuspb.Failure {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	client := historyservicemock.NewMockHistoryServiceClient(ctrl)
+	var got *nexuspb.Failure
+	client.EXPECT().CompleteNexusOperation(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *historyservice.CompleteNexusOperationRequest, _ ...grpc.CallOption) (*historyservice.CompleteNexusOperationResponse, error) {
+			got = req.GetFailure()
+			return &historyservice.CompleteNexusOperationResponse{}, nil
+		})
+	h := &nexusCompletionHandler{HistoryClient: client}
+	req := &nexusrpc.CompletionRequest{
+		State: state,
+		Error: &nexus.OperationError{State: state, OriginalFailure: originalFailure},
+	}
+
+	err := h.completeOperation(context.Background(), log.NewNoopLogger(), hsmCompletionToken(), nil, req, nil, false, blobSizeLimitError, blobSizeLimitWarn)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	return got
+}
+
+func TestCompleteOperation_HSM_FailureSize(t *testing.T) {
+	t.Parallel()
+
+	longMessage := strings.Repeat("this failure message is way too long to fit under the configured limits. ", 10)
+	t.Run("forwards failures below the limit", func(t *testing.T) {
+		original := &nexus.Failure{Message: "small failure", Metadata: map[string]string{"k": "v"}}
+		got := decodeCanonicalFailure(t, completeHSMAndCaptureFailure(t, nexus.OperationStateFailed, original, 1<<20, 1<<20))
+		want, err := commonnexus.NexusFailureToTemporalFailure(*nexusrpc.UnwrapFailure(original))
+		require.NoError(t, err)
+		require.True(t, proto.Equal(want, got))
+	})
+
+	t.Run("truncates typed failures", func(t *testing.T) {
+		original := wrappedTemporalFailure(t, &failurepb.Failure{
+			Message: longMessage,
+			FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+				ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{Type: "SomeApplicationError", NonRetryable: true},
+			},
+		})
+		const limit = 150
+		got := decodeCanonicalFailure(t, completeHSMAndCaptureFailure(t, nexus.OperationStateFailed, original, limit, 130))
+		require.LessOrEqual(t, got.Size(), limit)
+		require.Equal(t, common.FailureReasonFailureExceedsLimit, got.GetMessage())
+		require.True(t, got.GetServerFailureInfo().GetNonRetryable())
+		require.Equal(t, "SomeApplicationError", got.GetCause().GetApplicationFailureInfo().GetType())
+		require.Less(t, len(got.GetCause().GetMessage()), len(longMessage))
+	})
+
+	t.Run("uses the canonical size", func(t *testing.T) {
+		original := &failurepb.Failure{
+			Message: "a moderately sized application failure message used for boundary testing",
+			FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+				ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{Type: "SomeError", NonRetryable: true},
+			},
+		}
+		originalFailure, err := commonnexus.TemporalFailureToNexusFailure(original)
+		require.NoError(t, err)
+
+		wireSize := commonnexus.NexusFailureToProtoFailure(originalFailure).Size()
+		canonical, err := commonnexus.NexusFailureToTemporalFailure(originalFailure)
+		require.NoError(t, err)
+		canonicalSize := canonical.Size()
+		require.Greater(t, wireSize, canonicalSize)
+		limit := (wireSize + canonicalSize) / 2
+		require.Greater(t, limit, canonicalSize)
+		require.Less(t, limit, wireSize)
+
+		got := decodeCanonicalFailure(t, completeHSMAndCaptureFailure(t, nexus.OperationStateFailed, &originalFailure, limit, limit))
+		require.Equal(t, originalFailure.Message, got.GetMessage())
+	})
+}
+
+// completeChasmAndCaptureFailure returns the CHASM failure sent to History.
+func completeChasmAndCaptureFailure(
+	t *testing.T,
+	state nexus.OperationState,
+	originalFailure *nexus.Failure,
+	blobSizeLimitError, blobSizeLimitWarn int,
+) *failurepb.Failure {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	client := historyservicemock.NewMockHistoryServiceClient(ctrl)
+	var got *failurepb.Failure
+	client.EXPECT().CompleteNexusOperationChasm(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *historyservice.CompleteNexusOperationChasmRequest, _ ...grpc.CallOption) (*historyservice.CompleteNexusOperationChasmResponse, error) {
+			got = req.GetFailure()
+			return &historyservice.CompleteNexusOperationChasmResponse{}, nil
+		})
+	h := &nexusCompletionHandler{HistoryClient: client}
+	req := &nexusrpc.CompletionRequest{
+		State: state,
+		Error: &nexus.OperationError{State: state, OriginalFailure: originalFailure},
+	}
+
+	err := h.completeOperation(context.Background(), log.NewNoopLogger(), chasmCompletionToken(t), nil, req, nil, true, blobSizeLimitError, blobSizeLimitWarn)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	return got
+}
+
+func TestCompleteOperation_CHASM_FailureSize(t *testing.T) {
+	t.Parallel()
+
+	longMessage := strings.Repeat("this failure message is way too long to fit under the configured limits. ", 10)
+
+	t.Run("forwards failures below the limit", func(t *testing.T) {
+		original := &nexus.Failure{Message: "small failure", Metadata: map[string]string{"k": "v"}}
+		got := completeChasmAndCaptureFailure(t, nexus.OperationStateFailed, original, 1<<20, 1<<20)
+		want, err := commonnexus.NexusFailureToTemporalFailure(*nexusrpc.UnwrapFailure(original))
+		require.NoError(t, err)
+		require.True(t, proto.Equal(want, got))
+	})
+
+	for _, state := range []nexus.OperationState{nexus.OperationStateFailed, nexus.OperationStateCanceled} {
+		t.Run("truncates "+string(state)+" failures", func(t *testing.T) {
+			const limit = 150
+			got := completeChasmAndCaptureFailure(t, state, &nexus.Failure{Message: longMessage}, limit, 80)
+			require.LessOrEqual(t, got.Size(), limit)
+			require.Equal(t, common.FailureReasonFailureExceedsLimit, got.GetMessage())
+			require.Less(t, len(got.GetCause().GetMessage()), len(longMessage))
+		})
+	}
+}
+
+func TestTruncateOversizedFailure(t *testing.T) {
+	t.Parallel()
+
+	t.Run("within budget is returned unchanged", func(t *testing.T) {
+		f := &failurepb.Failure{Message: "small"}
+		got := truncateOversizedFailure(log.NewNoopLogger(), f, 1000, 500)
+		require.Same(t, f, got)
+	})
+
+	oversized := &failurepb.Failure{Message: strings.Repeat("a", 500)}
+	for _, tc := range []struct {
+		name       string
+		errorLimit int
+		warnLimit  int
+	}{
+		{"warn below error (typical config)", 200, 100},
+		{"warn equal to error", 200, 200},
+		{"warn misconfigured above error", 100, 1 << 20},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := truncateOversizedFailure(log.NewNoopLogger(), oversized, tc.errorLimit, tc.warnLimit)
+			require.LessOrEqual(t, got.Size(), tc.errorLimit, "truncated failure must respect the error limit regardless of the warn limit")
+			require.Equal(t, common.FailureReasonFailureExceedsLimit, got.GetMessage())
+			require.NotNil(t, got.GetCause())
 		})
 	}
 }

--- a/service/frontend/nexus_completion_http_handler_test.go
+++ b/service/frontend/nexus_completion_http_handler_test.go
@@ -16,6 +16,7 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	tokenspb "go.temporal.io/server/api/token/v1"
 	"go.temporal.io/server/common"
+	commonfailure "go.temporal.io/server/common/failure"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	commonnexus "go.temporal.io/server/common/nexus"
@@ -306,6 +307,19 @@ func TestCompleteOperation_HSM_FailureSize(t *testing.T) {
 		want := commonnexus.NexusFailureToProtoFailure(originalFailure)
 		require.True(t, proto.Equal(want, got))
 	})
+
+	t.Run("still truncates when the warn limit is misconfigured above the error limit", func(t *testing.T) {
+		original := wrappedTemporalFailure(t, &failurepb.Failure{
+			Message: longMessage,
+			FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+				ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{Type: "SomeApplicationError"},
+			},
+		})
+		const limit = 150
+		got := decodeCanonicalFailure(t, completeHSMAndCaptureFailure(t, nexus.OperationStateFailed, original, limit, 1<<20))
+		require.LessOrEqual(t, got.Size(), limit)
+		require.Equal(t, common.FailureReasonFailureExceedsLimit, got.GetMessage())
+	})
 }
 
 // completeChasmAndCaptureFailure returns the CHASM failure sent to History. It drives the failure through
@@ -419,4 +433,13 @@ func TestTruncateOversizedFailure(t *testing.T) {
 			require.NotNil(t, got.GetCause())
 		})
 	}
+
+	t.Run("errorLimit too small to fit any cause drops it entirely", func(t *testing.T) {
+		bareMarkerSize := commonfailure.NewServerFailure(common.FailureReasonFailureExceedsLimit, true).Size()
+		errorLimit := bareMarkerSize + 1
+		got := truncateOversizedFailure(oversized, errorLimit, errorLimit)
+		require.LessOrEqual(t, got.Size(), errorLimit)
+		require.Equal(t, common.FailureReasonFailureExceedsLimit, got.GetMessage())
+		require.Nil(t, got.GetCause())
+	})
 }

--- a/service/frontend/nexus_completion_http_handler_test.go
+++ b/service/frontend/nexus_completion_http_handler_test.go
@@ -17,6 +17,7 @@ import (
 	tokenspb "go.temporal.io/server/api/token/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/nexus/nexusrpc"
 	"go.temporal.io/server/components/nexusoperations"
@@ -227,17 +228,8 @@ func wrappedTemporalFailure(t *testing.T, cause *failurepb.Failure) *nexus.Failu
 	}
 }
 
-func completionFailure(t *testing.T, original *nexus.Failure, blobSizeLimitError, blobSizeLimitWarn int) (*failurepb.Failure, bool) {
-	t.Helper()
-	failure, err := commonnexus.NexusFailureToTemporalFailure(*nexusrpc.UnwrapFailure(original))
-	require.NoError(t, err)
-	if failure.Size() <= blobSizeLimitError {
-		return failure, false
-	}
-	return truncateOversizedFailure(failure, blobSizeLimitError, blobSizeLimitWarn), true
-}
-
-// completeHSMAndCaptureFailure returns the HSM failure sent to History.
+// completeHSMAndCaptureFailure returns the HSM failure sent to History. It drives the failure through
+// resolveFailureForCompletion, the same production code CompleteOperation calls.
 func completeHSMAndCaptureFailure(
 	t *testing.T,
 	state nexus.OperationState,
@@ -253,14 +245,15 @@ func completeHSMAndCaptureFailure(
 			got = req.GetFailure()
 			return &historyservice.CompleteNexusOperationResponse{}, nil
 		})
-	h := &nexusCompletionHandler{HistoryClient: client}
+	h := &nexusCompletionHandler{HistoryClient: client, ThrottledLogger: log.NewNoopLogger()}
 	req := &nexusrpc.CompletionRequest{
 		State: state,
 		Error: &nexus.OperationError{State: state, OriginalFailure: originalFailure},
 	}
-	failure, failureTruncated := completionFailure(t, originalFailure, blobSizeLimitError, blobSizeLimitWarn)
+	failure, failureTruncated, err := h.resolveFailureForCompletion(req, "namespace-id", "workflow-id", "run-id", blobSizeLimitError, blobSizeLimitWarn, metrics.NoopMetricsHandler)
+	require.NoError(t, err)
 
-	err := h.completeOperation(context.Background(), log.NewNoopLogger(), hsmCompletionToken(), nil, failure, failureTruncated, req, nil, false)
+	err = h.completeOperation(context.Background(), log.NewNoopLogger(), hsmCompletionToken(), nil, failure, failureTruncated, req, nil, false)
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	return got
@@ -315,7 +308,9 @@ func TestCompleteOperation_HSM_FailureSize(t *testing.T) {
 	})
 }
 
-// completeChasmAndCaptureFailure returns the CHASM failure sent to History.
+// completeChasmAndCaptureFailure returns the CHASM failure sent to History. It drives the failure through
+// resolveFailureForCompletion, the same production code CompleteOperation calls, rather than
+// reimplementing its unwrap/convert/size-check/truncate decision.
 func completeChasmAndCaptureFailure(
 	t *testing.T,
 	state nexus.OperationState,
@@ -331,14 +326,15 @@ func completeChasmAndCaptureFailure(
 			got = req.GetFailure()
 			return &historyservice.CompleteNexusOperationChasmResponse{}, nil
 		})
-	h := &nexusCompletionHandler{HistoryClient: client}
+	h := &nexusCompletionHandler{HistoryClient: client, ThrottledLogger: log.NewNoopLogger()}
 	req := &nexusrpc.CompletionRequest{
 		State: state,
 		Error: &nexus.OperationError{State: state, OriginalFailure: originalFailure},
 	}
-	failure, failureTruncated := completionFailure(t, originalFailure, blobSizeLimitError, blobSizeLimitWarn)
+	failure, failureTruncated, err := h.resolveFailureForCompletion(req, "namespace-id", "workflow-id", "run-id", blobSizeLimitError, blobSizeLimitWarn, metrics.NoopMetricsHandler)
+	require.NoError(t, err)
 
-	err := h.completeOperation(context.Background(), log.NewNoopLogger(), chasmCompletionToken(t), nil, failure, failureTruncated, req, nil, true)
+	err = h.completeOperation(context.Background(), log.NewNoopLogger(), chasmCompletionToken(t), nil, failure, failureTruncated, req, nil, true)
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	return got
@@ -357,13 +353,42 @@ func TestCompleteOperation_CHASM_FailureSize(t *testing.T) {
 		require.True(t, proto.Equal(want, got))
 	})
 
-	for _, state := range []nexus.OperationState{nexus.OperationStateFailed, nexus.OperationStateCanceled} {
-		t.Run("truncates "+string(state)+" failures", func(t *testing.T) {
+	// CHASM has no separate State field on the completion request: HandleNexusCompletion routes to
+	// onCanceled vs. onFailed based solely on whether the top-level failure carries CanceledFailureInfo,
+	// so that marker must survive truncation.
+	for _, tc := range []struct {
+		name     string
+		original *nexus.Failure
+		canceled bool
+	}{
+		{
+			name: "failed",
+			original: wrappedTemporalFailure(t, &failurepb.Failure{
+				Message: longMessage,
+				FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+					ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{Type: "SomeError"},
+				},
+			}),
+			canceled: false,
+		},
+		{
+			name: "canceled",
+			original: wrappedTemporalFailure(t, &failurepb.Failure{
+				Message: longMessage,
+				FailureInfo: &failurepb.Failure_CanceledFailureInfo{
+					CanceledFailureInfo: &failurepb.CanceledFailureInfo{},
+				},
+			}),
+			canceled: true,
+		},
+	} {
+		t.Run("truncates "+tc.name+" failures", func(t *testing.T) {
 			const limit = 150
-			got := completeChasmAndCaptureFailure(t, state, &nexus.Failure{Message: longMessage}, limit, 80)
+			got := completeChasmAndCaptureFailure(t, nexus.OperationStateFailed, tc.original, limit, 80)
 			require.LessOrEqual(t, got.Size(), limit)
 			require.Equal(t, common.FailureReasonFailureExceedsLimit, got.GetMessage())
 			require.Less(t, len(got.GetCause().GetMessage()), len(longMessage))
+			require.Equal(t, tc.canceled, got.GetCanceledFailureInfo() != nil)
 		})
 	}
 }

--- a/service/frontend/nexus_completion_http_handler_test.go
+++ b/service/frontend/nexus_completion_http_handler_test.go
@@ -198,7 +198,7 @@ func TestCompleteOperation_FrameworkFallback(t *testing.T) {
 			h := &nexusCompletionHandler{HistoryClient: client}
 			req := &nexusrpc.CompletionRequest{State: nexus.OperationStateSucceeded, OperationToken: "operation-token"}
 
-			err := h.completeOperation(context.Background(), log.NewNoopLogger(), tc.token(t), &commonpb.Payload{}, req, nil, !tc.chasmDisabled, 0, 0)
+			err := h.completeOperation(context.Background(), log.NewNoopLogger(), tc.token(t), &commonpb.Payload{}, nil, false, req, nil, !tc.chasmDisabled)
 			if tc.wantErr != nil {
 				require.ErrorIs(t, err, tc.wantErr)
 			} else {
@@ -227,6 +227,16 @@ func wrappedTemporalFailure(t *testing.T, cause *failurepb.Failure) *nexus.Failu
 	}
 }
 
+func completionFailure(t *testing.T, original *nexus.Failure, blobSizeLimitError, blobSizeLimitWarn int) (*failurepb.Failure, bool) {
+	t.Helper()
+	failure, err := commonnexus.NexusFailureToTemporalFailure(*nexusrpc.UnwrapFailure(original))
+	require.NoError(t, err)
+	if failure.Size() <= blobSizeLimitError {
+		return failure, false
+	}
+	return truncateOversizedFailure(failure, blobSizeLimitError, blobSizeLimitWarn), true
+}
+
 // completeHSMAndCaptureFailure returns the HSM failure sent to History.
 func completeHSMAndCaptureFailure(
 	t *testing.T,
@@ -248,8 +258,9 @@ func completeHSMAndCaptureFailure(
 		State: state,
 		Error: &nexus.OperationError{State: state, OriginalFailure: originalFailure},
 	}
+	failure, failureTruncated := completionFailure(t, originalFailure, blobSizeLimitError, blobSizeLimitWarn)
 
-	err := h.completeOperation(context.Background(), log.NewNoopLogger(), hsmCompletionToken(), nil, req, nil, false, blobSizeLimitError, blobSizeLimitWarn)
+	err := h.completeOperation(context.Background(), log.NewNoopLogger(), hsmCompletionToken(), nil, failure, failureTruncated, req, nil, false)
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	return got
@@ -261,9 +272,8 @@ func TestCompleteOperation_HSM_FailureSize(t *testing.T) {
 	longMessage := strings.Repeat("this failure message is way too long to fit under the configured limits. ", 10)
 	t.Run("forwards failures below the limit", func(t *testing.T) {
 		original := &nexus.Failure{Message: "small failure", Metadata: map[string]string{"k": "v"}}
-		got := decodeCanonicalFailure(t, completeHSMAndCaptureFailure(t, nexus.OperationStateFailed, original, 1<<20, 1<<20))
-		want, err := commonnexus.NexusFailureToTemporalFailure(*nexusrpc.UnwrapFailure(original))
-		require.NoError(t, err)
+		got := completeHSMAndCaptureFailure(t, nexus.OperationStateFailed, original, 1<<20, 1<<20)
+		want := commonnexus.NexusFailureToProtoFailure(*original)
 		require.True(t, proto.Equal(want, got))
 	})
 
@@ -296,14 +306,12 @@ func TestCompleteOperation_HSM_FailureSize(t *testing.T) {
 		wireSize := commonnexus.NexusFailureToProtoFailure(originalFailure).Size()
 		canonical, err := commonnexus.NexusFailureToTemporalFailure(originalFailure)
 		require.NoError(t, err)
-		canonicalSize := canonical.Size()
-		require.Greater(t, wireSize, canonicalSize)
-		limit := (wireSize + canonicalSize) / 2
-		require.Greater(t, limit, canonicalSize)
-		require.Less(t, limit, wireSize)
+		limit := canonical.Size()
+		require.Greater(t, wireSize, limit)
 
-		got := decodeCanonicalFailure(t, completeHSMAndCaptureFailure(t, nexus.OperationStateFailed, &originalFailure, limit, limit))
-		require.Equal(t, originalFailure.Message, got.GetMessage())
+		got := completeHSMAndCaptureFailure(t, nexus.OperationStateFailed, &originalFailure, limit, limit)
+		want := commonnexus.NexusFailureToProtoFailure(originalFailure)
+		require.True(t, proto.Equal(want, got))
 	})
 }
 
@@ -328,8 +336,9 @@ func completeChasmAndCaptureFailure(
 		State: state,
 		Error: &nexus.OperationError{State: state, OriginalFailure: originalFailure},
 	}
+	failure, failureTruncated := completionFailure(t, originalFailure, blobSizeLimitError, blobSizeLimitWarn)
 
-	err := h.completeOperation(context.Background(), log.NewNoopLogger(), chasmCompletionToken(t), nil, req, nil, true, blobSizeLimitError, blobSizeLimitWarn)
+	err := h.completeOperation(context.Background(), log.NewNoopLogger(), chasmCompletionToken(t), nil, failure, failureTruncated, req, nil, true)
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	return got
@@ -364,7 +373,7 @@ func TestTruncateOversizedFailure(t *testing.T) {
 
 	t.Run("within budget is returned unchanged", func(t *testing.T) {
 		f := &failurepb.Failure{Message: "small"}
-		got := truncateOversizedFailure(log.NewNoopLogger(), f, 1000, 500)
+		got := truncateOversizedFailure(f, 1000, 500)
 		require.Same(t, f, got)
 	})
 
@@ -379,7 +388,7 @@ func TestTruncateOversizedFailure(t *testing.T) {
 		{"warn misconfigured above error", 100, 1 << 20},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := truncateOversizedFailure(log.NewNoopLogger(), oversized, tc.errorLimit, tc.warnLimit)
+			got := truncateOversizedFailure(oversized, tc.errorLimit, tc.warnLimit)
 			require.LessOrEqual(t, got.Size(), tc.errorLimit, "truncated failure must respect the error limit regardless of the warn limit")
 			require.Equal(t, common.FailureReasonFailureExceedsLimit, got.GetMessage())
 			require.NotNil(t, got.GetCause())

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -1563,6 +1563,133 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncFailure(chasmEnabled boo
 	s.RequireHistoryEvent(hist, enumspb.EVENT_TYPE_NEXUS_OPERATION_FAILED)
 }
 
+// TestNexusOperationAsyncFailure_OversizedFailure verifies that a failed/canceled async completion
+// whose failure exceeds the target namespace's BlobSizeLimitError is truncated and accepted, rather
+// than rejected outright. Unlike an oversized result (see the large payload cases in
+// TestNexusOperationSyncCompletion_LargePayload and TestNexusOperationAsyncCompletion), an oversized
+// failure must still resolve the operation.
+func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncFailure_OversizedFailure(chasmEnabled bool) {
+	const blobSizeLimitWarn = 800
+	const blobSizeLimitError = 1000
+
+	testCases := []struct {
+		name         string
+		state        nexus.OperationState
+		canonicalMsg *failurepb.Failure
+		canceled     bool
+	}{
+		{
+			name:  "failed",
+			state: nexus.OperationStateFailed,
+			canonicalMsg: &failurepb.Failure{
+				Message: strings.Repeat("a", 5000),
+				FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+					ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{Type: "SomeApplicationError"},
+				},
+			},
+		},
+		{
+			name:  "canceled",
+			state: nexus.OperationStateCanceled,
+			canonicalMsg: &failurepb.Failure{
+				Message: strings.Repeat("a", 5000),
+				FailureInfo: &failurepb.Failure_CanceledFailureInfo{
+					CanceledFailureInfo: &failurepb.CanceledFailureInfo{},
+				},
+			},
+			canceled: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func(s *NexusWorkflowTestSuite) {
+			nf, err := commonnexus.TemporalFailureToNexusFailure(tc.canonicalMsg)
+			s.NoError(err)
+			opErr := &nexus.OperationError{
+				State: tc.state,
+				Cause: &nexus.FailureError{Failure: nf},
+			}
+
+			env := s.newTestEnv(
+				chasmEnabled,
+				testcore.WithDynamicConfig(dynamicconfig.BlobSizeLimitWarn, blobSizeLimitWarn),
+				testcore.WithDynamicConfig(dynamicconfig.BlobSizeLimitError, blobSizeLimitError),
+			)
+			ctx := s.Context()
+			taskQueue := testcore.RandomizeStr(s.T().Name())
+
+			var callbackToken, publicCallbackURL string
+
+			h := nexustest.Handler{
+				OnStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
+					callbackToken = options.CallbackHeader.Get(commonnexus.CallbackTokenHeader)
+					publicCallbackURL = options.CallbackURL
+					return &nexus.HandlerStartOperationResultAsync{OperationToken: "test"}, nil
+				},
+			}
+			endpointName := env.createRandomExternalNexusServer(ctx, s.T(), h)
+
+			callerWF := func(ctx workflow.Context) error {
+				c := workflow.NewNexusClient(endpointName, "service")
+				fut := c.ExecuteOperation(ctx, "operation", "input", workflow.NexusOperationOptions{})
+				return fut.Get(ctx, nil)
+			}
+
+			w := worker.New(env.SdkClient(), taskQueue, worker.Options{})
+			w.RegisterWorkflow(callerWF)
+			s.NoError(w.Start())
+			defer w.Stop()
+
+			run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+				TaskQueue: taskQueue,
+			}, callerWF)
+			s.NoError(err)
+
+			// Wait for the handler to be called by checking for the NexusOperationStarted event.
+			s.EventuallyWithT(func(t *assert.CollectT) {
+				hist := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: run.GetID()})
+				historyrequire.New(t).RequireHistoryEvent(hist, enumspb.EVENT_TYPE_NEXUS_OPERATION_STARTED)
+			}, time.Second*10, time.Millisecond*200)
+
+			completion := nexusrpc.CompleteOperationOptions{
+				Error:  opErr,
+				Header: nexus.Header{commonnexus.CallbackTokenHeader: callbackToken},
+			}
+			err = s.sendNexusCompletionRequest(ctx, publicCallbackURL, completion)
+			s.NoError(err, "an oversized failure must be truncated and accepted, not rejected")
+
+			err = run.Get(ctx, nil)
+			s.Error(err)
+
+			hist := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: run.GetID()})
+
+			var wrapperFailure *failurepb.Failure
+			if tc.canceled {
+				event := s.RequireHistoryEvent(hist, enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCELED)
+				wrapperFailure = event.GetNexusOperationCanceledEventAttributes().GetFailure()
+			} else {
+				event := s.RequireHistoryEvent(hist, enumspb.EVENT_TYPE_NEXUS_OPERATION_FAILED)
+				wrapperFailure = event.GetNexusOperationFailedEventAttributes().GetFailure()
+			}
+			failure := wrapperFailure.GetCause()
+			s.Equal(common.FailureReasonFailureExceedsLimit, failure.GetMessage())
+			s.LessOrEqual(failure.Size(), blobSizeLimitError)
+			if tc.canceled {
+				s.NotNil(failure.GetCanceledFailureInfo())
+			} else {
+				s.True(failure.GetServerFailureInfo().GetNonRetryable())
+			}
+			// The original 5000-byte message must survive, truncated rather than dropped entirely.
+			s.NotNil(failure.GetCause())
+			s.NotEmpty(failure.GetCause().GetMessage())
+			s.Less(len(failure.GetCause().GetMessage()), len(tc.canonicalMsg.GetMessage()))
+			if !tc.canceled {
+				s.Equal("SomeApplicationError", failure.GetCause().GetApplicationFailureInfo().GetType())
+			}
+		})
+	}
+}
+
 func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncCompletionErrors(chasmEnabled bool) {
 	s.Run("NamespaceNotFound", func(s *NexusWorkflowTestSuite) {
 		env := s.newTestEnv(chasmEnabled, testcore.WithDedicatedCluster())


### PR DESCRIPTION
## What changed?

`temporal://system` Nexus completion now enforces the target namespace’s `BlobSizeLimitError` for failed and canceled outcomes in both HSM and CHASM completion paths.

Oversized failures are truncated and wrapped in a `ServerFailure` rather than being persisted unbounded, preserving whether the outcome was a failure or a cancellation.

## Why?

The Nexus HTTP body limit is fixed, while `BlobSizeLimitError` is namespace-scoped and may be lower. Previously, a cross-namespace callback could persist a failure that fit the transport limit but exceeded the target namespace’s configured storage limit.

## How did you test it?

- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

Oversized failed or canceled completions now retain a truncated diagnostic failure instead of the full original payload.
