### PR TITLE
Timeout diagnostics (1/2): Report context extension history

### DIFF
--- a/common/testing/testcontext/context.go
+++ b/common/testing/testcontext/context.go
@@ -2,14 +2,15 @@ package testcontext
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"go.temporal.io/server/common/debug"
-	"go.temporal.io/server/common/util"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -26,6 +27,14 @@ const (
 	maxTimeout          = 2 * time.Minute
 	testNameMetadataKey = "temporal-test-name"
 	testTimeoutEnvVar   = "TEMPORAL_TEST_TIMEOUT"
+
+	extensionLimitTestContextCap  = "test context extension cap"
+	extensionLimitGoTestTimeout   = "go test timeout"
+	extensionLimitExplicitTimeout = "explicit test timeout"
+
+	// Keep extension audit output useful even when many helpers request extensions.
+	reportHeadExtensions = 1
+	reportTailExtensions = 3
 )
 
 // contextStore tracks one context state per test.
@@ -50,6 +59,11 @@ type config struct {
 // values are inherited, so any context derived from a test context carries the
 // mark too.
 type ownerKey struct{}
+
+type extensionGrant struct {
+	duration time.Duration
+	elapsed  time.Duration
+}
 
 // GoTestDeadline returns the deadline imposed by `go test -timeout`, if any.
 //
@@ -182,7 +196,50 @@ func EnsureRemaining(ctx context.Context, tb testing.TB, minRemaining time.Durat
 		return
 	}
 
-	st.timeoutContext.extend(time.Now().Add(minRemaining))
+	st.mu.Lock()
+	defer st.mu.Unlock()
+
+	activeExpiration := st.timeoutContext.effectiveExpiration()
+	requestedDeadline := time.Now().Add(minRemaining)
+	if !requestedDeadline.After(activeExpiration) {
+		return
+	}
+
+	// Cap the requested deadline at the context's ceiling.
+	limit := ""
+	ceiling, _ := st.timeoutContext.Deadline()
+	if ceiling.Before(requestedDeadline) {
+		requestedDeadline = ceiling
+		limit = st.extensionCeilingLimit
+	}
+
+	st.timeoutContext.extend(requestedDeadline)
+	extendedExpiration := st.timeoutContext.effectiveExpiration()
+	if extendedExpiration.After(activeExpiration) {
+		st.extensionGrants = append(st.extensionGrants, extensionGrant{
+			duration: extendedExpiration.Sub(activeExpiration),
+			elapsed:  time.Since(st.createdAt),
+		})
+		st.extensionLimit = limit
+	} else {
+		st.extensionDenied++
+		st.extensionLimit = limit
+	}
+}
+
+// ExtensionAudit returns the extension history for the test context that owns ctx.
+func ExtensionAudit(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	st, _ := ctx.Value(ownerKey{}).(*contextState)
+	if st == nil {
+		return ""
+	}
+
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	return st.extensionAuditLocked()
 }
 
 // contextState is the mutable test context state shared by test helpers.
@@ -195,12 +252,17 @@ type contextState struct {
 	mu sync.Mutex
 	// current is the context with every decorator attached. Never nil, so late
 	// callers see a canceled context instead of a panic.
-	current       context.Context
-	decoratorKeys []any
+	current               context.Context
+	decoratorKeys         []any
+	extensionGrants       []extensionGrant
+	extensionDenied       int
+	extensionLimit        string
+	extensionCeilingLimit string
 }
 
 func newContextState(tb testing.TB, timeout time.Duration, explicitTimeout bool) *contextState {
 	createdAt := time.Now()
+	activeExpiration := createdAt.Add(timeout)
 	limit := timeout
 	if !explicitTimeout {
 		// A defaulted or TEMPORAL_TEST_TIMEOUT-configured timeout may grow,
@@ -208,19 +270,32 @@ func newContextState(tb testing.TB, timeout time.Duration, explicitTimeout bool)
 		limit = max(limit, maxTimeout*debug.TimeoutMultiplier)
 	}
 	ceiling := createdAt.Add(limit)
-	if goTestDeadline, ok := GoTestDeadline(tb); ok {
-		ceiling = util.MinTime(ceiling, goTestDeadline)
+	ceilingLimit := extensionLimitTestContextCap
+	if explicitTimeout {
+		ceilingLimit = extensionLimitExplicitTimeout
+	}
+	if goTestDeadline, ok := GoTestDeadline(tb); ok && goTestDeadline.Before(ceiling) {
+		ceiling = goTestDeadline
+		ceilingLimit = extensionLimitGoTestTimeout
+	}
+	if parentDeadline, ok := tb.Context().Deadline(); ok && parentDeadline.Before(ceiling) {
+		ceiling = parentDeadline
+		ceilingLimit = ""
 	}
 
 	st := &contextState{
-		createdAt: createdAt,
-		timeout:   timeout,
+		createdAt:             createdAt,
+		timeout:               timeout,
+		extensionCeilingLimit: ceilingLimit,
 	}
-	st.timeoutContext = newTimeoutContext(tb.Context(), ceiling, createdAt.Add(timeout))
+	st.timeoutContext = newTimeoutContext(tb.Context(), ceiling, activeExpiration)
 	ctx := context.WithValue(st.timeoutContext, ownerKey{}, st)
 
 	// Annotate gRPC requests with the test name for OTEL tracing.
 	st.current = metadata.AppendToOutgoingContext(ctx, testNameMetadataKey, tb.Name())
+	if ceilingLimit == extensionLimitGoTestTimeout && !ceiling.After(activeExpiration) {
+		st.extensionLimit = ceilingLimit
+	}
 	return st
 }
 
@@ -242,8 +317,8 @@ func getOrCreateContextState(tb testing.TB, cfg config) *contextState {
 			delete(testContexts.byTest, tb)
 			testContexts.Unlock()
 
-			if timedOut, timeout := st.cleanup(); timedOut {
-				tb.Errorf("test exceeded timeout of %v", timeout)
+			if message := st.cleanup(); message != "" {
+				tb.Errorf("%s", message)
 			}
 		})
 	}
@@ -258,17 +333,93 @@ func getOrCreateContextState(tb testing.TB, cfg config) *contextState {
 }
 
 // cleanup cancels the test context and reports whether its active timeout had
