### PR TITLE
Add standalone activity dispatch hook

### DIFF
--- a/chasm/lib/activity/attempt.go
+++ b/chasm/lib/activity/attempt.go
@@ -293,15 +293,16 @@ func (a *Activity) firstDispatchTime() time.Time {
 }
 
 func (a *Activity) newActivityDispatchTask(ctx chasm.Context) *activitypb.ActivityDispatchTask {
+	attempt := a.LastAttempt.Get(ctx)
 	dispatchReason := activitypb.DISPATCH_REASON_IMMEDIATE
-	if a.GetFirstAttemptStartedTime() != nil {
+	if attempt.GetCount() > 1 {
 		dispatchReason = activitypb.DISPATCH_REASON_RETRY
-	} else if a.GetStartDelay().AsDuration() > 0 {
+	} else if a.GetFirstAttemptStartedTime() == nil && a.GetStartDelay().AsDuration() > 0 {
 		dispatchReason = activitypb.DISPATCH_REASON_START_DELAY
 	}
 
 	return &activitypb.ActivityDispatchTask{
-		Stamp:            a.LastAttempt.Get(ctx).GetStamp(),
+		Stamp:            attempt.GetStamp(),
 		DispatchReason:   dispatchReason,
 		StartDelayBucket: startDelayBucket(a.GetStartDelay().AsDuration()),
 	}

--- a/chasm/lib/activity/attempt_test.go
+++ b/chasm/lib/activity/attempt_test.go
@@ -109,6 +109,7 @@ func TestStartDelayBucket(t *testing.T) {
 func TestNewActivityDispatchTask(t *testing.T) {
 	testCases := []struct {
 		name                    string
+		attemptCount            int32
 		startDelay              time.Duration
 		firstAttemptStartedTime *timestamppb.Timestamp
 		expectedReason          activitypb.DispatchReason
@@ -116,26 +117,37 @@ func TestNewActivityDispatchTask(t *testing.T) {
 	}{
 		{
 			name:           "immediate",
+			attemptCount:   1,
 			expectedReason: activitypb.DISPATCH_REASON_IMMEDIATE,
 			expectedBucket: activitypb.START_DELAY_BUCKET_NONE,
 		},
 		{
 			name:           "start delay",
+			attemptCount:   1,
 			startDelay:     time.Hour,
 			expectedReason: activitypb.DISPATCH_REASON_START_DELAY,
 			expectedBucket: activitypb.START_DELAY_BUCKET_1H_6H,
 		},
 		{
-			name:                    "retry without configured start delay",
-			firstAttemptStartedTime: timestamppb.Now(),
-			expectedReason:          activitypb.DISPATCH_REASON_RETRY,
-			expectedBucket:          activitypb.START_DELAY_BUCKET_NONE,
+			name:           "attempt number is authoritative for retry",
+			attemptCount:   2,
+			expectedReason: activitypb.DISPATCH_REASON_RETRY,
+			expectedBucket: activitypb.START_DELAY_BUCKET_NONE,
 		},
 		{
 			name:                    "retry preserves configured start delay bucket",
+			attemptCount:            2,
 			startDelay:              time.Hour,
 			firstAttemptStartedTime: timestamppb.Now(),
 			expectedReason:          activitypb.DISPATCH_REASON_RETRY,
+			expectedBucket:          activitypb.START_DELAY_BUCKET_1H_6H,
+		},
+		{
+			name:                    "attempt 1 after a prior worker start with configured start delay",
+			attemptCount:            1,
+			startDelay:              time.Hour,
+			firstAttemptStartedTime: timestamppb.Now(),
+			expectedReason:          activitypb.DISPATCH_REASON_IMMEDIATE,
 			expectedBucket:          activitypb.START_DELAY_BUCKET_1H_6H,
 		},
 	}
@@ -148,7 +160,10 @@ func TestNewActivityDispatchTask(t *testing.T) {
 					StartDelay:              durationpb.New(tc.startDelay),
 					FirstAttemptStartedTime: tc.firstAttemptStartedTime,
 				},
-				LastAttempt: chasm.NewDataField(ctx, &activitypb.ActivityAttemptState{Stamp: 1}),
+				LastAttempt: chasm.NewDataField(ctx, &activitypb.ActivityAttemptState{
+					Count: tc.attemptCount,
+					Stamp: 1,
+				}),
 			}
 
 			task := activity.newActivityDispatchTask(ctx)

--- a/chasm/lib/activity/statemachine_test.go
+++ b/chasm/lib/activity/statemachine_test.go
@@ -391,7 +391,7 @@ func TestPauseUnpauseReplacesDispatch(t *testing.T) {
 				LastAttempt: chasm.NewDataField(ctx, attemptState),
 			}
 			handler := newActivityDispatchTaskHandler(activityDispatchTaskHandlerOptions{})
-			oldTask := &activitypb.ActivityDispatchTask{Stamp: 7, DispatchReason: tc.expectedReason}
+			oldTask := &activitypb.ActivityDispatchTask{Stamp: 7}
 
 			err := TransitionPaused.Apply(activity, ctx, pauseEvent{metricsHandler: metrics.NoopMetricsHandler})
 			require.NoError(t, err)
@@ -1306,8 +1306,8 @@ func TestTransitionResetFromPaused(t *testing.T) {
 	}
 }
 
-// TestTransitionResetClearsCurrentRetryInterval verifies that TransitionReset clears the retry
-// interval so a reset activity is not delayed by a previous backoff period.
+// TestResetDuringRetryBackoff verifies that a reset during retry backoff clears the retry interval,
+// restarts at attempt 1, and replaces the pending retry dispatch with an immediate one.
 func TestResetDuringRetryBackoff(t *testing.T) {
 	ctx := &chasm.MockMutableContext{}
 	ctx.HandleNow = func(chasm.Component) time.Time { return defaultTime }
@@ -1332,7 +1332,7 @@ func TestResetDuringRetryBackoff(t *testing.T) {
 		Outcome:     chasm.NewDataField(ctx, &activitypb.ActivityOutcome{}),
 	}
 	handler := newActivityDispatchTaskHandler(activityDispatchTaskHandlerOptions{})
-	oldTask := &activitypb.ActivityDispatchTask{Stamp: 7, DispatchReason: activitypb.DISPATCH_REASON_RETRY}
+	oldTask := &activitypb.ActivityDispatchTask{Stamp: 7}
 
 	err := TransitionReset.Apply(act, ctx, resetEvent{resetTime: defaultTime, metricsHandler: metrics.NoopMetricsHandler})
 	require.NoError(t, err)

--- a/chasm/lib/activity/statemachine_test.go
+++ b/chasm/lib/activity/statemachine_test.go
@@ -369,6 +369,53 @@ func TestTransitionRescheduled(t *testing.T) {
 	}
 }
 
+func TestPauseUnpauseReplacesDispatch(t *testing.T) {
+	testCases := []struct {
+		attemptCount   int32
+		expectedReason activitypb.DispatchReason
+	}{
+		{attemptCount: 1, expectedReason: activitypb.DISPATCH_REASON_IMMEDIATE},
+		{attemptCount: 3, expectedReason: activitypb.DISPATCH_REASON_RETRY},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("attempt=%d", tc.attemptCount), func(t *testing.T) {
+			ctx := &chasm.MockMutableContext{}
+			ctx.HandleNow = func(chasm.Component) time.Time { return defaultTime }
+			attemptState := &activitypb.ActivityAttemptState{Count: tc.attemptCount, Stamp: 7}
+			activity := &Activity{
+				ActivityState: &activitypb.ActivityState{
+					Status:       activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
+					ScheduleTime: timestamppb.New(defaultTime),
+				},
+				LastAttempt: chasm.NewDataField(ctx, attemptState),
+			}
+			handler := newActivityDispatchTaskHandler(activityDispatchTaskHandlerOptions{})
+			oldTask := &activitypb.ActivityDispatchTask{Stamp: 7, DispatchReason: tc.expectedReason}
+
+			err := TransitionPaused.Apply(activity, ctx, pauseEvent{metricsHandler: metrics.NoopMetricsHandler})
+			require.NoError(t, err)
+			require.Equal(t, activitypb.ACTIVITY_EXECUTION_STATUS_PAUSED, activity.GetStatus())
+			valid, err := handler.Validate(ctx, activity, chasm.TaskInvocation{}, oldTask)
+			require.NoError(t, err)
+			require.False(t, valid)
+
+			err = TransitionUnpaused.Apply(activity, ctx, unpauseEvent{
+				req: &workflowservice.UnpauseActivityExecutionRequest{},
+			})
+			require.NoError(t, err)
+			require.Equal(t, tc.attemptCount, attemptState.GetCount())
+			require.Len(t, ctx.Tasks, 1)
+			dispatchTask := ctx.Tasks[0].Payload.(*activitypb.ActivityDispatchTask)
+			require.Equal(t, int32(9), dispatchTask.GetStamp())
+			require.Equal(t, tc.expectedReason, dispatchTask.GetDispatchReason())
+			valid, err = handler.Validate(ctx, activity, chasm.TaskInvocation{}, dispatchTask)
+			require.NoError(t, err)
+			require.True(t, valid)
+		})
+	}
+}
+
 func TestTransitionStarted(t *testing.T) {
 	ctx := &chasm.MockMutableContext{}
 	ctx.HandleNow = func(chasm.Component) time.Time { return defaultTime }
@@ -1100,6 +1147,8 @@ func TestTransitionResetHeartbeat(t *testing.T) {
 				metricsHandler: metrics.NoopMetricsHandler,
 			})
 			require.NoError(t, err)
+			dispatchTask := ctx.Tasks[len(ctx.Tasks)-1].Payload.(*activitypb.ActivityDispatchTask)
+			require.Equal(t, activitypb.DISPATCH_REASON_IMMEDIATE, dispatchTask.GetDispatchReason())
 			if resetHeartbeat {
 				require.Nil(t, act.LastHeartbeat.Get(ctx).GetDetails())
 				require.Nil(t, act.LastHeartbeat.Get(ctx).GetRecordedTime())
@@ -1186,6 +1235,10 @@ func TestDeferredResetHeartbeat(t *testing.T) {
 					require.Equal(t, timestamppb.New(defaultTime), act.LastHeartbeat.Get(ctx).GetRecordedTime())
 				}
 				require.Len(t, ctx.Tasks, tc.expectedTaskCount)
+				if tc.expectedTaskCount > 0 {
+					dispatchTask := ctx.Tasks[tc.expectedTaskCount-1].Payload.(*activitypb.ActivityDispatchTask)
+					require.Equal(t, activitypb.DISPATCH_REASON_IMMEDIATE, dispatchTask.GetDispatchReason())
+				}
 			})
 		}
 	}
