### PR TITLE
Enforce JWT audience for Nexus HTTP handlers

### DIFF
--- a/common/authorization/interceptor.go
+++ b/common/authorization/interceptor.go
@@ -197,7 +197,7 @@ func (a *Interceptor) InterceptStream(
 	if !bypassAuth {
 		tlsConnection := TLSInfoFromContext(ctx)
 		headerGetter := headers.NewGRPCHeaderGetter(ctx)
-		authInfo := a.GetAuthInfoForNonUnaryRequest(ctx, tlsConnection, headerGetter)
+		authInfo := a.GetAuthInfoForRequest(ctx, tlsConnection, headerGetter)
 
 		var claims *Claims
 		if authInfo != nil {
@@ -239,8 +239,8 @@ type wrappedServerStream struct {
 
 func (w *wrappedServerStream) Context() context.Context { return w.ctx }
 
-// GetAuthInfoForNonUnaryRequest extracts auth info for a request without unary gRPC request metadata.
-func (a *Interceptor) GetAuthInfoForNonUnaryRequest(
+// GetAuthInfoForRequest extracts auth info for a request without unary gRPC request metadata.
+func (a *Interceptor) GetAuthInfoForRequest(
 	ctx context.Context,
 	tlsConnection *credentials.TLSInfo,
 	header headers.HeaderGetter,

--- a/common/authorization/interceptor.go
+++ b/common/authorization/interceptor.go
@@ -197,7 +197,6 @@ func (a *Interceptor) InterceptStream(
 	if !bypassAuth {
 		tlsConnection := TLSInfoFromContext(ctx)
 		headerGetter := headers.NewGRPCHeaderGetter(ctx)
-
 		authInfo := a.GetAuthInfoForNonUnaryRequest(ctx, tlsConnection, headerGetter)
 
 		var claims *Claims

--- a/common/authorization/interceptor.go
+++ b/common/authorization/interceptor.go
@@ -30,6 +30,7 @@ type (
 
 type (
 	// JWTAudienceMapper returns JWT audience for a given request. req and info are nil from streaming RPCs.
+	// They are also nil for non-unary HTTP requests.
 	JWTAudienceMapper interface {
 		Audience(ctx context.Context, req any, info *grpc.UnaryServerInfo) string
 	}
@@ -197,13 +198,7 @@ func (a *Interceptor) InterceptStream(
 		tlsConnection := TLSInfoFromContext(ctx)
 		headerGetter := headers.NewGRPCHeaderGetter(ctx)
 
-		authInfo := a.GetAuthInfo(tlsConnection, headerGetter, func() string {
-			// Skip the mapper for tokenless streams; calling custom impls with nil req/info would be a behavior change.
-			if a.audienceGetter == nil || headerGetter.Get(a.authHeaderName) == "" {
-				return ""
-			}
-			return a.audienceGetter.Audience(ctx, nil, nil)
-		})
+		authInfo := a.GetAuthInfoForNonUnaryRequest(ctx, tlsConnection, headerGetter)
 
 		var claims *Claims
 		if authInfo != nil {
@@ -244,6 +239,21 @@ type wrappedServerStream struct {
 }
 
 func (w *wrappedServerStream) Context() context.Context { return w.ctx }
+
+// GetAuthInfoForNonUnaryRequest extracts auth info for a request without unary gRPC request metadata.
+func (a *Interceptor) GetAuthInfoForNonUnaryRequest(
+	ctx context.Context,
+	tlsConnection *credentials.TLSInfo,
+	header headers.HeaderGetter,
+) *AuthInfo {
+	return a.GetAuthInfo(tlsConnection, header, func() string {
+		// Skip the mapper for tokenless streams; calling custom impls with nil req/info would be a behavior change.
+		if a.audienceGetter == nil || header == nil || header.Get(a.authHeaderName) == "" {
+			return ""
+		}
+		return a.audienceGetter.Audience(ctx, nil, nil)
+	})
+}
 
 // GetAuthInfo extracts auth info from TLS info and headers.
 // Returns nil if either the policy's claimMapper or authorizer are nil or when there is no auth information in the

--- a/common/authorization/interceptor.go
+++ b/common/authorization/interceptor.go
@@ -29,8 +29,7 @@ type (
 )
 
 type (
-	// JWTAudienceMapper returns JWT audience for a given request. req and info are nil from streaming RPCs.
-	// They are also nil for non-unary HTTP requests.
+	// JWTAudienceMapper returns JWT audience for a given request. req and info are nil for gRPC streams and Nexus HTTP requests.
 	JWTAudienceMapper interface {
 		Audience(ctx context.Context, req any, info *grpc.UnaryServerInfo) string
 	}
@@ -239,14 +238,15 @@ type wrappedServerStream struct {
 
 func (w *wrappedServerStream) Context() context.Context { return w.ctx }
 
-// GetAuthInfoForRequest extracts auth info for a request without unary gRPC request metadata.
+// GetAuthInfoForRequest extracts auth info for gRPC streams and Nexus HTTP requests,
+// where there is no unary request to hand to the audience mapper.
 func (a *Interceptor) GetAuthInfoForRequest(
 	ctx context.Context,
 	tlsConnection *credentials.TLSInfo,
 	header headers.HeaderGetter,
 ) *AuthInfo {
 	return a.GetAuthInfo(tlsConnection, header, func() string {
-		// Skip the mapper for tokenless streams; calling custom impls with nil req/info would be a behavior change.
+		// The audience only applies to a token, so skip the mapper when there isn't one.
 		if a.audienceGetter == nil || header == nil || header.Get(a.authHeaderName) == "" {
 			return ""
 		}

--- a/common/authorization/interceptor.go
+++ b/common/authorization/interceptor.go
@@ -196,7 +196,7 @@ func (a *Interceptor) InterceptStream(
 	if !bypassAuth {
 		tlsConnection := TLSInfoFromContext(ctx)
 		headerGetter := headers.NewGRPCHeaderGetter(ctx)
-		authInfo := a.GetAuthInfoForRequest(ctx, tlsConnection, headerGetter)
+		authInfo := a.ExtractAuthInfoForRequest(ctx, tlsConnection, headerGetter)
 
 		var claims *Claims
 		if authInfo != nil {
@@ -238,9 +238,9 @@ type wrappedServerStream struct {
 
 func (w *wrappedServerStream) Context() context.Context { return w.ctx }
 
-// GetAuthInfoForRequest extracts auth info for gRPC streams and Nexus HTTP requests,
+// ExtractAuthInfoForRequest extracts auth info for gRPC streams and Nexus HTTP requests,
 // where there is no unary request to hand to the audience mapper.
-func (a *Interceptor) GetAuthInfoForRequest(
+func (a *Interceptor) ExtractAuthInfoForRequest(
 	ctx context.Context,
 	tlsConnection *credentials.TLSInfo,
 	header headers.HeaderGetter,

--- a/common/authorization/interceptor.go
+++ b/common/authorization/interceptor.go
@@ -238,8 +238,8 @@ type wrappedServerStream struct {
 
 func (w *wrappedServerStream) Context() context.Context { return w.ctx }
 
-// ExtractAuthInfoForRequest extracts auth info for gRPC streams and Nexus HTTP requests,
-// where there is no unary request to hand to the audience mapper.
+// ExtractAuthInfoForRequest extracts auth info for gRPC streams and Nexus HTTP requests.
+// It invokes JWTAudienceMapper.Audience with nil req and info because those arguments describe unary gRPC calls.
 func (a *Interceptor) ExtractAuthInfoForRequest(
 	ctx context.Context,
 	tlsConnection *credentials.TLSInfo,

--- a/common/authorization/interceptor_test.go
+++ b/common/authorization/interceptor_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"errors"
+	"net/http"
 	"slices"
 	"testing"
 
@@ -849,6 +850,60 @@ func (s *authorizerInterceptorSuite) TestInterceptStream_AudienceMapperSkippedWi
 	ss := &mockServerStream{ctx: inCtx}
 	err := interceptor.InterceptStream(nil, ss, streamInfo, streamHandler)
 	s.NoError(err)
+}
+
+func (s *authorizerInterceptorSuite) TestGetAuthInfoForNonUnaryRequest_AudiencePassedToClaimMapper() {
+	mockAudienceMapper := NewMockJWTAudienceMapper(s.controller)
+	mockAudienceMapper.EXPECT().Audience(ctx, nil, nil).Return("request-audience")
+
+	interceptor := NewInterceptor(
+		s.mockClaimMapper,
+		s.mockAuthorizer,
+		s.mockMetricsHandler,
+		log.NewNoopLogger(),
+		mockNamespaceChecker(testNamespace),
+		mockAudienceMapper,
+		"",
+		"",
+		dynamicconfig.GetBoolPropertyFn(false),
+		dynamicconfig.GetBoolPropertyFn(false),
+		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true),
+		dynamicconfig.GetBoolPropertyFn(false),
+	)
+
+	authInfo := interceptor.GetAuthInfoForNonUnaryRequest(
+		ctx,
+		nil,
+		http.Header{"Authorization": {"Bearer some-token"}},
+	)
+
+	s.Equal(&AuthInfo{AuthToken: "Bearer some-token", Audience: "request-audience"}, authInfo)
+}
+
+func (s *authorizerInterceptorSuite) TestGetAuthInfoForNonUnaryRequest_AudienceMapperSkippedWithoutToken() {
+	mockAudienceMapper := NewMockJWTAudienceMapper(s.controller)
+	interceptor := NewInterceptor(
+		s.mockClaimMapper,
+		s.mockAuthorizer,
+		s.mockMetricsHandler,
+		log.NewNoopLogger(),
+		mockNamespaceChecker(testNamespace),
+		mockAudienceMapper,
+		"",
+		"",
+		dynamicconfig.GetBoolPropertyFn(false),
+		dynamicconfig.GetBoolPropertyFn(false),
+		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true),
+		dynamicconfig.GetBoolPropertyFn(false),
+	)
+
+	cert := &x509.Certificate{Subject: pkix.Name{CommonName: "client"}}
+	tlsInfo := &credentials.TLSInfo{State: tls.ConnectionState{VerifiedChains: [][]*x509.Certificate{{cert}}}}
+	authInfo := interceptor.GetAuthInfoForNonUnaryRequest(ctx, tlsInfo, http.Header{})
+
+	s.Empty(authInfo.AuthToken)
+	s.Empty(authInfo.Audience)
+	s.NotNil(authInfo.TLSSubject)
 }
 
 func (s *authorizerInterceptorSuite) TestInterceptStream_ContextPropagated() {

--- a/common/authorization/interceptor_test.go
+++ b/common/authorization/interceptor_test.go
@@ -900,6 +900,7 @@ func (s *authorizerInterceptorSuite) TestGetAuthInfoForRequest_AudienceMapperSki
 	cert := &x509.Certificate{Subject: pkix.Name{CommonName: "client"}}
 	tlsInfo := &credentials.TLSInfo{State: tls.ConnectionState{VerifiedChains: [][]*x509.Certificate{{cert}}}}
 	authInfo := interceptor.GetAuthInfoForRequest(ctx, tlsInfo, http.Header{})
+	s.Require().NotNil(authInfo)
 
 	s.Empty(authInfo.AuthToken)
 	s.Empty(authInfo.Audience)

--- a/common/authorization/interceptor_test.go
+++ b/common/authorization/interceptor_test.go
@@ -852,7 +852,7 @@ func (s *authorizerInterceptorSuite) TestInterceptStream_AudienceMapperSkippedWi
 	s.NoError(err)
 }
 
-func (s *authorizerInterceptorSuite) TestGetAuthInfoForNonUnaryRequest_AudiencePassedToClaimMapper() {
+func (s *authorizerInterceptorSuite) TestGetAuthInfoForRequest_AudiencePassedToClaimMapper() {
 	mockAudienceMapper := NewMockJWTAudienceMapper(s.controller)
 	mockAudienceMapper.EXPECT().Audience(ctx, nil, nil).Return("request-audience")
 
@@ -871,7 +871,7 @@ func (s *authorizerInterceptorSuite) TestGetAuthInfoForNonUnaryRequest_AudienceP
 		dynamicconfig.GetBoolPropertyFn(false),
 	)
 
-	authInfo := interceptor.GetAuthInfoForNonUnaryRequest(
+	authInfo := interceptor.GetAuthInfoForRequest(
 		ctx,
 		nil,
 		http.Header{"Authorization": {"Bearer some-token"}},
@@ -880,7 +880,7 @@ func (s *authorizerInterceptorSuite) TestGetAuthInfoForNonUnaryRequest_AudienceP
 	s.Equal(&AuthInfo{AuthToken: "Bearer some-token", Audience: "request-audience"}, authInfo)
 }
 
-func (s *authorizerInterceptorSuite) TestGetAuthInfoForNonUnaryRequest_AudienceMapperSkippedWithoutToken() {
+func (s *authorizerInterceptorSuite) TestGetAuthInfoForRequest_AudienceMapperSkippedWithoutToken() {
 	mockAudienceMapper := NewMockJWTAudienceMapper(s.controller)
 	interceptor := NewInterceptor(
 		s.mockClaimMapper,
@@ -899,7 +899,7 @@ func (s *authorizerInterceptorSuite) TestGetAuthInfoForNonUnaryRequest_AudienceM
 
 	cert := &x509.Certificate{Subject: pkix.Name{CommonName: "client"}}
 	tlsInfo := &credentials.TLSInfo{State: tls.ConnectionState{VerifiedChains: [][]*x509.Certificate{{cert}}}}
-	authInfo := interceptor.GetAuthInfoForNonUnaryRequest(ctx, tlsInfo, http.Header{})
+	authInfo := interceptor.GetAuthInfoForRequest(ctx, tlsInfo, http.Header{})
 
 	s.Empty(authInfo.AuthToken)
 	s.Empty(authInfo.Audience)

--- a/common/authorization/interceptor_test.go
+++ b/common/authorization/interceptor_test.go
@@ -881,7 +881,7 @@ func (s *authorizerInterceptorSuite) TestInterceptStream_ContextPropagated() {
 	s.NotNil(handlerCtx)
 }
 
-func (s *authorizerInterceptorSuite) TestGetAuthInfoForRequest_AudiencePassedToClaimMapper() {
+func (s *authorizerInterceptorSuite) TestExtractAuthInfoForRequest_AudiencePassedToClaimMapper() {
 	mockAudienceMapper := NewMockJWTAudienceMapper(s.controller)
 	mockAudienceMapper.EXPECT().Audience(ctx, nil, nil).Return("request-audience")
 
@@ -900,7 +900,7 @@ func (s *authorizerInterceptorSuite) TestGetAuthInfoForRequest_AudiencePassedToC
 		dynamicconfig.GetBoolPropertyFn(false),
 	)
 
-	authInfo := interceptor.GetAuthInfoForRequest(
+	authInfo := interceptor.ExtractAuthInfoForRequest(
 		ctx,
 		nil,
 		http.Header{"Authorization": {"Bearer some-token"}},
@@ -909,7 +909,7 @@ func (s *authorizerInterceptorSuite) TestGetAuthInfoForRequest_AudiencePassedToC
 	s.Equal(&AuthInfo{AuthToken: "Bearer some-token", Audience: "request-audience"}, authInfo)
 }
 
-func (s *authorizerInterceptorSuite) TestGetAuthInfoForRequest_AudienceMapperSkippedWithoutToken() {
+func (s *authorizerInterceptorSuite) TestExtractAuthInfoForRequest_AudienceMapperSkippedWithoutToken() {
 	mockAudienceMapper := NewMockJWTAudienceMapper(s.controller)
 	interceptor := NewInterceptor(
 		s.mockClaimMapper,
@@ -928,7 +928,7 @@ func (s *authorizerInterceptorSuite) TestGetAuthInfoForRequest_AudienceMapperSki
 
 	cert := &x509.Certificate{Subject: pkix.Name{CommonName: "client"}}
 	tlsInfo := &credentials.TLSInfo{State: tls.ConnectionState{VerifiedChains: [][]*x509.Certificate{{cert}}}}
-	authInfo := interceptor.GetAuthInfoForRequest(ctx, tlsInfo, http.Header{})
+	authInfo := interceptor.ExtractAuthInfoForRequest(ctx, tlsInfo, http.Header{})
 	s.Require().NotNil(authInfo)
 
 	s.Empty(authInfo.AuthToken)

--- a/common/authorization/interceptor_test.go
+++ b/common/authorization/interceptor_test.go
@@ -852,6 +852,35 @@ func (s *authorizerInterceptorSuite) TestInterceptStream_AudienceMapperSkippedWi
 	s.NoError(err)
 }
 
+func (s *authorizerInterceptorSuite) TestInterceptStream_ContextPropagated() {
+	// Verify the handler receives a wrapped stream with the modified context.
+	streamTarget := &CallTarget{
+		Namespace: "",
+		APIName:   streamInfo.FullMethod,
+		Request:   nil,
+	}
+	s.mockMetricsHandler.EXPECT().WithTags(
+		metrics.OperationTag(metrics.AuthorizationScope),
+		metrics.NamespaceUnknownTag(),
+	).Return(s.mockMetricsHandler)
+	s.mockAuthorizer.EXPECT().Authorize(gomock.Any(), nil, streamTarget).
+		Return(Result{Decision: DecisionAllow}, nil)
+
+	// Inject a spoofed principal header; it must be stripped in the handler's context.
+	inCtx := metadata.NewIncomingContext(ctx, metadata.MD{})
+
+	var handlerCtx context.Context
+	streamHandler := func(srv any, stream grpc.ServerStream) error {
+		handlerCtx = stream.Context()
+		return nil
+	}
+
+	ss := &mockServerStream{ctx: inCtx}
+	err := s.interceptor.InterceptStream(nil, ss, streamInfo, streamHandler)
+	s.NoError(err)
+	s.NotNil(handlerCtx)
+}
+
 func (s *authorizerInterceptorSuite) TestGetAuthInfoForRequest_AudiencePassedToClaimMapper() {
 	mockAudienceMapper := NewMockJWTAudienceMapper(s.controller)
 	mockAudienceMapper.EXPECT().Audience(ctx, nil, nil).Return("request-audience")
@@ -905,33 +934,4 @@ func (s *authorizerInterceptorSuite) TestGetAuthInfoForRequest_AudienceMapperSki
 	s.Empty(authInfo.AuthToken)
 	s.Empty(authInfo.Audience)
 	s.NotNil(authInfo.TLSSubject)
-}
-
-func (s *authorizerInterceptorSuite) TestInterceptStream_ContextPropagated() {
-	// Verify the handler receives a wrapped stream with the modified context.
-	streamTarget := &CallTarget{
-		Namespace: "",
-		APIName:   streamInfo.FullMethod,
-		Request:   nil,
-	}
-	s.mockMetricsHandler.EXPECT().WithTags(
-		metrics.OperationTag(metrics.AuthorizationScope),
-		metrics.NamespaceUnknownTag(),
-	).Return(s.mockMetricsHandler)
-	s.mockAuthorizer.EXPECT().Authorize(gomock.Any(), nil, streamTarget).
-		Return(Result{Decision: DecisionAllow}, nil)
-
-	// Inject a spoofed principal header; it must be stripped in the handler's context.
-	inCtx := metadata.NewIncomingContext(ctx, metadata.MD{})
-
-	var handlerCtx context.Context
-	streamHandler := func(srv any, stream grpc.ServerStream) error {
-		handlerCtx = stream.Context()
-		return nil
-	}
-
-	ss := &mockServerStream{ctx: inCtx}
-	err := s.interceptor.InterceptStream(nil, ss, streamInfo, streamHandler)
-	s.NoError(err)
-	s.NotNil(handlerCtx)
 }

--- a/service/frontend/nexus_completion_http_handler.go
+++ b/service/frontend/nexus_completion_http_handler.go
@@ -584,7 +584,7 @@ func (c *requestContext) interceptRequest(ctx context.Context, request *nexusrpc
 
 	var err error
 	var claims *authorization.Claims
-	if authInfo := c.AuthInterceptor.GetAuthInfoForNonUnaryRequest(ctx, tlsInfo, request.HTTPRequest.Header); authInfo != nil {
+	if authInfo := c.AuthInterceptor.GetAuthInfoForRequest(ctx, tlsInfo, request.HTTPRequest.Header); authInfo != nil {
 		claims, err = c.AuthInterceptor.GetClaims(authInfo)
 		if err != nil {
 			return err

--- a/service/frontend/nexus_completion_http_handler.go
+++ b/service/frontend/nexus_completion_http_handler.go
@@ -582,9 +582,7 @@ func (c *requestContext) interceptRequest(ctx context.Context, request *nexusrpc
 		}
 	}
 
-	authInfo := c.AuthInterceptor.GetAuthInfo(tlsInfo, request.HTTPRequest.Header, func() string {
-		return "" // TODO: support audience getter
-	})
+	authInfo := c.AuthInterceptor.GetAuthInfoForNonUnaryRequest(ctx, tlsInfo, request.HTTPRequest.Header)
 
 	var claims *authorization.Claims
 	var err error

--- a/service/frontend/nexus_completion_http_handler.go
+++ b/service/frontend/nexus_completion_http_handler.go
@@ -582,11 +582,9 @@ func (c *requestContext) interceptRequest(ctx context.Context, request *nexusrpc
 		}
 	}
 
-	authInfo := c.AuthInterceptor.GetAuthInfoForNonUnaryRequest(ctx, tlsInfo, request.HTTPRequest.Header)
-
-	var claims *authorization.Claims
 	var err error
-	if authInfo != nil {
+	var claims *authorization.Claims
+	if authInfo := c.AuthInterceptor.GetAuthInfoForNonUnaryRequest(ctx, tlsInfo, request.HTTPRequest.Header); authInfo != nil {
 		claims, err = c.AuthInterceptor.GetClaims(authInfo)
 		if err != nil {
 			return err

--- a/service/frontend/nexus_completion_http_handler.go
+++ b/service/frontend/nexus_completion_http_handler.go
@@ -587,7 +587,9 @@ func (c *requestContext) interceptRequest(ctx context.Context, request *nexusrpc
 	if authInfo := c.AuthInterceptor.GetAuthInfoForRequest(ctx, tlsInfo, request.HTTPRequest.Header); authInfo != nil {
 		claims, err = c.AuthInterceptor.GetClaims(authInfo)
 		if err != nil {
-			return err
+			c.outcomeTag = metrics.OutcomeTag("unauthorized")
+			c.logger.Error("failed to get claims for nexus completion request", tag.Error(err))
+			return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeUnauthenticated, "unauthorized")
 		}
 		// Make the auth info and claims available on the context.
 		ctx = c.AuthInterceptor.EnhanceContext(ctx, authInfo, claims)

--- a/service/frontend/nexus_completion_http_handler.go
+++ b/service/frontend/nexus_completion_http_handler.go
@@ -587,9 +587,14 @@ func (c *requestContext) interceptRequest(ctx context.Context, request *nexusrpc
 	if authInfo := c.AuthInterceptor.GetAuthInfoForRequest(ctx, tlsInfo, request.HTTPRequest.Header); authInfo != nil {
 		claims, err = c.AuthInterceptor.GetClaims(authInfo)
 		if err != nil {
-			c.outcomeTag = metrics.OutcomeTag("unauthorized")
 			c.logger.Error("failed to get claims for nexus completion request", tag.Error(err))
-			return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeUnauthenticated, "unauthorized")
+			var permissionDeniedError *serviceerror.PermissionDenied
+			if errors.As(err, &permissionDeniedError) {
+				c.outcomeTag = metrics.OutcomeTag("unauthorized")
+			} else {
+				c.outcomeTag = metrics.OutcomeTag("internal_auth_error")
+			}
+			return convertNexusClaimMapperError(err)
 		}
 		// Make the auth info and claims available on the context.
 		ctx = c.AuthInterceptor.EnhanceContext(ctx, authInfo, claims)

--- a/service/frontend/nexus_completion_http_handler.go
+++ b/service/frontend/nexus_completion_http_handler.go
@@ -584,7 +584,7 @@ func (c *requestContext) interceptRequest(ctx context.Context, request *nexusrpc
 
 	var err error
 	var claims *authorization.Claims
-	if authInfo := c.AuthInterceptor.GetAuthInfoForRequest(ctx, tlsInfo, request.HTTPRequest.Header); authInfo != nil {
+	if authInfo := c.AuthInterceptor.ExtractAuthInfoForRequest(ctx, tlsInfo, request.HTTPRequest.Header); authInfo != nil {
 		claims, err = c.AuthInterceptor.GetClaims(authInfo)
 		if err != nil {
 			c.logger.Error("failed to get claims for nexus completion request", tag.Error(err))

--- a/service/frontend/nexus_completion_http_handler_test.go
+++ b/service/frontend/nexus_completion_http_handler_test.go
@@ -15,6 +15,7 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	tokenspb "go.temporal.io/server/api/token/v1"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/nexus/nexusrpc"
 	"go.temporal.io/server/components/nexusoperations"
@@ -79,9 +80,12 @@ func TestNexusCompletionHTTPHandler_JWTAudience(t *testing.T) {
 
 			err := requestContext.interceptRequest(context.Background(), &nexusrpc.CompletionRequest{HTTPRequest: httpRequest})
 			if tc.wantDenied {
-				var permissionDenied *serviceerror.PermissionDenied
-				require.ErrorAs(t, err, &permissionDenied)
+				var handlerError *nexus.HandlerError
+				require.ErrorAs(t, err, &handlerError)
+				require.Equal(t, nexus.HandlerErrorTypeUnauthenticated, handlerError.Type)
+				require.Equal(t, metrics.OutcomeTag("unauthorized"), requestContext.outcomeTag)
 			} else {
+				// Claim mapping succeeded, so the request reached errorAuthorizer's sentinel error.
 				var handlerError *nexus.HandlerError
 				require.ErrorAs(t, err, &handlerError)
 				require.Equal(t, nexus.HandlerErrorTypeInternal, handlerError.Type)

--- a/service/frontend/nexus_completion_http_handler_test.go
+++ b/service/frontend/nexus_completion_http_handler_test.go
@@ -2,6 +2,8 @@ package frontend
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/nexus-rpc/sdk-go/nexus"
@@ -13,6 +15,7 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	tokenspb "go.temporal.io/server/api/token/v1"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/nexus/nexusrpc"
 	"go.temporal.io/server/components/nexusoperations"
 	"go.temporal.io/server/nexusworkflowref"
@@ -21,6 +24,71 @@ import (
 )
 
 const convTestRequestID = "request-id"
+
+func TestNexusCompletionHTTPHandler_JWTAudience(t *testing.T) {
+	testCases := []struct {
+		name               string
+		token              string
+		tokenAudience      string
+		configuredAudience string
+		wantDenied         bool
+	}{
+		{
+			name:               "matching audience",
+			token:              "Bearer token",
+			tokenAudience:      "nexus-api",
+			configuredAudience: "nexus-api",
+		},
+		{
+			name:               "mismatching audience",
+			token:              "Bearer token",
+			tokenAudience:      "other-api",
+			configuredAudience: "nexus-api",
+			wantDenied:         true,
+		},
+		{
+			name:          "no configured audience",
+			token:         "Bearer token",
+			tokenAudience: "other-api",
+		},
+		{
+			name:               "no token",
+			configuredAudience: "nexus-api",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &nexusCompletionHandler{
+				AuthInterceptor: newAudienceTestInterceptor(tc.tokenAudience, tc.configuredAudience, errorAuthorizer{}),
+				Logger:          log.NewNoopLogger(),
+			}
+			requestContext := &requestContext{
+				nexusCompletionHandler: h,
+				namespace: namespace.NewLocalNamespaceForTest(
+					&persistencespb.NamespaceInfo{Name: "test-namespace"},
+					nil,
+					"active",
+				),
+				logger: log.NewNoopLogger(),
+			}
+			httpRequest := httptest.NewRequest(http.MethodPost, "/", nil)
+			if tc.token != "" {
+				httpRequest.Header.Set("Authorization", tc.token)
+			}
+
+			err := requestContext.interceptRequest(context.Background(), &nexusrpc.CompletionRequest{HTTPRequest: httpRequest})
+			if tc.wantDenied {
+				var permissionDenied *serviceerror.PermissionDenied
+				require.ErrorAs(t, err, &permissionDenied)
+			} else {
+				var handlerError *nexus.HandlerError
+				require.ErrorAs(t, err, &handlerError)
+				require.Equal(t, nexus.HandlerErrorTypeInternal, handlerError.Type)
+			}
+		})
+	}
+}
 
 // hsmCompletionToken builds the HSM token used by these conversion tests.
 func hsmCompletionToken() *tokenspb.NexusOperationCompletion {

--- a/service/frontend/nexus_completion_http_handler_test.go
+++ b/service/frontend/nexus_completion_http_handler_test.go
@@ -2,6 +2,7 @@ package frontend
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -90,6 +91,60 @@ func TestNexusCompletionHTTPHandler_JWTAudience(t *testing.T) {
 				require.ErrorAs(t, err, &handlerError)
 				require.Equal(t, nexus.HandlerErrorTypeInternal, handlerError.Type)
 			}
+		})
+	}
+}
+
+func TestNexusCompletionHTTPHandler_ClaimMapperInternalErrors(t *testing.T) {
+	plainErr := errors.New("claim mapper unavailable")
+	testCases := []struct {
+		name            string
+		claimMapperErr  error
+		wantHandlerType nexus.HandlerErrorType
+	}{
+		{
+			name:            "gRPC internal error",
+			claimMapperErr:  serviceerror.NewInternal("claim mapper unavailable"),
+			wantHandlerType: nexus.HandlerErrorTypeInternal,
+		},
+		{
+			name:           "plain internal error",
+			claimMapperErr: plainErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &nexusCompletionHandler{
+				AuthInterceptor: newTestAuthInterceptor(
+					errorClaimMapper{err: tc.claimMapperErr},
+					"nexus-api",
+					errorAuthorizer{},
+				),
+				Logger: log.NewNoopLogger(),
+			}
+			requestContext := &requestContext{
+				nexusCompletionHandler: h,
+				namespace: namespace.NewLocalNamespaceForTest(
+					&persistencespb.NamespaceInfo{Name: "test-namespace"},
+					nil,
+					"active",
+				),
+				logger: log.NewNoopLogger(),
+			}
+			httpRequest := httptest.NewRequest(http.MethodPost, "/", nil)
+			httpRequest.Header.Set("Authorization", "Bearer token")
+
+			err := requestContext.interceptRequest(context.Background(), &nexusrpc.CompletionRequest{HTTPRequest: httpRequest})
+
+			if tc.wantHandlerType == "" {
+				require.ErrorIs(t, err, plainErr)
+			} else {
+				var handlerError *nexus.HandlerError
+				require.ErrorAs(t, err, &handlerError)
+				require.Equal(t, tc.wantHandlerType, handlerError.Type)
+			}
+			require.Equal(t, metrics.OutcomeTag("internal_auth_error"), requestContext.outcomeTag)
 		})
 	}
 }

--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -141,6 +141,14 @@ func (c *operationContext) matchingRequest(req *nexuspb.Request) *matchingservic
 	}
 }
 
+func convertNexusClaimMapperError(err error) error {
+	var permissionDeniedError *serviceerror.PermissionDenied
+	if errors.As(err, &permissionDeniedError) {
+		return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeUnauthenticated, "unauthorized")
+	}
+	return commonnexus.ConvertGRPCError(err, false)
+}
+
 func (c *operationContext) augmentContext(ctx context.Context, header nexus.Header) context.Context {
 	ctx = metrics.AddMetricsContext(ctx)
 	ctx = interceptor.AddTelemetryContext(ctx, c.metricsHandlerForInterceptors)

--- a/service/frontend/nexus_handler_test.go
+++ b/service/frontend/nexus_handler_test.go
@@ -40,6 +40,44 @@ func (mockAuthorizer) Authorize(ctx context.Context, caller *authorization.Claim
 
 var _ authorization.Authorizer = mockAuthorizer{}
 
+type audienceClaimMapper struct {
+	tokenAudience string
+}
+
+func (m audienceClaimMapper) GetClaims(authInfo *authorization.AuthInfo) (*authorization.Claims, error) {
+	if authInfo.Audience != "" && authInfo.Audience != m.tokenAudience {
+		return nil, serviceerror.NewPermissionDenied("audience mismatch", "")
+	}
+	return &authorization.Claims{System: authorization.RoleAdmin}, nil
+}
+
+type errorAuthorizer struct{}
+
+func (errorAuthorizer) Authorize(context.Context, *authorization.Claims, *authorization.CallTarget) (authorization.Result, error) {
+	return authorization.Result{}, serviceerror.NewInternal("stop after authorization")
+}
+
+func newAudienceTestInterceptor(
+	tokenAudience string,
+	configuredAudience string,
+	authorizer authorization.Authorizer,
+) *authorization.Interceptor {
+	return authorization.NewInterceptor(
+		audienceClaimMapper{tokenAudience: tokenAudience},
+		authorizer,
+		metrics.NoopMetricsHandler,
+		log.NewNoopLogger(),
+		mockNamespaceChecker("test-namespace"),
+		authorization.NewAudienceMapper(configuredAudience),
+		"",
+		"",
+		dynamicconfig.GetBoolPropertyFn(true),
+		dynamicconfig.GetBoolPropertyFn(false),
+		dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
+		dynamicconfig.GetBoolPropertyFn(false),
+	)
+}
+
 type mockRateLimiter struct {
 	allow bool
 }

--- a/service/frontend/nexus_handler_test.go
+++ b/service/frontend/nexus_handler_test.go
@@ -51,6 +51,14 @@ func (m audienceClaimMapper) GetClaims(authInfo *authorization.AuthInfo) (*autho
 	return &authorization.Claims{System: authorization.RoleAdmin}, nil
 }
 
+type errorClaimMapper struct {
+	err error
+}
+
+func (m errorClaimMapper) GetClaims(*authorization.AuthInfo) (*authorization.Claims, error) {
+	return nil, m.err
+}
+
 type errorAuthorizer struct{}
 
 func (errorAuthorizer) Authorize(context.Context, *authorization.Claims, *authorization.CallTarget) (authorization.Result, error) {
@@ -62,8 +70,20 @@ func newAudienceTestInterceptor(
 	configuredAudience string,
 	authorizer authorization.Authorizer,
 ) *authorization.Interceptor {
-	return authorization.NewInterceptor(
+	return newTestAuthInterceptor(
 		audienceClaimMapper{tokenAudience: tokenAudience},
+		configuredAudience,
+		authorizer,
+	)
+}
+
+func newTestAuthInterceptor(
+	claimMapper authorization.ClaimMapper,
+	configuredAudience string,
+	authorizer authorization.Authorizer,
+) *authorization.Interceptor {
+	return authorization.NewInterceptor(
+		claimMapper,
 		authorizer,
 		metrics.NoopMetricsHandler,
 		log.NewNoopLogger(),

--- a/service/frontend/nexus_operation_http_handler.go
+++ b/service/frontend/nexus_operation_http_handler.go
@@ -319,9 +319,7 @@ func (h *NexusOperationHTTPHandler) parseTLSAndAuthInfo(r *http.Request, nc *nex
 		}
 	}
 
-	authInfo := h.auth.GetAuthInfo(tlsInfo, r.Header, func() string {
-		return "" // TODO: support audience getter
-	})
+	authInfo := h.auth.GetAuthInfoForNonUnaryRequest(r.Context(), tlsInfo, r.Header)
 
 	var err error
 	if authInfo != nil {

--- a/service/frontend/nexus_operation_http_handler.go
+++ b/service/frontend/nexus_operation_http_handler.go
@@ -319,10 +319,8 @@ func (h *NexusOperationHTTPHandler) parseTLSAndAuthInfo(r *http.Request, nc *nex
 		}
 	}
 
-	authInfo := h.auth.GetAuthInfoForNonUnaryRequest(r.Context(), tlsInfo, r.Header)
-
 	var err error
-	if authInfo != nil {
+	if authInfo := h.auth.GetAuthInfoForNonUnaryRequest(r.Context(), tlsInfo, r.Header); authInfo != nil {
 		nc.claims, err = h.auth.GetClaims(authInfo)
 		if err != nil {
 			return nil, err

--- a/service/frontend/nexus_operation_http_handler.go
+++ b/service/frontend/nexus_operation_http_handler.go
@@ -320,7 +320,7 @@ func (h *NexusOperationHTTPHandler) parseTLSAndAuthInfo(r *http.Request, nc *nex
 	}
 
 	var err error
-	if authInfo := h.auth.GetAuthInfoForNonUnaryRequest(r.Context(), tlsInfo, r.Header); authInfo != nil {
+	if authInfo := h.auth.GetAuthInfoForRequest(r.Context(), tlsInfo, r.Header); authInfo != nil {
 		nc.claims, err = h.auth.GetClaims(authInfo)
 		if err != nil {
 			return nil, err

--- a/service/frontend/nexus_operation_http_handler.go
+++ b/service/frontend/nexus_operation_http_handler.go
@@ -320,7 +320,7 @@ func (h *NexusOperationHTTPHandler) parseTLSAndAuthInfo(r *http.Request, nc *nex
 	}
 
 	var err error
-	if authInfo := h.auth.GetAuthInfoForRequest(r.Context(), tlsInfo, r.Header); authInfo != nil {
+	if authInfo := h.auth.ExtractAuthInfoForRequest(r.Context(), tlsInfo, r.Header); authInfo != nil {
 		nc.claims, err = h.auth.GetClaims(authInfo)
 		if err != nil {
 			return nil, err

--- a/service/frontend/nexus_operation_http_handler.go
+++ b/service/frontend/nexus_operation_http_handler.go
@@ -165,7 +165,7 @@ func (h *NexusOperationHTTPHandler) dispatchNexusTaskByNamespaceAndTaskQueue(w h
 	rWithAuthCtx, err := h.parseTLSAndAuthInfo(r, nc)
 	if err != nil {
 		logger.Error("failed to get claims", tag.Error(err))
-		h.writeFailure(w, r, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeUnauthenticated, "unauthorized"))
+		h.writeFailure(w, r, convertNexusClaimMapperError(err))
 		return
 	}
 	r = rWithAuthCtx
@@ -228,7 +228,7 @@ func (h *NexusOperationHTTPHandler) dispatchNexusTaskByEndpoint(w http.ResponseW
 	rWithAuthCtx, err := h.parseTLSAndAuthInfo(r, nc)
 	if err != nil {
 		logger.Error("failed to get claims", tag.Error(err))
-		h.writeFailure(w, r, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeUnauthenticated, "unauthorized"))
+		h.writeFailure(w, r, convertNexusClaimMapperError(err))
 		return
 	}
 	r = rWithAuthCtx

--- a/service/frontend/nexus_operation_http_handler_test.go
+++ b/service/frontend/nexus_operation_http_handler_test.go
@@ -73,6 +73,59 @@ func doNexusHTTPRequest(t *testing.T, router *mux.Router, endpointID string) *ht
 	return rec
 }
 
+func TestNexusOperationHTTPHandler_JWTAudience(t *testing.T) {
+	testCases := []struct {
+		name               string
+		token              string
+		tokenAudience      string
+		configuredAudience string
+		wantDenied         bool
+	}{
+		{
+			name:               "matching audience",
+			token:              "Bearer token",
+			tokenAudience:      "nexus-api",
+			configuredAudience: "nexus-api",
+		},
+		{
+			name:               "mismatching audience",
+			token:              "Bearer token",
+			tokenAudience:      "other-api",
+			configuredAudience: "nexus-api",
+			wantDenied:         true,
+		},
+		{
+			name:          "no configured audience",
+			token:         "Bearer token",
+			tokenAudience: "other-api",
+		},
+		{
+			name:               "no token",
+			configuredAudience: "nexus-api",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &NexusOperationHTTPHandler{
+				auth: newAudienceTestInterceptor(tc.tokenAudience, tc.configuredAudience, mockAuthorizer{}),
+			}
+			r := httptest.NewRequest(http.MethodPost, "/", nil)
+			if tc.token != "" {
+				r.Header.Set("Authorization", tc.token)
+			}
+
+			_, err := h.parseTLSAndAuthInfo(r, &nexusContext{})
+			if tc.wantDenied {
+				var permissionDenied *serviceerror.PermissionDenied
+				require.ErrorAs(t, err, &permissionDenied)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestDispatchNexusTaskByEndpoint_NotFound_NonRetryable(t *testing.T) {
 	reg := nexustest.FakeEndpointRegistry{
 		OnGetByID: func(_ context.Context, _ string) (*persistencespb.NexusEndpointEntry, error) {

--- a/service/frontend/nexus_operation_http_handler_test.go
+++ b/service/frontend/nexus_operation_http_handler_test.go
@@ -3,6 +3,7 @@ package frontend
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -122,6 +123,75 @@ func TestNexusOperationHTTPHandler_JWTAudience(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestNexusOperationHTTPHandler_ClaimMapperErrors(t *testing.T) {
+	endpointEntry := &persistencespb.NexusEndpointEntry{
+		Id: "test-endpoint-id",
+		Endpoint: &persistencespb.NexusEndpoint{
+			Spec: &persistencespb.NexusEndpointSpec{
+				Name: "test-endpoint",
+				Target: &persistencespb.NexusEndpointTarget{
+					Variant: &persistencespb.NexusEndpointTarget_Worker_{
+						Worker: &persistencespb.NexusEndpointTarget_Worker{
+							NamespaceId: "test-ns-id",
+							TaskQueue:   "test-task-queue",
+						},
+					},
+				},
+			},
+		},
+	}
+	reg := nexustest.FakeEndpointRegistry{
+		OnGetByID: func(_ context.Context, _ string) (*persistencespb.NexusEndpointEntry, error) {
+			return endpointEntry, nil
+		},
+	}
+	nsReg := &fakeNamespaceRegistry{
+		getNamespaceName: func(namespace.ID) (namespace.Name, error) {
+			return "test-namespace", nil
+		},
+	}
+	testCases := []struct {
+		name       string
+		err        error
+		wantStatus int
+	}{
+		{
+			name:       "permission denied",
+			err:        serviceerror.NewPermissionDenied("audience mismatch", ""),
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "internal error",
+			err:        serviceerror.NewInternal("claim mapper unavailable"),
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:       "plain internal error",
+			err:        errors.New("claim mapper unavailable"),
+			wantStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, router := newTestNexusOperationHTTPHandler(reg, nsReg)
+			h.auth = newTestAuthInterceptor(
+				errorClaimMapper{err: tc.err},
+				"nexus-api",
+				mockAuthorizer{},
+			)
+			path := "/" + commonnexus.RouteDispatchNexusTaskByEndpoint.Path("test-endpoint-id") + "/test-service/test-operation"
+			req := httptest.NewRequest(http.MethodPost, path, nil)
+			req.Header.Set("Authorization", "Bearer token")
+			rec := httptest.NewRecorder()
+
+			router.ServeHTTP(rec, req)
+
+			require.Equal(t, tc.wantStatus, rec.Code)
 		})
 	}
 }


### PR DESCRIPTION
## What changed?

Enforce that audience in the Nexus operation and completion HTTP handlers.

## Why?

The gRPC handlers enforce `global.authorization.audience`, while the Nexus HTTP handlers previously passed an empty audience. 

## Potential risks

When `global.authorization.audience` is configured, Nexus clients must now present JWTs containing that audience. Requests with mismatched audiences that were previously accepted will be rejected. 