-// already fired, and how long after createdAt that was.
-func (s *contextState) cleanup() (timedOut bool, timeout time.Duration) {
+// already fired, returning its failure message.
+func (s *contextState) cleanup() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	s.timeoutContext.cancel()
-	err := s.timeoutContext.Err()
-	effectiveExpiration := s.timeoutContext.effectiveExpiration()
-	timedOut = err == context.DeadlineExceeded
-	timeout = effectiveExpiration.Sub(s.createdAt)
+	var timeoutMessage string
+	if s.timeoutContext.Err() == context.DeadlineExceeded {
+		timeoutMessage = s.timeoutExceededMessageLocked()
+	}
 
 	// Keep current: it is canceled now, but callers still racing with cleanup
 	// must get a context, not a panic.
-	return timedOut, timeout
+	return timeoutMessage
+}
+
+func (s *contextState) timeoutExceededMessageLocked() string {
+	currentTimeout := s.timeoutContext.effectiveExpiration().Sub(s.createdAt)
+
+	message := fmt.Sprintf("test exceeded timeout of %v", reportDuration(s.timeout))
+	if s.extensionLimit == extensionLimitGoTestTimeout {
+		message = fmt.Sprintf("test exceeded go test timeout before test context timeout of %v", reportDuration(s.timeout))
+	} else if currentTimeout > s.timeout && s.extensionLimit == extensionLimitTestContextCap {
+		ceiling, _ := s.timeoutContext.Deadline()
+		message = fmt.Sprintf(
+			"test exceeded test context extension cap of %v (originally %v)",
+			reportDuration(ceiling.Sub(s.createdAt)),
+			reportDuration(s.timeout),
+		)
+	} else if currentTimeout > s.timeout {
+		message = fmt.Sprintf("test exceeded extended timeout of %v (originally %v)", reportDuration(currentTimeout), reportDuration(s.timeout))
+	}
+	if audit := s.extensionAuditLocked(); audit != "" {
+		message += "\n" + audit
+	}
+	return message
+}
+
+func (s *contextState) extensionAuditLocked() string {
+	if len(s.extensionGrants) == 0 && s.extensionDenied == 0 {
+		return ""
+	}
+
+	var total time.Duration
+	for _, grant := range s.extensionGrants {
+		total += grant.duration
+	}
+	var message strings.Builder
+	fmt.Fprintf(&message, "ctx extensions   = %d (+%v total", len(s.extensionGrants), reportDuration(total))
+	if s.extensionLimit != "" {
+		message.WriteString("; limited by " + s.extensionLimit)
+	}
+	message.WriteString(")")
+	writeGrant := func(i int, grant extensionGrant) {
+		fmt.Fprintf(&message, "\n  %d. +%v after %v", i+1, reportDuration(grant.duration), reportDuration(grant.elapsed))
+	}
+	if len(s.extensionGrants) <= reportHeadExtensions+reportTailExtensions {
+		for i, grant := range s.extensionGrants {
+			writeGrant(i, grant)
+		}
+	} else {
+		for i, grant := range s.extensionGrants[:reportHeadExtensions] {
+			writeGrant(i, grant)
+		}
+		omitted := len(s.extensionGrants) - reportHeadExtensions - reportTailExtensions
+		fmt.Fprintf(&message, "\n  ... %d extensions omitted ...", omitted)
+		for i, grant := range s.extensionGrants[len(s.extensionGrants)-reportTailExtensions:] {
+			writeGrant(len(s.extensionGrants)-reportTailExtensions+i, grant)
+		}
+	}
+	if s.extensionDenied == 1 {
+		message.WriteString("\n1 context extension denied")
+	} else if s.extensionDenied > 1 {
+		fmt.Fprintf(&message, "\n%d context extensions denied", s.extensionDenied)
+	}
+	return message.String()
+}
+
+// Keep this formatting consistent with await timeout reports, which embed this text.
+func reportDuration(d time.Duration) string {
+	if d > -time.Millisecond && d < time.Millisecond {
+		rounded := d.Round(time.Microsecond)
+		if rounded != 0 {
+			return rounded.String()
+		}
+	}
+	return d.Round(time.Millisecond).String()
 }
 
 // effectiveTimeout resolves the timeout to use and reports whether it was

--- a/common/testing/testcontext/context.go
+++ b/common/testing/testcontext/context.go
@@ -248,6 +248,7 @@ type contextState struct {
 	// timeout is the timeout the context was created with; immutable.
 	timeout        time.Duration
 	timeoutContext *timeoutContext
+	deadlineClaims sync.Map
 
 	mu sync.Mutex
 	// current is the context with every decorator attached. Never nil, so late
@@ -288,7 +289,7 @@ func newContextState(tb testing.TB, timeout time.Duration, explicitTimeout bool)
 		timeout:               timeout,
 		extensionCeilingLimit: ceilingLimit,
 	}
-	st.timeoutContext = newTimeoutContext(tb.Context(), ceiling, activeExpiration)
+	st.timeoutContext = newTimeoutContext(tb.Context(), ceiling, activeExpiration, st)
 	ctx := context.WithValue(st.timeoutContext, ownerKey{}, st)
 
 	// Annotate gRPC requests with the test name for OTEL tracing.
@@ -335,40 +336,29 @@ func getOrCreateContextState(tb testing.TB, cfg config) *contextState {
 // cleanup cancels the test context and reports whether its active timeout had
 // already fired, returning its failure message.
 func (s *contextState) cleanup() string {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	s.timeoutContext.cancel()
-	var timeoutMessage string
-	if s.timeoutContext.Err() == context.DeadlineExceeded {
-		timeoutMessage = s.timeoutExceededMessageLocked()
+	cause := internalDeadlineExceededCause(s.timeoutContext)
+	if cause == nil || cause.owner != s || !cause.reported.CompareAndSwap(false, true) {
+		return ""
 	}
 
 	// Keep current: it is canceled now, but callers still racing with cleanup
 	// must get a context, not a panic.
-	return timeoutMessage
+	return s.deadlineExceededMessage(cause.deadline, "")
 }
 
-func (s *contextState) timeoutExceededMessageLocked() string {
-	currentTimeout := s.timeoutContext.effectiveExpiration().Sub(s.createdAt)
+func (s *contextState) deadlineExceededMessage(deadline time.Time, supplementalDetails string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
-	message := fmt.Sprintf("test exceeded timeout of %v", reportDuration(s.timeout))
-	if s.extensionLimit == extensionLimitGoTestTimeout {
-		message = fmt.Sprintf("test exceeded go test timeout before test context timeout of %v", reportDuration(s.timeout))
-	} else if currentTimeout > s.timeout && s.extensionLimit == extensionLimitTestContextCap {
-		ceiling, _ := s.timeoutContext.Deadline()
-		message = fmt.Sprintf(
-			"test exceeded test context extension cap of %v (originally %v)",
-			reportDuration(ceiling.Sub(s.createdAt)),
-			reportDuration(s.timeout),
-		)
-	} else if currentTimeout > s.timeout {
-		message = fmt.Sprintf("test exceeded extended timeout of %v (originally %v)", reportDuration(currentTimeout), reportDuration(s.timeout))
+	effectiveTimeout := deadline.Sub(s.createdAt)
+	message := fmt.Sprintf("testcontext deadline exceeded after %v", reportDuration(effectiveTimeout))
+	if effectiveTimeout > s.timeout {
+		message += fmt.Sprintf(" (originally %v)", reportDuration(s.timeout))
+	} else if s.extensionLimit == extensionLimitGoTestTimeout && effectiveTimeout < s.timeout {
+		message += fmt.Sprintf(" (configured %v; limited by go test timeout)", reportDuration(s.timeout))
 	}
-	if audit := s.extensionAuditLocked(); audit != "" {
-		message += "\n" + audit
-	}
-	return message
+	return appendDeadlineDetails(message, s.extensionAuditLocked(), supplementalDetails)
 }
 
 func (s *contextState) extensionAuditLocked() string {

--- a/common/testing/testcontext/context_test.go
+++ b/common/testing/testcontext/context_test.go
@@ -137,7 +137,7 @@ func TestCleanup(t *testing.T) {
 				<-ctx.Done() // let the deadline pass
 			})
 
-			require.Equal(t, fmt.Sprintf("test exceeded timeout of %v", timeout), tb.error())
+			require.Equal(t, fmt.Sprintf("testcontext deadline exceeded after %v", timeout), tb.error())
 		})
 	})
 