@@ -1246,38 +1299,53 @@ func TestTransitionResetFromPaused(t *testing.T) {
 			require.Len(t, ctx.Tasks, tc.expectedTaskCount)
 
 			// Last task is always the dispatch task
-			_, ok := ctx.Tasks[tc.expectedTaskCount-1].Payload.(*activitypb.ActivityDispatchTask)
+			dispatchTask, ok := ctx.Tasks[tc.expectedTaskCount-1].Payload.(*activitypb.ActivityDispatchTask)
 			require.True(t, ok, "expected ActivityDispatchTask as last task")
+			require.Equal(t, activitypb.DISPATCH_REASON_IMMEDIATE, dispatchTask.GetDispatchReason())
 		})
 	}
 }
 
 // TestTransitionResetClearsCurrentRetryInterval verifies that TransitionReset clears the retry
 // interval so a reset activity is not delayed by a previous backoff period.
-func TestTransitionResetClearsCurrentRetryInterval(t *testing.T) {
+func TestResetDuringRetryBackoff(t *testing.T) {
 	ctx := &chasm.MockMutableContext{}
 	ctx.HandleNow = func(chasm.Component) time.Time { return defaultTime }
 	attemptState := &activitypb.ActivityAttemptState{
 		Count:                2,
+		Stamp:                7,
 		CurrentRetryInterval: durationpb.New(30 * time.Second),
 	}
 
 	act := &Activity{
 		ActivityState: &activitypb.ActivityState{
-			ActivityType:           &commonpb.ActivityType{Name: "test-activity-type"},
-			RetryPolicy:            defaultRetryPolicy,
-			ScheduleToCloseTimeout: durationpb.New(defaultScheduleToCloseTimeout),
-			ScheduleToStartTimeout: durationpb.New(defaultScheduleToStartTimeout),
-			StartToCloseTimeout:    durationpb.New(defaultStartToCloseTimeout),
-			Status:                 activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
-			TaskQueue:              &taskqueuepb.TaskQueue{Name: "test-task-queue"},
+			ActivityType:            &commonpb.ActivityType{Name: "test-activity-type"},
+			RetryPolicy:             defaultRetryPolicy,
+			ScheduleToCloseTimeout:  durationpb.New(defaultScheduleToCloseTimeout),
+			ScheduleToStartTimeout:  durationpb.New(defaultScheduleToStartTimeout),
+			StartToCloseTimeout:     durationpb.New(defaultStartToCloseTimeout),
+			Status:                  activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
+			TaskQueue:               &taskqueuepb.TaskQueue{Name: "test-task-queue"},
+			FirstAttemptStartedTime: timestamppb.New(defaultTime.Add(-time.Minute)),
 		},
 		LastAttempt: chasm.NewDataField(ctx, attemptState),
 		Outcome:     chasm.NewDataField(ctx, &activitypb.ActivityOutcome{}),
 	}
+	handler := newActivityDispatchTaskHandler(activityDispatchTaskHandlerOptions{})
+	oldTask := &activitypb.ActivityDispatchTask{Stamp: 7, DispatchReason: activitypb.DISPATCH_REASON_RETRY}
 
 	err := TransitionReset.Apply(act, ctx, resetEvent{resetTime: defaultTime, metricsHandler: metrics.NoopMetricsHandler})
 	require.NoError(t, err)
-	require.Nil(t, attemptState.GetCurrentRetryInterval(), "TransitionReset must clear CurrentRetryInterval")
-	require.Equal(t, int32(1), attemptState.Count, "TransitionReset must reset Count to 1")
+	require.Nil(t, attemptState.GetCurrentRetryInterval())
+	require.Equal(t, int32(1), attemptState.GetCount())
+
+	dispatchTask := ctx.Tasks[len(ctx.Tasks)-1].Payload.(*activitypb.ActivityDispatchTask)
+	require.Equal(t, int32(8), dispatchTask.GetStamp())
+	require.Equal(t, activitypb.DISPATCH_REASON_IMMEDIATE, dispatchTask.GetDispatchReason())
+	valid, err := handler.Validate(ctx, act, chasm.TaskInvocation{}, oldTask)
+	require.NoError(t, err)
+	require.False(t, valid)
+	valid, err = handler.Validate(ctx, act, chasm.TaskInvocation{}, dispatchTask)
+	require.NoError(t, err)
+	require.True(t, valid)
 }

--- a/chasm/lib/activity/tasks.go
+++ b/chasm/lib/activity/tasks.go
@@ -64,18 +64,24 @@ func (h *activityDispatchTaskHandler) Execute(
 		return err
 	}
 
+	// Invoke the hook at the final dispatch boundary so it observes only validated
+	// active tasks and can wrap the Matching call.
 	if h.opts.DispatchTaskHook != nil {
 		return h.opts.DispatchTaskHook(
 			ctx,
 			activityRef.NamespaceID,
 			task,
 			func(ctx context.Context) error {
-				return h.sendToMatching(ctx, request)
+				_, err := h.opts.MatchingClient.AddActivityTask(ctx, request)
+
+				return err
 			},
 		)
 	}
 
-	return h.sendToMatching(ctx, request)
+	_, err = h.opts.MatchingClient.AddActivityTask(ctx, request)
+
+	return err
 }
 
 // Discard spills the task to matching instead of silently discarding it on standby clusters when the activity
