### PR TITLE
Deprecate unused single-axis outbound predicate types

### DIFF
--- a/api/persistence/v1/predicates.pb.go
+++ b/api/persistence/v1/predicates.pb.go
@@ -141,6 +141,7 @@ func (x *Predicate) GetNamespaceIdPredicateAttributes() *NamespaceIdPredicateAtt
 	return nil
 }
 
+// Deprecated: Marked as deprecated in temporal/server/api/persistence/v1/predicates.proto.
 func (x *Predicate) GetTaskTypePredicateAttributes() *TaskTypePredicateAttributes {
 	if x != nil {
 		if x, ok := x.Attributes.(*Predicate_TaskTypePredicateAttributes); ok {
@@ -150,6 +151,7 @@ func (x *Predicate) GetTaskTypePredicateAttributes() *TaskTypePredicateAttribute
 	return nil
 }
 
+// Deprecated: Marked as deprecated in temporal/server/api/persistence/v1/predicates.proto.
 func (x *Predicate) GetDestinationPredicateAttributes() *DestinationPredicateAttributes {
 	if x != nil {
 		if x, ok := x.Attributes.(*Predicate_DestinationPredicateAttributes); ok {
@@ -159,6 +161,7 @@ func (x *Predicate) GetDestinationPredicateAttributes() *DestinationPredicateAtt
 	return nil
 }
 
+// Deprecated: Marked as deprecated in temporal/server/api/persistence/v1/predicates.proto.
 func (x *Predicate) GetOutboundTaskGroupPredicateAttributes() *OutboundTaskGroupPredicateAttributes {
 	if x != nil {
 		if x, ok := x.Attributes.(*Predicate_OutboundTaskGroupPredicateAttributes); ok {
@@ -206,14 +209,26 @@ type Predicate_NamespaceIdPredicateAttributes struct {
 }
 
 type Predicate_TaskTypePredicateAttributes struct {
+	// Deprecated: superseded by outbound_task_predicate_attributes (#6445), which combines
+	// task type, namespace and destination into one predicate. Kept only so a shard checkpointed
+	// before that change, and never checkpointed since, still deserializes correctly.
+	//
+	// Deprecated: Marked as deprecated in temporal/server/api/persistence/v1/predicates.proto.
 	TaskTypePredicateAttributes *TaskTypePredicateAttributes `protobuf:"bytes,8,opt,name=task_type_predicate_attributes,json=taskTypePredicateAttributes,proto3,oneof"`
 }
 
 type Predicate_DestinationPredicateAttributes struct {
+	// Deprecated: superseded by outbound_task_predicate_attributes (#6445); see above.
+	//
+	// Deprecated: Marked as deprecated in temporal/server/api/persistence/v1/predicates.proto.
 	DestinationPredicateAttributes *DestinationPredicateAttributes `protobuf:"bytes,9,opt,name=destination_predicate_attributes,json=destinationPredicateAttributes,proto3,oneof"`
 }
 
 type Predicate_OutboundTaskGroupPredicateAttributes struct {
+	// Deprecated: superseded by outbound_task_predicate_attributes (#6445); see above. Not to be
+	// confused with that message's own task_group field, which is very much in use.
+	//
+	// Deprecated: Marked as deprecated in temporal/server/api/persistence/v1/predicates.proto.
 	OutboundTaskGroupPredicateAttributes *OutboundTaskGroupPredicateAttributes `protobuf:"bytes,10,opt,name=outbound_task_group_predicate_attributes,json=outboundTaskGroupPredicateAttributes,proto3,oneof"`
 }
 
@@ -489,6 +504,7 @@ func (x *NamespaceIdPredicateAttributes) GetNamespaceIds() []string {
 	return nil
 }
 
+// Deprecated: see the deprecated task_type_predicate_attributes field on Predicate.
 type TaskTypePredicateAttributes struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	TaskTypes     []v1.TaskType          `protobuf:"varint,1,rep,packed,name=task_types,json=taskTypes,proto3,enum=temporal.server.api.enums.v1.TaskType" json:"task_types,omitempty"`
@@ -533,6 +549,7 @@ func (x *TaskTypePredicateAttributes) GetTaskTypes() []v1.TaskType {
 	return nil
 }
 
+// Deprecated: see the deprecated destination_predicate_attributes field on Predicate.
 type DestinationPredicateAttributes struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Destinations  []string               `protobuf:"bytes,1,rep,name=destinations,proto3" json:"destinations,omitempty"`
@@ -577,6 +594,8 @@ func (x *DestinationPredicateAttributes) GetDestinations() []string {
 	return nil
 }
 
+// Deprecated: see the deprecated outbound_task_group_predicate_attributes field on Predicate.
+// Not to be confused with OutboundTaskPredicateAttributes.Group.task_group, which is in use.
 type OutboundTaskGroupPredicateAttributes struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Groups        []string               `protobuf:"bytes,1,rep,name=groups,proto3" json:"groups,omitempty"`
@@ -729,7 +748,7 @@ var File_temporal_server_api_persistence_v1_predicates_proto protoreflect.FileDe
 
 const file_temporal_server_api_persistence_v1_predicates_proto_rawDesc = "" +
 	"\n" +
-	"3temporal/server/api/persistence/v1/predicates.proto\x12\"temporal.server.api.persistence.v1\x1a,temporal/server/api/enums/v1/predicate.proto\x1a'temporal/server/api/enums/v1/task.proto\"\xc1\v\n" +
+	"3temporal/server/api/persistence/v1/predicates.proto\x12\"temporal.server.api.persistence.v1\x1a,temporal/server/api/enums/v1/predicate.proto\x1a'temporal/server/api/enums/v1/task.proto\"\xcd\v\n" +
 	"\tPredicate\x12R\n" +
 	"\x0epredicate_type\x18\x01 \x01(\x0e2+.temporal.server.api.enums.v1.PredicateTypeR\rpredicateType\x12\x88\x01\n" +
 	"\x1euniversal_predicate_attributes\x18\x02 \x01(\v2@.temporal.server.api.persistence.v1.UniversalPredicateAttributesH\x00R\x1cuniversalPredicateAttributes\x12|\n" +
@@ -737,11 +756,11 @@ const file_temporal_server_api_persistence_v1_predicates_proto_rawDesc = "" +
 	"\x18and_predicate_attributes\x18\x04 \x01(\v2:.temporal.server.api.persistence.v1.AndPredicateAttributesH\x00R\x16andPredicateAttributes\x12s\n" +
 	"\x17or_predicate_attributes\x18\x05 \x01(\v29.temporal.server.api.persistence.v1.OrPredicateAttributesH\x00R\x15orPredicateAttributes\x12v\n" +
 	"\x18not_predicate_attributes\x18\x06 \x01(\v2:.temporal.server.api.persistence.v1.NotPredicateAttributesH\x00R\x16notPredicateAttributes\x12\x8f\x01\n" +
-	"!namespace_id_predicate_attributes\x18\a \x01(\v2B.temporal.server.api.persistence.v1.NamespaceIdPredicateAttributesH\x00R\x1enamespaceIdPredicateAttributes\x12\x86\x01\n" +
-	"\x1etask_type_predicate_attributes\x18\b \x01(\v2?.temporal.server.api.persistence.v1.TaskTypePredicateAttributesH\x00R\x1btaskTypePredicateAttributes\x12\x8e\x01\n" +
-	" destination_predicate_attributes\x18\t \x01(\v2B.temporal.server.api.persistence.v1.DestinationPredicateAttributesH\x00R\x1edestinationPredicateAttributes\x12\xa2\x01\n" +
+	"!namespace_id_predicate_attributes\x18\a \x01(\v2B.temporal.server.api.persistence.v1.NamespaceIdPredicateAttributesH\x00R\x1enamespaceIdPredicateAttributes\x12\x8a\x01\n" +
+	"\x1etask_type_predicate_attributes\x18\b \x01(\v2?.temporal.server.api.persistence.v1.TaskTypePredicateAttributesB\x02\x18\x01H\x00R\x1btaskTypePredicateAttributes\x12\x92\x01\n" +
+	" destination_predicate_attributes\x18\t \x01(\v2B.temporal.server.api.persistence.v1.DestinationPredicateAttributesB\x02\x18\x01H\x00R\x1edestinationPredicateAttributes\x12\xa6\x01\n" +
 	"(outbound_task_group_predicate_attributes\x18\n" +
-	" \x01(\v2H.temporal.server.api.persistence.v1.OutboundTaskGroupPredicateAttributesH\x00R$outboundTaskGroupPredicateAttributes\x12\x92\x01\n" +
+	" \x01(\v2H.temporal.server.api.persistence.v1.OutboundTaskGroupPredicateAttributesB\x02\x18\x01H\x00R$outboundTaskGroupPredicateAttributes\x12\x92\x01\n" +
 	"\"outbound_task_predicate_attributes\x18\v \x01(\v2C.temporal.server.api.persistence.v1.OutboundTaskPredicateAttributesH\x00R\x1foutboundTaskPredicateAttributesB\f\n" +
 	"\n" +
 	"attributes\"\x1e\n" +

--- a/api/persistence/v1/predicates.pb.go
+++ b/api/persistence/v1/predicates.pb.go
@@ -209,16 +209,18 @@ type Predicate_NamespaceIdPredicateAttributes struct {
 }
 
 type Predicate_TaskTypePredicateAttributes struct {
-	// Deprecated: superseded by outbound_task_predicate_attributes (#6445), which combines
-	// task type, namespace and destination into one predicate. Kept only so a shard checkpointed
-	// before that change, and never checkpointed since, still deserializes correctly.
+	// Deprecated: never built by any queue's grouper. Kept only so a shard that still holds one
+	// from before the outbound queue existed, and hasn't recompacted since, still deserializes
+	// correctly.
 	//
 	// Deprecated: Marked as deprecated in temporal/server/api/persistence/v1/predicates.proto.
 	TaskTypePredicateAttributes *TaskTypePredicateAttributes `protobuf:"bytes,8,opt,name=task_type_predicate_attributes,json=taskTypePredicateAttributes,proto3,oneof"`
 }
 
 type Predicate_DestinationPredicateAttributes struct {
-	// Deprecated: superseded by outbound_task_predicate_attributes (#6445); see above.
+	// Deprecated: superseded by outbound_task_predicate_attributes (#6445), which combines
+	// task group, namespace and destination into one predicate. Kept only so a shard checkpointed
+	// before that change, and never checkpointed since, still deserializes correctly.
 	//
 	// Deprecated: Marked as deprecated in temporal/server/api/persistence/v1/predicates.proto.
 	DestinationPredicateAttributes *DestinationPredicateAttributes `protobuf:"bytes,9,opt,name=destination_predicate_attributes,json=destinationPredicateAttributes,proto3,oneof"`

--- a/proto/internal/temporal/server/api/persistence/v1/predicates.proto
+++ b/proto/internal/temporal/server/api/persistence/v1/predicates.proto
@@ -16,9 +16,15 @@ message Predicate {
     OrPredicateAttributes or_predicate_attributes = 5;
     NotPredicateAttributes not_predicate_attributes = 6;
     NamespaceIdPredicateAttributes namespace_id_predicate_attributes = 7;
-    TaskTypePredicateAttributes task_type_predicate_attributes = 8;
-    DestinationPredicateAttributes destination_predicate_attributes = 9;
-    OutboundTaskGroupPredicateAttributes outbound_task_group_predicate_attributes = 10;
+    // Deprecated: superseded by outbound_task_predicate_attributes (#6445), which combines
+    // task type, namespace and destination into one predicate. Kept only so a shard checkpointed
+    // before that change, and never checkpointed since, still deserializes correctly.
+    TaskTypePredicateAttributes task_type_predicate_attributes = 8 [deprecated = true];
+    // Deprecated: superseded by outbound_task_predicate_attributes (#6445); see above.
+    DestinationPredicateAttributes destination_predicate_attributes = 9 [deprecated = true];
+    // Deprecated: superseded by outbound_task_predicate_attributes (#6445); see above. Not to be
+    // confused with that message's own task_group field, which is very much in use.
+    OutboundTaskGroupPredicateAttributes outbound_task_group_predicate_attributes = 10 [deprecated = true];
     OutboundTaskPredicateAttributes outbound_task_predicate_attributes = 11;
   }
 }
@@ -43,14 +49,18 @@ message NamespaceIdPredicateAttributes {
   repeated string namespace_ids = 1;
 }
 
+// Deprecated: see the deprecated task_type_predicate_attributes field on Predicate.
 message TaskTypePredicateAttributes {
   repeated temporal.server.api.enums.v1.TaskType task_types = 1;
 }
 
+// Deprecated: see the deprecated destination_predicate_attributes field on Predicate.
 message DestinationPredicateAttributes {
   repeated string destinations = 1;
 }
 
+// Deprecated: see the deprecated outbound_task_group_predicate_attributes field on Predicate.
+// Not to be confused with OutboundTaskPredicateAttributes.Group.task_group, which is in use.
 message OutboundTaskGroupPredicateAttributes {
   repeated string groups = 1;
 }

--- a/proto/internal/temporal/server/api/persistence/v1/predicates.proto
+++ b/proto/internal/temporal/server/api/persistence/v1/predicates.proto
@@ -16,11 +16,13 @@ message Predicate {
     OrPredicateAttributes or_predicate_attributes = 5;
     NotPredicateAttributes not_predicate_attributes = 6;
     NamespaceIdPredicateAttributes namespace_id_predicate_attributes = 7;
-    // Deprecated: superseded by outbound_task_predicate_attributes (#6445), which combines
-    // task type, namespace and destination into one predicate. Kept only so a shard checkpointed
-    // before that change, and never checkpointed since, still deserializes correctly.
+    // Deprecated: never built by any queue's grouper. Kept only so a shard that still holds one
+    // from before the outbound queue existed, and hasn't recompacted since, still deserializes
+    // correctly.
     TaskTypePredicateAttributes task_type_predicate_attributes = 8 [deprecated = true];
-    // Deprecated: superseded by outbound_task_predicate_attributes (#6445); see above.
+    // Deprecated: superseded by outbound_task_predicate_attributes (#6445), which combines
+    // task group, namespace and destination into one predicate. Kept only so a shard checkpointed
+    // before that change, and never checkpointed since, still deserializes correctly.
     DestinationPredicateAttributes destination_predicate_attributes = 9 [deprecated = true];
     // Deprecated: superseded by outbound_task_predicate_attributes (#6445); see above. Not to be
     // confused with that message's own task_group field, which is very much in use.

--- a/service/history/queues/convert.go
+++ b/service/history/queues/convert.go
@@ -301,7 +301,8 @@ func FromPersistenceTaskTypePredicate(
 	attributes *persistencespb.TaskTypePredicateAttributes,
 ) tasks.Predicate {
 	//nolint:staticcheck // NewTypePredicate is deprecated for new construction; this is the one
-	// legitimate caller, deserializing a shard checkpointed before #6445 unified this predicate.
+	// legitimate caller, deserializing a shard from before any grouper stopped building this
+	// predicate type (no grouper ever has).
 	return tasks.NewTypePredicate(attributes.TaskTypes)
 }
 

--- a/service/history/queues/convert.go
+++ b/service/history/queues/convert.go
@@ -300,6 +300,8 @@ func ToPersistenceTaskTypePredicate(
 func FromPersistenceTaskTypePredicate(
 	attributes *persistencespb.TaskTypePredicateAttributes,
 ) tasks.Predicate {
+	//nolint:staticcheck // NewTypePredicate is deprecated for new construction; this is the one
+	// legitimate caller, deserializing a shard checkpointed before #6445 unified this predicate.
 	return tasks.NewTypePredicate(attributes.TaskTypes)
 }
 
@@ -319,6 +321,9 @@ func ToPersistenceDestinationPredicate(
 func FromPersistenceDestinationPredicate(
 	attributes *persistencespb.DestinationPredicateAttributes,
 ) tasks.Predicate {
+	//nolint:staticcheck // NewDestinationPredicate is deprecated for new construction; this is
+	// the one legitimate caller, deserializing a shard checkpointed before #6445 unified this
+	// predicate.
 	return tasks.NewDestinationPredicate(attributes.Destinations)
 }
 
@@ -338,6 +343,9 @@ func ToPersistenceOutboundTaskGroupPredicate(
 func FromPersistenceOutboundTaskGroupPredicate(
 	attributes *persistencespb.OutboundTaskGroupPredicateAttributes,
 ) tasks.Predicate {
+	//nolint:staticcheck // NewOutboundTaskGroupPredicate is deprecated for new construction; this
+	// is the one legitimate caller, deserializing a shard checkpointed before #6445 unified this
+	// predicate.
 	return tasks.NewOutboundTaskGroupPredicate(attributes.Groups)
 }
 

--- a/service/history/queues/convert_test.go
+++ b/service/history/queues/convert_test.go
@@ -53,10 +53,10 @@ func (s *convertSuite) TestConvertPredicate_And() {
 			),
 			predicates.Or[tasks.Task](
 				tasks.NewOutboundTaskPredicate([]tasks.TaskGroupNamespaceIDAndDestination{
-					{"g1", "n1", "d1"},
+					{TaskGroup: "g1", NamespaceID: "n1", Destination: "d1"},
 				}),
 				tasks.NewOutboundTaskPredicate([]tasks.TaskGroupNamespaceIDAndDestination{
-					{"g2", "n2", "d2"},
+					{TaskGroup: "g2", NamespaceID: "n2", Destination: "d2"},
 				}),
 			),
 		),
@@ -72,7 +72,7 @@ func (s *convertSuite) TestConvertPredicate_And() {
 			predicates.And[tasks.Task](
 				tasks.NewNamespacePredicate([]string{uuid.NewString()}),
 				tasks.NewOutboundTaskPredicate([]tasks.TaskGroupNamespaceIDAndDestination{
-					{"g1", "n1", "d1"},
+					{TaskGroup: "g1", NamespaceID: "n1", Destination: "d1"},
 				}),
 			),
 		),
@@ -96,10 +96,10 @@ func (s *convertSuite) TestConvertPredicate_Or() {
 			),
 			predicates.And[tasks.Task](
 				tasks.NewOutboundTaskPredicate([]tasks.TaskGroupNamespaceIDAndDestination{
-					{"g1", "n1", "d1"},
+					{TaskGroup: "g1", NamespaceID: "n1", Destination: "d1"},
 				}),
 				tasks.NewOutboundTaskPredicate([]tasks.TaskGroupNamespaceIDAndDestination{
-					{"g2", "n2", "d2"},
+					{TaskGroup: "g2", NamespaceID: "n2", Destination: "d2"},
 				}),
 			),
 		),
@@ -115,7 +115,7 @@ func (s *convertSuite) TestConvertPredicate_Or() {
 			predicates.And[tasks.Task](
 				tasks.NewNamespacePredicate([]string{uuid.NewString()}),
 				tasks.NewOutboundTaskPredicate([]tasks.TaskGroupNamespaceIDAndDestination{
-					{"g1", "n1", "d1"},
+					{TaskGroup: "g1", NamespaceID: "n1", Destination: "d1"},
 				}),
 			),
 		),
@@ -141,7 +141,7 @@ func (s *convertSuite) TestConvertPredicate_Not() {
 		predicates.Not(predicates.Not(predicates.Empty[tasks.Task]())),
 		predicates.Not[tasks.Task](tasks.NewNamespacePredicate([]string{uuid.NewString()})),
 		predicates.Not[tasks.Task](tasks.NewOutboundTaskPredicate([]tasks.TaskGroupNamespaceIDAndDestination{
-			{"g1", "n1", "d1"},
+			{TaskGroup: "g1", NamespaceID: "n1", Destination: "d1"},
 		})),
 	}
 
@@ -220,8 +220,8 @@ func (s *convertSuite) TestConvertQueueState() {
 			NewScope(
 				NewRandomRange(),
 				tasks.NewOutboundTaskPredicate([]tasks.TaskGroupNamespaceIDAndDestination{
-					{"g1", "n1", "d1"},
-					{"g2", "n2", "d2"},
+					{TaskGroup: "g1", NamespaceID: "n1", Destination: "d1"},
+					{TaskGroup: "g2", NamespaceID: "n2", Destination: "d2"},
 				}),
 			),
 		},

--- a/service/history/queues/convert_test.go
+++ b/service/history/queues/convert_test.go
@@ -52,11 +52,11 @@ func (s *convertSuite) TestConvertPredicate_And() {
 				tasks.NewNamespacePredicate([]string{uuid.NewString()}),
 			),
 			predicates.Or[tasks.Task](
-				tasks.NewTypePredicate([]enumsspb.TaskType{
-					enumsspb.TASK_TYPE_ACTIVITY_RETRY_TIMER,
+				tasks.NewOutboundTaskPredicate([]tasks.TaskGroupNamespaceIDAndDestination{
+					{"g1", "n1", "d1"},
 				}),
-				tasks.NewTypePredicate([]enumsspb.TaskType{
-					enumsspb.TASK_TYPE_DELETE_HISTORY_EVENT,
+				tasks.NewOutboundTaskPredicate([]tasks.TaskGroupNamespaceIDAndDestination{
+					{"g2", "n2", "d2"},
 				}),
 			),
 		),
@@ -71,8 +71,8 @@ func (s *convertSuite) TestConvertPredicate_And() {
 			predicates.Not(predicates.Empty[tasks.Task]()),
 			predicates.And[tasks.Task](
 				tasks.NewNamespacePredicate([]string{uuid.NewString()}),
-				tasks.NewTypePredicate([]enumsspb.TaskType{
-					enumsspb.TASK_TYPE_DELETE_HISTORY_EVENT,
+				tasks.NewOutboundTaskPredicate([]tasks.TaskGroupNamespaceIDAndDestination{
+					{"g1", "n1", "d1"},
 				}),
 			),
 		),
@@ -95,11 +95,11 @@ func (s *convertSuite) TestConvertPredicate_Or() {
 				tasks.NewNamespacePredicate([]string{uuid.NewString()}),
 			),
 			predicates.And[tasks.Task](
-				tasks.NewTypePredicate([]enumsspb.TaskType{
-					enumsspb.TASK_TYPE_ACTIVITY_RETRY_TIMER,
+				tasks.NewOutboundTaskPredicate([]tasks.TaskGroupNamespaceIDAndDestination{
+					{"g1", "n1", "d1"},
 				}),
-				tasks.NewTypePredicate([]enumsspb.TaskType{
-					enumsspb.TASK_TYPE_DELETE_HISTORY_EVENT,
+				tasks.NewOutboundTaskPredicate([]tasks.TaskGroupNamespaceIDAndDestination{
+					{"g2", "n2", "d2"},
 				}),
 			),
 		),
@@ -114,8 +114,8 @@ func (s *convertSuite) TestConvertPredicate_Or() {
 			predicates.Not(predicates.Empty[tasks.Task]()),
 			predicates.And[tasks.Task](
 				tasks.NewNamespacePredicate([]string{uuid.NewString()}),
-				tasks.NewTypePredicate([]enumsspb.TaskType{
-					enumsspb.TASK_TYPE_DELETE_HISTORY_EVENT,
+				tasks.NewOutboundTaskPredicate([]tasks.TaskGroupNamespaceIDAndDestination{
+					{"g1", "n1", "d1"},
 				}),
 			),
 		),
@@ -132,16 +132,16 @@ func (s *convertSuite) TestConvertPredicate_Not() {
 		predicates.Not(predicates.Empty[tasks.Task]()),
 		predicates.Not(predicates.And[tasks.Task](
 			tasks.NewNamespacePredicate([]string{uuid.NewString()}),
-			tasks.NewTypePredicate([]enumsspb.TaskType{}),
+			tasks.NewOutboundTaskPredicate(nil),
 		)),
 		predicates.Not(predicates.Or[tasks.Task](
 			tasks.NewNamespacePredicate([]string{uuid.NewString()}),
-			tasks.NewTypePredicate([]enumsspb.TaskType{}),
+			tasks.NewOutboundTaskPredicate(nil),
 		)),
 		predicates.Not(predicates.Not(predicates.Empty[tasks.Task]())),
 		predicates.Not[tasks.Task](tasks.NewNamespacePredicate([]string{uuid.NewString()})),
-		predicates.Not[tasks.Task](tasks.NewTypePredicate([]enumsspb.TaskType{
-			enumsspb.TASK_TYPE_ACTIVITY_RETRY_TIMER,
+		predicates.Not[tasks.Task](tasks.NewOutboundTaskPredicate([]tasks.TaskGroupNamespaceIDAndDestination{
+			{"g1", "n1", "d1"},
 		})),
 	}
 
@@ -219,9 +219,9 @@ func (s *convertSuite) TestConvertQueueState() {
 			),
 			NewScope(
 				NewRandomRange(),
-				tasks.NewTypePredicate([]enumsspb.TaskType{
-					enumsspb.TASK_TYPE_ACTIVITY_TIMEOUT,
-					enumsspb.TASK_TYPE_ACTIVITY_RETRY_TIMER,
+				tasks.NewOutboundTaskPredicate([]tasks.TaskGroupNamespaceIDAndDestination{
+					{"g1", "n1", "d1"},
+					{"g2", "n2", "d2"},
 				}),
 			),
 		},

--- a/service/history/queues/queue_base_test.go
+++ b/service/history/queues/queue_base_test.go
@@ -559,7 +559,7 @@ func (s *queueBaseSuite) TestCheckPoint_SlicePredicateAction() {
 	exclusiveReaderHighWatermark := tasks.MaximumKey
 	scopes := NewRandomScopes(3)
 	scopes[0].Predicate = tasks.NewNamespacePredicate([]string{uuid.NewString()})
-	scopes[2].Predicate = tasks.NewOutboundTaskPredicate([]tasks.TaskGroupNamespaceIDAndDestination{{"g1", "n1", "d1"}})
+	scopes[2].Predicate = tasks.NewOutboundTaskPredicate([]tasks.TaskGroupNamespaceIDAndDestination{{TaskGroup: "g1", NamespaceID: "n1", Destination: "d1"}})
 	initialQueueState := &queueState{
 		readerScopes: map[int64][]Scope{
 			DefaultReaderId: scopes,

--- a/service/history/queues/queue_base_test.go
+++ b/service/history/queues/queue_base_test.go
@@ -139,10 +139,12 @@ func (s *queueBaseSuite) TestNewProcessBase_WithPreviousState_RestoreSucceed() {
 							ExclusiveMax: &persistencespb.TaskKey{FireTime: timestamppb.New(tasks.DefaultFireTime), TaskId: 3000},
 						},
 						Predicate: &persistencespb.Predicate{
-							PredicateType: enumsspb.PREDICATE_TYPE_TASK_TYPE,
-							Attributes: &persistencespb.Predicate_TaskTypePredicateAttributes{
-								TaskTypePredicateAttributes: &persistencespb.TaskTypePredicateAttributes{
-									TaskTypes: []enumsspb.TaskType{enumsspb.TASK_TYPE_ACTIVITY_RETRY_TIMER},
+							PredicateType: enumsspb.PREDICATE_TYPE_OUTBOUND_TASK,
+							Attributes: &persistencespb.Predicate_OutboundTaskPredicateAttributes{
+								OutboundTaskPredicateAttributes: &persistencespb.OutboundTaskPredicateAttributes{
+									Groups: []*persistencespb.OutboundTaskPredicateAttributes_Group{
+										{TaskGroup: "g1", NamespaceId: "n1", Destination: "d1"},
+									},
 								},
 							},
 						},
@@ -557,7 +559,7 @@ func (s *queueBaseSuite) TestCheckPoint_SlicePredicateAction() {
 	exclusiveReaderHighWatermark := tasks.MaximumKey
 	scopes := NewRandomScopes(3)
 	scopes[0].Predicate = tasks.NewNamespacePredicate([]string{uuid.NewString()})
-	scopes[2].Predicate = tasks.NewTypePredicate([]enumsspb.TaskType{enumsspb.TASK_TYPE_ACTIVITY_RETRY_TIMER})
+	scopes[2].Predicate = tasks.NewOutboundTaskPredicate([]tasks.TaskGroupNamespaceIDAndDestination{{"g1", "n1", "d1"}})
 	initialQueueState := &queueState{
 		readerScopes: map[int64][]Scope{
 			DefaultReaderId: scopes,

--- a/service/history/queues/scope_test.go
+++ b/service/history/queues/scope_test.go
@@ -198,7 +198,7 @@ func (s *scopeSuite) TestCanMergeByRange() {
 		predicate,
 		tasks.NewNamespacePredicate(namespaceIDs),
 		tasks.NewNamespacePredicate([]string{uuid.NewString(), uuid.NewString(), uuid.NewString(), uuid.NewString()}),
-		tasks.NewOutboundTaskPredicate([]tasks.TaskGroupNamespaceIDAndDestination{{"g1", "n1", "d1"}}),
+		tasks.NewOutboundTaskPredicate([]tasks.TaskGroupNamespaceIDAndDestination{{TaskGroup: "g1", NamespaceID: "n1", Destination: "d1"}}),
 	}
 	s.True(predicate.Equals(testPredicates[0]))
 	s.True(predicate.Equals(testPredicates[1]))

--- a/service/history/queues/scope_test.go
+++ b/service/history/queues/scope_test.go
@@ -198,7 +198,7 @@ func (s *scopeSuite) TestCanMergeByRange() {
 		predicate,
 		tasks.NewNamespacePredicate(namespaceIDs),
 		tasks.NewNamespacePredicate([]string{uuid.NewString(), uuid.NewString(), uuid.NewString(), uuid.NewString()}),
-		tasks.NewTypePredicate([]enumsspb.TaskType{enumsspb.TASK_TYPE_ACTIVITY_RETRY_TIMER}),
+		tasks.NewOutboundTaskPredicate([]tasks.TaskGroupNamespaceIDAndDestination{{"g1", "n1", "d1"}}),
 	}
 	s.True(predicate.Equals(testPredicates[0]))
 	s.True(predicate.Equals(testPredicates[1]))
@@ -284,7 +284,7 @@ func (s *scopeSuite) TestCanMergeByPredicate() {
 
 	s.True(scope.CanMergeByPredicate(scope))
 	s.True(scope.CanMergeByPredicate(NewScope(r, predicate)))
-	s.True(scope.CanMergeByPredicate(NewScope(r, tasks.NewTypePredicate([]enumsspb.TaskType{}))))
+	s.True(scope.CanMergeByPredicate(NewScope(r, tasks.NewOutboundTaskPredicate(nil))))
 
 	s.False(scope.CanMergeByPredicate(NewScope(NewRandomRange(), predicate)))
 	s.False(scope.CanMergeByPredicate(NewScope(NewRandomRange(), predicates.Universal[tasks.Task]())))

--- a/service/history/tasks/predicates.go
+++ b/service/history/tasks/predicates.go
@@ -151,8 +151,8 @@ func (n *OutboundTaskGroupPredicate) Size() int {
 	return size
 }
 
-// Deprecated: superseded by NewOutboundTaskPredicate (#6445). Only called from
-// service/history/queues/convert.go to deserialize a shard checkpointed before that change.
+// Deprecated: never constructed by any queue's grouper. Only called from
+// service/history/queues/convert.go to deserialize a legacy shard.
 func NewTypePredicate(
 	types []enumsspb.TaskType,
 ) *TypePredicate {

--- a/service/history/tasks/predicates.go
+++ b/service/history/tasks/predicates.go
@@ -69,6 +69,8 @@ func (n *NamespacePredicate) Size() int {
 	return size
 }
 
+// Deprecated: superseded by NewOutboundTaskPredicate (#6445). Only called from
+// service/history/queues/convert.go to deserialize a shard checkpointed before that change.
 func NewDestinationPredicate(
 	destinations []string,
 ) *DestinationPredicate {
@@ -108,6 +110,8 @@ func (n *DestinationPredicate) Size() int {
 	return size
 }
 
+// Deprecated: superseded by NewOutboundTaskPredicate (#6445). Only called from
+// service/history/queues/convert.go to deserialize a shard checkpointed before that change.
 func NewOutboundTaskGroupPredicate(
 	groups []string,
 ) *OutboundTaskGroupPredicate {
@@ -147,6 +151,8 @@ func (n *OutboundTaskGroupPredicate) Size() int {
 	return size
 }
 
+// Deprecated: superseded by NewOutboundTaskPredicate (#6445). Only called from
+// service/history/queues/convert.go to deserialize a shard checkpointed before that change.
 func NewTypePredicate(
 	types []enumsspb.TaskType,
 ) *TypePredicate {
@@ -265,69 +271,6 @@ func AndPredicates(a Predicate, b Predicate) Predicate {
 				}
 			}
 		}
-	case *TypePredicate:
-		switch b := b.(type) {
-		case *TypePredicate:
-			intersection := intersect(a.Types, b.Types)
-			if len(intersection) == 0 {
-				return predicates.Empty[Task]()
-			}
-			return &TypePredicate{
-				Types: intersection,
-			}
-		case *predicates.NotImpl[Task]:
-			if exclude, ok := b.Predicate.(*TypePredicate); ok {
-				difference := difference(a.Types, exclude.Types)
-				if len(difference) == 0 {
-					return predicates.Empty[Task]()
-				}
-				return &TypePredicate{
-					Types: difference,
-				}
-			}
-		}
-	case *DestinationPredicate:
-		switch b := b.(type) {
-		case *DestinationPredicate:
-			intersection := intersect(a.Destinations, b.Destinations)
-			if len(intersection) == 0 {
-				return predicates.Empty[Task]()
-			}
-			return &DestinationPredicate{
-				Destinations: intersection,
-			}
-		case *predicates.NotImpl[Task]:
-			if exclude, ok := b.Predicate.(*DestinationPredicate); ok {
-				difference := difference(a.Destinations, exclude.Destinations)
-				if len(difference) == 0 {
-					return predicates.Empty[Task]()
-				}
-				return &DestinationPredicate{
-					Destinations: difference,
-				}
-			}
-		}
-	case *OutboundTaskGroupPredicate:
-		switch b := b.(type) {
-		case *OutboundTaskGroupPredicate:
-			intersection := intersect(a.Groups, b.Groups)
-			if len(intersection) == 0 {
-				return predicates.Empty[Task]()
-			}
-			return &OutboundTaskGroupPredicate{
-				Groups: intersection,
-			}
-		case *predicates.NotImpl[Task]:
-			if exclude, ok := b.Predicate.(*OutboundTaskGroupPredicate); ok {
-				difference := difference(a.Groups, exclude.Groups)
-				if len(difference) == 0 {
-					return predicates.Empty[Task]()
-				}
-				return &OutboundTaskGroupPredicate{
-					Groups: difference,
-				}
-			}
-		}
 	case *OutboundTaskPredicate:
 		switch b := b.(type) {
 		case *OutboundTaskPredicate:
@@ -381,24 +324,6 @@ func OrPredicates(a Predicate, b Predicate) Predicate {
 		if b, ok := b.(*NamespacePredicate); ok {
 			return &NamespacePredicate{
 				NamespaceIDs: union(a.NamespaceIDs, b.NamespaceIDs),
-			}
-		}
-	case *TypePredicate:
-		if b, ok := b.(*TypePredicate); ok {
-			return &TypePredicate{
-				Types: union(a.Types, b.Types),
-			}
-		}
-	case *DestinationPredicate:
-		if b, ok := b.(*DestinationPredicate); ok {
-			return &DestinationPredicate{
-				Destinations: union(a.Destinations, b.Destinations),
-			}
-		}
-	case *OutboundTaskGroupPredicate:
-		if b, ok := b.(*OutboundTaskGroupPredicate); ok {
-			return &OutboundTaskGroupPredicate{
-				Groups: union(a.Groups, b.Groups),
 			}
 		}
 	case *OutboundTaskPredicate:

--- a/service/history/tasks/predicates_test.go
+++ b/service/history/tasks/predicates_test.go
@@ -66,7 +66,7 @@ func (s *predicatesSuite) TestNamespacePredicate_Equals() {
 	s.True(p.Equals(NewNamespacePredicate(namespaceIDs)))
 
 	s.False(p.Equals(NewNamespacePredicate([]string{uuid.NewString(), uuid.NewString()})))
-	s.False(p.Equals(NewTypePredicate([]enumsspb.TaskType{enumsspb.TASK_TYPE_ACTIVITY_RETRY_TIMER})))
+	s.False(p.Equals(NewOutboundTaskPredicate([]TaskGroupNamespaceIDAndDestination{{"g1", "n1", "d1"}})))
 	s.False(p.Equals(predicates.Universal[Task]()))
 }
 
@@ -175,7 +175,7 @@ func (s *predicatesSuite) TestDestinationPredicate_Equals() {
 	s.True(p.Equals(NewDestinationPredicate(destinations)))
 
 	s.False(p.Equals(NewDestinationPredicate([]string{uuid.NewString(), uuid.NewString()})))
-	s.False(p.Equals(NewTypePredicate([]enumsspb.TaskType{enumsspb.TASK_TYPE_ACTIVITY_RETRY_TIMER})))
+	s.False(p.Equals(NewOutboundTaskPredicate([]TaskGroupNamespaceIDAndDestination{{"g1", "n1", "d1"}})))
 	s.False(p.Equals(predicates.Universal[Task]()))
 }
 
@@ -217,7 +217,7 @@ func (s *predicatesSuite) TestOutboundTaskGroupPredicate_Equals() {
 	s.True(p.Equals(NewOutboundTaskGroupPredicate(groups)))
 
 	s.False(p.Equals(NewOutboundTaskGroupPredicate([]string{"3", "4"})))
-	s.False(p.Equals(NewTypePredicate([]enumsspb.TaskType{enumsspb.TASK_TYPE_ACTIVITY_RETRY_TIMER})))
+	s.False(p.Equals(NewOutboundTaskPredicate([]TaskGroupNamespaceIDAndDestination{{"g1", "n1", "d1"}})))
 	s.False(p.Equals(predicates.Universal[Task]()))
 }
 
@@ -297,7 +297,7 @@ func (s *predicatesSuite) TestOutboundTaskPredicate_Equals() {
 		{"g1", "n1", "d3"},
 		{"g2", "n2", "d4"},
 	})))
-	s.False(p.Equals(NewTypePredicate([]enumsspb.TaskType{enumsspb.TASK_TYPE_ACTIVITY_RETRY_TIMER})))
+	s.False(p.Equals(NewNamespacePredicate([]string{uuid.NewString()})))
 	s.False(p.Equals(predicates.Universal[Task]()))
 }
 
@@ -323,30 +323,8 @@ func (s *predicatesSuite) TestAndPredicates() {
 			expectedResult: NewNamespacePredicate([]string{"namespace2"}),
 		},
 		{
-			predicateA: NewTypePredicate([]enumsspb.TaskType{
-				enumsspb.TASK_TYPE_ACTIVITY_TIMEOUT,
-			}),
-			predicateB: NewTypePredicate([]enumsspb.TaskType{
-				enumsspb.TASK_TYPE_ACTIVITY_TIMEOUT,
-				enumsspb.TASK_TYPE_DELETE_HISTORY_EVENT,
-			}),
-			expectedResult: NewTypePredicate([]enumsspb.TaskType{
-				enumsspb.TASK_TYPE_ACTIVITY_TIMEOUT,
-			}),
-		},
-		{
-			predicateA:     NewDestinationPredicate([]string{"dest1", "dest2"}),
-			predicateB:     NewDestinationPredicate([]string{"dest2", "dest3"}),
-			expectedResult: NewDestinationPredicate([]string{"dest2"}),
-		},
-		{
 			predicateA:     NewNamespacePredicate([]string{"namespace1", "namespace2"}),
 			predicateB:     NewNamespacePredicate([]string{"namespace3"}),
-			expectedResult: predicates.Empty[Task](),
-		},
-		{
-			predicateA:     NewOutboundTaskGroupPredicate([]string{"g1", "g2"}),
-			predicateB:     NewOutboundTaskGroupPredicate([]string{"g3"}),
 			expectedResult: predicates.Empty[Task](),
 		},
 		{
@@ -360,14 +338,17 @@ func (s *predicatesSuite) TestAndPredicates() {
 			expectedResult: predicates.Empty[Task](),
 		},
 		{
+			// Cross-type combination that no case-specific branch simplifies, so it falls back
+			// to the generic wrapper. NamespacePredicate/OutboundTaskPredicate are both still
+			// live types; either would do here.
 			predicateA: NewNamespacePredicate([]string{"namespace1"}),
-			predicateB: NewTypePredicate([]enumsspb.TaskType{
-				enumsspb.TASK_TYPE_ACTIVITY_TIMEOUT,
+			predicateB: NewOutboundTaskPredicate([]TaskGroupNamespaceIDAndDestination{
+				{"g1", "n1", "d1"},
 			}),
 			expectedResult: predicates.And(
 				NewNamespacePredicate([]string{"namespace1"}),
-				NewTypePredicate([]enumsspb.TaskType{
-					enumsspb.TASK_TYPE_ACTIVITY_TIMEOUT,
+				NewOutboundTaskPredicate([]TaskGroupNamespaceIDAndDestination{
+					{"g1", "n1", "d1"},
 				}),
 			),
 		},
@@ -410,29 +391,6 @@ func (s *predicatesSuite) TestOrPredicates() {
 			expectedResult: NewNamespacePredicate([]string{"namespace1", "namespace2", "namespace3"}),
 		},
 		{
-			predicateA: NewTypePredicate([]enumsspb.TaskType{
-				enumsspb.TASK_TYPE_ACTIVITY_TIMEOUT,
-			}),
-			predicateB: NewTypePredicate([]enumsspb.TaskType{
-				enumsspb.TASK_TYPE_ACTIVITY_TIMEOUT,
-				enumsspb.TASK_TYPE_DELETE_HISTORY_EVENT,
-			}),
-			expectedResult: NewTypePredicate([]enumsspb.TaskType{
-				enumsspb.TASK_TYPE_ACTIVITY_TIMEOUT,
-				enumsspb.TASK_TYPE_DELETE_HISTORY_EVENT,
-			}),
-		},
-		{
-			predicateA:     NewDestinationPredicate([]string{"dest1", "dest2"}),
-			predicateB:     NewDestinationPredicate([]string{"dest2", "dest3"}),
-			expectedResult: NewDestinationPredicate([]string{"dest1", "dest2", "dest3"}),
-		},
-		{
-			predicateA:     NewOutboundTaskGroupPredicate([]string{"g1", "g2"}),
-			predicateB:     NewOutboundTaskGroupPredicate([]string{"g2", "g3"}),
-			expectedResult: NewOutboundTaskGroupPredicate([]string{"g1", "g2", "g3"}),
-		},
-		{
 			predicateA: NewOutboundTaskPredicate([]TaskGroupNamespaceIDAndDestination{
 				{"g1", "n1", "d1"},
 				{"g2", "n2", "d2"},
@@ -447,14 +405,17 @@ func (s *predicatesSuite) TestOrPredicates() {
 			}),
 		},
 		{
+			// Cross-type combination that no case-specific branch simplifies, so it falls back
+			// to the generic wrapper. NamespacePredicate/OutboundTaskPredicate are both still
+			// live types; either would do here.
 			predicateA: NewNamespacePredicate([]string{"namespace1"}),
-			predicateB: NewTypePredicate([]enumsspb.TaskType{
-				enumsspb.TASK_TYPE_ACTIVITY_TIMEOUT,
+			predicateB: NewOutboundTaskPredicate([]TaskGroupNamespaceIDAndDestination{
+				{"g1", "n1", "d1"},
 			}),
 			expectedResult: predicates.Or(
 				NewNamespacePredicate([]string{"namespace1"}),
-				NewTypePredicate([]enumsspb.TaskType{
-					enumsspb.TASK_TYPE_ACTIVITY_TIMEOUT,
+				NewOutboundTaskPredicate([]TaskGroupNamespaceIDAndDestination{
+					{"g1", "n1", "d1"},
 				}),
 			),
 		},


### PR DESCRIPTION
## What changed?

Marks three `Predicate` oneof fields, and the messages they hold, `[deprecated = true]` in `predicates.proto`, with a comment on each pointing at what replaced them: `TaskTypePredicateAttributes`, `DestinationPredicateAttributes`, and `OutboundTaskGroupPredicateAttributes`. Regenerated `api/persistence/v1/predicates.pb.go`
accordingly.

On top of the annotation, also removes the dead code those three types left behind:

- The `*TypePredicate`/`*DestinationPredicate`/`*OutboundTaskGroupPredicate` case blocks in `AndPredicates`/`OrPredicates` (`service/history/tasks/predicates.go`). Combining two of these now falls through to the existing generic `predicates.And`/`predicates.Or` wrapper instead of a type-specific simplification.
- `// Deprecated: ...` GoDoc comments on `NewTypePredicate`, `NewDestinationPredicate`, and `NewOutboundTaskGroupPredicate`, so `staticcheck` flags any new caller.
- Test fixtures that used one of these three types incidentally are swapped to a still-supported type. The tests that cover these types are untouched, so that old stored shards work correctly if they ever do happen to be reloaded.

## Why?

These three types are never constructed anywhere in the server today. The only place any of them is referenced outside their own message definitions and unit tests is the read-path switch in `service/history/queues/convert.go`, which exists to deserialize a variant if it happens to be stored in a very old shard.

- `TaskTypePredicateAttributes` was added speculatively to be able to create task-keyed predicates.
- `DestinationPredicateAttributes` and `OutboundTaskGroupPredicateAttributes` both were introduced during the outbounb queue's development. Two months later they were unified into one composite predicate, `OutboundTaskPredicateAttributes.Group{task_group, namespace_id, destination}`

Removing their `AndPredicates`/`OrPredicates` case blocks is safe because both functions already fall back to a generic, correct wrapper (`predicates.And`/`predicates.Or`) for any pair they don't specifically simplify. Losing a type's branch only costs simplification precision and not correctness.

## How did you test it?

- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

`make proto` regenerated only `predicates.pb.go`. `go build ./...` and `go test ./service/history/tasks/... ./service/history/queues/... ./api/persistence/...` all pass.