@@ -153,9 +153,10 @@ func TestCleanup(t *testing.T) {
 			})
 
 			require.Equal(t, strings.Join([]string{
-				"test exceeded extended timeout of 1m40s (originally 1m30s)",
-				"ctx extensions   = 1 (+10s total)",
-				"  1. +10s after 0s",
+				"testcontext deadline exceeded after 1m40s (originally 1m30s)",
+				"details:",
+				"  ctx extensions   = 1 (+10s total)",
+				"    1. +10s after 0s",
 			}, "\n"), tb.error())
 		})
 	})
@@ -172,9 +173,10 @@ func TestCleanup(t *testing.T) {
 			})
 
 			require.Equal(t, strings.Join([]string{
-				"test exceeded test context extension cap of 2m0s (originally 1m30s)",
-				"ctx extensions   = 1 (+30s total; limited by test context extension cap)",
-				"  1. +30s after 0s",
+				"testcontext deadline exceeded after 2m0s (originally 1m30s)",
+				"details:",
+				"  ctx extensions   = 1 (+30s total; limited by test context extension cap)",
+				"    1. +30s after 0s",
 			}, "\n"), tb.error())
 		})
 	})
@@ -190,7 +192,7 @@ func TestCleanup(t *testing.T) {
 				<-ctx.Done()
 			})
 
-			require.Equal(t, "test exceeded go test timeout before test context timeout of 10s", tb.error())
+			require.Equal(t, "testcontext deadline exceeded after 5s (configured 10s; limited by go test timeout)", tb.error())
 		})
 	})
 
@@ -204,7 +206,7 @@ func TestCleanup(t *testing.T) {
 				<-For(tb).Done()
 			})
 
-			require.Equal(t, "test exceeded timeout of 1m30s", tb.error())
+			require.Equal(t, "testcontext deadline exceeded after 1m30s", tb.error())
 		})
 	})
 
@@ -232,7 +234,7 @@ func TestEnvTimeout(t *testing.T) {
 				<-For(tb).Done()
 			})
 
-			require.Equal(t, "test exceeded timeout of 10s", tb.error())
+			require.Equal(t, "testcontext deadline exceeded after 10s", tb.error())
 		})
 	})
 

--- a/common/testing/testcontext/context_test.go
+++ b/common/testing/testcontext/context_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -140,22 +141,73 @@ func TestCleanup(t *testing.T) {
 		})
 	})
 
-	t.Run("reports extended effective timeout", func(t *testing.T) {
+	t.Run("reports extension history", func(t *testing.T) {
 		t.Parallel()
 
 		synctest.Test(t, func(t *testing.T) {
-			timeout := DefaultTimeout() + 10*time.Second
-
 			tb := newRecordingTB()
 			tb.run(func() {
 				ctx := For(tb)
-				EnsureRemaining(ctx, tb, timeout)
+				EnsureRemaining(ctx, tb, DefaultTimeout()+10*time.Second)
 				<-ctx.Done()
 			})
 
-			require.Equal(t, fmt.Sprintf("test exceeded timeout of %v", timeout), tb.error())
+			require.Equal(t, strings.Join([]string{
+				"test exceeded extended timeout of 1m40s (originally 1m30s)",
+				"ctx extensions   = 1 (+10s total)",
+				"  1. +10s after 0s",
+			}, "\n"), tb.error())
 		})
 	})
+
+	t.Run("reports extension cap", func(t *testing.T) {
+		t.Parallel()
+
+		synctest.Test(t, func(t *testing.T) {
+			tb := newRecordingTB()
+			tb.run(func() {
+				ctx := For(tb)
+				EnsureRemaining(ctx, tb, 10*time.Minute)
+				<-ctx.Done()
+			})
+
+			require.Equal(t, strings.Join([]string{
+				"test exceeded test context extension cap of 2m0s (originally 1m30s)",
+				"ctx extensions   = 1 (+30s total; limited by test context extension cap)",
+				"  1. +30s after 0s",
+			}, "\n"), tb.error())
+		})
+	})
+
+	t.Run("reports go test timeout", func(t *testing.T) {
+		t.Parallel()
+
+		synctest.Test(t, func(t *testing.T) {
+			tb := newRecordingTB()
+			tb.deadline = time.Now().Add(5 * time.Second)
+			tb.run(func() {
+				ctx := For(tb, WithTimeout(10*time.Second))
+				<-ctx.Done()
+			})
+
+			require.Equal(t, "test exceeded go test timeout before test context timeout of 10s", tb.error())
+		})
+	})
+
+	t.Run("does not report a later go test timeout", func(t *testing.T) {
+		t.Parallel()
+
+		synctest.Test(t, func(t *testing.T) {
+			tb := newRecordingTB()
+			tb.deadline = time.Now().Add(100 * time.Second)
+			tb.run(func() {
+				<-For(tb).Done()
+			})
+
+			require.Equal(t, "test exceeded timeout of 1m30s", tb.error())
+		})
+	})
+
 }
 
 func TestEnvTimeout(t *testing.T) {
@@ -231,22 +283,16 @@ func TestEnsureRemaining(t *testing.T) {
 
 		synctest.Test(t, func(t *testing.T) {
 			start := time.Now()
-			tb := newRecordingTB()
-			tb.run(func() {
-				ctx := For(tb)
-				ceiling, ok := ctx.Deadline()
-				require.True(t, ok)
-				require.Equal(t, start.Add(maxTimeout), ceiling)
+			ctx := For(t)
+			ceiling, ok := ctx.Deadline()
+			require.True(t, ok)
+			require.Equal(t, start.Add(maxTimeout), ceiling)
 
-				EnsureRemaining(ctx, tb, 10*time.Minute)
+			EnsureRemaining(ctx, t, 10*time.Minute)
 
-				deadline, ok := ctx.Deadline()
-				require.True(t, ok)
-				require.Equal(t, ceiling, deadline)
-				<-ctx.Done()
-			})
-
-			require.Equal(t, fmt.Sprintf("test exceeded timeout of %v", maxTimeout), tb.error())
+			deadline, ok := ctx.Deadline()
+			require.True(t, ok)
+			require.Equal(t, ceiling, deadline)
 		})
 	})
 
@@ -263,6 +309,10 @@ func TestEnsureRemaining(t *testing.T) {
 			require.True(t, ok)
 			require.Equal(t, start.Add(100*time.Millisecond), deadline)
 			require.Same(t, ctx, For(t), "context should not have been replaced")
+			require.Equal(t, strings.Join([]string{
+				"ctx extensions   = 0 (+0s total; limited by explicit test timeout)",
+				"1 context extension denied",
+			}, "\n"), ExtensionAudit(ctx))
 		})
 	})
 