@@ -91,7 +97,9 @@ func (h *activityDispatchTaskHandler) Discard(
 		return err
 	}
 
-	return h.sendToMatching(ctx, request)
+	_, err = h.opts.MatchingClient.AddActivityTask(ctx, request)
+
+	return err
 }
 
 func (h *activityDispatchTaskHandler) createMatchingRequest(
@@ -104,15 +112,6 @@ func (h *activityDispatchTaskHandler) createMatchingRequest(
 		(*Activity).createAddActivityTaskRequest,
 		activityRef.NamespaceID,
 	)
-}
-
-func (h *activityDispatchTaskHandler) sendToMatching(
-	ctx context.Context,
-	request *matchingservice.AddActivityTaskRequest,
-) error {
-	_, err := h.opts.MatchingClient.AddActivityTask(ctx, request)
-
-	return err
 }
 
 type scheduleToStartTimeoutTaskHandler struct {

--- a/chasm/lib/activity/tasks.go
+++ b/chasm/lib/activity/tasks.go
@@ -13,12 +13,16 @@ import (
 	"go.uber.org/fx"
 )
 
-// DispatchTaskHook wraps an activity dispatch on the active cluster after CHASM validation and before it is sent to Matching.
+// DispatchTaskHook wraps a validated activity dispatch on the active cluster before it is sent to
+// Matching. The hook must call dispatch exactly once. If it returns nil without calling dispatch,
+// task processing completes successfully without sending the Activity to Matching. Hook errors are
+// returned to task processing; returning an error after dispatch succeeds may cause the task to
+// retry and resend. Standby discard spills bypass the hook.
 type DispatchTaskHook func(
-	context.Context,
-	string,
-	*activitypb.ActivityDispatchTask,
-	func(context.Context) error,
+	ctx context.Context,
+	namespaceID string,
+	task *activitypb.ActivityDispatchTask,
+	dispatch func(context.Context) error,
 ) error
 
 type activityDispatchTaskHandlerOptions struct {
@@ -81,13 +85,6 @@ func (h *activityDispatchTaskHandler) Discard(
 	activityRef chasm.ComponentRef,
 	_ chasm.TaskAttributes,
 	_ *activitypb.ActivityDispatchTask,
-) error {
-	return h.dispatchActivity(ctx, activityRef)
-}
-
-func (h *activityDispatchTaskHandler) dispatchActivity(
-	ctx context.Context,
-	activityRef chasm.ComponentRef,
 ) error {
 	request, err := h.createMatchingRequest(ctx, activityRef)
 	if err != nil {

--- a/chasm/lib/activity/tasks.go
+++ b/chasm/lib/activity/tasks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/server/api/matchingservice/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/activity/gen/activitypb/v1"
 	"go.temporal.io/server/common/metrics"
@@ -12,10 +13,19 @@ import (
 	"go.uber.org/fx"
 )
 
+// DispatchTaskHook wraps an activity dispatch on the active cluster after CHASM validation and before it is sent to Matching.
+type DispatchTaskHook func(
+	context.Context,
+	string,
+	*activitypb.ActivityDispatchTask,
+	func(context.Context) error,
+) error
+
 type activityDispatchTaskHandlerOptions struct {
 	fx.In
 
-	MatchingClient resource.MatchingClient
+	MatchingClient   resource.MatchingClient
+	DispatchTaskHook DispatchTaskHook `optional:"true"`
 }
 
 type activityDispatchTaskHandler struct {
@@ -43,9 +53,25 @@ func (h *activityDispatchTaskHandler) Execute(
 	ctx context.Context,
 	activityRef chasm.ComponentRef,
 	_ chasm.TaskAttributes,
-	_ *activitypb.ActivityDispatchTask,
+	task *activitypb.ActivityDispatchTask,
 ) error {
-	return h.pushToMatching(ctx, activityRef)
+	request, err := h.createMatchingRequest(ctx, activityRef)
+	if err != nil {
+		return err
+	}
+
+	if h.opts.DispatchTaskHook != nil {
+		return h.opts.DispatchTaskHook(
+			ctx,
+			activityRef.NamespaceID,
+			task,
+			func(ctx context.Context) error {
+				return h.sendToMatching(ctx, request)
+			},
+		)
+	}
+
+	return h.sendToMatching(ctx, request)
 }
 
 // Discard spills the task to matching instead of silently discarding it on standby clusters when the activity
@@ -56,24 +82,38 @@ func (h *activityDispatchTaskHandler) Discard(
 	_ chasm.TaskAttributes,
 	_ *activitypb.ActivityDispatchTask,
 ) error {
-	return h.pushToMatching(ctx, activityRef)
+	return h.dispatchActivity(ctx, activityRef)
 }
 
-func (h *activityDispatchTaskHandler) pushToMatching(
+func (h *activityDispatchTaskHandler) dispatchActivity(
 	ctx context.Context,
 	activityRef chasm.ComponentRef,
 ) error {
-	request, err := chasm.ReadComponent(
+	request, err := h.createMatchingRequest(ctx, activityRef)
+	if err != nil {
+		return err
+	}
+
+	return h.sendToMatching(ctx, request)
+}
+
+func (h *activityDispatchTaskHandler) createMatchingRequest(
+	ctx context.Context,
+	activityRef chasm.ComponentRef,
+) (*matchingservice.AddActivityTaskRequest, error) {
+	return chasm.ReadComponent(
 		ctx,
 		activityRef,
 		(*Activity).createAddActivityTaskRequest,
 		activityRef.NamespaceID,
 	)
-	if err != nil {
-		return err
-	}
+}
 
-	_, err = h.opts.MatchingClient.AddActivityTask(ctx, request)
+func (h *activityDispatchTaskHandler) sendToMatching(
+	ctx context.Context,
+	request *matchingservice.AddActivityTaskRequest,
+) error {
+	_, err := h.opts.MatchingClient.AddActivityTask(ctx, request)
 
 	return err
 }

--- a/chasm/lib/activity/tasks_test.go
+++ b/chasm/lib/activity/tasks_test.go
@@ -2,6 +2,7 @@ package activity
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -76,6 +77,73 @@ func TestActivityDispatchTaskHook(t *testing.T) {
 		err := handler.Execute(chasm.NewEngineContext(context.Background(), engine), activityRef, chasm.TaskAttributes{}, task)
 		require.NoError(t, err)
 		require.Equal(t, 1, hookCalls)
+	})
+
+	t.Run("honors hook result", func(t *testing.T) {
+		hookErr := errors.New("hook failed")
+		testCases := []struct {
+			name    string
+			hookErr error
+		}{
+			{name: "suppresses dispatch"},
+			{name: "propagates error", hookErr: hookErr},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				controller := gomock.NewController(t)
+				engine := chasm.NewMockEngine(controller)
+				activityRef := chasm.NewComponentRef[*Activity](chasm.ExecutionKey{NamespaceID: "namespace-id"})
+				chasmCtx := &chasm.MockMutableContext{
+					MockContext: chasm.MockContext{
+						HandleRef: func(chasm.Component) ([]byte, error) {
+							return []byte("component-ref"), nil
+						},
+					},
+				}
+				activity := &Activity{
+					ActivityState: &activitypb.ActivityState{
+						TaskQueue: &taskqueuepb.TaskQueue{Name: "task-queue"},
+					},
+					LastAttempt: chasm.NewDataField(chasmCtx, &activitypb.ActivityAttemptState{Stamp: 7}),
+				}
+
+				engine.EXPECT().ReadComponent(gomock.Any(), activityRef, gomock.Any()).DoAndReturn(
+					func(
+						_ context.Context,
+						_ chasm.ComponentRef,
+						readFn func(chasm.Context, chasm.Component) error,
+						_ ...chasm.TransitionOption,
+					) error {
+						return readFn(chasmCtx, activity)
+					},
+				)
+
+				handler := newActivityDispatchTaskHandler(activityDispatchTaskHandlerOptions{
+					MatchingClient: matchingservicemock.NewMockMatchingServiceClient(controller),
+					DispatchTaskHook: func(
+						context.Context,
+						string,
+						*activitypb.ActivityDispatchTask,
+						func(context.Context) error,
+					) error {
+						return tc.hookErr
+					},
+				})
+
+				err := handler.Execute(
+					chasm.NewEngineContext(context.Background(), engine),
+					activityRef,
+					chasm.TaskAttributes{},
+					&activitypb.ActivityDispatchTask{},
+				)
+				if tc.hookErr == nil {
+					require.NoError(t, err)
+				} else {
+					require.ErrorIs(t, err, tc.hookErr)
+				}
+			})
+		}
 	})
 
 	t.Run("skipped when request construction fails", func(t *testing.T) {

--- a/chasm/lib/activity/tasks_test.go
+++ b/chasm/lib/activity/tasks_test.go
@@ -8,7 +8,9 @@ import (
 	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	"go.temporal.io/server/api/matchingservicemock/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/activity/gen/activitypb/v1"
 	"go.temporal.io/server/common"
@@ -16,9 +18,153 @@ import (
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/metrics/metricstest"
 	"go.temporal.io/server/common/retrypolicy"
+	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+func TestActivityDispatchTaskHook(t *testing.T) {
+	t.Run("wraps active dispatch", func(t *testing.T) {
+		controller := gomock.NewController(t)
+		engine := chasm.NewMockEngine(controller)
+		matchingClient := matchingservicemock.NewMockMatchingServiceClient(controller)
+		activityRef := chasm.NewComponentRef[*Activity](chasm.ExecutionKey{NamespaceID: "namespace-id"})
+		task := &activitypb.ActivityDispatchTask{DispatchReason: activitypb.DISPATCH_REASON_RETRY}
+		chasmCtx := &chasm.MockMutableContext{
+			MockContext: chasm.MockContext{
+				HandleRef: func(chasm.Component) ([]byte, error) {
+					return []byte("component-ref"), nil
+				},
+			},
+		}
+		activity := &Activity{
+			ActivityState: &activitypb.ActivityState{
+				TaskQueue: &taskqueuepb.TaskQueue{Name: "task-queue"},
+			},
+			LastAttempt: chasm.NewDataField(chasmCtx, &activitypb.ActivityAttemptState{Stamp: 7}),
+		}
+
+		engine.EXPECT().ReadComponent(gomock.Any(), activityRef, gomock.Any()).DoAndReturn(
+			func(
+				_ context.Context,
+				_ chasm.ComponentRef,
+				readFn func(chasm.Context, chasm.Component) error,
+				_ ...chasm.TransitionOption,
+			) error {
+				return readFn(chasmCtx, activity)
+			},
+		)
+		matchingClient.EXPECT().AddActivityTask(gomock.Any(), gomock.Any()).Return(nil, nil)
+
+		hookCalls := 0
+		handler := newActivityDispatchTaskHandler(activityDispatchTaskHandlerOptions{
+			MatchingClient: matchingClient,
+			DispatchTaskHook: func(
+				ctx context.Context,
+				namespaceID string,
+				actualTask *activitypb.ActivityDispatchTask,
+				dispatch func(context.Context) error,
+			) error {
+				hookCalls++
+				require.Equal(t, "namespace-id", namespaceID)
+				require.Same(t, task, actualTask)
+
+				return dispatch(ctx)
+			},
+		})
+
+		err := handler.Execute(chasm.NewEngineContext(context.Background(), engine), activityRef, chasm.TaskAttributes{}, task)
+		require.NoError(t, err)
+		require.Equal(t, 1, hookCalls)
+	})
+
+	t.Run("skipped when request construction fails", func(t *testing.T) {
+		controller := gomock.NewController(t)
+		engine := chasm.NewMockEngine(controller)
+		activityRef := chasm.NewComponentRef[*Activity](chasm.ExecutionKey{NamespaceID: "namespace-id"})
+		validationErr := serviceerror.NewNotFound("task is no longer valid")
+
+		engine.EXPECT().ReadComponent(gomock.Any(), activityRef, gomock.Any()).Return(validationErr)
+
+		hookCalls := 0
+		handler := newActivityDispatchTaskHandler(activityDispatchTaskHandlerOptions{
+			MatchingClient: matchingservicemock.NewMockMatchingServiceClient(controller),
+			DispatchTaskHook: func(
+				context.Context,
+				string,
+				*activitypb.ActivityDispatchTask,
+				func(context.Context) error,
+			) error {
+				hookCalls++
+				return nil
+			},
+		})
+
+		err := handler.Execute(
+			chasm.NewEngineContext(context.Background(), engine),
+			activityRef,
+			chasm.TaskAttributes{},
+			&activitypb.ActivityDispatchTask{},
+		)
+		require.ErrorIs(t, err, validationErr)
+		require.Zero(t, hookCalls)
+	})
+
+	t.Run("bypassed on standby discard", func(t *testing.T) {
+		controller := gomock.NewController(t)
+		engine := chasm.NewMockEngine(controller)
+		matchingClient := matchingservicemock.NewMockMatchingServiceClient(controller)
+		activityRef := chasm.NewComponentRef[*Activity](chasm.ExecutionKey{NamespaceID: "namespace-id"})
+		chasmCtx := &chasm.MockMutableContext{
+			MockContext: chasm.MockContext{
+				HandleRef: func(chasm.Component) ([]byte, error) {
+					return []byte("component-ref"), nil
+				},
+			},
+		}
+		activity := &Activity{
+			ActivityState: &activitypb.ActivityState{
+				TaskQueue: &taskqueuepb.TaskQueue{Name: "task-queue"},
+			},
+			LastAttempt: chasm.NewDataField(chasmCtx, &activitypb.ActivityAttemptState{Stamp: 7}),
+		}
+
+		engine.EXPECT().ReadComponent(gomock.Any(), activityRef, gomock.Any()).DoAndReturn(
+			func(
+				_ context.Context,
+				_ chasm.ComponentRef,
+				readFn func(chasm.Context, chasm.Component) error,
+				_ ...chasm.TransitionOption,
+			) error {
+				return readFn(chasmCtx, activity)
+			},
+		)
+		matchingClient.EXPECT().AddActivityTask(gomock.Any(), gomock.Any()).Return(nil, nil)
+
+		hookCalls := 0
+		handler := newActivityDispatchTaskHandler(activityDispatchTaskHandlerOptions{
+			MatchingClient: matchingClient,
+			DispatchTaskHook: func(
+				context.Context,
+				string,
+				*activitypb.ActivityDispatchTask,
+				func(context.Context) error,
+			) error {
+				hookCalls++
+				return nil
+			},
+		})
+
+		err := handler.Discard(
+			chasm.NewEngineContext(context.Background(), engine),
+			activityRef,
+			chasm.TaskAttributes{},
+			&activitypb.ActivityDispatchTask{DispatchReason: activitypb.DISPATCH_REASON_RETRY},
+		)
+		require.NoError(t, err)
+		require.Zero(t, hookCalls)
+	})
+}
 
 func TestScheduleToCloseTimeoutTaskValidateStamp(t *testing.T) {
 	handler := newScheduleToCloseTimeoutTaskHandler()


### PR DESCRIPTION
## What changed?
  - Corrected standalone activity dispatch-reason classification for resets and retries.
  - Added a dispatch hook that runs after CHASM validation and before sending the activity to Matching.
  - Added coverage for retry, reset, and pause/unpause transitions.

## Why?
Consumers need a reliable way to classify and intercept standalone activity dispatches. Reset attempt 1 was previously classified as a retry, and processing before CHASM validation could include stale tasks replaced by reset, update, pause, or unpause operations.
These changes ensure dispatch reasons reflect the actual attempt and allow integrations to act only on valid dispatches.

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
- An incorrectly implemented dispatch hook could block, drop, or duplicate an activity dispatch.
- Hook errors now propagate through task processing and may cause the dispatch task to retry.
- Consumers relying on the previous reset dispatch classification may observe reset attempt 1 changing from RETRY to IMMEDIATE.

  When no hook is configured, dispatch behavior remains unchanged.
