### PR TITLE
fix(chasm-scheduler): dedupe idle pure task with singleton registration

### DIFF
--- a/chasm/chasmtest/task_helpers.go
+++ b/chasm/chasmtest/task_helpers.go
@@ -3,6 +3,7 @@ package chasmtest
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"time"
 
 	"go.temporal.io/server/chasm"
@@ -80,6 +81,35 @@ func (e *Engine) FirePureTasks(ref chasm.ComponentRef, referenceTime time.Time) 
 		return executed, err
 	}
 	return executed, nil
+}
+
+// PureTaskCount returns how many persisted pure tasks of the given payload
+// type exist across the execution at ref that are due by referenceTime,
+// without executing, validating, or otherwise mutating any of them.
+//
+// Unlike [Engine.Tasks], which only reflects the physical head-of-queue task,
+// this walks every logical pure task entry - useful for asserting that a task
+// type does not accumulate duplicates (e.g. after registering it with
+// [chasm.WithSingletonTask]).
+func (e *Engine) PureTaskCount(ref chasm.ComponentRef, referenceTime time.Time, taskType reflect.Type) (int, error) {
+	exec, err := e.executionForRef(ref)
+	if err != nil {
+		return 0, err
+	}
+
+	count := 0
+	err = exec.node.EachPureTask(
+		referenceTime,
+		func(_ chasm.NodePureTask, _ chasm.TaskAttributes, taskInstance any) (bool, error) {
+			if reflect.TypeOf(taskInstance) == taskType {
+				count++
+			}
+			// Never report as executed: this is a read-only probe and must
+			// not mutate or invalidate any task.
+			return false, nil
+		},
+	)
+	return count, err
 }
 
 // ExecuteSideEffectTask validates and executes a side effect task.