@@ -393,15 +443,66 @@ func TestEnsureRemaining(t *testing.T) {
 
 }
 
+func TestExtensionAudit(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx := For(t)
+		EnsureRemaining(ctx, t, DefaultTimeout()+10*time.Second)
+
+		timer := time.NewTimer(5 * time.Second)
+		<-timer.C
+
+		EnsureRemaining(ctx, t, DefaultTimeout()+20*time.Second)
+		EnsureRemaining(ctx, t, 10*time.Minute)
+		EnsureRemaining(ctx, t, 10*time.Minute)
+
+		require.Equal(t, strings.Join([]string{
+			"ctx extensions   = 3 (+30s total; limited by test context extension cap)",
+			"  1. +10s after 0s",
+			"  2. +15s after 5s",
+			"  3. +5s after 5s",
+			"1 context extension denied",
+		}, "\n"), ExtensionAudit(ctx))
+	})
+}
+
+func TestExtensionAuditTruncatesGrants(t *testing.T) {
+	t.Parallel()
+
+	st := contextState{
+		extensionGrants: []extensionGrant{
+			{duration: time.Second, elapsed: 0},
+			{duration: 2 * time.Second, elapsed: time.Second},
+			{duration: 3 * time.Second, elapsed: 2 * time.Second},
+			{duration: 4 * time.Second, elapsed: 3 * time.Second},
+			{duration: 5 * time.Second, elapsed: 4 * time.Second},
+			{duration: 6 * time.Second, elapsed: 5 * time.Second},
+		},
+		extensionDenied: 2,
+	}
+
+	require.Equal(t, strings.Join([]string{
+		"ctx extensions   = 6 (+21s total)",
+		"  1. +1s after 0s",
+		"  ... 2 extensions omitted ...",
+		"  4. +4s after 3s",
+		"  5. +5s after 4s",
+		"  6. +6s after 5s",
+		"2 context extensions denied",
+	}, "\n"), st.extensionAuditLocked())
+}
+
 // recordingTB records failures instead of failing a real test.
 //
