### PR TITLE
Always start worker service in functional tests

### DIFF
--- a/docs/superpowers/specs/2026-08-24-always-start-worker-service-design.md
+++ b/docs/superpowers/specs/2026-08-24-always-start-worker-service-design.md
@@ -1,0 +1,37 @@
+# Always Start the Worker Service in Functional Tests
+
+## Goal
+
+Remove the `WithWorkerService` opt-in and start the system worker service for every functional-test cluster. The draft PR's CI run will provide the runtime and memory data needed to evaluate the impact.
+
+## Design
+
+Make worker startup an invariant of `testcore` clusters instead of a per-test option:
+
+- Remove `WithWorkerService` and all call sites.
+- Remove the worker-specific fields and option plumbing from test environments, cluster requests, and cluster configuration.
+- Construct every shared, dedicated, and suite-scoped cluster with the worker service enabled.
+- Stop treating worker usage alone as a reason to create a fresh dedicated cluster. Tests without other cluster-global requirements will use the normal shared or pooled cluster path.
+- Keep cluster-creation telemetry accurate by reporting that the worker is enabled for every created cluster.
+
+This intentionally measures the complete steady-state behavior, including any benefit from reusing worker-enabled clusters instead of creating clusters solely for worker-dependent tests.
+
+## Failure Handling
+
+Worker startup continues through the existing test-cluster startup path, so startup failures fail cluster setup as they do for currently opted-in tests. No new runtime error path is introduced.
+
+## Testing
+
+- Update the default functional-test health-check coverage so it proves the worker service starts without an opt-in.
+- Add or update focused cluster-routing tests to prove worker-specific configuration no longer forces a fresh cluster.
+- Run the relevant `testcore` tests with `-tags test_dep`.
+- Run formatting and `make lint-code` before creating the draft PR.
+
+## Trade-offs
+
+- Runtime and memory may increase because every functional-test cluster hosts the worker service; measuring that impact is the purpose of the draft PR.
+- Worker-dependent tests can reuse shared or pooled clusters when they have no other isolation requirement, reducing cluster churn but changing their prior isolation behavior.
+- Removing the option and its plumbing is simpler than retaining a compatibility no-op and prevents future tests from assuming worker startup is conditional.
+- The change does not alter production service configuration or introduce new security behavior.
+
+At substantially higher test concurrency, each concurrently active cluster carries worker-service overhead, while cluster reuse limits the number of clusters created. Existing cluster-pool limits continue to bound concurrency.