--- a/chasm/lib/scheduler/library.go
+++ b/chasm/lib/scheduler/library.go
@@ -85,6 +85,7 @@ func (l *Library) Tasks() []*chasm.RegistrableTask {
 		chasm.NewRegistrablePureTask(
 			"idle",
 			l.SchedulerIdleTaskHandler,
+			chasm.WithSingletonTask(chasm.SingletonTaskModeReplace),
 		),
 		chasm.NewRegistrableSideEffectTask(
 			"callbacks",

--- a/chasm/lib/scheduler/scheduler_idle_task_dedup_test.go
+++ b/chasm/lib/scheduler/scheduler_idle_task_dedup_test.go
@@ -75,7 +75,7 @@ func TestScheduler_IdleTask_DoesNotAccumulateAcrossCompletionBurst(t *testing.T)
 	// where every occurrence is kicked off back-to-back near "now" regardless
 	// of how spread out their eventual completions are.
 	const completions = 5
-	for i := 0; i < completions; i++ {
+	for i := range completions {
 		_, _, err = chasm.UpdateComponent(engineCtx, rootRef,
 			func(s *scheduler.Scheduler, ctx chasm.MutableContext, _ struct{}) (struct{}, error) {
 				invoker := s.Invoker.Get(ctx)
@@ -98,7 +98,7 @@ func TestScheduler_IdleTask_DoesNotAccumulateAcrossCompletionBurst(t *testing.T)
 	// durations. Each call is its own transaction, matching separate
 	// completion callbacks arriving independently.
 	var idleCloseTime time.Time
-	for i := 0; i < completions; i++ {
+	for i := range completions {
 		_, _, err = chasm.UpdateComponent(engineCtx, rootRef,
 			func(s *scheduler.Scheduler, ctx chasm.MutableContext, _ struct{}) (struct{}, error) {
 				return struct{}{}, s.HandleNexusCompletion(ctx, &persistencespb.ChasmNexusCompletion{
@@ -124,7 +124,7 @@ func TestScheduler_IdleTask_DoesNotAccumulateAcrossCompletionBurst(t *testing.T)
 	// CloseTimes differ, but StartTime - what getLastEventTime actually reads
 	// - doesn't), so without deduplication each of the `completions` calls
 	// above appends its own SchedulerIdleTask. There should only ever be one.
-	count, err := engine.PureTaskCount(rootRef, idleCloseTime, reflect.TypeOf(&schedulerpb.SchedulerIdleTask{}))
+	count, err := engine.PureTaskCount(rootRef, idleCloseTime, reflect.TypeFor[*schedulerpb.SchedulerIdleTask]())
 	require.NoError(t, err)
 	require.Equal(t, 1, count,
 		"expected exactly one idle pure task after a completion burst, found %d", count)

--- a/chasm/lib/scheduler/scheduler_idle_task_dedup_test.go
+++ b/chasm/lib/scheduler/scheduler_idle_task_dedup_test.go
@@ -1,0 +1,131 @@
+package scheduler_test
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	schedulespb "go.temporal.io/server/api/schedule/v1"
+	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/chasmtest"
+	"go.temporal.io/server/chasm/lib/scheduler"
+	schedulerpb "go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
+	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/testing/testlogger"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// TestScheduler_IdleTask_DoesNotAccumulateAcrossCompletionBurst reproduces the
+// idle-task leak seen with a historical, ALLOW_ALL backfill: many buffered
+// starts are kicked off at nearly the same wall-clock instant, then complete
+// over an extended window. Each completion independently invalidates and
+// re-arms the idle task (see the comment on HandleNexusCompletion), but since
+// idleDeadline is derived from getLastEventTime - which reads BufferedStart's
+// real start time, not its completion time - every one of those completions
+// recomputes the *same* deadline. SchedulerIdleTaskHandler.Validate only
+// detects drift (a deadline that moved), so identical recomputed deadlines
+// pass validation every time and the duplicates are never cleaned up. Only
+// singleton task registration (deduplicating at insertion time, independent
+// of what Validate would decide) prevents the leak.
+func TestScheduler_IdleTask_DoesNotAccumulateAcrossCompletionBurst(t *testing.T) {
+	logger := testlogger.NewTestLogger(t, testlogger.FailOnExpectedErrorOnly)
+	specProcessor := scheduler.NewSpecProcessor(defaultConfig(), metrics.NoopMetricsHandler, logger, newLegacySpecBuilder(0, 0))
+	registry := chasm.NewRegistry(logger)
+	require.NoError(t, registry.Register(&chasm.CoreLibrary{}))
+	require.NoError(t, registry.Register(newTestLibrary(logger, specProcessor)))
+
+	timeSource := clock.NewEventTimeSource()
+	timeSource.Update(time.Now())
+	engine := chasmtest.NewEngine(t, registry, chasmtest.WithTimeSource(timeSource))
+	engineCtx := chasm.NewEngineContext(context.Background(), engine)
+	rootRef := chasm.NewComponentRef[*scheduler.Scheduler](chasm.ExecutionKey{
+		NamespaceID: namespaceID,
+		BusinessID:  scheduleID,
+	})
+
+	now := timeSource.Now()
+
+	// A schedule with no remaining actions goes idle as soon as it's created -
+	// there's no spec-driven wakeup to keep it open.
+	schedule := defaultSchedule()
+	schedule.State.LimitedActions = true
+	schedule.State.RemainingActions = 0
+
+	handler := scheduler.NewTestHandler(logger)
+	_, err := handler.CreateSchedule(engineCtx, &schedulerpb.CreateScheduleRequest{
+		NamespaceId: namespaceID,
+		FrontendRequest: &workflowservice.CreateScheduleRequest{
+			Namespace:  namespace,
+			ScheduleId: scheduleID,
+			Schedule:   schedule,
+			RequestId:  "req-create",
+		},
+	})
+	require.NoError(t, err)
+
+	// Seed several running buffered starts, all with StartTime pinned to the
+	// same instant - the realistic shape of a historical ALLOW_ALL backfill,
+	// where every occurrence is kicked off back-to-back near "now" regardless
+	// of how spread out their eventual completions are.
+	const completions = 5
+	for i := 0; i < completions; i++ {
+		_, _, err = chasm.UpdateComponent(engineCtx, rootRef,
+			func(s *scheduler.Scheduler, ctx chasm.MutableContext, _ struct{}) (struct{}, error) {
+				invoker := s.Invoker.Get(ctx)
+				invoker.BufferedStarts = append(invoker.BufferedStarts, &schedulespb.BufferedStart{
+					RequestId:  fmt.Sprintf("req-%d", i),
+					WorkflowId: fmt.Sprintf("wf-%d", i),
+					RunId:      fmt.Sprintf("run-%d", i),
+					Attempt:    1,
+					ActualTime: timestamppb.New(now),
+					StartTime:  timestamppb.New(now),
+				})
+				return struct{}{}, nil
+			}, struct{}{})
+		require.NoError(t, err)
+	}
+
+	// Complete each buffered start through the real Nexus-completion path -
+	// exactly what HandleNexusCompletion processes in production - spreading
+	// the completions out in time to mirror workflows that ran for different
+	// durations. Each call is its own transaction, matching separate
+	// completion callbacks arriving independently.
+	var idleCloseTime time.Time
+	for i := 0; i < completions; i++ {
+		_, _, err = chasm.UpdateComponent(engineCtx, rootRef,
+			func(s *scheduler.Scheduler, ctx chasm.MutableContext, _ struct{}) (struct{}, error) {
+				return struct{}{}, s.HandleNexusCompletion(ctx, &persistencespb.ChasmNexusCompletion{
+					RequestId: fmt.Sprintf("req-%d", i),
+					Outcome: &persistencespb.ChasmNexusCompletion_Success{
+						Success: &commonpb.Payload{},
+					},
+					CloseTime: timestamppb.New(now.Add(time.Duration(i) * time.Hour)),
+				})
+			}, struct{}{})
+		require.NoError(t, err)
+
+		_, err = chasm.ReadComponent(engineCtx, rootRef,
+			func(s *scheduler.Scheduler, ctx chasm.Context, _ struct{}) (struct{}, error) {
+				require.NotNil(t, s.IdleCloseTime, "expected an idle task to be armed after every completion")
+				idleCloseTime = s.IdleCloseTime.AsTime()
+				return struct{}{}, nil
+			}, struct{}{})
+		require.NoError(t, err)
+	}
+
+	// Every completion independently recomputed the same idle deadline (their
+	// CloseTimes differ, but StartTime - what getLastEventTime actually reads
+	// - doesn't), so without deduplication each of the `completions` calls
+	// above appends its own SchedulerIdleTask. There should only ever be one.
+	count, err := engine.PureTaskCount(rootRef, idleCloseTime, reflect.TypeOf(&schedulerpb.SchedulerIdleTask{}))
+	require.NoError(t, err)
+	require.Equal(t, 1, count,
+		"expected exactly one idle pure task after a completion burst, found %d", count)
+}


### PR DESCRIPTION
## Problem

The scheduler's `idle` pure task can accumulate unbounded duplicate entries in a
`Scheduler` component's `PureTasks` list. Each duplicate is logically identical
(same type, same computed deadline) but is never cleaned up, so the component's
persisted state grows by one task per `Generator.Generate()` invocation for as
long as the schedule keeps re-evaluating idleness without its idle deadline
actually changing.

### How the idle task is scheduled

`GeneratorTaskHandler.Execute` (`chasm/lib/scheduler/generator_tasks.go`) is the
single place that arms the idle task. Whenever a generator tick determines the
schedule currently has no more work to do, it unconditionally appends a new
`SchedulerIdleTask`:

```go
if isIdle {
    ctx.AddTask(scheduler, chasm.TaskAttributes{
        ScheduledTime: idleExpiration,
    }, &schedulerpb.SchedulerIdleTask{
        IdleTimeTotal: durationpb.New(idleTimeTotal),
    })
    ...
}
```

`Generate()` is called from several places whenever the schedule's state
changes in a way that *might* affect idle eligibility: on schedule creation,
after a spec/patch update, after a backfiller completes, after the
migration-time callback-reconciliation task resolves stale running-workflow
state, and — critically — every time a scheduled action completes
(`Scheduler.HandleNexusCompletion` in `scheduler.go`). Each of these call
sites is individually correct: after any of these events, the schedule
genuinely might need to (re)arm its idle task. The bug is that nothing
prevents two of these evaluations, in sequence, from both deciding "yes, arm
an idle task" and both actually doing so.

### Why `Generate()` has to be called from so many places

This isn't incidental duplication in the code — it's structurally required by
how idle-task invalidation works. `idleDeadline` is derived from
`getLastEventTime`, which advances whenever the schedule is created, updated,
or an action completes (`scheduler.go`, `getLastEventTime`/`recentActions`).
Any of those events can retroactively make an already-armed idle task's
`ScheduledTime` stale — `SchedulerIdleTaskHandler.Validate` will correctly
detect that (`idleExpiration.After(taskAttrs.ScheduledTime)`) and delete it at
the next transaction close.

But validation only *deletes* stale tasks; nothing about it *replaces* them.
If a completion invalidates the current idle task and nothing re-arms a new
one, the schedule ends up with no idle task at all and — if there's also no
spec-driven next wakeup — never closes. So every code path that can move
`getLastEventTime` forward has to independently call `Generate()` afterward,
specifically to re-arm a fresh idle task at the new deadline. This is exactly
what the comment on the Nexus-completion handler says: *"Generate immediately
after recording completions, so that an idle task can be scheduled if no more
actions are remaining. Necessary as additional events invalidate in-flight
idle tasks."*

In other words, the design already assumes "invalidate now, someone else
re-arms" is the pattern, and deliberately fans that "someone else" out to
several call sites so that no event which can invalidate the idle task also
leaves it un-replaced. The missing piece is that "re-arm a fresh one" doesn't
first check whether a still-valid one already exists — see below.

### Why the existing validation doesn't catch it

CHASM already has a task-invalidation pass that runs at transaction close
(`Node.closeTransactionCleanupInvalidTasks`), which calls each task type's
registered `Validate` function and deletes any task that comes back invalid.
For the idle task, `SchedulerIdleTaskHandler.Validate` recomputes what the
current idle deadline *should* be and compares it to the task's own
`ScheduledTime`:

```go
idleExpiration := scheduler.idleDeadline(ctx, task.IdleTimeTotal.AsDuration())
if idleExpiration.After(taskAttrs.ScheduledTime) {
    return false, nil // deadline moved later — this task is stale
}
if idleExpiration.Before(taskAttrs.ScheduledTime) {
    // deadline moved earlier — log a warning, but still fire (safe default)
}
return true, nil
```

This predicate is designed to catch *drift*: it assumes there is at most one
idle task in flight, and asks "has the deadline this task represents become
outdated?" It has no way to express "there is already a valid idle task for
this component; a second one is redundant." When the recomputed deadline is
identical to an existing task's `ScheduledTime` — which happens whenever the
inputs to `idleDeadline` (last event time, configured idle duration) haven't
changed between two `Generate()` calls — the comparison falls through to
"valid," and the duplicate survives validation indefinitely. This is a general
property of any schedule that experiences several `Generate()`-triggering
events in a short window without genuinely idle-invalidating input changing
in between (e.g. a burst of buffered-start completions), not something
specific to any one workload.

Net effect: the idle task list can only grow, never self-heal, because the
validation function was written to detect staleness, not duplication.

### `BufferedStart` timestamps: nominal vs. actual vs. desired vs. start

The example below leans on `BufferedStart.ActualTime`, so it's worth being
precise about what that field means, since "actual" reads ambiguously (actual
as in "wall-clock now" vs. "actual as opposed to nominal"). Per
`message.proto` and `spec_processor.go`, a `BufferedStart` carries four
distinct timestamps:

- **`nominal_time`** — the pre-jitter, calendar-defined occurrence time (e.g.
  "the 15th of the month at 00:00 UTC"). This is what the schedule's spec
  literally says should happen, and what workflow IDs are derived from.
- **`actual_time`** — the post-jitter *target* time for this occurrence
  (`nominal_time` + jitter, if any is configured). This is the time the
  action is *scheduled to fire at* — but it is a property of the occurrence
  itself, not a record of when the server happened to process it. For a
  live/on-time schedule the two are close together by construction. For a
  backfill, `actual_time` is still computed the same way — from the
  requested historical range — so it lands squarely in the past, not at
  `time.Now()`. See `spec_processor.go`'s `ProcessTimeRange`, where both
  fields are populated from the same `NextTime` walk over `[start, end]`:
  `NominalTime: next.Nominal`, `ActualTime: next.Next`.
- **`desired_time`** — usually unset (interpreted as == `actual_time`); only
  set when a start is blocked behind a still-running prior action under an
  overlap policy, in which case it's set to that prior action's close time.
  Used purely for latency metrics (how long a start waited behind another).
- **`start_time`** — the one field that *does* represent a real wall-clock
  timestamp: it's populated only once the workflow is actually kicked off,
  with the true time the `StartWorkflowExecution` happened. This is the
  closest thing to "when did this actually, physically fire."

So: `actual_time` answers "when was this occurrence supposed to fire" (post-
jitter), not "when did we get around to firing it" — that's `start_time`.
For a backfill covering a historical range, both `nominal_time` and
`actual_time` are historical by design; only `start_time` reflects real
processing time.

This matters because `start_time` — not `actual_time` — is what
`getLastEventTime` actually reads. `Invoker.recentActions()`
(`invoker.go`) maps each `BufferedStart` into a public
`ScheduleActionResult`, and deliberately aliases fields along the way:

```go
results = append(results, &schedulepb.ScheduleActionResult{
    ScheduleTime: start.GetActualTime(), // nominal-ish: when it was due
    ActualTime:   start.GetStartTime(),  // when it really started
    ...
})
```

`getLastEventTime` then reads `a.GetActualTime()` off of *that* result type —
which is `BufferedStart.StartTime`, the real wall-clock time the workflow was
started, not the historical occurrence time. That's the detail the scenario
below depends on.

### Concrete example

A schedule receives a backfill request whose `start_time`/`end_time` range is
entirely in the past (e.g. backfilling several years of a monthly schedule),
with `overlap_policy: ALLOW_ALL`. Because the whole range is historical and
overlap is unrestricted, the Backfiller processes many occurrences in quick
succession, and the Invoker starts and completes many buffered actions in a
tight burst.

Each action completion runs `Scheduler.HandleNexusCompletion`, which calls
`invoker.recordCompletedAction` followed by `generator.Generate(ctx)`. Every
one of those `Generate()` calls reaches the `isIdle` branch (there's no more
future work once the backfill range is exhausted) and appends a new
`SchedulerIdleTask`.

`idleDeadline` computes the deadline from
`max(Info.CreateTime, Info.UpdateTime, max(recentActions.ActualTime))`, and —
per the previous section — `recentActions().ActualTime` is really each
`BufferedStart.StartTime`: the real wall-clock moment the workflow was
started, not its (historical) occurrence time. Under `ALLOW_ALL`, the
Backfiller doesn't wait for one occurrence to finish before starting the
next, so all of these workflows get started within milliseconds of each
other, right around the schedule's own `CreateTime`. Their eventual
completions, on the other hand, can be spread out arbitrarily — each
workflow runs for however long it runs, and `HandleNexusCompletion` fires
whenever that particular one happens to finish.

The result: every completion in the burst calls `Generate()` at a different
wall-clock moment, but each one recomputes `idleDeadline` from inputs
(`CreateTime`, and every buffered start's `StartTime`) that were all fixed
at the very beginning of the backfill and never changed. `max(...)` resolves
to the same value every time, regardless of how spread out the completions
themselves are. The computed idle deadline is therefore identical across the
whole burst — not because the occurrences were historical, but because the
thing `idleDeadline` actually measures (when work was last *started*) never
moved during the burst, even though real time (and the burst of completion
events) kept advancing.

Result: N completions produce N appended idle tasks, all with the exact same
`ScheduledTime`. `Validate` sees `idleExpiration == taskAttrs.ScheduledTime`
for every one of them and reports each as valid, so none are ever cleaned up.
The component's persisted task list grows by one entry per completed
backfilled action, with no upper bound tied to the size of the backfill
request.

This is a general failure mode, not specific to backfills — any sequence of
events that repeatedly triggers `Generate()` without changing the inputs to
`idleDeadline` will reproduce it. Backfills into the past with `ALLOW_ALL`
are simply the easiest way to produce a long, fast burst of such events.

## Fix: singleton task registration

CHASM has a general mechanism for exactly this shape of problem:
`chasm.WithSingletonTask(mode)`, passed as an option when registering a task
type. When a component adds a new task of a type registered with
`WithSingletonTask`, `Node.applySingletonMode` looks for an existing task of
the same type on that component (by `TaskTypeID`) *before* the new task is
appended, and:

- `SingletonTaskModeReplace`: removes the existing task from the list (and its
  cached deserialized value), then lets the new task be appended in its place.
- `SingletonTaskModeIgnore`: drops the new task, leaving the existing one
  untouched.

This runs at insertion time, independent of whatever the `Validate` function
would later decide, so it doesn't matter whether the new and old tasks would
compute to the same or different deadlines — there can only ever be one task
of that type on the component at a time.

The scheduler's `idle` task is a natural fit for `SingletonTaskModeReplace`:
conceptually there should only ever be one pending idle task per schedule at a
time, and whenever a new one is armed it should supersede whatever was there
before (the new one reflects the most current view of when the schedule
should close).

### Change

Register the `idle` pure task with `WithSingletonTask(SingletonTaskModeReplace)`
in `chasm/lib/scheduler/library.go`, alongside its existing
`NewRegistrablePureTask` registration. No changes are needed at any
`Generate()` call site, and `SchedulerIdleTaskHandler.Validate` is left as-is —
it still correctly closes the schedule when the (now singular) idle task's
deadline has actually elapsed, and still correctly invalidates it when the
schedule is unpaused/reopened/backfilled again.

## Scope / non-goals

- This PR only addresses the `idle` task type. Other scheduler pure task types
  (`generate`, `execute`, `processBuffer`, `backfill`, `callbacks`,
  `migrateToWorkflow`) were audited for the same class of bug but are out of
  scope here; follow-up noted separately if any are found to need it.
- This does not change idle-detection semantics (when a schedule is
  considered idle) — only how many redundant task entries get persisted while
  it evaluates that state repeatedly.

## Risk

Low. `WithSingletonTask` is an existing, already-used CHASM primitive; this
change only affects how many copies of the idle task are stored, not its
scheduled time, payload, or handler behavior. Existing schedules with already
-persisted duplicate idle tasks will self-heal the next time any of the
duplicates is validated (the first stale/duplicate one processed will be
removed via existing cleanup, and no new duplicates will be added going
forward).

## Test plan

- Added `TestScheduler_IdleTask_DoesNotAccumulateAcrossCompletionBurst`
  (`chasm/lib/scheduler/scheduler_idle_task_dedup_test.go`), built on the real
  `chasmtest.Engine` rather than calling task handlers directly: it creates a
  schedule with no remaining actions, seeds several running `BufferedStart`s
  all started at the same instant, then completes each one through the actual
  `Scheduler.HandleNexusCompletion` path (one per transaction, with distinct
  `CloseTime`s to mirror workflows that ran for different durations). Written
  and confirmed failing (6 idle tasks for 1 creation + 5 completions) before
  the fix; passes (1 task) after.
- To make the assertion possible, added `Engine.PureTaskCount` to
  `chasm/chasmtest/task_helpers.go` — a read-only counterpart to
  `Engine.FirePureTasks` that walks every logical pure task entry of a given
  payload type without executing or validating any of them. This was
  necessary because CHASM only ever promotes the head of a component's task
  list to a physical task, so a count based on physical/visible tasks alone
  (e.g. `Engine.Tasks`) cannot detect duplicate logical entries sitting behind
  it.
- Ran the full existing scheduler and CHASM suites
  (`go test ./chasm/...`) to confirm no regressions, including
  `TestGeneratorTask_*`, `TestHandleNexusCompletion_*`, and
  `TestBackfiller_*`.