-// NOTE: it deliberately does not implement Deadline, so it stands in for a
-// testing.TB without a `go test -timeout` deadline.
+// By default it reports no Deadline, so it stands in for a testing.TB without
+// a `go test -timeout` deadline.
 type recordingTB struct {
 	testing.TB
 
 	ctx       context.Context
 	cancelCtx context.CancelFunc
+	deadline  time.Time
 
 	mu       sync.Mutex
 	cleanups []func()
@@ -424,6 +525,10 @@ func (r *recordingTB) Name() string {
 
 func (r *recordingTB) Context() context.Context {
 	return r.ctx
+}
+
+func (r *recordingTB) Deadline() (time.Time, bool) {
+	return r.deadline, !r.deadline.IsZero()
 }
 
 func (r *recordingTB) Cleanup(fn func()) {

--- a/common/testing/testcontext/deadline.go
+++ b/common/testing/testcontext/deadline.go
@@ -32,9 +32,11 @@ func WithDeadline(parent context.Context, deadline time.Time) (context.Context, 
 	if owner == nil {
 		return context.WithDeadline(parent, deadline)
 	}
+	activeExpiration, testcontextOwnsExpiration := owner.timeoutContext.activeExpirationOwnership()
 	if parentDeadline, ok := parent.Deadline(); ok &&
 		!deadline.Before(parentDeadline) &&
-		parentDeadline.Before(owner.timeoutContext.effectiveExpiration()) {
+		(parentDeadline.Before(activeExpiration) ||
+			(parentDeadline.Equal(activeExpiration) && !testcontextOwnsExpiration)) {
 		// A tighter deadline added by the caller remains caller-owned even
 		// when this derived context requests that exact deadline.
 		return context.WithDeadline(parent, deadline)

--- a/common/testing/testcontext/deadline.go
+++ b/common/testing/testcontext/deadline.go
@@ -12,6 +12,8 @@ import (
 
 // DeadlineExceeded identifies a deadline owned by testcontext. It wraps
 // context.DeadlineExceeded, so either error matches through errors.Is.
+//
+//nolint:staticcheck // Match context.DeadlineExceeded at testcontext call sites.
 var DeadlineExceeded = fmt.Errorf("testcontext deadline exceeded: %w", context.DeadlineExceeded)
 
 type deadlineExceededCause struct {

--- a/common/testing/testcontext/deadline.go
+++ b/common/testing/testcontext/deadline.go
@@ -1,0 +1,101 @@
+package testcontext
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// DeadlineExceeded identifies a deadline owned by testcontext. It wraps
+// context.DeadlineExceeded, so either error matches through errors.Is.
+var DeadlineExceeded = fmt.Errorf("testcontext deadline exceeded: %w", context.DeadlineExceeded)
+
+type deadlineExceededCause struct {
+	deadline time.Time
+	owner    *contextState
+	reported *atomic.Bool
+}
+
+// WithDeadline derives a deadline from parent. When parent belongs to a test
+// context, expiry carries DeadlineExceeded as its cause. Foreign contexts keep
+// the standard context deadline cause.
+func WithDeadline(parent context.Context, deadline time.Time) (context.Context, context.CancelFunc) {
+	if parent == nil {
+		// Preserve context.WithDeadline's nil-parent panic and message.
+		return context.WithDeadline(parent, deadline)
+	}
+	owner, _ := parent.Value(ownerKey{}).(*contextState)
+	if owner == nil {
+		return context.WithDeadline(parent, deadline)
+	}
+	return context.WithDeadlineCause(parent, deadline, newDeadlineExceededCause(deadline, owner))
+}
+
+// FailIfDeadlineExceeded reports and stops the test when ctx ended at a
+// testcontext-owned deadline. It returns false without touching tb for every
+// other termination. supplementalDetails is optional caller-formatted text
+// appended to the canonical testcontext report.
+func FailIfDeadlineExceeded(ctx context.Context, tb testing.TB, supplementalDetails string) bool {
+	if ctx == nil {
+		return false
+	}
+	cause := internalDeadlineExceededCause(ctx)
+	if cause == nil || cause.owner == nil {
+		return false
+	}
+
+	tb.Helper()
+	if !cause.reported.CompareAndSwap(false, true) {
+		tb.FailNow()
+		return true
+	}
+
+	tb.Fatalf("%s", cause.owner.deadlineExceededMessage(cause.deadline, supplementalDetails))
+	return true
+}
+
+func internalDeadlineExceededCause(ctx context.Context) *deadlineExceededCause {
+	var cause *deadlineExceededCause
+	if !errors.As(context.Cause(ctx), &cause) {
+		return nil
+	}
+	return cause
+}
+
+func appendDeadlineDetails(message string, details ...string) string {
+	var nonEmpty []string
+	for _, detail := range details {
+		if detail = strings.TrimSpace(detail); detail != "" {
+			nonEmpty = append(nonEmpty, detail)
+		}
+	}
+	if len(nonEmpty) == 0 {
+		return message
+	}
+	return message + "\ndetails:\n  " + strings.ReplaceAll(strings.Join(nonEmpty, "\n"), "\n", "\n  ")
+}
+
+func (c *deadlineExceededCause) Error() string {
+	return DeadlineExceeded.Error()
+}
+
+func (c *deadlineExceededCause) Unwrap() error {
+	return DeadlineExceeded
+}
+
+func newDeadlineExceededCause(deadline time.Time, owner *contextState) *deadlineExceededCause {
+	reported := &atomic.Bool{}
+	if owner != nil {
+		actual, _ := owner.deadlineClaims.LoadOrStore(deadline, reported)
+		reported = actual.(*atomic.Bool)
+	}
+	return &deadlineExceededCause{
+		deadline: deadline,
+		owner:    owner,
+		reported: reported,
+	}
+}

--- a/common/testing/testcontext/deadline.go
+++ b/common/testing/testcontext/deadline.go
@@ -32,6 +32,13 @@ func WithDeadline(parent context.Context, deadline time.Time) (context.Context, 
 	if owner == nil {
 		return context.WithDeadline(parent, deadline)
 	}
+	if parentDeadline, ok := parent.Deadline(); ok &&
+		!deadline.Before(parentDeadline) &&
+		parentDeadline.Before(owner.timeoutContext.effectiveExpiration()) {
+		// A tighter deadline added by the caller remains caller-owned even
+		// when this derived context requests that exact deadline.
+		return context.WithDeadline(parent, deadline)
+	}
 	return context.WithDeadlineCause(parent, deadline, newDeadlineExceededCause(deadline, owner))
 }
 

--- a/common/testing/testcontext/deadline_test.go
+++ b/common/testing/testcontext/deadline_test.go
@@ -52,9 +52,12 @@ func TestWithDeadline(t *testing.T) {
 		t.Parallel()
 
 		synctest.Test(t, func(t *testing.T) {
-			parent, cancelParent := context.WithTimeout(For(t), time.Second)
-			defer cancelParent()
-			ctx, cancel := WithDeadline(parent, time.Now().Add(2*time.Second))
+			parentDeadline := time.Now().Add(time.Second)
+			parent := reportedDeadlineContext{
+				Context:  For(t),
+				deadline: parentDeadline,
+			}
+			ctx, cancel := WithDeadline(parent, parentDeadline)
 			defer cancel()
 
 			time.Sleep(time.Second) //nolint:forbidigo // advance to the caller-owned deadline
@@ -65,6 +68,15 @@ func TestWithDeadline(t *testing.T) {
 			require.ErrorIs(t, context.Cause(ctx), context.DeadlineExceeded)
 		})
 	})
+}
+
+type reportedDeadlineContext struct {
+	context.Context
+	deadline time.Time
+}
+
+func (c reportedDeadlineContext) Deadline() (time.Time, bool) {
+	return c.deadline, true
 }
 
 func TestFailIfDeadlineExceeded(t *testing.T) {

--- a/common/testing/testcontext/deadline_test.go
+++ b/common/testing/testcontext/deadline_test.go
@@ -68,6 +68,32 @@ func TestWithDeadline(t *testing.T) {
 			require.ErrorIs(t, context.Cause(ctx), context.DeadlineExceeded)
 		})
 	})
+
+	t.Run("preserves a parent-capped testcontext deadline", func(t *testing.T) {
+		t.Parallel()
+
+		synctest.Test(t, func(t *testing.T) {
+			ownerTB := newRecordingTB()
+			deadline := time.Now().Add(time.Second)
+			ownerTB.ctx = reportedDeadlineContext{
+				Context:  ownerTB.ctx,
+				deadline: deadline,
+			}
+			parent := For(ownerTB, WithTimeout(10*time.Second))
+			owner := parent.Value(ownerKey{}).(*contextState)
+			owner.timeoutContext.timer.Stop() // simulate the testcontext timer lagging at the shared deadline
+
+			ctx, cancel := WithDeadline(parent, deadline)
+			defer cancel()
+			time.Sleep(time.Second) //nolint:forbidigo // advance to the parent-owned deadline
+			<-ctx.Done()
+
+			require.Equal(t, context.DeadlineExceeded, ctx.Err())
+			require.False(t, errors.Is(context.Cause(ctx), DeadlineExceeded))
+			require.ErrorIs(t, context.Cause(ctx), context.DeadlineExceeded)
+			ownerTB.runCleanups()
+		})
+	})
 }
 
 type reportedDeadlineContext struct {

--- a/common/testing/testcontext/deadline_test.go
+++ b/common/testing/testcontext/deadline_test.go
@@ -2,7 +2,6 @@ package testcontext
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -43,7 +42,7 @@ func TestWithDeadline(t *testing.T) {
 			<-ctx.Done()
 
 			require.Equal(t, context.DeadlineExceeded, ctx.Err())
-			require.False(t, errors.Is(context.Cause(ctx), DeadlineExceeded))
+			require.NotErrorIs(t, context.Cause(ctx), DeadlineExceeded)
 			require.ErrorIs(t, context.Cause(ctx), context.DeadlineExceeded)
 		})
 	})
@@ -64,7 +63,7 @@ func TestWithDeadline(t *testing.T) {
 			<-ctx.Done()
 
 			require.Equal(t, context.DeadlineExceeded, ctx.Err())
-			require.False(t, errors.Is(context.Cause(ctx), DeadlineExceeded))
+			require.NotErrorIs(t, context.Cause(ctx), DeadlineExceeded)
 			require.ErrorIs(t, context.Cause(ctx), context.DeadlineExceeded)
 		})
 	})
@@ -89,7 +88,7 @@ func TestWithDeadline(t *testing.T) {
 			<-ctx.Done()
 
 			require.Equal(t, context.DeadlineExceeded, ctx.Err())
-			require.False(t, errors.Is(context.Cause(ctx), DeadlineExceeded))
+			require.NotErrorIs(t, context.Cause(ctx), DeadlineExceeded)
 			require.ErrorIs(t, context.Cause(ctx), context.DeadlineExceeded)
 			ownerTB.runCleanups()
 		})

