### PR TITLE
Add wide events for child workflow resends

### DIFF
--- a/common/wideevents/replication_events.go
+++ b/common/wideevents/replication_events.go
@@ -111,6 +111,7 @@ const (
 
 	ParentChildPhaseVerifyChildCompletion = "verify_child_completion"
 	ParentChildPhaseParentResend          = "parent_resend"
+	ParentChildPhaseChildResend           = "child_resend"
 
 	ParentChildOutcomeNotFound          = "not_found"
 	ParentChildOutcomeCompletionMissing = "completion_missing"

--- a/service/history/api/verifychildworkflowcompletionrecorded/api.go
+++ b/service/history/api/verifychildworkflowcompletionrecorded/api.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"time"
 
 	"go.temporal.io/api/serviceerror"
@@ -332,67 +331,22 @@ func emitParentResendLifecycleEvent(
 	err error,
 	details map[string]any,
 ) {
-	eventDetails := make(map[string]any, len(details)+11)
-	maps.Copy(eventDetails, details)
-	eventDetails["event_type"] = wideevents.ParentChildLifecycleEventType
-	eventDetails["phase"] = wideevents.ParentChildPhaseParentResend
-	eventDetails["outcome"] = outcome
-	eventDetails["local_cluster"] = shardContext.GetClusterMetadata().GetCurrentClusterName()
-	eventDetails["parent_namespace_id"] = request.GetNamespaceId()
-	eventDetails["parent_workflow_id"] = request.GetParentExecution().GetWorkflowId()
-	eventDetails["parent_run_id"] = request.GetParentExecution().GetRunId()
-	eventDetails["parent_workflow_state"] = parentWorkflowState
-	eventDetails["child_workflow_id"] = request.GetChildExecution().GetWorkflowId()
-	eventDetails["child_run_id"] = request.GetChildExecution().GetRunId()
-	eventDetails["parent_initiated_id"] = request.GetParentInitiatedId()
-	eventDetails["parent_initiated_version"] = request.GetParentInitiatedVersion()
-
-	namespaceName := ""
-	if entry, namespaceErr := shardContext.GetNamespaceRegistry().GetNamespaceByID(namespace.ID(request.GetNamespaceId())); namespaceErr == nil {
-		namespaceName = entry.Name().String()
-	}
-	sourceCluster, ok := eventDetails["source_cluster"].(string)
-	if !ok {
-		sourceCluster = ""
-	}
-	delete(eventDetails, "source_cluster")
-	if err != nil {
-		eventDetails["error"] = err.Error()
-		eventDetails["error_type"] = util.ErrorType(err)
-	}
-	payload := wideevents.ReplicationLifecyclePayload{
-		TaskType:      wideevents.ReplTaskSyncWorkflowState,
-		Shard:         shardContext.GetShardID(),
-		Namespace:     namespaceName,
-		NamespaceID:   request.GetNamespaceId(),
-		WorkflowID:    request.GetParentExecution().GetWorkflowId(),
-		RunID:         request.GetParentExecution().GetRunId(),
-		SourceCluster: sourceCluster,
-	}
-	switch outcome {
-	case wideevents.ParentChildOutcomeScheduled,
-		wideevents.ParentChildOutcomeStarted,
-		wideevents.ParentChildOutcomeDeduplicated:
-		eventDetails["operation"] = wideevents.ReplOperationStandbyVerificationSyncState
-		eventDetails["message"] = "Parent workflow resend checkpoint"
-		payload.Phase = wideevents.ReplicationExecuting
-		payload.Details = eventDetails
-		wideevents.Emit(shardContext.GetEventLogger(), payload)
-	case wideevents.ParentChildOutcomeSucceeded, wideevents.ParentChildOutcomeSourceNotFound:
-		eventDetails["operation"] = wideevents.ReplOperationStandbyVerificationSyncState
-		eventDetails["message"] = "Parent workflow resend checkpoint"
-		payload.Phase = wideevents.ReplicationApplied
-		payload.Outcome = wideevents.ParentChildOutcomeVerified
-		payload.Details = eventDetails
-		wideevents.Emit(shardContext.GetEventLogger(), payload)
-	default:
-		wideevents.EmitReplicationError(
-			shardContext.GetEventLogger(),
-			payload,
-			wideevents.ReplOperationStandbyVerificationSyncState,
-			"Parent workflow resend checkpoint",
-			err,
-			eventDetails,
-		)
-	}
+	details["parent_namespace_id"] = request.GetNamespaceId()
+	details["parent_workflow_id"] = request.GetParentExecution().GetWorkflowId()
+	details["parent_run_id"] = request.GetParentExecution().GetRunId()
+	details["parent_workflow_state"] = parentWorkflowState
+	details["child_workflow_id"] = request.GetChildExecution().GetWorkflowId()
+	details["child_run_id"] = request.GetChildExecution().GetRunId()
+	details["parent_initiated_id"] = request.GetParentInitiatedId()
+	details["parent_initiated_version"] = request.GetParentInitiatedVersion()
+	workflowresend.EmitLifecycleEvent(
+		shardContext,
+		namespace.ID(request.GetNamespaceId()),
+		request.GetParentExecution(),
+		wideevents.ParentChildPhaseParentResend,
+		"Parent workflow resend checkpoint",
+		outcome,
+		err,
+		details,
+	)
 }

--- a/service/history/api/verifychildworkflowcompletionrecorded/api.go
+++ b/service/history/api/verifychildworkflowcompletionrecorded/api.go
@@ -195,15 +195,13 @@ func Invoke(
 	case workflowresend.SubmitResultAtCapacity:
 		metrics.ParentWorkflowResendLimited.With(metricsHandler).Record(1)
 		if emitLifecycle {
-			details := parentResendEventDetails(errVerify)
-			details["max_in_flight"] = shardContext.GetConfig().WorkflowResendHostMaxInFlight()
 			emitParentResendLifecycleEvent(
 				shardContext,
 				request,
 				parentWorkflowState,
 				wideevents.ParentChildOutcomeLimited,
 				nil,
-				details,
+				parentResendEventDetails(errVerify),
 			)
 		}
 	default:
@@ -339,14 +337,14 @@ func emitParentResendLifecycleEvent(
 	details["child_run_id"] = request.GetChildExecution().GetRunId()
 	details["parent_initiated_id"] = request.GetParentInitiatedId()
 	details["parent_initiated_version"] = request.GetParentInitiatedVersion()
-	workflowresend.EmitLifecycleEvent(
-		shardContext,
-		namespace.ID(request.GetNamespaceId()),
-		request.GetParentExecution(),
-		wideevents.ParentChildPhaseParentResend,
-		"Parent workflow resend checkpoint",
-		outcome,
-		err,
-		details,
-	)
+	workflowresend.EmitLifecycleEvent(workflowresend.LifecycleEvent{
+		ShardContext: shardContext,
+		NamespaceID:  namespace.ID(request.GetNamespaceId()),
+		Execution:    request.GetParentExecution(),
+		ResendPhase:  wideevents.ParentChildPhaseParentResend,
+		Message:      "Parent workflow resend checkpoint",
+		Outcome:      outcome,
+		Err:          err,
+		Details:      details,
+	})
 }

--- a/service/history/api/verifyfirstworkflowtaskscheduled/api.go
+++ b/service/history/api/verifyfirstworkflowtaskscheduled/api.go
@@ -121,14 +121,12 @@ func Invoke(
 	case workflowresend.SubmitResultAtCapacity:
 		metrics.ChildWorkflowResendLimited.With(metricsHandler).Record(1)
 		if emitLifecycle {
-			details := childResendEventDetails(errVerify)
-			details["max_in_flight"] = shardContext.GetConfig().WorkflowResendHostMaxInFlight()
 			emitChildResendLifecycleEvent(
 				shardContext,
 				req,
 				wideevents.ParentChildOutcomeLimited,
 				nil,
-				details,
+				childResendEventDetails(errVerify),
 			)
 		}
 	default:
@@ -294,14 +292,14 @@ func emitChildResendLifecycleEvent(
 	details["child_namespace_id"] = request.GetNamespaceId()
 	details["child_workflow_id"] = request.GetWorkflowExecution().GetWorkflowId()
 	details["child_run_id"] = request.GetWorkflowExecution().GetRunId()
-	workflowresend.EmitLifecycleEvent(
-		shardContext,
-		namespace.ID(request.GetNamespaceId()),
-		request.GetWorkflowExecution(),
-		wideevents.ParentChildPhaseChildResend,
-		"Child workflow resend checkpoint",
-		outcome,
-		err,
-		details,
-	)
+	workflowresend.EmitLifecycleEvent(workflowresend.LifecycleEvent{
+		ShardContext: shardContext,
+		NamespaceID:  namespace.ID(request.GetNamespaceId()),
+		Execution:    request.GetWorkflowExecution(),
+		ResendPhase:  wideevents.ParentChildPhaseChildResend,
+		Message:      "Child workflow resend checkpoint",
+		Outcome:      outcome,
+		Err:          err,
+		Details:      details,
+	})
 }

--- a/service/history/api/verifyfirstworkflowtaskscheduled/api.go
+++ b/service/history/api/verifyfirstworkflowtaskscheduled/api.go
@@ -20,6 +20,8 @@ import (
 	"go.temporal.io/server/common/persistence/transitionhistory"
 	"go.temporal.io/server/common/persistence/versionhistory"
 	"go.temporal.io/server/common/rpc"
+	"go.temporal.io/server/common/util"
+	"go.temporal.io/server/common/wideevents"
 	"go.temporal.io/server/service/history/api"
 	"go.temporal.io/server/service/history/api/workflowresend"
 	"go.temporal.io/server/service/history/consts"
@@ -56,6 +58,7 @@ func Invoke(
 	}
 
 	metricsHandler := shardContext.GetMetricsHandler()
+	emitLifecycle := shardContext.GetConfig().EmitReplicationLifecycleEvents()
 	resend := func(ctx context.Context) error {
 		metrics.ChildWorkflowResendAttempts.With(metricsHandler).Record(1)
 		startTime := time.Now().UTC()
@@ -68,6 +71,7 @@ func Invoke(
 			versionedTransition,
 			versionHistories,
 			errVerify,
+			emitLifecycle,
 		)
 		metrics.ChildWorkflowResendLatency.With(metricsHandler).Record(time.Since(startTime))
 		if err != nil && !isExpectedResendError(err) {
@@ -88,6 +92,15 @@ func Invoke(
 		childKey,
 		shardContext.GetConfig().ReplicationTaskApplyTimeout(),
 		func(ctx context.Context) {
+			if emitLifecycle {
+				emitChildResendLifecycleEvent(
+					shardContext,
+					req,
+					wideevents.ParentChildOutcomeScheduled,
+					nil,
+					childResendEventDetails(errVerify),
+				)
+			}
 			_ = resend(ctx)
 		},
 	)
@@ -96,8 +109,28 @@ func Invoke(
 		// Accepted work records its attempt when execution starts.
 	case workflowresend.SubmitResultDuplicate:
 		metrics.ChildWorkflowResendSkipped.With(metricsHandler).Record(1)
+		if emitLifecycle {
+			emitChildResendLifecycleEvent(
+				shardContext,
+				req,
+				wideevents.ParentChildOutcomeDeduplicated,
+				nil,
+				childResendEventDetails(errVerify),
+			)
+		}
 	case workflowresend.SubmitResultAtCapacity:
 		metrics.ChildWorkflowResendLimited.With(metricsHandler).Record(1)
+		if emitLifecycle {
+			details := childResendEventDetails(errVerify)
+			details["max_in_flight"] = shardContext.GetConfig().WorkflowResendHostMaxInFlight()
+			emitChildResendLifecycleEvent(
+				shardContext,
+				req,
+				wideevents.ParentChildOutcomeLimited,
+				nil,
+				details,
+			)
+		}
 	default:
 		// SubmitResultFailed and unknown values are admission failures.
 		metrics.ChildWorkflowResendFailures.With(metricsHandler).Record(1)
@@ -188,7 +221,23 @@ func resendChildAndVerify(
 	versionedTransition *persistencespb.VersionedTransition,
 	versionHistories *historyspb.VersionHistories,
 	errVerify error,
+	emitLifecycle bool,
 ) error {
+	activeClusterName := ""
+	emitResult := func(outcome string, eventErr error, stage string) {
+		if !emitLifecycle {
+			return
+		}
+		details := childResendEventDetails(errVerify)
+		if activeClusterName != "" {
+			details["source_cluster"] = activeClusterName
+		}
+		if stage != "" {
+			details["stage"] = stage
+		}
+		emitChildResendLifecycleEvent(shardContext, req, outcome, eventErr, details)
+	}
+
 	result, err := workflowresend.SyncWorkflowStateFromSource(
 		ctx,
 		shardContext,
@@ -196,20 +245,63 @@ func resendChildAndVerify(
 		req.WorkflowExecution,
 		versionedTransition,
 		versionHistories,
-		nil,
+		func(sourceCluster string) {
+			activeClusterName = sourceCluster
+			emitResult(wideevents.ParentChildOutcomeStarted, nil, "sync_workflow_state")
+		},
 	)
 	if err != nil {
+		emitResult(wideevents.ParentChildOutcomeFailed, err, "sync_workflow_state")
 		return err
 	}
 	switch result {
 	case workflowresend.SyncWorkflowStateResultSourceNotFound:
+		emitResult(
+			wideevents.ParentChildOutcomeSourceNotFound,
+			serviceerror.NewNotFound("child workflow not found on source cluster"),
+			"sync_workflow_state",
+		)
 		return nil
 	case workflowresend.SyncWorkflowStateResultSkipped:
 		return errVerify
 	case workflowresend.SyncWorkflowStateResultApplied:
-		_, _, _, err = verifyFirstWorkflowTaskScheduled(ctx, req, workflowConsistencyChecker)
-		return err
 	default:
 		return fmt.Errorf("unknown workflow state sync result: %d", result)
 	}
+
+	_, _, _, err = verifyFirstWorkflowTaskScheduled(ctx, req, workflowConsistencyChecker)
+	if err != nil {
+		emitResult(wideevents.ParentChildOutcomeFailed, err, "verify_after_resend")
+		return err
+	}
+	emitResult(wideevents.ParentChildOutcomeSucceeded, nil, "")
+	return nil
+}
+
+func childResendEventDetails(initialError error) map[string]any {
+	return map[string]any{
+		"initial_error_type": util.ErrorType(initialError),
+	}
+}
+
+func emitChildResendLifecycleEvent(
+	shardContext historyi.ShardContext,
+	request *historyservice.VerifyFirstWorkflowTaskScheduledRequest,
+	outcome string,
+	err error,
+	details map[string]any,
+) {
+	details["child_namespace_id"] = request.GetNamespaceId()
+	details["child_workflow_id"] = request.GetWorkflowExecution().GetWorkflowId()
+	details["child_run_id"] = request.GetWorkflowExecution().GetRunId()
+	workflowresend.EmitLifecycleEvent(
+		shardContext,
+		namespace.ID(request.GetNamespaceId()),
+		request.GetWorkflowExecution(),
+		wideevents.ParentChildPhaseChildResend,
+		"Child workflow resend checkpoint",
+		outcome,
+		err,
+		details,
+	)
 }

--- a/service/history/api/workflowresend/wide_events.go
+++ b/service/history/api/workflowresend/wide_events.go
@@ -1,0 +1,79 @@
+package workflowresend
+
+import (
+	"maps"
+
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/util"
+	"go.temporal.io/server/common/wideevents"
+	historyi "go.temporal.io/server/service/history/interfaces"
+)
+
+// EmitLifecycleEvent emits a parent or child workflow resend checkpoint.
+func EmitLifecycleEvent(
+	shardContext historyi.ShardContext,
+	namespaceID namespace.ID,
+	execution *commonpb.WorkflowExecution,
+	resendPhase string,
+	message string,
+	outcome string,
+	err error,
+	details map[string]any,
+) {
+	eventDetails := make(map[string]any, len(details)+4)
+	maps.Copy(eventDetails, details)
+	eventDetails["event_type"] = wideevents.ParentChildLifecycleEventType
+	eventDetails["phase"] = resendPhase
+	eventDetails["outcome"] = outcome
+	eventDetails["local_cluster"] = shardContext.GetClusterMetadata().GetCurrentClusterName()
+
+	namespaceName := ""
+	if entry, namespaceErr := shardContext.GetNamespaceRegistry().GetNamespaceByID(namespaceID); namespaceErr == nil {
+		namespaceName = entry.Name().String()
+	}
+	sourceCluster, ok := eventDetails["source_cluster"].(string)
+	if !ok {
+		sourceCluster = ""
+	}
+	delete(eventDetails, "source_cluster")
+	if err != nil {
+		eventDetails["error"] = err.Error()
+		eventDetails["error_type"] = util.ErrorType(err)
+	}
+	payload := wideevents.ReplicationLifecyclePayload{
+		TaskType:      wideevents.ReplTaskSyncWorkflowState,
+		Shard:         shardContext.GetShardID(),
+		Namespace:     namespaceName,
+		NamespaceID:   namespaceID.String(),
+		WorkflowID:    execution.GetWorkflowId(),
+		RunID:         execution.GetRunId(),
+		SourceCluster: sourceCluster,
+	}
+	switch outcome {
+	case wideevents.ParentChildOutcomeScheduled,
+		wideevents.ParentChildOutcomeStarted,
+		wideevents.ParentChildOutcomeDeduplicated:
+		eventDetails["operation"] = wideevents.ReplOperationStandbyVerificationSyncState
+		eventDetails["message"] = message
+		payload.Phase = wideevents.ReplicationExecuting
+		payload.Details = eventDetails
+		wideevents.Emit(shardContext.GetEventLogger(), payload)
+	case wideevents.ParentChildOutcomeSucceeded, wideevents.ParentChildOutcomeSourceNotFound:
+		eventDetails["operation"] = wideevents.ReplOperationStandbyVerificationSyncState
+		eventDetails["message"] = message
+		payload.Phase = wideevents.ReplicationApplied
+		payload.Outcome = wideevents.ParentChildOutcomeVerified
+		payload.Details = eventDetails
+		wideevents.Emit(shardContext.GetEventLogger(), payload)
+	default:
+		wideevents.EmitReplicationError(
+			shardContext.GetEventLogger(),
+			payload,
+			wideevents.ReplOperationStandbyVerificationSyncState,
+			message,
+			err,
+			eventDetails,
+		)
+	}
+}

--- a/service/history/api/workflowresend/wide_events.go
+++ b/service/history/api/workflowresend/wide_events.go
@@ -10,26 +10,28 @@ import (
 	historyi "go.temporal.io/server/service/history/interfaces"
 )
 
+type LifecycleEvent struct {
+	ShardContext historyi.ShardContext
+	NamespaceID  namespace.ID
+	Execution    *commonpb.WorkflowExecution
+	ResendPhase  string
+	Message      string
+	Outcome      string
+	Err          error
+	Details      map[string]any
+}
+
 // EmitLifecycleEvent emits a parent or child workflow resend checkpoint.
-func EmitLifecycleEvent(
-	shardContext historyi.ShardContext,
-	namespaceID namespace.ID,
-	execution *commonpb.WorkflowExecution,
-	resendPhase string,
-	message string,
-	outcome string,
-	err error,
-	details map[string]any,
-) {
-	eventDetails := make(map[string]any, len(details)+4)
-	maps.Copy(eventDetails, details)
+func EmitLifecycleEvent(event LifecycleEvent) {
+	eventDetails := make(map[string]any, len(event.Details)+4)
+	maps.Copy(eventDetails, event.Details)
 	eventDetails["event_type"] = wideevents.ParentChildLifecycleEventType
-	eventDetails["phase"] = resendPhase
-	eventDetails["outcome"] = outcome
-	eventDetails["local_cluster"] = shardContext.GetClusterMetadata().GetCurrentClusterName()
+	eventDetails["phase"] = event.ResendPhase
+	eventDetails["outcome"] = event.Outcome
+	eventDetails["local_cluster"] = event.ShardContext.GetClusterMetadata().GetCurrentClusterName()
 
 	namespaceName := ""
-	if entry, namespaceErr := shardContext.GetNamespaceRegistry().GetNamespaceByID(namespaceID); namespaceErr == nil {
+	if entry, namespaceErr := event.ShardContext.GetNamespaceRegistry().GetNamespaceByID(event.NamespaceID); namespaceErr == nil {
 		namespaceName = entry.Name().String()
 	}
 	sourceCluster, ok := eventDetails["source_cluster"].(string)
@@ -37,42 +39,42 @@ func EmitLifecycleEvent(
 		sourceCluster = ""
 	}
 	delete(eventDetails, "source_cluster")
-	if err != nil {
-		eventDetails["error"] = err.Error()
-		eventDetails["error_type"] = util.ErrorType(err)
+	if event.Err != nil {
+		eventDetails["error"] = event.Err.Error()
+		eventDetails["error_type"] = util.ErrorType(event.Err)
 	}
 	payload := wideevents.ReplicationLifecyclePayload{
 		TaskType:      wideevents.ReplTaskSyncWorkflowState,
-		Shard:         shardContext.GetShardID(),
+		Shard:         event.ShardContext.GetShardID(),
 		Namespace:     namespaceName,
-		NamespaceID:   namespaceID.String(),
-		WorkflowID:    execution.GetWorkflowId(),
-		RunID:         execution.GetRunId(),
+		NamespaceID:   event.NamespaceID.String(),
+		WorkflowID:    event.Execution.GetWorkflowId(),
+		RunID:         event.Execution.GetRunId(),
 		SourceCluster: sourceCluster,
 	}
-	switch outcome {
+	switch event.Outcome {
 	case wideevents.ParentChildOutcomeScheduled,
 		wideevents.ParentChildOutcomeStarted,
 		wideevents.ParentChildOutcomeDeduplicated:
 		eventDetails["operation"] = wideevents.ReplOperationStandbyVerificationSyncState
-		eventDetails["message"] = message
+		eventDetails["message"] = event.Message
 		payload.Phase = wideevents.ReplicationExecuting
 		payload.Details = eventDetails
-		wideevents.Emit(shardContext.GetEventLogger(), payload)
+		wideevents.Emit(event.ShardContext.GetEventLogger(), payload)
 	case wideevents.ParentChildOutcomeSucceeded, wideevents.ParentChildOutcomeSourceNotFound:
 		eventDetails["operation"] = wideevents.ReplOperationStandbyVerificationSyncState
-		eventDetails["message"] = message
+		eventDetails["message"] = event.Message
 		payload.Phase = wideevents.ReplicationApplied
 		payload.Outcome = wideevents.ParentChildOutcomeVerified
 		payload.Details = eventDetails
-		wideevents.Emit(shardContext.GetEventLogger(), payload)
+		wideevents.Emit(event.ShardContext.GetEventLogger(), payload)
 	default:
 		wideevents.EmitReplicationError(
-			shardContext.GetEventLogger(),
+			event.ShardContext.GetEventLogger(),
 			payload,
 			wideevents.ReplOperationStandbyVerificationSyncState,
-			message,
-			err,
+			event.Message,
+			event.Err,
 			eventDetails,
 		)
 	}

--- a/service/history/history_engine2_test.go
+++ b/service/history/history_engine2_test.go
@@ -3164,7 +3164,7 @@ func (s *engine2Suite) TestVerifyFirstWorkflowTaskScheduled_ResendChildLimited()
 	details := wideEventDetails(parentChildRecords(capture)[0])
 	s.Equal(wideevents.ParentChildPhaseChildResend, details["phase"])
 	s.Equal(util.ErrorType(&serviceerror.NotFound{}), details["initial_error_type"])
-	s.InDelta(0, details["max_in_flight"], 0)
+	s.NotContains(details, "max_in_flight")
 }
 
 func (s *engine2Suite) TestVerifyChildExecutionCompletionRecorded_WorkflowNotExist() {
@@ -3503,7 +3503,7 @@ func (s *engine2Suite) TestVerifyChildExecutionCompletionRecorded_ResendParentLi
 	s.Require().Equal([]string{string(wideevents.ParentChildOutcomeLimited)}, parentChildOutcomes(capture))
 	details := wideEventDetails(parentChildRecords(capture)[0])
 	s.Equal(util.ErrorType(&serviceerror.NotFound{}), details["initial_error_type"])
-	s.InDelta(0, details["max_in_flight"], 0)
+	s.NotContains(details, "max_in_flight")
 }
 
 func (s *engine2Suite) TestVerifyChildExecutionCompletionRecorded_SkipsResendForRemovedNamespace() {

--- a/service/history/history_engine2_test.go
+++ b/service/history/history_engine2_test.go
@@ -2684,6 +2684,8 @@ func (s *engine2Suite) TestRecordChildExecutionCompleted_MissingChildStartedEven
 
 func (s *engine2Suite) TestVerifyFirstWorkflowTaskScheduled_ResendChildAsync() {
 	s.config.EnableChildWorkflowResend = func() bool { return true }
+	s.config.EmitReplicationLifecycleEvents = dynamicconfig.GetBoolPropertyFn(true)
+	capture := s.parentChildEventCapture
 
 	request := &historyservice.VerifyFirstWorkflowTaskScheduledRequest{
 		NamespaceId: tests.NamespaceID.String(),
@@ -2768,6 +2770,66 @@ func (s *engine2Suite) TestVerifyFirstWorkflowTaskScheduled_ResendChildAsync() {
 	case <-time.After(10 * time.Second):
 		s.Fail("background child resend was not re-verified")
 	}
+	await.RequireTrue(s.T(), func() bool {
+		return len(parentChildOutcomes(capture)) >= 3
+	}, 10*time.Second, 10*time.Millisecond)
+	s.Require().Equal([]string{
+		string(wideevents.ParentChildOutcomeScheduled),
+		string(wideevents.ParentChildOutcomeStarted),
+		string(wideevents.ParentChildOutcomeSucceeded),
+	}, parentChildOutcomes(capture))
+	records := parentChildRecords(capture)
+	details := wideEventDetails(records[1])
+	attributes := wideEventAttributes(records[1])
+	s.Equal(wideevents.ParentChildPhaseChildResend, details["phase"])
+	s.Equal(request.GetNamespaceId(), details["child_namespace_id"])
+	s.Equal(request.GetWorkflowExecution().GetWorkflowId(), details["child_workflow_id"])
+	s.Equal(request.GetWorkflowExecution().GetRunId(), details["child_run_id"])
+	s.Equal(util.ErrorType(&serviceerror.NotFound{}), details["initial_error_type"])
+	s.Equal("sync_workflow_state", details["stage"])
+	s.Equal(cluster.TestCurrentClusterName, attributes["source_cluster"].AsString())
+	s.Equal(string(wideevents.ReplicationApplied), wideEventAttributes(records[2])["phase"].AsString())
+	s.Equal(wideevents.ParentChildOutcomeVerified, wideEventAttributes(records[2])["outcome"].AsString())
+}
+
+func (s *engine2Suite) TestVerifyFirstWorkflowTaskScheduled_ResendChildSourceNotFound() {
+	s.config.EnableChildWorkflowResend = func() bool { return true }
+	s.config.EmitReplicationLifecycleEvents = dynamicconfig.GetBoolPropertyFn(true)
+	capture := s.parentChildEventCapture
+
+	request := &historyservice.VerifyFirstWorkflowTaskScheduledRequest{
+		NamespaceId: tests.NamespaceID.String(),
+		WorkflowExecution: &commonpb.WorkflowExecution{
+			WorkflowId: tests.WorkflowID,
+			RunId:      tests.RunID,
+		},
+		ResendChild: true,
+	}
+	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil, &serviceerror.NotFound{})
+
+	mockClusterMetadata := cluster.NewMockMetadata(s.controller)
+	mockClusterMetadata.EXPECT().GetClusterID().Return(tests.Version).AnyTimes()
+	mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestAlternativeClusterName).AnyTimes()
+	mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo)
+	mockClusterMetadata.EXPECT().ClusterNameForFailoverVersion(true, tests.Version).Return(cluster.TestCurrentClusterName).AnyTimes()
+	s.mockShard.SetClusterMetadata(mockClusterMetadata)
+	s.mockShard.Resource.RemoteAdminClient.EXPECT().SyncWorkflowState(gomock.Any(), gomock.Any()).
+		Return(nil, serviceerror.NewNotFound("child missing on source"))
+
+	err := s.historyEngine.VerifyFirstWorkflowTaskScheduled(metrics.AddMetricsContext(s.T().Context()), request)
+	s.Require().ErrorAs(err, new(*serviceerror.NotFound))
+	await.RequireTrue(s.T(), func() bool {
+		return len(parentChildOutcomes(capture)) >= 3
+	}, 10*time.Second, 10*time.Millisecond)
+	s.Require().Equal([]string{
+		string(wideevents.ParentChildOutcomeScheduled),
+		string(wideevents.ParentChildOutcomeStarted),
+		string(wideevents.ParentChildOutcomeSourceNotFound),
+	}, parentChildOutcomes(capture))
+	record := parentChildRecords(capture)[2]
+	s.Equal(string(wideevents.ReplicationApplied), wideEventAttributes(record)["phase"].AsString())
+	s.Equal(wideevents.ParentChildOutcomeVerified, wideEventAttributes(record)["outcome"].AsString())
+	s.Equal(util.ErrorType(serviceerror.NewNotFound("")), wideEventDetails(record)["error_type"])
 }
 
 func (s *engine2Suite) TestVerifyFirstWorkflowTaskScheduled_NilSchedulerResendsSynchronously() {
@@ -2997,9 +3059,11 @@ func (s *engine2Suite) TestVerifyFirstWorkflowTaskScheduled_SkipsApplyWhenActive
 
 func (s *engine2Suite) TestVerifyFirstWorkflowTaskScheduled_ResendChildDeduped() {
 	s.config.EnableChildWorkflowResend = func() bool { return true }
+	s.config.EmitReplicationLifecycleEvents = dynamicconfig.GetBoolPropertyFn(true)
+	eventCapture := s.parentChildEventCapture
 	metricsHandler := metricstest.NewCaptureHandler()
-	capture := metricsHandler.StartCapture()
-	defer metricsHandler.StopCapture(capture)
+	metricsCapture := metricsHandler.StartCapture()
+	defer metricsHandler.StopCapture(metricsCapture)
 	s.mockShard.SetMetricsHandler(metricsHandler)
 
 	request := &historyservice.VerifyFirstWorkflowTaskScheduledRequest{
@@ -3048,6 +3112,11 @@ func (s *engine2Suite) TestVerifyFirstWorkflowTaskScheduled_ResendChildDeduped()
 
 	err = s.historyEngine.VerifyFirstWorkflowTaskScheduled(ctx, request)
 	s.ErrorAs(err, &notFound)
+	s.Require().Equal([]string{
+		string(wideevents.ParentChildOutcomeScheduled),
+		string(wideevents.ParentChildOutcomeStarted),
+		string(wideevents.ParentChildOutcomeDeduplicated),
+	}, parentChildOutcomes(eventCapture))
 
 	close(release)
 	select {
@@ -3055,13 +3124,47 @@ func (s *engine2Suite) TestVerifyFirstWorkflowTaskScheduled_ResendChildDeduped()
 	case <-time.After(10 * time.Second):
 		s.Fail("background child resend did not finish")
 	}
+	await.RequireTrue(s.T(), func() bool {
+		return len(parentChildOutcomes(eventCapture)) >= 4
+	}, 10*time.Second, 10*time.Millisecond)
+	s.Require().Equal([]string{
+		string(wideevents.ParentChildOutcomeScheduled),
+		string(wideevents.ParentChildOutcomeStarted),
+		string(wideevents.ParentChildOutcomeDeduplicated),
+		string(wideevents.ParentChildOutcomeFailed),
+	}, parentChildOutcomes(eventCapture))
 	s.resendScheduler.InitiateShutdown()
 	s.resendScheduler.WaitShutdown()
-	metricSnapshot := capture.Snapshot()
+	metricSnapshot := metricsCapture.Snapshot()
 	s.Require().Len(metricSnapshot[metrics.ChildWorkflowResendAttempts.Name()], 1)
 	s.Require().Len(metricSnapshot[metrics.ChildWorkflowResendSkipped.Name()], 1)
 	s.Require().Len(metricSnapshot[metrics.ChildWorkflowResendFailures.Name()], 1)
 	s.Require().Len(metricSnapshot[metrics.ChildWorkflowResendLatency.Name()], 1)
+}
+
+func (s *engine2Suite) TestVerifyFirstWorkflowTaskScheduled_ResendChildLimited() {
+	s.config.EnableChildWorkflowResend = func() bool { return true }
+	s.config.WorkflowResendHostMaxInFlight = func() int { return 0 }
+	s.config.EmitReplicationLifecycleEvents = dynamicconfig.GetBoolPropertyFn(true)
+	capture := s.parentChildEventCapture
+
+	request := &historyservice.VerifyFirstWorkflowTaskScheduledRequest{
+		NamespaceId: tests.NamespaceID.String(),
+		WorkflowExecution: &commonpb.WorkflowExecution{
+			WorkflowId: tests.WorkflowID,
+			RunId:      tests.RunID,
+		},
+		ResendChild: true,
+	}
+	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil, &serviceerror.NotFound{})
+
+	err := s.historyEngine.VerifyFirstWorkflowTaskScheduled(metrics.AddMetricsContext(s.T().Context()), request)
+	s.Require().ErrorAs(err, new(*serviceerror.NotFound))
+	s.Require().Equal([]string{string(wideevents.ParentChildOutcomeLimited)}, parentChildOutcomes(capture))
+	details := wideEventDetails(parentChildRecords(capture)[0])
+	s.Equal(wideevents.ParentChildPhaseChildResend, details["phase"])
+	s.Equal(util.ErrorType(&serviceerror.NotFound{}), details["initial_error_type"])
+	s.InDelta(0, details["max_in_flight"], 0)
 }
 
 func (s *engine2Suite) TestVerifyChildExecutionCompletionRecorded_WorkflowNotExist() {


### PR DESCRIPTION
## What changed?

Added wide events for the child workflow resend lifecycle, including:

- scheduled
- started
- succeeded
- source not found
- failed
- deduplicated
- limited by the host-level concurrency cap

## Why?

Child workflow resends run asynchronously, making missing-child replication issues difficult to diagnose from request logs alone.

These events make it possible to trace scheduler admission, remote state synchronization, verification, and terminal outcomes while keeping parent and child resend events consistent.

## How did you test it?

- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>