### PR TITLE
history: preserve ResourceExhausted from search attribute provider

### DIFF
--- a/service/history/api/get_history_util.go
+++ b/service/history/api/get_history_util.go
@@ -357,6 +357,14 @@ func ProcessOutgoingSearchAttributes(
 ) error {
 	saTypeMap, err := saProvider.GetSearchAttributes(persistenceVisibilityMgr.GetIndexName(), false)
 	if err != nil {
+		// Preserve a persistence rate-limit error's type instead of flattening it to
+		// Unavailable: common/backoff.Retry only applies its longer throttle backoff to
+		// *serviceerror.ResourceExhausted (via a direct type assertion), so wrapping it here
+		// would cause callers to retry against an already-exhausted persistence budget at the
+		// ordinary, faster rate.
+		if common.IsResourceExhausted(err) {
+			return err
+		}
 		return serviceerror.NewUnavailablef(consts.ErrUnableToGetSearchAttributesMessage, err)
 	}
 	for _, event := range events {

--- a/service/history/api/get_history_util_test.go
+++ b/service/history/api/get_history_util_test.go
@@ -7,9 +7,50 @@ import (
 	"github.com/stretchr/testify/require"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
+	"go.temporal.io/api/serviceerror"
 	historyspb "go.temporal.io/server/api/history/v1"
 	"go.temporal.io/server/common/headers"
+	"go.temporal.io/server/common/persistence/visibility/manager"
+	"go.temporal.io/server/common/searchattribute"
+	"go.uber.org/mock/gomock"
 )
+
+// TestProcessOutgoingSearchAttributes_PreservesResourceExhausted is a
+// regression test for #11571: a persistence rate-limit error from the search
+// attribute provider was flattened into a generic Unavailable error, so
+// common/backoff.Retry's longer throttle backoff (which only applies to
+// *serviceerror.ResourceExhausted via a direct type assertion) never kicked
+// in, and retries ran at the ordinary rate against an already exhausted
+// persistence budget.
+func TestProcessOutgoingSearchAttributes_PreservesResourceExhausted(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+
+	resourceExhausted := serviceerror.NewResourceExhausted(enumspb.RESOURCE_EXHAUSTED_CAUSE_PERSISTENCE_LIMIT, "persistence rate limit exceeded")
+	saProvider := searchattribute.NewMockProvider(ctrl)
+	saProvider.EXPECT().GetSearchAttributes(gomock.Any(), false).Return(searchattribute.NameTypeMap{}, resourceExhausted)
+	visibilityMgr := manager.NewMockVisibilityManager(ctrl)
+	visibilityMgr.EXPECT().GetIndexName().Return("test-index")
+
+	err := ProcessOutgoingSearchAttributes(saProvider, nil, nil, "test-namespace", visibilityMgr)
+	require.Same(t, resourceExhausted, err, "ResourceExhausted must be returned as-is, not wrapped as Unavailable")
+	require.IsType(t, &serviceerror.ResourceExhausted{}, err)
+}
+
+// TestProcessOutgoingSearchAttributes_WrapsOtherErrors verifies non-rate-limit
+// errors are still wrapped into a client-safe Unavailable error, as before.
+func TestProcessOutgoingSearchAttributes_WrapsOtherErrors(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+
+	saProvider := searchattribute.NewMockProvider(ctrl)
+	saProvider.EXPECT().GetSearchAttributes(gomock.Any(), false).Return(searchattribute.NameTypeMap{}, serviceerror.NewInternal("boom"))
+	visibilityMgr := manager.NewMockVisibilityManager(ctrl)
+	visibilityMgr.EXPECT().GetIndexName().Return("test-index")
+
+	err := ProcessOutgoingSearchAttributes(saProvider, nil, nil, "test-namespace", visibilityMgr)
+	require.IsType(t, &serviceerror.Unavailable{}, err)
+}
 
 func TestShouldIncludeTransientOrSpeculativeTasks(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Fixes #11571

## Problem

`ProcessOutgoingSearchAttributes` (`service/history/api/get_history_util.go:358`) unconditionally wraps any error from `saProvider.GetSearchAttributes` into a generic `*serviceerror.Unavailable`:

```go
saTypeMap, err := saProvider.GetSearchAttributes(persistenceVisibilityMgr.GetIndexName(), false)
if err != nil {
      return serviceerror.NewUnavailablef(consts.ErrUnableToGetSearchAttributesMessage, err)
}
```

`GetSearchAttributes` can fail with a genuine `*serviceerror.ResourceExhausted` when persistence rate-limits `GetCurrentClusterMetadata` inside the search-attribute cache refresh (`common/searchattribute/manager.go`). Wrapping it discards that type.

`common/backoff.Retry` (`common/backoff/retry.go:80`) applies its longer throttle backoff only via a direct type assertion — `if _, ok := err.(*serviceerror.ResourceExhausted); ok`. With the error flattened to `Unavailable`, that assertion never matches, so callers retry at the ordinary, faster rate against an already-exhausted persistence budget, contradicting the intent described at `service/history/queues/executable.go:795`.

## Fix

Return the `ResourceExhausted` error as-is (using the existing `common.IsResourceExhausted` helper, matching the same preserve-known-type pattern already used elsewhere in the codebase, e.g. `common/rpc/interceptor/frontend_service_error.go`) so its concrete type survives to the retry layer. Every other error is still wrapped into the same client-safe `Unavailable` message as before — this only changes behavior for the one error type the issue reports.

## Testing

- `go build ./service/history/...` and `go vet ./service/history/api/...` — clean.
- `go test ./service/history/api/...` — full package passes, zero regressions.
- Two new regression tests using the existing `searchattribute.MockProvider`/`manager.MockVisibilityManager` mocks:
  - `TestProcessOutgoingSearchAttributes_PreservesResourceExhausted` — asserts a `ResourceExhausted` from the provider comes back unwrapped (same error, same concrete type).
  - `TestProcessOutgoingSearchAttributes_WrapsOtherErrors` — asserts a non-rate-limit error (e.g. `Internal`) is still wrapped into `Unavailable`, confirming existing behavior for other error types is unchanged.

Release note (bug fix): Fixed a bug where a persistence rate-limit error encountered while resolving search attributes for outgoing history events was reported as a generic Unavailable error instead of ResourceExhausted, causing callers to retry at the ordinary rate instead of applying the intended throttle backoff.