--- a/common/testing/testcontext/deadline_test.go
+++ b/common/testing/testcontext/deadline_test.go
@@ -1,0 +1,177 @@
+package testcontext
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithDeadline(t *testing.T) {
+	t.Parallel()
+
+	t.Run("attributes a testcontext deadline", func(t *testing.T) {
+		t.Parallel()
+
+		synctest.Test(t, func(t *testing.T) {
+			ctx, cancel := WithDeadline(For(t), time.Now().Add(time.Second))
+			defer cancel()
+
+			time.Sleep(time.Second) //nolint:forbidigo // advance to the derived deadline
+			<-ctx.Done()
+
+			require.Equal(t, context.DeadlineExceeded, ctx.Err())
+			require.ErrorIs(t, context.Cause(ctx), DeadlineExceeded)
+			require.ErrorIs(t, context.Cause(ctx), context.DeadlineExceeded)
+		})
+	})
+
+	t.Run("preserves a foreign deadline", func(t *testing.T) {
+		t.Parallel()
+
+		synctest.Test(t, func(t *testing.T) {
+			ctx, cancel := WithDeadline(t.Context(), time.Now().Add(time.Second))
+			defer cancel()
+
+			time.Sleep(time.Second) //nolint:forbidigo // advance to the derived deadline
+			<-ctx.Done()
+
+			require.Equal(t, context.DeadlineExceeded, ctx.Err())
+			require.False(t, errors.Is(context.Cause(ctx), DeadlineExceeded))
+			require.ErrorIs(t, context.Cause(ctx), context.DeadlineExceeded)
+		})
+	})
+
+	t.Run("preserves a tighter caller deadline", func(t *testing.T) {
+		t.Parallel()
+
+		synctest.Test(t, func(t *testing.T) {
+			parent, cancelParent := context.WithTimeout(For(t), time.Second)
+			defer cancelParent()
+			ctx, cancel := WithDeadline(parent, time.Now().Add(2*time.Second))
+			defer cancel()
+
+			time.Sleep(time.Second) //nolint:forbidigo // advance to the caller-owned deadline
+			<-ctx.Done()
+
+			require.Equal(t, context.DeadlineExceeded, ctx.Err())
+			require.False(t, errors.Is(context.Cause(ctx), DeadlineExceeded))
+			require.ErrorIs(t, context.Cause(ctx), context.DeadlineExceeded)
+		})
+	})
+}
+
+func TestFailIfDeadlineExceeded(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		tb := newRecordingTB()
+		tb.run(func() {
+			ctx, cancel := WithDeadline(For(tb, WithTimeout(10*time.Second)), time.Now().Add(time.Second))
+			defer cancel()
+
+			time.Sleep(time.Second) //nolint:forbidigo // advance to the owned deadline
+			<-ctx.Done()
+			FailIfDeadlineExceeded(ctx, tb, "operation = Require\nattempts = 3")
+		})
+
+		require.Equal(t, "testcontext deadline exceeded after 1s\ndetails:\n  operation = Require\n  attempts = 3", tb.fatal())
+		require.Empty(t, tb.error())
+	})
+}
+
+func TestFailIfDeadlineExceededIgnoresForeignDeadline(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		defer cancel()
+		time.Sleep(time.Second) //nolint:forbidigo // advance to the foreign deadline
+		<-ctx.Done()
+
+		tb := &returningReportingTB{}
+		require.False(t, FailIfDeadlineExceeded(ctx, tb, "ignored"))
+		require.Zero(t, tb.fatals.Load())
+		require.Zero(t, tb.failNows.Load())
+	})
+}
+
+func TestFailIfDeadlineExceededReportsOnce(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		ownerTB := newRecordingTB()
+		ctx := For(ownerTB, WithTimeout(time.Second))
+		time.Sleep(time.Second) //nolint:forbidigo // advance to the owned deadline
+		<-ctx.Done()
+
+		tb := &returningReportingTB{}
+		var wg sync.WaitGroup
+		for range 8 {
+			wg.Go(func() {
+				require.True(t, FailIfDeadlineExceeded(ctx, tb, "attempts = 3"))
+			})
+		}
+		wg.Wait()
+		ownerTB.runCleanups()
+
+		require.Equal(t, int32(1), tb.fatals.Load())
+		require.Equal(t, int32(7), tb.failNows.Load())
+		require.Empty(t, ownerTB.error())
+	})
+}
+
+func TestFailIfDeadlineExceededSharesClaimForSameDeadline(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		ownerTB := newRecordingTB()
+		parent := For(ownerTB, WithTimeout(10*time.Second))
+		deadline := time.Now().Add(time.Second)
+		first, cancelFirst := WithDeadline(parent, deadline)
+		defer cancelFirst()
+		second, cancelSecond := WithDeadline(parent, deadline)
+		defer cancelSecond()
+
+		time.Sleep(time.Second) //nolint:forbidigo // advance to the shared deadline
+		<-first.Done()
+		<-second.Done()
+
+		tb := &returningReportingTB{}
+		require.True(t, FailIfDeadlineExceeded(first, tb, "first"))
+		require.True(t, FailIfDeadlineExceeded(second, tb, "second"))
+		ownerTB.runCleanups()
+
+		require.Equal(t, int32(1), tb.fatals.Load())
+		require.Equal(t, int32(1), tb.failNows.Load())
+		require.Empty(t, ownerTB.error())
+	})
+}
+
+type returningReportingTB struct {
+	testing.TB
+	fatals   atomic.Int32
+	failNows atomic.Int32
+
+	mu      sync.Mutex
+	message string
+}
+
+func (r *returningReportingTB) Helper() {}
+
+func (r *returningReportingTB) Fatalf(format string, args ...any) {
+	r.fatals.Add(1)
+	r.mu.Lock()
+	r.message = fmt.Sprintf(format, args...)
+	r.mu.Unlock()
+}
+
+func (r *returningReportingTB) FailNow() {
+	r.failNows.Add(1)
+}

--- a/common/testing/testcontext/timeout_context.go
+++ b/common/testing/testcontext/timeout_context.go
@@ -100,6 +100,13 @@ func (c *timeoutContext) effectiveExpiration() time.Time {
 	return c.activeExpiration
 }
 
+func (c *timeoutContext) activeExpirationOwnership() (time.Time, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	owned := !c.hasParentDeadline || c.activeExpiration.Before(c.parentDeadline)
+	return c.activeExpiration, owned
+}
+
 func (c *timeoutContext) cancel() {
 	c.finish(context.Canceled, context.Canceled)
 }