--- a/tests/activity_api_batch_reset_test.go
+++ b/tests/activity_api_batch_reset_test.go
@@ -35,7 +35,6 @@ func TestActivityAPIBatchResetClientTestSuite(t *testing.T) {
 func newBatchResetEnv(t *testing.T) *testcore.TestEnv {
 	return testcore.NewEnv(
 		t,
-		testcore.WithWorkerService("batch operations"),
 		// These tests intentionally start multiple batch operations in the same namespace.
 		// The default per-namespace limit is 1, so raise it to the functional test limit.
 		testcore.WithDynamicConfig(dynamicconfig.FrontendMaxConcurrentBatchOperationPerNamespace, testcore.ClientSuiteLimit),

--- a/tests/activity_api_batch_terminate_test.go
+++ b/tests/activity_api_batch_terminate_test.go
@@ -29,12 +29,11 @@ func TestActivityAPIBatchTerminateClientTestSuite(t *testing.T) {
 	parallelsuite.Run(t, &ActivityAPIBatchTerminateClientTestSuite{})
 }
 
-// newStandaloneActivityBatchEnv builds a standalone-activity test env that also
-// has the batcher worker service running so that activity batch operations
-// (terminate/cancel/delete) can be exercised end-to-end. It mirrors
-// standaloneActivityTestSuite.newTestEnv (enabling the CHASM/activity feature
-// flags) and additionally enables the "batch operations" worker service and
-// raises the per-namespace concurrent batch limit to the functional-test limit.
+// newStandaloneActivityBatchEnv builds a standalone-activity test env where
+// activity batch operations (terminate/cancel/delete) can be exercised
+// end-to-end. It mirrors standaloneActivityTestSuite.newTestEnv (enabling the
+// CHASM/activity feature flags) and raises the per-namespace concurrent batch
+// limit to the functional-test limit.
 func newStandaloneActivityBatchEnv(t *testing.T) *standaloneActivityEnv {
 	return newStandaloneActivityBatchEnvWithBatchOperations(t, true)
 }
@@ -43,7 +42,6 @@ func newStandaloneActivityBatchEnvWithBatchOperations(t *testing.T, enabled bool
 	env := &standaloneActivityEnv{
 		TestEnv: testcore.NewEnv(
 			t,
-			testcore.WithWorkerService("batch operations"),
 			// These tests intentionally start multiple batch operations in the same namespace.
 			// The default per-namespace limit is 1, so raise it to the functional test limit.
 			testcore.WithDynamicConfig(dynamicconfig.FrontendMaxConcurrentBatchOperationPerNamespace, testcore.ClientSuiteLimit),

--- a/tests/activity_api_batch_unpause_test.go
+++ b/tests/activity_api_batch_unpause_test.go
@@ -200,7 +200,7 @@ func (s *ActivityApiBatchUnpauseClientTestSuite) TestActivityBatchUnpause_Succes
 }
 
 func (s *ActivityApiBatchUnpauseClientTestSuite) TestActivityBatchUnpause_MatchAll() {
-	env := testcore.NewEnv(s.T(), testcore.WithWorkerService("batch operations"))
+	env := testcore.NewEnv(s.T())
 	ctx := s.Context()
 
 	const workflowCount = 10

--- a/tests/activity_api_batch_update_options_test.go
+++ b/tests/activity_api_batch_update_options_test.go
@@ -48,7 +48,6 @@ func (s *ActivityAPIBatchUpdateOptionsSuite) createBatchUpdateOptionsWorkflow(en
 
 func (s *ActivityAPIBatchUpdateOptionsSuite) TestActivityBatchUpdateOptionsSuccess() {
 	env := testcore.NewEnv(s.T(),
-		testcore.WithWorkerService("batch operations"),
 		testcore.WithDynamicConfig(dynamicconfig.FrontendMaxConcurrentBatchOperationPerNamespace, testcore.ClientSuiteLimit),
 	)
 
@@ -196,7 +195,6 @@ func (s *ActivityAPIBatchUpdateOptionsSuite) TestActivityBatchUpdateOptionsSucce
 
 func (s *ActivityAPIBatchUpdateOptionsSuite) TestActivityBatchUpdateOptionsMatchAll() {
 	env := testcore.NewEnv(s.T(),
-		testcore.WithWorkerService("batch operations"),
 		testcore.WithDynamicConfig(dynamicconfig.FrontendMaxConcurrentBatchOperationPerNamespace, testcore.ClientSuiteLimit),
 	)
 
@@ -288,7 +286,6 @@ func (s *ActivityAPIBatchUpdateOptionsSuite) TestActivityBatchUpdateOptionsMatch
 
 func (s *ActivityAPIBatchUpdateOptionsSuite) TestActivityBatchUpdateOptionsFailed() {
 	env := testcore.NewEnv(s.T(),
-		testcore.WithWorkerService("batch operations"),
 		testcore.WithDynamicConfig(dynamicconfig.FrontendMaxConcurrentBatchOperationPerNamespace, testcore.ClientSuiteLimit),
 	)
 

--- a/tests/advanced_visibility_test.go
+++ b/tests/advanced_visibility_test.go
@@ -2482,7 +2482,7 @@ func (s *AdvancedVisibilitySuite) TestWorkerTaskReachability_Unversioned_InTaskQ
 }
 
 func (s *AdvancedVisibilitySuite) TestBuildIdScavenger_DeletesUnusedBuildId(enableUnifiedQueryConverter bool) {
-	env := s.newTestEnv(enableUnifiedQueryConverter, testcore.WithWorkerService("build id scavenger workflow"))
+	env := s.newTestEnv(enableUnifiedQueryConverter)
 	tq := s.T().Name()
 	buildIdv0 := s.T().Name() + "-v0"
 	buildIdv1 := s.T().Name() + "-v1"

--- a/tests/callbacks_test.go
+++ b/tests/callbacks_test.go
@@ -57,7 +57,7 @@ func (s *CallbacksSuite) TestScheduledCallbackTokenMigration_LegacyWriteEnvelope
 	testOpts := append([]testcore.TestOption{}, opts...)
 	testOpts = append(
 		testOpts,
-		scheduleCommonOpts(s.T())...,
+		scheduleCommonOpts()...,
 	)
 	testOpts = append(
 		testOpts,

--- a/tests/chasm_test.go
+++ b/tests/chasm_test.go
@@ -63,7 +63,6 @@ func newChasmTestEnv(suiteContext func() context.Context, t *testing.T, unified 
 	env := testcore.NewEnv(
 		t,
 		testcore.WithDedicatedCluster(),
-		testcore.WithWorkerService("delete namespace workflow"),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 		testcore.WithDynamicConfig(dynamicconfig.VisibilityEnableUnifiedQueryConverter, unified),
 		testcore.WithDynamicConfig(dynamicconfig.DeleteNamespaceUseChasmDeleteExecution, true),

--- a/tests/client_misc_test.go
+++ b/tests/client_misc_test.go
@@ -1065,7 +1065,7 @@ func (s *ClientMiscTestSuite) Test_StickyWorkerRestartWorkflowTask() {
 }
 
 func (s *ClientMiscTestSuite) TestBatchSignal() {
-	env := testcore.NewEnv(s.T(), testcore.WithWorkerService("batch operations"))
+	env := testcore.NewEnv(s.T())
 
 	type myData struct {
 		Stuff  string
@@ -1125,7 +1125,6 @@ func (s *ClientMiscTestSuite) TestBatchSignal() {
 // Describe — the visibility query and reason).
 func (s *ClientMiscTestSuite) TestListBatchOperations() {
 	env := testcore.NewEnv(s.T(),
-		testcore.WithWorkerService("batch operations"),
 		// This test starts multiple batch operations in the same namespace; the
 		// default per-namespace limit is 1, so raise it to the functional-test limit.
 		testcore.WithDynamicConfig(dynamicconfig.FrontendMaxConcurrentBatchOperationPerNamespace, testcore.ClientSuiteLimit),
@@ -1232,7 +1231,7 @@ func (s *ClientMiscTestSuite) TestListBatchOperations() {
 }
 
 func (s *ClientMiscTestSuite) TestBatchReset() {
-	env := testcore.NewEnv(s.T(), testcore.WithWorkerService("batch operations"))
+	env := testcore.NewEnv(s.T())
 	var count atomic.Int32
 
 	activityFn := func(ctx context.Context) (int32, error) {
@@ -1296,7 +1295,7 @@ func (s *ClientMiscTestSuite) TestBatchReset() {
 }
 
 func (s *ClientMiscTestSuite) TestBatchResetByBuildId() {
-	env := testcore.NewEnv(s.T(), testcore.WithWorkerService("batch operations"))
+	env := testcore.NewEnv(s.T())
 	tq := testcore.RandomizeStr(s.T().Name())
 	buildPrefix := uuid.NewString()[:6] + "-"
 	buildIdv1 := buildPrefix + "v1"

--- a/tests/dlq_test.go
+++ b/tests/dlq_test.go
@@ -252,7 +252,7 @@ func (s *DLQSuite) TestReadArtificialDLQTasks() {
 // DLQ, this test then purges the DLQ and verifies that the task was deleted.
 // This test will then call DescribeDLQJob and CancelDLQJob api to verify.
 func (s *DLQSuite) TestPurgeRealWorkflow() {
-	env := s.newTestEnv(testcore.WithWorkerService("dlq purge workflow"))
+	env := s.newTestEnv()
 
 	_, dlqMessageID := s.executeDoomedWorkflow(env)
 
@@ -281,7 +281,7 @@ func (s *DLQSuite) TestPurgeRealWorkflow() {
 // above test is more for testing specific CLI flags when reading from the DLQ.
 // This test will then call DescribeDLQJob and CancelDLQJob api to verify.
 func (s *DLQSuite) TestMergeRealWorkflow() {
-	env := s.newTestEnv(testcore.WithWorkerService("dlq merge workflow"))
+	env := s.newTestEnv()
 
 	// Verify that we can execute a normal workflow.
 	run := s.executeWorkflow(env, "dlq-test-ok-workflow-id")
@@ -324,7 +324,7 @@ func (s *DLQSuite) TestMergeRealWorkflow() {
 }
 
 func (s *DLQSuite) TestCancelRunningMerge() {
-	env := s.newTestEnv(testcore.WithWorkerService("dlq merge workflow"))
+	env := s.newTestEnv()
 	env.deleteBlockCh = make(chan any)
 
 	// Execute several doomed workflows.

--- a/tests/leakcheck/leak_test.go
+++ b/tests/leakcheck/leak_test.go
@@ -131,8 +131,7 @@ func buildRunTeardownCluster(t *testing.T, leakCheck *objectleak.ObjectLeakCheck
 	// The subtest ensures all env cleanups complete before this returns.
 	t.Run("cluster", func(t *testing.T) {
 		env := testcore.NewEnv(t,
-			testcore.WithDedicatedCluster(),
-			testcore.WithWorkerService("leak regression test"))
+			testcore.WithDedicatedCluster())
 
 		worker = env.SdkWorker()
 		worker.RegisterWorkflow(smokeWorkflow)

--- a/tests/namespace_test.go
+++ b/tests/namespace_test.go
@@ -36,7 +36,6 @@ func TestNamespaceSuite(t *testing.T) {
 
 func (s *namespaceTestSuite) newTestEnv(opts ...testcore.TestOption) *testcore.TestEnv {
 	baseOpts := []testcore.TestOption{
-		testcore.WithWorkerService("namespace deletion tests require the system worker service"),
 		testcore.WithDynamicConfig(dynamicconfig.TransferProcessorUpdateAckInterval, 1*time.Second),
 		testcore.WithDynamicConfig(dynamicconfig.VisibilityProcessorUpdateAckInterval, 1*time.Second),
 	}

--- a/tests/purge_dlq_tasks_api_test.go
+++ b/tests/purge_dlq_tasks_api_test.go
@@ -39,8 +39,7 @@ func (s *PurgeDLQTasksSuite) TestPurgeDLQTasks() {
 		faultCount    *atomic.Int32
 	}{
 		{
-			name:       "HappyPath",
-			envOptions: []testcore.TestOption{testcore.WithWorkerService("purge DLQ workflow")},
+			name: "HappyPath",
 		},
 		{
 			name: "MissingSourceCluster",
@@ -57,8 +56,7 @@ func (s *PurgeDLQTasksSuite) TestPurgeDLQTasks() {
 			apiErr: "TargetCluster",
 		},
 		{
-			name:       "QueueDoesNotExist",
-			envOptions: []testcore.TestOption{testcore.WithWorkerService("purge DLQ workflow")},
+			name: "QueueDoesNotExist",
 			mutateRequest: func(request *adminservice.PurgeDLQTasksRequest) {
 				request.DlqKey.TargetCluster = "does-not-exist"
 			},
@@ -67,7 +65,6 @@ func (s *PurgeDLQTasksSuite) TestPurgeDLQTasks() {
 		{
 			name: "DeleteTasksUnavailableError",
 			envOptions: []testcore.TestOption{
-				testcore.WithWorkerService("purge DLQ workflow"),
 				testcore.WithPersistenceFaultInjection(&config.FaultInjection{
 					Injector: func(target config.FaultInjectionTarget) error {
 						if target.Store == config.QueueV2Name &&

--- a/tests/schedule_migration_test.go
+++ b/tests/schedule_migration_test.go
@@ -1315,7 +1315,6 @@ func TestScheduleMigrationV1ToV2NoDuplicateRecentActions(t *testing.T) {
 	// a CHASM sentinel (which would block the migration activity).
 	env := newScheduleEnv(
 		t,
-		testcore.WithWorkerService("V1 scheduler"),
 		testcore.WithSdkWorker(),
 	)
 
@@ -1463,7 +1462,6 @@ func TestScheduleMigrationDeferredWithRunningWorkflow(t *testing.T) {
 	// (workflow-backed) schedule rather than a CHASM sentinel.
 	env := newScheduleEnv(
 		t,
-		testcore.WithWorkerService("V1 scheduler"),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerMigrationWithRunningWorkflows, false),
 	)
 
@@ -1964,7 +1962,6 @@ func (s *ScheduleMigrationTestSuite) TestPatchScheduleContextMetadata() {
 func TestScheduleMigration_StaleRunningDoesNotSkipPending(t *testing.T) {
 	env := newScheduleEnv(
 		t,
-		testcore.WithWorkerService("scheduler operations"),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 	)
 
@@ -2237,7 +2234,6 @@ func TestScheduleMigration_NoRunningWorkflows_GeneratorStarts(t *testing.T) {
 
 	env := newScheduleEnv(
 		t,
-		testcore.WithWorkerService("scheduler operations"),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 	)
 	env.OverrideDynamicConfig(chasmscheduler.CurrentTweakables, tweakables)

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -61,17 +61,12 @@ var (
 	}
 )
 
-func scheduleCommonOpts(t *testing.T) []testcore.TestOption {
-	opts := []testcore.TestOption{
+func scheduleCommonOpts() []testcore.TestOption {
+	return []testcore.TestOption{
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerSentinels, true),
 		testcore.WithDynamicConfig(dynamicconfig.FrontendAllowedExperiments, []string{"*"}),
 	}
-	if strings.HasPrefix(t.Name(), "TestScheduleV1") {
-		// only v1 needs the worker service
-		opts = append(opts, testcore.WithWorkerService("V1 scheduler"))
-	}
-	return opts
 }
 
 func newScheduleEnv(t *testing.T, opts ...testcore.TestOption) *testcore.TestEnv {
@@ -161,7 +156,7 @@ func intervalSpec(every time.Duration) *schedulepb.ScheduleSpec {
 func newEnvWithIdleTime(t *testing.T, idleTime time.Duration, extra ...testcore.TestOption) *testcore.TestEnv {
 	tweakables := chasmscheduler.DefaultTweakables
 	tweakables.IdleTime = idleTime
-	opts := append(scheduleCommonOpts(t), testcore.WithDynamicConfig(chasmscheduler.CurrentTweakables, tweakables))
+	opts := append(scheduleCommonOpts(), testcore.WithDynamicConfig(chasmscheduler.CurrentTweakables, tweakables))
 	return newScheduleEnv(t, append(opts, extra...)...)
 }
 
@@ -310,7 +305,7 @@ const (
 // were mislabeled FAILED), so a manual cancel/terminate would silently stop all
 // future runs.
 func testPauseOnFailureIgnoresCancelTerminate(t *testing.T, newContext contextFactory, stop terminalStop) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 	ctx := newContext(testcore.NewContext())
 
 	sid := testcore.RandomizeStr("sched-pauseonfail")
@@ -450,7 +445,7 @@ func TestScheduleCHASM(t *testing.T) {
 }
 
 func testDescribeCatchupWindowAfterCreateAndUpdate(t *testing.T) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	ctx := chasmContextFactory(testcontext.For(t))
 	sid := testcore.RandomizeStr("sched-catchup-window-desc")
@@ -573,7 +568,7 @@ func runSharedScheduleTests(t *testing.T, newContext contextFactory) {
 // BUFFER_ONE keeps exactly one start in the buffer while the first workflow
 // is still running.
 func testBufferSizeReportedWhenBuffered(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := testcore.RandomizeStr("sched-buffer-size")
 	wid := testcore.RandomizeStr("sched-buffer-size-wf")
@@ -640,7 +635,7 @@ func testBufferOverrunDropsActions(t *testing.T, newContext contextFactory) {
 	// fast-interval ticks. Only the CHASM scheduler reads these tweakables.
 	tweakables := chasmscheduler.DefaultTweakables
 	tweakables.MaxBufferSize = 2
-	opts := append(scheduleCommonOpts(t), testcore.WithDynamicConfig(chasmscheduler.CurrentTweakables, tweakables))
+	opts := append(scheduleCommonOpts(), testcore.WithDynamicConfig(chasmscheduler.CurrentTweakables, tweakables))
 	s := testcore.NewEnv(t, opts...)
 
 	sid := testcore.RandomizeStr("sched-buffer-overrun")
@@ -685,7 +680,7 @@ func testBufferOverrunDropsActions(t *testing.T, newContext contextFactory) {
 // from RUNNING to COMPLETED. V1's scheduler workflow does not advance its
 // memo while paused, so the listed status stays at RUNNING until unpause.
 func testRecentActionsAdvanceWhilePaused(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := testcore.RandomizeStr("sched-recentactions-paused")
 	wid := testcore.RandomizeStr("sched-recentactions-paused-wf")
@@ -736,7 +731,7 @@ func testRecentActionsAdvanceWhilePaused(t *testing.T, newContext contextFactory
 // while paused, so its projected times would freeze at pause time and
 // eventually all sit in the past - hence this test is registered CHASM-only.
 func testFutureActionTimesAdvanceWhilePaused(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := testcore.RandomizeStr("sched-future-actions-paused")
 	wid := testcore.RandomizeStr("sched-future-actions-paused-wf")
@@ -773,7 +768,7 @@ func testFutureActionTimesAdvanceWhilePaused(t *testing.T, newContext contextFac
 // the first buffered action, and that action must fire once the running workflow
 // completes.
 func testBufferOneDeferredFiresAfterCompletion(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := testcore.RandomizeStr("sched-buffer-one-deferred")
 	wid := testcore.RandomizeStr("sched-buffer-one-deferred-wf")
@@ -849,7 +844,7 @@ func testBufferOneDeferredFiresAfterCompletion(t *testing.T, newContext contextF
 }
 
 func testDeletedScheduleOperations(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := "sched-test-deleted-ops"
 	wid := "sched-test-deleted-ops-wf"
@@ -905,7 +900,7 @@ func testDeletedScheduleOperations(t *testing.T, newContext contextFactory) {
 }
 
 func testBasics(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := "sched-test-basics"
 	wid := "sched-test-basics-wf"
@@ -1335,7 +1330,7 @@ func testBasics(t *testing.T, newContext contextFactory) {
 }
 
 func testInput(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := "sched-test-input"
 	wid := "sched-test-input-wf"
@@ -1399,7 +1394,7 @@ func testInput(t *testing.T, newContext contextFactory) {
 }
 
 func testLastCompletionAndError(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := "sched-test-last"
 	wid := "sched-test-last-wf"
@@ -1480,7 +1475,7 @@ func testScheduleContinuesAfterWorkflowRetryFailure(t *testing.T, newContext con
 	// completions by the request ID carried in the completion callback token (which survives the new
 	// runs created by retries). That requires the envelope token format, which is gated off by default
 	// for safe rollout, so enable it explicitly here.
-	opts := append(scheduleCommonOpts(t), testcore.WithDynamicConfig(callback.EncodeInternalTokenWithEnvelope, true))
+	opts := append(scheduleCommonOpts(), testcore.WithDynamicConfig(callback.EncodeInternalTokenWithEnvelope, true))
 	s := newScheduleEnv(t, opts...)
 
 	sid := testcore.RandomizeStr("sched-retry-fail")
@@ -1569,7 +1564,7 @@ func testScheduledWorkflowContinueAsNewCompletion(t *testing.T, newContext conte
 	// The scheduler matches the continued-as-new run's completion by the request ID carried in the
 	// completion callback token, which only survives continue-as-new in the envelope token format.
 	// That format is gated off by default for safe rollout, so enable it explicitly here.
-	opts := append(scheduleCommonOpts(t), testcore.WithDynamicConfig(callback.EncodeInternalTokenWithEnvelope, true))
+	opts := append(scheduleCommonOpts(), testcore.WithDynamicConfig(callback.EncodeInternalTokenWithEnvelope, true))
 	s := newScheduleEnv(t, opts...)
 
 	sid := testcore.RandomizeStr("sched-can-completion")
@@ -1682,7 +1677,7 @@ func testScheduledWorkflowContinueAsNewCompletion(t *testing.T, newContext conte
 }
 
 func testListSchedulesReturnsWorkflowStatus(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := "sched-test-list-running"
 	wid := "sched-test-list-running-wf"
@@ -1782,7 +1777,7 @@ func testListSchedulesReturnsWorkflowStatus(t *testing.T, newContext contextFact
 // must stay bounded no matter how many actions the schedule takes. Both the V1
 // and V2 (CHASM) schedulers apply this cap, so it runs as a shared test.
 func testListSchedulesRecentActionsCapped(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 	ctx := newContext(testcore.NewContext())
 
 	// The list memo caps RecentActions at this many entries (V1
@@ -1824,7 +1819,7 @@ func testListSchedulesRecentActionsCapped(t *testing.T, newContext contextFactor
 }
 
 func testUpdateIntervalTakesEffect(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := "sched-test-update-interval"
 	wid := "sched-test-update-interval-wf"
@@ -1889,7 +1884,7 @@ func testUpdateIntervalTakesEffect(t *testing.T, newContext contextFactory) {
 }
 
 func testListScheduleMatchingTimes(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := "sched-test-list-matching-times"
 
@@ -1938,7 +1933,7 @@ func testListScheduleMatchingTimes(t *testing.T, newContext contextFactory) {
 }
 
 func testLimitMemoSpecSize(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	expectedLimit := scheduler.CurrentTweakablePolicies.SpecFieldLengthLimit
 
@@ -2009,7 +2004,7 @@ func testLimitMemoSpecSize(t *testing.T, newContext contextFactory) {
 }
 
 func testCountSchedules(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	// Create multiple schedules with different paused states
 	sidPrefix := "sched-test-count-"
@@ -2079,7 +2074,7 @@ func testCountSchedules(t *testing.T, newContext contextFactory) {
 }
 
 func testListSchedulesPagination(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	const numSchedules = 4
 	sidPrefix := "sched-test-pagination-"
@@ -2150,7 +2145,7 @@ func testListSchedulesPagination(t *testing.T, newContext contextFactory) {
 }
 
 func testListSchedulesFilterAndEntryFields(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := "sched-test-list-fields"
 	wt := "sched-test-list-fields-wt"
@@ -2243,7 +2238,7 @@ func testListSchedulesFilterAndEntryFields(t *testing.T, newContext contextFacto
 }
 
 func testListSchedulesFilterByScheduleID(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid1 := "sched-filter-by-id-alpha"
 	sid2 := "sched-filter-by-id-beta"
@@ -2374,7 +2369,7 @@ func testListSchedulesFilterByScheduleID(t *testing.T, newContext contextFactory
 }
 
 func testScheduleInternalTaskQueue(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 	errorMessageKeyword := "internal per-namespace task queue"
 
 	// Test CreateSchedule with internal task queue
@@ -2466,7 +2461,7 @@ func testScheduleInternalTaskQueue(t *testing.T, newContext contextFactory) {
 }
 
 func testScheduledWorkflowDoubleReset(t *testing.T, newContext contextFactory, enableCHASMCallbacks bool) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 	s.OverrideDynamicConfig(dynamicconfig.EnableCHASMCallbacks, enableCHASMCallbacks)
 
 	sid := "sched-test-double-reset"
@@ -2623,7 +2618,7 @@ func testScheduledWorkflowDoubleReset(t *testing.T, newContext contextFactory, e
 }
 
 func testResetWithAdditionalCallback(t *testing.T, newContext contextFactory, enableCHASMCallbacks bool) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 	s.OverrideDynamicConfig(dynamicconfig.EnableCHASMCallbacks, enableCHASMCallbacks)
 	s.OverrideDynamicConfig(
 		callback.AllowedAddresses,
@@ -2793,7 +2788,7 @@ func testResetWithAdditionalCallback(t *testing.T, newContext contextFactory, en
 // testCreatesWorkflowSentinel tests that creating a CHASM schedule also starts a
 // dummy workflow to reserve the schedule ID in the V1 workflow ID-space.
 func testCreatesWorkflowSentinel(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := testcore.RandomizeStr("sid")
 	wid := testcore.RandomizeStr("wid")
@@ -2856,7 +2851,7 @@ func testCreatesWorkflowSentinel(t *testing.T, newContext contextFactory) {
 }
 
 func testStateSizeBytesReported(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := testcore.RandomizeStr("sched-state-size")
 	wid := testcore.RandomizeStr("sched-state-size-wf")
@@ -2901,7 +2896,7 @@ func testStateSizeBytesReported(t *testing.T, newContext contextFactory) {
 // testCreatesCHASMSentinel tests that creating a V1 schedule also creates a
 // CHASM sentinel to reserve the schedule ID in the CHASM execution space.
 func testCreatesCHASMSentinel(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := testcore.RandomizeStr("sid")
 	wid := testcore.RandomizeStr("wid")
@@ -2986,7 +2981,7 @@ func testCreatesCHASMSentinel(t *testing.T, newContext contextFactory) {
 // testSkipsWorkflowSentinelWhenDisabled asserts that a CHASM CreateSchedule
 // does not start the dummy V1 workflow when EnableCHASMSchedulerSentinels is off.
 func testSkipsWorkflowSentinelWhenDisabled(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, append(scheduleCommonOpts(t),
+	s := newScheduleEnv(t, append(scheduleCommonOpts(),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerSentinels, false),
 	)...)
 
@@ -3035,7 +3030,7 @@ func testSkipsWorkflowSentinelWhenDisabled(t *testing.T, newContext contextFacto
 // testSkipsCHASMSentinelWhenDisabled asserts that a V1 CreateSchedule does not
 // create a CHASM sentinel when EnableCHASMSchedulerSentinels is off.
 func testSkipsCHASMSentinelWhenDisabled(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, append(scheduleCommonOpts(t),
+	s := newScheduleEnv(t, append(scheduleCommonOpts(),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerSentinels, false),
 	)...)
 
@@ -3089,7 +3084,7 @@ func testSkipsCHASMSentinelWhenDisabled(t *testing.T, newContext contextFactory)
 }
 
 func testCreateScheduleAlreadyExists(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := "sched-test-already-exists"
 
@@ -3136,7 +3131,7 @@ func testCreateScheduleAlreadyExists(t *testing.T, newContext contextFactory) {
 // temporal.ErrScheduleAlreadyRunning. This tests the SDK's behavior E2E against
 // the handler. A similar test exists in the features repository.
 func testCreateScheduleDuplicateSdkError(t *testing.T, useCHASM bool) {
-	opts := scheduleCommonOpts(t)
+	opts := scheduleCommonOpts()
 	if useCHASM {
 		opts = append(opts, testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerCreation, true))
 	}
@@ -3175,7 +3170,7 @@ func testPatchRejectsExcessBackfillers(t *testing.T, newContext contextFactory) 
 	tweakables := chasmscheduler.DefaultTweakables
 	tweakables.MaxBufferSize = 300
 	tweakables.GeneratorBufferReserveSize = 25
-	opts := append(scheduleCommonOpts(t), testcore.WithDynamicConfig(chasmscheduler.CurrentTweakables, tweakables))
+	opts := append(scheduleCommonOpts(), testcore.WithDynamicConfig(chasmscheduler.CurrentTweakables, tweakables))
 	s := newScheduleEnv(t, opts...)
 	sid := "sched-test-too-many-backfillers"
 	wt := "sched-test-too-many-backfillers-wt"
@@ -3256,7 +3251,7 @@ func testPatchRejectsExcessBackfillers(t *testing.T, newContext contextFactory) 
 }
 
 func testMigrationCallbackAttach(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := testcore.RandomizeStr("sid")
 	wid := testcore.RandomizeStr("wid")
@@ -3386,7 +3381,7 @@ func testMigrationCallbackAttach(t *testing.T, newContext contextFactory) {
 // testCHASMCanListV1Schedules tests that a schedule created in the V1 stack
 // will also be visible in the V2 stack.
 func testCHASMCanListV1Schedules(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := "schedule-created-on-v1"
 	schedule := &schedulepb.Schedule{
@@ -3457,7 +3452,7 @@ func testCHASMCanListV1Schedules(t *testing.T, newContext contextFactory) {
 
 // testRefresh applies to V1 scheduler only; V2 does not support/need manual refresh.
 func testRefresh(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := "sched-test-refresh"
 	wid := "sched-test-refresh-wf"
@@ -3567,7 +3562,7 @@ func testRefresh(t *testing.T, newContext contextFactory) {
 // testListBeforeRun only applies to V1, as V2 scheduler does not involve the
 // per-NS worker or workflow.
 func testListBeforeRun(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, append(scheduleCommonOpts(t),
+	s := newScheduleEnv(t, append(scheduleCommonOpts(),
 		testcore.WithDynamicConfig(dynamicconfig.WorkerPerNamespaceWorkerCount, 0),
 	)...)
 
@@ -3615,7 +3610,7 @@ func testListBeforeRun(t *testing.T, newContext contextFactory) {
 
 // testRateLimit applies only to V1, as V2 scheduler does not impose its own rate limiting.
 func testRateLimit(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, append(scheduleCommonOpts(t),
+	s := newScheduleEnv(t, append(scheduleCommonOpts(),
 		testcore.WithDynamicConfig(dynamicconfig.SchedulerNamespaceStartWorkflowRPS, 1.0),
 	)...)
 
@@ -3670,7 +3665,7 @@ func testRateLimit(t *testing.T, newContext contextFactory) {
 
 // testNextTimeCache only applies to V1.
 func testNextTimeCache(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := "sched-test-next-time-cache"
 	wid := "sched-test-next-time-cache-wf"
@@ -3827,7 +3822,7 @@ func assertRecentActionsNoDuplicateRunIDs(t *testing.T, actions []*schedulepb.Sc
 	}
 }
 func testUpdateScheduleMemo(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := "sched-test-update-memo"
 	wid := "sched-test-update-memo-wf"
@@ -3951,7 +3946,7 @@ func testUpdateScheduleMemo(t *testing.T, newContext contextFactory) {
 }
 
 func testUpdateScheduleMemoRejected(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := "sched-test-update-memo-rejected"
 	wid := "sched-test-update-memo-rejected-wf"
@@ -4015,7 +4010,7 @@ func testUpdateScheduleMemoOnly(t *testing.T, newContext contextFactory) {
 	// the schedule when the field is nil, similar to how memo and search_attributes are handled.
 	t.Skip("memo-only updates not yet supported: omitting the schedule field unsets the schedule")
 
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := "sched-test-update-memo-only"
 	wid := "sched-test-update-memo-only-wf"
@@ -4084,7 +4079,7 @@ func testUpdateScheduleMemoOnly(t *testing.T, newContext contextFactory) {
 }
 
 func testCHASMUnpauseResumesProcessing(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := "sched-test-unpause-resumes"
 	wid := "sched-test-unpause-resumes-wf"
@@ -4268,7 +4263,7 @@ func testPausedScheduleNeverIdles(t *testing.T, newContext contextFactory) {
 // manual-only pattern - can be created without timing out and remains
 // describable.
 func testPausedEmptySpecStaysOpen(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := testcore.RandomizeStr("sched-paused-empty-spec")
 	wid := testcore.RandomizeStr("sched-paused-empty-spec-wf")
@@ -4317,7 +4312,7 @@ func testPausedEmptySpecStaysOpen(t *testing.T, newContext contextFactory) {
 // patch on a running schedule fires an extra action and leaves the schedule
 // active.
 func testTriggerImmediatelyOnActiveSchedule(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := testcore.RandomizeStr("sched-trigger-on-active")
 	wid := testcore.RandomizeStr("sched-trigger-on-active-wf")
@@ -4368,7 +4363,7 @@ func testTriggerImmediatelyOnActiveSchedule(t *testing.T, newContext contextFact
 // an action even when the schedule is paused. Manual starts bypass the paused
 // gate via useScheduledAction's Manual carve-out in processBuffer.
 func testTriggerImmediatelyOnPausedSchedule(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := testcore.RandomizeStr("sched-trigger-on-paused")
 	wid := testcore.RandomizeStr("sched-trigger-on-paused-wf")
@@ -4407,7 +4402,7 @@ func testTriggerImmediatelyOnPausedSchedule(t *testing.T, newContext contextFact
 // testTriggerImmediatelyAfterActionsExhausted verifies that TriggerImmediately
 // fires an action even on a schedule that has no LimitedActions slots left.
 func testTriggerImmediatelyAfterActionsExhausted(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := testcore.RandomizeStr("sched-trigger-after-exhausted")
 	wid := testcore.RandomizeStr("sched-trigger-after-exhausted-wf")
@@ -4449,7 +4444,7 @@ func testBackfillReprocessesCompletedAction(
 	paused bool,
 	intervalsOnEachSide int,
 ) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := testcore.NewEnv(t, scheduleCommonOpts()...)
 
 	sid := testcore.RandomizeStr("sched-backfill-reprocess")
 	wid := testcore.RandomizeStr("sched-backfill-reprocess-wf")
@@ -4527,7 +4522,7 @@ func testBackfillWithBufferOneOverlap(t *testing.T, newContext contextFactory) {
 	//   go test ./tests/ -run 'TestScheduleCHASM/Backfill/BufferOneOverlap' -v
 	t.Skip("BUFFER_ONE backfill deferred re-enable is broken on both V1 and CHASM; see test doc")
 
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := testcore.RandomizeStr("sched-backfill-buffer-one")
 	wid := testcore.RandomizeStr("sched-backfill-buffer-one-wf")
@@ -4571,7 +4566,7 @@ func testBackfillWithBufferOneOverlap(t *testing.T, newContext contextFactory) {
 // is narrower than the spec interval - no spec tick lands inside it, so no
 // actions fire and the backfiller still drains cleanly.
 func testBackfillRangeSmallerThanInterval(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := testcore.RandomizeStr("sched-backfill-narrow")
 	wid := testcore.RandomizeStr("sched-backfill-narrow-wf")
@@ -4612,7 +4607,7 @@ func testBackfillRangeSmallerThanInterval(t *testing.T, newContext contextFactor
 // testBackfillWithSkipOverlap verifies that SKIP overlap correctly collapses a
 // multi-tick backfill range to a single workflow execution.
 func testBackfillWithSkipOverlap(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := testcore.RandomizeStr("sched-backfill-skip")
 	wid := testcore.RandomizeStr("sched-backfill-skip-wf")
@@ -4641,7 +4636,7 @@ func testBackfillWithSkipOverlap(t *testing.T, newContext contextFactory) {
 }
 
 func testUpdateScheduleRequestIDTooLong(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := "sched-test-update-reqid-too-long"
 	wid := "sched-test-update-reqid-too-long-wf"
@@ -4673,7 +4668,7 @@ func testUpdateScheduleRequestIDTooLong(t *testing.T, newContext contextFactory)
 }
 
 func testLargeScheduleID(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 	ctx := newContext(testcore.NewContext())
 
 	// The V1 sentinel shares the SQL workflow ID limit with the schedule ID
@@ -4698,7 +4693,7 @@ func testLargeScheduleID(t *testing.T, newContext contextFactory) {
 
 func testUpdateScheduleBlobSizeLimit(t *testing.T, newContext contextFactory) {
 	s := newScheduleEnv(t,
-		append(scheduleCommonOpts(t),
+		append(scheduleCommonOpts(),
 			testcore.WithDynamicConfig(dynamicconfig.BlobSizeLimitError, 1000),
 			testcore.WithDynamicConfig(dynamicconfig.BlobSizeLimitWarn, 500),
 		)...,
@@ -4764,9 +4759,7 @@ func testUpdateScheduleBlobSizeLimit(t *testing.T, newContext contextFactory) {
 // after EnableCHASMSchedulerCreation is on: at 50%, two schedules whose IDs
 // bucket on opposite sides of the rollout land on different stacks.
 func TestScheduleCreationRolloutPercent(t *testing.T) {
-	opts := append(scheduleCommonOpts(t),
-		// V1 worker is needed because at 50% rollout some schedules land on V1.
-		testcore.WithWorkerService("V1 scheduler"),
+	opts := append(scheduleCommonOpts(),
 		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerCreation, true),
 		testcore.WithDynamicConfig(dynamicconfig.CHASMSchedulerCreationRolloutPercent, 50),
 	)
@@ -5065,7 +5058,7 @@ func testBackfillBlocksIdleClose(t *testing.T, newContext contextFactory) {
 // testMultiRangeBackfillCountedExactlyOnce asserts that the `ActionCount` is
 // correctly counted when multiple backfillers are concurrently running.
 func testMultiRangeBackfillCountedExactlyOnce(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := testcore.RandomizeStr("sched-multi-range-backfill")
 	wid := testcore.RandomizeStr("sched-multi-range-backfill-wf")
@@ -5119,7 +5112,7 @@ func testMultiRangeBackfillCountedExactlyOnce(t *testing.T, newContext contextFa
 // a backfill request to completion, even though the schedule otherwise has no
 // automated actions running.
 func testBackfillOnPausedSchedule(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 
 	sid := testcore.RandomizeStr("sched-backfill-paused")
 	wid := testcore.RandomizeStr("sched-backfill-paused-wf")
@@ -5152,7 +5145,7 @@ func testBackfillOnPausedSchedule(t *testing.T, newContext contextFactory) {
 // ScheduleNextActionTime search attribute is published to visibility and is
 // queryable through the frontend ListSchedules API.
 func TestScheduleNextActionTimeVisibility(t *testing.T) {
-	opts := scheduleCommonOpts(t)
+	opts := scheduleCommonOpts()
 	s := newScheduleEnv(t, opts...)
 
 	v2Sid := testcore.RandomizeStr("sched-next-action-v2")
@@ -5235,7 +5228,7 @@ func TestScheduleNextActionTimeVisibility(t *testing.T) {
 func TestMirroredIncludeExcludeSpec(t *testing.T) {
 	// A tiny compute bound trips the mirrored spec near-instantly; the default (~1.2M candidate
 	// scans per GetNextTime) makes this test burn seconds of CPU on every scheduler code path.
-	opts := append(scheduleCommonOpts(t), testcore.WithDynamicConfig(dynamicconfig.SchedulerSpecMaxIterations, 1000))
+	opts := append(scheduleCommonOpts(), testcore.WithDynamicConfig(dynamicconfig.SchedulerSpecMaxIterations, 1000))
 	s := testcore.NewEnv(t, opts...)
 
 	sid := testcore.RandomizeStr("sched-cancelling-spec")
@@ -5268,7 +5261,7 @@ func TestMirroredIncludeExcludeSpec(t *testing.T) {
 // mirrored spec via UpdateSchedule, exercising the spec-recompile path on an existing schedule.
 func TestMirroredIncludeExcludeSpecOnUpdate(t *testing.T) {
 	// A tiny compute bound trips the mirrored spec near-instantly (see TestMirroredIncludeExcludeSpec).
-	opts := append(scheduleCommonOpts(t), testcore.WithDynamicConfig(dynamicconfig.SchedulerSpecMaxIterations, 1000))
+	opts := append(scheduleCommonOpts(), testcore.WithDynamicConfig(dynamicconfig.SchedulerSpecMaxIterations, 1000))
 	s := testcore.NewEnv(t, opts...)
 
 	sid := testcore.RandomizeStr("sched-cancelling-update")
@@ -5315,7 +5308,7 @@ func TestMirroredIncludeExcludeSpecOnUpdate(t *testing.T) {
 // horizon (an interval 10x the horizon) still fills FutureActionTimes, since each far-future
 // time is found in a single interval step rather than by scanning.
 func TestScheduleFarFutureActionTimes(t *testing.T) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := testcore.NewEnv(t, scheduleCommonOpts()...)
 
 	sid := testcore.RandomizeStr("sched-far-future")
 	wid := testcore.RandomizeStr("sched-far-future-wf")
@@ -5371,7 +5364,7 @@ func TestScheduleFarFutureActionTimes(t *testing.T) {
 // evaluates cheaply, so the schedule keeps dispatching actions while RecentActions and
 // FutureActionTimes keep updating.
 func TestScheduleManyCalendars(t *testing.T) {
-	s := testcore.NewEnv(t, scheduleCommonOpts(t)...)
+	s := testcore.NewEnv(t, scheduleCommonOpts()...)
 
 	sid := testcore.RandomizeStr("sched-many-calendars")
 	wid := testcore.RandomizeStr("sched-many-calendars-wf")
@@ -5455,7 +5448,7 @@ func TestScheduleManyCalendars(t *testing.T) {
 // behind it. The counts aren't surfaced on the list entry, so we assert via the
 // query rather than by reading the entry's SAs.
 func TestScheduleCountsVisibility(t *testing.T) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	s := newScheduleEnv(t, scheduleCommonOpts()...)
 	newContext := chasmContextFactory
 
 	sid := testcore.RandomizeStr("sched-counts-v2")

--- a/tests/schedule_workflow_pause_interaction_test.go
+++ b/tests/schedule_workflow_pause_interaction_test.go
@@ -114,8 +114,8 @@ func runSchedulePauseRecoveryMatrix(t *testing.T, newContext contextFactory) {
 
 // pauseInteractionOpts returns the schedule test options plus the dynamic config
 // required to enable the workflow pause feature.
-func pauseInteractionOpts(t *testing.T) []testcore.TestOption {
-	return append(scheduleCommonOpts(t),
+func pauseInteractionOpts() []testcore.TestOption {
+	return append(scheduleCommonOpts(),
 		testcore.WithDynamicConfig(dynamicconfig.WorkflowPauseEnabled, true),
 	)
 }
@@ -141,7 +141,7 @@ func setupPausedScheduledWorkflow(
 	policy enumspb.ScheduleOverlapPolicy,
 	register func(s *testcore.TestEnv, wt string),
 ) *scheduledPauseFixture {
-	env := newScheduleEnv(t, pauseInteractionOpts(t)...)
+	env := newScheduleEnv(t, pauseInteractionOpts()...)
 
 	sid := testcore.RandomizeStr("sched-pause-" + policy.String())
 	wid := testcore.RandomizeStr("sched-pause-wf-" + policy.String())
@@ -433,7 +433,7 @@ func testSchedulePauseContinueAsNew(t *testing.T, newContext contextFactory) {
 	// The scheduler matches the continued run's completion by the request ID in
 	// the completion callback token, which only survives continue-as-new in the
 	// envelope token format (gated off by default).
-	opts := append(pauseInteractionOpts(t), testcore.WithDynamicConfig(callback.EncodeInternalTokenWithEnvelope, true))
+	opts := append(pauseInteractionOpts(), testcore.WithDynamicConfig(callback.EncodeInternalTokenWithEnvelope, true))
 
 	// First run waits for the "go" signal, then continues-as-new; the continued
 	// run completes immediately.
@@ -528,7 +528,7 @@ func testSchedulePauseReset(t *testing.T, newContext contextFactory) {
 		)
 	}
 
-	f := setupPausedTriggeredWorkflow(t, newContext, pauseInteractionOpts(t), "sched-pause-reset", register, afterStart)
+	f := setupPausedTriggeredWorkflow(t, newContext, pauseInteractionOpts(), "sched-pause-reset", register, afterStart)
 
 	// Reset the paused workflow to a point before it was paused.
 	resetResp, err := f.env.FrontendClient().ResetWorkflowExecution(f.ctx, &workflowservice.ResetWorkflowExecutionRequest{

--- a/tests/testcore/functional_test_base.go
+++ b/tests/testcore/functional_test_base.go
@@ -95,7 +95,6 @@ type (
 		DCRedirectionPolicy       config.DCRedirectionPolicy
 		DynamicConfigOverrides    map[dynamicconfig.Key]any
 		EnableMTLS                bool
-		EnableWorkerService       bool
 		FaultInjectionConfig      *config.FaultInjection
 		NumHistoryShards          int32
 		Logger                    log.Logger
@@ -141,12 +140,6 @@ func withArchivalConfig() TestClusterOption {
 func withMTLS() TestClusterOption {
 	return func(params *testClusterParams) {
 		params.EnableMTLS = true
-	}
-}
-
-func withWorkerService(enabled bool) TestClusterOption {
-	return func(params *testClusterParams) {
-		params.EnableWorkerService = enabled
 	}
 }
 
@@ -274,9 +267,8 @@ func (s *FunctionalTestBase) SetupSuiteWithCluster(options ...TestClusterOption)
 	testClusterRouter.dedicated.reserveSlot(s.T())
 	s.setupCluster(options...)
 	clusterRequest{
-		kind:              clusterKindDedicated,
-		dedicatedReason:   "legacy-suite",
-		needWorkerService: ApplyTestClusterOptions(options).EnableWorkerService,
+		kind:            clusterKindDedicated,
+		dedicatedReason: "legacy-suite",
 	}.recordCreation(s.T())
 }
 
@@ -315,7 +307,6 @@ func (s *FunctionalTestBase) setupCluster(options ...TestClusterOption) {
 		EnableReplicationRecorder: params.EnableReplicationRecorder,
 		EnableArchival:            params.EnableArchival,
 		AdditionalServerOptions:   params.AdditionalServerOptions,
-		WorkerConfig:              WorkerConfig{DisableWorker: !params.EnableWorkerService},
 	}
 	if params.SpanExporter != nil {
 		setSpanExporter(s.testClusterConfig, "test", params.SpanExporter)
@@ -403,9 +394,7 @@ func (s *FunctionalTestBase) checkTestShard() {
 }
 
 func ApplyTestClusterOptions(options []TestClusterOption) testClusterParams {
-	params := testClusterParams{
-		EnableWorkerService: true,
-	}
+	var params testClusterParams
 	for _, opt := range options {
 		opt(&params)
 	}

--- a/tests/testcore/test_cluster_pool.go
+++ b/tests/testcore/test_cluster_pool.go
@@ -226,18 +226,17 @@ const (
 
 // clusterRequest describes what a test needs from the cluster router.
 type clusterRequest struct {
-	kind              string // set by the router: shared, dedicated, or suite-scoped
-	dedicated         bool
-	dedicatedReason   string
-	needWorkerService bool
-	dynamicConfig     map[dynamicconfig.Key]any
-	clusterOpts       []TestClusterOption
+	kind            string // set by the router: shared, dedicated, or suite-scoped
+	dedicated       bool
+	dedicatedReason string
+	dynamicConfig   map[dynamicconfig.Key]any
+	clusterOpts     []TestClusterOption
 }
 
 // mustBeFresh reports whether the request requires a brand-new cluster that
 // cannot be reused.
 func (r clusterRequest) mustBeFresh() bool {
-	return r.needWorkerService || len(r.dynamicConfig) > 0 || len(r.clusterOpts) > 0
+	return len(r.dynamicConfig) > 0 || len(r.clusterOpts) > 0
 }
 
 // needsDedicated reports whether the request must be served by a dedicated
@@ -275,7 +274,7 @@ func (r clusterRequest) recordCreation(t *testing.T) {
 		"test":   t.Name(),
 		"kind":   r.kind,
 		"reason": r.reason(),
-		"worker": r.needWorkerService,
+		"worker": true,
 	})
 	if err != nil {
 		return
@@ -326,10 +325,7 @@ func (p *clusterRouter) getSuiteScoped(t *testing.T) *FunctionalTestBase {
 	suiteClusterAny, _ := p.suiteScoped.LoadOrStore(rootName, &suiteScopedCluster{})
 	suiteCluster := suiteClusterAny.(*suiteScopedCluster)
 	suiteCluster.once.Do(func() {
-		// TODO(stephan, #10580): remove this workaround once the proper cluster-pool fix lands.
-		// Enable the worker service on suite-scoped clusters. The only current user (Versioning3) needs the system
-		// worker for worker-deployment APIs.
-		suiteCluster.cluster = p.createCluster(t, clusterRequest{kind: clusterKindSuiteScoped, needWorkerService: true})
+		suiteCluster.cluster = p.createCluster(t, clusterRequest{kind: clusterKindSuiteScoped})
 	})
 	suiteCluster.cluster.SetT(t)
 	return suiteCluster.cluster
@@ -362,8 +358,7 @@ func (p *clusterRouter) createCluster(t *testing.T, req clusterRequest) *Functio
 	tbase := &FunctionalTestBase{}
 	tbase.SetT(t)
 
-	// The worker service is off unless the request explicitly needs it.
-	opts := []TestClusterOption{withWorkerService(req.needWorkerService)}
+	var opts []TestClusterOption
 	if req.kind != clusterKindDedicated {
 		opts = append(opts, WithSharedCluster())
 	}

--- a/tests/testcore/test_env.go
+++ b/tests/testcore/test_env.go
@@ -90,7 +90,6 @@ type TestOption func(*testOptions)
 
 type testOptions struct {
 	dedicatedCluster         bool
-	needWorkerService        bool
 	dedicatedReason          string
 	disableTestloggerFailure bool
 	dynamicConfigSettings    []dynamicConfigOverride
@@ -147,16 +146,6 @@ func WithSdkWorker() TestOption {
 func WithTestVars(fn func(*testvars.TestVars) *testvars.TestVars) TestOption {
 	return func(o *testOptions) {
 		o.testVars = fn
-	}
-}
-
-// WithWorkerService enables the system worker service. The service is off by
-// default to avoid the worker overhead. This implies a dedicated cluster.
-func WithWorkerService(reason string) TestOption {
-	return func(o *testOptions) {
-		o.dedicatedCluster = true
-		o.needWorkerService = true
-		o.dedicatedReason = "worker service required: " + reason
 	}
 }
 
@@ -284,11 +273,10 @@ func NewEnv(t *testing.T, opts ...TestOption) *TestEnv {
 
 	// Obtain the test cluster from the router.
 	base := testClusterRouter.get(t, clusterRequest{
-		dedicated:         options.dedicatedCluster,
-		needWorkerService: options.needWorkerService,
-		dedicatedReason:   options.dedicatedReason,
-		dynamicConfig:     startupConfig,
-		clusterOpts:       options.clusterOptions,
+		dedicated:       options.dedicatedCluster,
+		dedicatedReason: options.dedicatedReason,
+		dynamicConfig:   startupConfig,
+		clusterOpts:     options.clusterOptions,
 	})
 	cluster := base.GetTestCluster()
 

--- a/tests/testcore/test_env_test.go
+++ b/tests/testcore/test_env_test.go
@@ -3,8 +3,13 @@ package testcore
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"go.temporal.io/server/common/testing/parallelsuite"
+	"go.temporal.io/server/service/worker"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 type TestEnvSuite struct {
@@ -45,4 +50,27 @@ func (s *TestEnvSuite) TestDedicatedClusterGuard_ConcurrentRecord() {
 	}
 	wg.Wait()
 	s.NoError(guard.validate())
+}
+
+func (s *TestEnvSuite) TestWorkerServiceStartsByDefault() {
+	env := NewEnv(s.T())
+	conn, err := grpc.NewClient(
+		env.WorkerGRPCAddress(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	s.Require().NoError(err)
+	defer func() { s.Require().NoError(conn.Close()) }()
+
+	healthClient := healthpb.NewHealthClient(conn)
+	s.Await(
+		func(s *TestEnvSuite) {
+			resp, err := healthClient.Check(s.Context(), &healthpb.HealthCheckRequest{
+				Service: worker.ServiceName,
+			})
+			s.NoError(err)
+			s.Equal(healthpb.HealthCheckResponse_SERVING, resp.Status)
+		},
+		10*time.Second,
+		100*time.Millisecond,
+	)
 }

--- a/tests/versioning_3_test.go
+++ b/tests/versioning_3_test.go
@@ -4923,7 +4923,7 @@ func (s *Versioning3Suite) TestPinnedCaN_FailedTransientNotificationRefiresDespi
 // made current again, then reset-by-build-ID resets the workflow before v2 usage
 // so the reset run resumes on v1.
 func (s *Versioning3Suite) TestPinnedCaN_ResetByBuildIDAfterRollback() {
-	env := s.setupEnv(testcore.WithWorkerService("batch operations"))
+	env := s.setupEnv()
 
 	tv := env.Tv()
 	tv1 := tv.WithBuildIDNumber(1)

--- a/tests/worker_deployment_version_test.go
+++ b/tests/worker_deployment_version_test.go
@@ -1889,8 +1889,6 @@ func (s *DeploymentVersionSuite) setAndCheckOverrideWithExpectedOutput(env *test
 // The following tests test the VersioningOverride functionality when passed via the UpdateWorkflowExecutionOptions API.
 func (s *DeploymentVersionSuite) TestUpdateWorkflowExecutionOptions_SetPinned_CacheMissAndHits() {
 	env := s.newTestEnv(
-		// TODO: remove WithWorkerService once legacy suite-scoped cluster behavior is removed.
-		testcore.WithWorkerService("worker-deployment version membership cache test"),
 		testcore.WithDynamicConfig(dynamicconfig.VersionMembershipCacheTTL, 5*time.Second),
 	)
 
@@ -2868,8 +2866,6 @@ func (s *DeploymentVersionSuite) makeAutoUpgradeOverride() *workflowpb.Versionin
 
 func (s *DeploymentVersionSuite) TestStartWorkflowExecution_WithPinnedOverride_CacheMissAndHits() {
 	env := s.newTestEnv(
-		// TODO: remove WithWorkerService once legacy suite-scoped cluster behavior is removed.
-		testcore.WithWorkerService("worker-deployment version membership cache test"),
 		testcore.WithDynamicConfig(dynamicconfig.VersionMembershipCacheTTL, 5*time.Second),
 	)
 
@@ -2920,8 +2916,6 @@ func (s *DeploymentVersionSuite) TestStartWorkflowExecution_WithUnpinnedOverride
 
 func (s *DeploymentVersionSuite) TestSignalWithStartWorkflowExecution_WithPinnedOverride_CacheMissAndHits() {
 	env := s.newTestEnv(
-		// TODO: remove WithWorkerService once legacy suite-scoped cluster behavior is removed.
-		testcore.WithWorkerService("worker-deployment version membership cache test"),
 		testcore.WithDynamicConfig(dynamicconfig.VersionMembershipCacheTTL, 5*time.Second),
 	)
 

--- a/tests/workflow_api_batch_terminate_test.go
+++ b/tests/workflow_api_batch_terminate_test.go
@@ -29,15 +29,14 @@ func TestWorkflowAPIBatchTerminateClientTestSuite(t *testing.T) {
 	parallelsuite.Run(t, &WorkflowAPIBatchTerminateClientTestSuite{})
 }
 
-// newWorkflowBatchEnv builds a test env with the "batch operations" worker
-// service running so that workflow batch operations (terminate/cancel/signal/
-// delete/reset/update options) can be exercised end-to-end. It raises the
+// newWorkflowBatchEnv builds a test env where workflow batch operations
+// (terminate/cancel/signal/delete/reset/update options) can be exercised
+// end-to-end. It raises the
 // per-namespace concurrent batch limit, since these tests intentionally start
 // multiple batch operations in the same namespace (the default limit is 1).
 func newWorkflowBatchEnv(t *testing.T) *testcore.TestEnv {
 	return testcore.NewEnv(
 		t,
-		testcore.WithWorkerService("batch operations"),
 		testcore.WithDynamicConfig(dynamicconfig.FrontendMaxConcurrentBatchOperationPerNamespace, testcore.ClientSuiteLimit),
 		testcore.WithDynamicConfig(dynamicconfig.WorkflowPauseEnabled, true),
 	)

--- a/tests/workflow_reset_test.go
+++ b/tests/workflow_reset_test.go
@@ -238,7 +238,7 @@ func (s *WorkflowResetSuite) TestOriginalExecutionRunId() {
 
 // Test that the workflow options are updated when the workflow is reset.
 func (s *WorkflowResetSuite) TestResetWorkflowWithOptionsUpdate() {
-	env := testcore.NewEnv(s.T(), testcore.WithWorkerService("worker-deployment version registration"))
+	env := testcore.NewEnv(s.T())
 	deploymentName := "testing"
 	buildID := "v.123"
 
@@ -316,7 +316,7 @@ func (s *WorkflowResetSuite) TestResetWorkflowWithOptionsUpdate() {
 
 // Test batch reset operation with version update as post reset operation
 func (s *WorkflowResetSuite) TestBatchResetWithOptionsUpdate() {
-	env := testcore.NewEnv(s.T(), testcore.WithWorkerService("batch operations"))
+	env := testcore.NewEnv(s.T())
 	deploymentName := "batch-testing"
 	buildID := "v.456"
 


### PR DESCRIPTION
## What changed?

- Start the system worker service for every functional-test cluster.
- Remove `WithWorkerService` and its worker-specific routing and configuration plumbing.
- Let tests that only needed the worker opt-in use normal shared or pooled cluster reuse.

## Why?

This draft lets us measure the CI runtime and memory impact of making the worker service always on.

## Testing

- `go test -tags test_dep ./tests/testcore -count=1`
- `go test -tags test_dep ./tests/... -run '^$' -count=1`
- `make lint-code` skipped as requested; CI will provide the lint result.