--- a/common/testing/testcontext/timeout_context.go
+++ b/common/testing/testcontext/timeout_context.go
@@ -11,9 +11,12 @@ import (
 // when Done closes and only moves forward through extend.
 type timeoutContext struct {
 	context.Context
-	ceiling time.Time
-	done    chan struct{}
-	owner   *contextState
+	parent            context.Context
+	parentDeadline    time.Time
+	hasParentDeadline bool
+	ceiling           time.Time
+	done              chan struct{}
+	owner             *contextState
 
 	mu                 sync.Mutex
 	activeExpiration   time.Time
@@ -24,7 +27,8 @@ type timeoutContext struct {
 }
 
 func newTimeoutContext(parent context.Context, ceiling, activeExpiration time.Time, owner *contextState) *timeoutContext {
-	if parentDeadline, ok := parent.Deadline(); ok && parentDeadline.Before(ceiling) {
+	parentDeadline, hasParentDeadline := parent.Deadline()
+	if hasParentDeadline && parentDeadline.Before(ceiling) {
 		ceiling = parentDeadline
 	}
 	if ceiling.Before(activeExpiration) {
@@ -32,12 +36,15 @@ func newTimeoutContext(parent context.Context, ceiling, activeExpiration time.Ti
 	}
 	causeContext, cancelCause := context.WithCancelCause(context.WithoutCancel(parent))
 	ctx := &timeoutContext{
-		Context:          causeContext,
-		ceiling:          ceiling,
-		done:             make(chan struct{}),
-		owner:            owner,
-		activeExpiration: activeExpiration,
-		cancelCause:      cancelCause,
+		Context:           causeContext,
+		parent:            parent,
+		parentDeadline:    parentDeadline,
+		hasParentDeadline: hasParentDeadline,
+		ceiling:           ceiling,
+		done:              make(chan struct{}),
+		owner:             owner,
+		activeExpiration:  activeExpiration,
+		cancelCause:       cancelCause,
 	}
 
 	// Either callback may run immediately, and finishLocked needs both handles
@@ -117,10 +124,15 @@ func (c *timeoutContext) expire() {
 		c.timer.Reset(remaining)
 		return
 	}
-	c.finishLocked(
-		context.DeadlineExceeded,
-		newDeadlineExceededCause(c.activeExpiration, c.owner),
-	)
+	err := error(context.DeadlineExceeded)
+	cause := err
+	if !c.hasParentDeadline || c.activeExpiration.Before(c.parentDeadline) {
+		cause = newDeadlineExceededCause(c.activeExpiration, c.owner)
+	} else if parentErr := c.parent.Err(); parentErr != nil {
+		err = parentErr
+		cause = context.Cause(c.parent)
+	}
+	c.finishLocked(err, cause)
 }
 
 func (c *timeoutContext) finishLocked(err, cause error) {

--- a/common/testing/testcontext/timeout_context.go
+++ b/common/testing/testcontext/timeout_context.go
@@ -13,26 +13,31 @@ type timeoutContext struct {
 	context.Context
 	ceiling time.Time
 	done    chan struct{}
+	owner   *contextState
 
 	mu                 sync.Mutex
 	activeExpiration   time.Time
 	timer              *time.Timer
 	stopParentCallback func() bool
+	cancelCause        context.CancelCauseFunc
 	err                error
 }
 
-func newTimeoutContext(parent context.Context, ceiling, activeExpiration time.Time) *timeoutContext {
+func newTimeoutContext(parent context.Context, ceiling, activeExpiration time.Time, owner *contextState) *timeoutContext {
 	if parentDeadline, ok := parent.Deadline(); ok && parentDeadline.Before(ceiling) {
 		ceiling = parentDeadline
 	}
 	if ceiling.Before(activeExpiration) {
 		activeExpiration = ceiling
 	}
+	causeContext, cancelCause := context.WithCancelCause(context.WithoutCancel(parent))
 	ctx := &timeoutContext{
-		Context:          context.WithoutCancel(parent),
+		Context:          causeContext,
 		ceiling:          ceiling,
 		done:             make(chan struct{}),
+		owner:            owner,
 		activeExpiration: activeExpiration,
+		cancelCause:      cancelCause,
 	}
 
 	// Either callback may run immediately, and finishLocked needs both handles
@@ -40,7 +45,7 @@ func newTimeoutContext(parent context.Context, ceiling, activeExpiration time.Ti
 	ctx.mu.Lock()
 	ctx.timer = time.AfterFunc(time.Until(activeExpiration), ctx.expire)
 	ctx.stopParentCallback = context.AfterFunc(parent, func() {
-		ctx.finish(parent.Err())
+		ctx.finish(parent.Err(), context.Cause(parent))
 	})
 	ctx.mu.Unlock()
 	return ctx
@@ -89,14 +94,14 @@ func (c *timeoutContext) effectiveExpiration() time.Time {
 }
 
 func (c *timeoutContext) cancel() {
-	c.finish(context.Canceled)
+	c.finish(context.Canceled, context.Canceled)
 }
 
-func (c *timeoutContext) finish(err error) {
+func (c *timeoutContext) finish(err, cause error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.finishLocked(err)
+	c.finishLocked(err, cause)
 }
 
 func (c *timeoutContext) expire() {
@@ -112,14 +117,18 @@ func (c *timeoutContext) expire() {
 		c.timer.Reset(remaining)
 		return
 	}
-	c.finishLocked(context.DeadlineExceeded)
+	c.finishLocked(
+		context.DeadlineExceeded,
+		newDeadlineExceededCause(c.activeExpiration, c.owner),
+	)
 }
 
-func (c *timeoutContext) finishLocked(err error) {
+func (c *timeoutContext) finishLocked(err, cause error) {
 	if c.err != nil {
 		return
 	}
 	c.err = err
+	c.cancelCause(cause)
 	close(c.done)
 	c.timer.Stop()
 	c.stopParentCallback()

--- a/common/testing/testcontext/timeout_context_test.go
+++ b/common/testing/testcontext/timeout_context_test.go
@@ -2,6 +2,7 @@ package testcontext
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"testing/synctest"
@@ -15,7 +16,7 @@ func TestTimeoutContextReportsCeilingAndExpiresAtActiveExpiration(t *testing.T) 
 
 	synctest.Test(t, func(t *testing.T) {
 		start := time.Now()
-		ctx := newTimeoutContext(t.Context(), start.Add(time.Minute), start.Add(10*time.Second))
+		ctx := newTimeoutContext(t.Context(), start.Add(time.Minute), start.Add(10*time.Second), nil)
 
 		deadline, ok := ctx.Deadline()
 		require.True(t, ok)
@@ -34,7 +35,7 @@ func TestTimeoutContextInheritsParentDeadline(t *testing.T) {
 		start := time.Now()
 		parent, cancel := context.WithDeadline(t.Context(), start.Add(time.Second))
 		defer cancel()
-		ctx := newTimeoutContext(parent, start.Add(time.Minute), start.Add(10*time.Second))
+		ctx := newTimeoutContext(parent, start.Add(time.Minute), start.Add(10*time.Second), nil)
 
 		deadline, ok := ctx.Deadline()
 		require.True(t, ok)
@@ -52,7 +53,7 @@ func TestTimeoutContextStartsCanceledWithCanceledParent(t *testing.T) {
 	parent, cancelParent := context.WithCancel(t.Context())
 	cancelParent()
 	start := time.Now()
-	ctx := newTimeoutContext(parent, start.Add(time.Minute), start.Add(10*time.Second))
+	ctx := newTimeoutContext(parent, start.Add(time.Minute), start.Add(10*time.Second), nil)
 
 	<-ctx.Done()
 	require.ErrorIs(t, ctx.Err(), context.Canceled)
@@ -63,7 +64,7 @@ func TestTimeoutContextExtensionKeepsIdentityAlivePastOldDeadline(t *testing.T) 
 
 	synctest.Test(t, func(t *testing.T) {
 		start := time.Now()
-		ctx := newTimeoutContext(t.Context(), start.Add(time.Minute), start.Add(10*time.Second))
+		ctx := newTimeoutContext(t.Context(), start.Add(time.Minute), start.Add(10*time.Second), nil)
 
 		ctx.extend(start.Add(20 * time.Second))
 		time.Sleep(11 * time.Second) //nolint:forbidigo // advance past the original active deadline
@@ -80,7 +81,7 @@ func TestTimeoutContextExtensionsAreMonotonic(t *testing.T) {
 
 	synctest.Test(t, func(t *testing.T) {
 		start := time.Now()
-		ctx := newTimeoutContext(t.Context(), start.Add(time.Minute), start.Add(10*time.Second))
+		ctx := newTimeoutContext(t.Context(), start.Add(time.Minute), start.Add(10*time.Second), nil)
 
 		var wg sync.WaitGroup
 		for _, extension := range []time.Duration{15 * time.Second, 30 * time.Second, 20 * time.Second, 25 * time.Second} {
@@ -125,7 +126,7 @@ func TestTimeoutContextCancellationIsTerminal(t *testing.T) {
 			synctest.Test(t, func(t *testing.T) {
 				start := time.Now()
 				parent, cancelParent := context.WithCancel(t.Context())
-				ctx := newTimeoutContext(parent, start.Add(time.Minute), start.Add(10*time.Second))
+				ctx := newTimeoutContext(parent, start.Add(time.Minute), start.Add(10*time.Second), nil)
 
 				tc.cancel(cancelParent, ctx)
 				<-ctx.Done()
@@ -142,7 +143,7 @@ func TestTimeoutContextDerivedDeadlineRemainsTighter(t *testing.T) {
 
 	synctest.Test(t, func(t *testing.T) {
 		start := time.Now()
-		ctx := newTimeoutContext(t.Context(), start.Add(time.Minute), start.Add(10*time.Second))
+		ctx := newTimeoutContext(t.Context(), start.Add(time.Minute), start.Add(10*time.Second), nil)
 		derived, cancel := context.WithTimeout(ctx, 20*time.Second)
 		defer cancel()
 
@@ -164,14 +165,47 @@ func TestTimeoutContextCauseRemainsDeadlineExceededAfterParentCancellation(t *te
 	synctest.Test(t, func(t *testing.T) {
 		start := time.Now()
 		parent, cancelParent := context.WithCancel(t.Context())
-		ctx := newTimeoutContext(parent, start.Add(time.Minute), start.Add(time.Second))
+		ctx := newTimeoutContext(parent, start.Add(time.Minute), start.Add(time.Second), nil)
 
 		time.Sleep(time.Second) //nolint:forbidigo // advance to the active expiration
 		<-ctx.Done()
+		require.Equal(t, context.DeadlineExceeded, ctx.Err())
+		require.ErrorIs(t, context.Cause(ctx), DeadlineExceeded)
 		require.ErrorIs(t, context.Cause(ctx), context.DeadlineExceeded)
 
 		cancelParent()
 		require.ErrorIs(t, context.Cause(ctx), context.DeadlineExceeded)
+	})
+}
+
+func TestTimeoutContextPreservesParentCause(t *testing.T) {
+	t.Parallel()
+
+	parent, cancelParent := context.WithCancelCause(t.Context())
+	start := time.Now()
+	ctx := newTimeoutContext(parent, start.Add(time.Minute), start.Add(10*time.Second), nil)
+	parentCause := errors.New("parent stopped")
+	cancelParent(parentCause)
+
+	<-ctx.Done()
+	require.Equal(t, context.Canceled, ctx.Err())
+	require.ErrorIs(t, context.Cause(ctx), parentCause)
+}
+
+func TestTimeoutContextDerivedContextPreservesCause(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		start := time.Now()
+		ctx := newTimeoutContext(t.Context(), start.Add(time.Minute), start.Add(time.Second), nil)
+		derived, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		time.Sleep(time.Second) //nolint:forbidigo // advance to the active expiration
+		<-derived.Done()
+
+		require.Equal(t, context.DeadlineExceeded, derived.Err())
+		require.ErrorIs(t, context.Cause(derived), DeadlineExceeded)
 	})
 }
 
@@ -180,7 +214,7 @@ func TestTimeoutContextExpirationIsTerminal(t *testing.T) {
 
 	synctest.Test(t, func(t *testing.T) {
 		start := time.Now()
-		ctx := newTimeoutContext(t.Context(), start.Add(time.Minute), start.Add(time.Second))
+		ctx := newTimeoutContext(t.Context(), start.Add(time.Minute), start.Add(time.Second), nil)
 
 		time.Sleep(time.Second) //nolint:forbidigo // advance to the active expiration
 		<-ctx.Done()
@@ -196,7 +230,7 @@ func TestTimeoutContextIgnoresStaleExpirationAfterExtension(t *testing.T) {
 
 	synctest.Test(t, func(t *testing.T) {
 		start := time.Now()
-		ctx := newTimeoutContext(t.Context(), start.Add(time.Minute), start.Add(time.Second))
+		ctx := newTimeoutContext(t.Context(), start.Add(time.Minute), start.Add(time.Second), nil)
 
 		ctx.extend(start.Add(2 * time.Second))
 		ctx.expire() // simulate the original timer callback racing after extension

--- a/common/testing/testcontext/timeout_context_test.go
+++ b/common/testing/testcontext/timeout_context_test.go
@@ -62,7 +62,7 @@ func TestTimeoutContextDoesNotClaimParentDeadline(t *testing.T) {
 		<-ctx.Done()
 
 		require.Equal(t, context.DeadlineExceeded, ctx.Err())
-		require.False(t, errors.Is(context.Cause(ctx), DeadlineExceeded))
+		require.NotErrorIs(t, context.Cause(ctx), DeadlineExceeded)
 		require.ErrorIs(t, context.Cause(ctx), context.DeadlineExceeded)
 	})
 }

--- a/common/testing/testcontext/timeout_context_test.go
+++ b/common/testing/testcontext/timeout_context_test.go
@@ -47,6 +47,26 @@ func TestTimeoutContextInheritsParentDeadline(t *testing.T) {
 	})
 }
 
+func TestTimeoutContextDoesNotClaimParentDeadline(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		start := time.Now()
+		parent := reportedDeadlineContext{
+			Context:  t.Context(),
+			deadline: start.Add(time.Second),
+		}
+		ctx := newTimeoutContext(parent, start.Add(time.Minute), start.Add(10*time.Second), nil)
+
+		time.Sleep(time.Second) //nolint:forbidigo // advance to the parent-owned deadline
+		<-ctx.Done()
+
+		require.Equal(t, context.DeadlineExceeded, ctx.Err())
+		require.False(t, errors.Is(context.Cause(ctx), DeadlineExceeded))
+		require.ErrorIs(t, context.Cause(ctx), context.DeadlineExceeded)
+	})
+}
+
 func TestTimeoutContextStartsCanceledWithCanceledParent(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What changed?

Tracks each granted and denied test-context extension. 

## Why?

Timeout failures need to explain how the test deadline evolved and whether the test-context cap or `go test -timeout` limited it. 