### PR TITLE
Capture panics in Visibility query converter

### DIFF
--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -763,7 +763,7 @@ func (s *VisibilityStore) convertQuery(
 		return nil, err
 	}
 
-	c := query.NewQueryConverter(&queryConverter{}, namespaceName, saTypeMap, saMapper).
+	c := query.NewQueryConverter(&queryConverter{}, namespaceName, saTypeMap, saMapper, s.logger).
 		WithChasmMapper(chasmMapper).
 		WithArchetypeID(archetypeID)
 

--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -763,8 +763,14 @@ func (s *VisibilityStore) convertQuery(
 		return nil, err
 	}
 
-	c := query.NewQueryConverter(&queryConverter{}, namespaceName, saTypeMap, saMapper, s.logger).
-		WithChasmMapper(chasmMapper).
+	c := query.NewQueryConverter(
+		&queryConverter{},
+		namespaceName,
+		saTypeMap,
+		saMapper,
+		s.metricsHandler,
+		s.logger,
+	).WithChasmMapper(chasmMapper).
 		WithArchetypeID(archetypeID)
 
 	queryParams, err := c.Convert(queryString)

--- a/common/persistence/visibility/store/query/converter.go
+++ b/common/persistence/visibility/store/query/converter.go
@@ -14,6 +14,7 @@ import (
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/searchattribute/sadefs"
@@ -65,7 +66,8 @@ type (
 
 		seenNamespaceDivision bool
 
-		logger log.Logger
+		metricsHandler metrics.Handler
+		logger         log.Logger
 	}
 
 	QueryConverterOptionFunc[ExprT any] func(*QueryConverter[ExprT])
@@ -137,6 +139,7 @@ func NewQueryConverter[ExprT any](
 	namespaceName namespace.Name,
 	saTypeMap searchattribute.NameTypeMap,
 	saMapper searchattribute.Mapper,
+	metricsHandler metrics.Handler,
 	logger log.Logger,
 ) *QueryConverter[ExprT] {
 	c := &QueryConverter[ExprT]{
@@ -149,7 +152,8 @@ func NewQueryConverter[ExprT any](
 
 		seenNamespaceDivision: false,
 
-		logger: logger,
+		metricsHandler: metricsHandler,
+		logger:         logger,
 	}
 	return c
 }
@@ -187,7 +191,7 @@ func (c *QueryConverter[ExprT]) Convert(
 ) (_ *QueryParams[ExprT], retError error) {
 	// Convert function may throw unexpected panics (eg: bugs).
 	// Capture them here to replace with an error.
-	defer log.CapturePanic(c.logger, &retError)
+	defer metrics.CapturePanic(c.logger, c.metricsHandler, &retError)
 
 	queryParams, err := c.convertWhereString(queryString)
 	if err != nil {

--- a/common/persistence/visibility/store/query/converter.go
+++ b/common/persistence/visibility/store/query/converter.go
@@ -13,6 +13,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/searchattribute/sadefs"
@@ -63,6 +64,8 @@ type (
 		archetypeID   chasm.ArchetypeID
 
 		seenNamespaceDivision bool
+
+		logger log.Logger
 	}
 
 	QueryConverterOptionFunc[ExprT any] func(*QueryConverter[ExprT])
@@ -134,6 +137,7 @@ func NewQueryConverter[ExprT any](
 	namespaceName namespace.Name,
 	saTypeMap searchattribute.NameTypeMap,
 	saMapper searchattribute.Mapper,
+	logger log.Logger,
 ) *QueryConverter[ExprT] {
 	c := &QueryConverter[ExprT]{
 		storeQC:       storeQC,
@@ -144,6 +148,8 @@ func NewQueryConverter[ExprT any](
 		saMapper:      saMapper,
 
 		seenNamespaceDivision: false,
+
+		logger: logger,
 	}
 	return c
 }
@@ -178,7 +184,11 @@ func (c *QueryConverter[ExprT]) SeenNamespaceDivision() bool {
 
 func (c *QueryConverter[ExprT]) Convert(
 	queryString string,
-) (*QueryParams[ExprT], error) {
+) (_ *QueryParams[ExprT], retError error) {
+	// Convert function may throw unexpected panics (eg: bugs).
+	// Capture them here to replace with an error.
+	defer log.CapturePanic(c.logger, &retError)
+
 	queryParams, err := c.convertWhereString(queryString)
 	if err != nil {
 		return nil, err

--- a/common/persistence/visibility/store/query/converter_test.go
+++ b/common/persistence/visibility/store/query/converter_test.go
@@ -11,6 +11,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/searchattribute/sadefs"
@@ -19,7 +20,6 @@ import (
 
 const (
 	testNamespaceName = namespace.Name("test-namespace")
-	testNamespaceID   = namespace.ID("test-namespace-id")
 )
 
 func TestWithSearchAttributeInterceptor(t *testing.T) {
@@ -29,31 +29,18 @@ func TestWithSearchAttributeInterceptor(t *testing.T) {
 	storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
 
 	// QueryConverter without explicit SearchAttributeInterceptor sets the nop interceptor.
-	c := NewQueryConverter(
-		storeQCMock,
-		testNamespaceName,
-		searchattribute.TestNameTypeMap(),
-		&searchattribute.TestMapper{},
-	)
+	c := newTestQueryConverter(storeQCMock)
 	r.Equal(nopSearchAttributeInterceptor, c.saInterceptor)
 
 	// Setting nil interceptor sets the nop interceptor.
-	c = NewQueryConverter(
-		storeQCMock,
-		testNamespaceName,
-		searchattribute.TestNameTypeMap(),
-		&searchattribute.TestMapper{},
-	).WithSearchAttributeInterceptor(nil)
+	c = newTestQueryConverter(storeQCMock).
+		WithSearchAttributeInterceptor(nil)
 	r.Equal(nopSearchAttributeInterceptor, c.saInterceptor)
 
 	// Setting non-nil interceptor
 	i := &testSearchAttributeInterceptor{}
-	c = NewQueryConverter(
-		storeQCMock,
-		testNamespaceName,
-		searchattribute.TestNameTypeMap(),
-		&searchattribute.TestMapper{},
-	).WithSearchAttributeInterceptor(i)
+	c = newTestQueryConverter(storeQCMock).
+		WithSearchAttributeInterceptor(i)
 	r.Equal(i, c.saInterceptor)
 }
 
@@ -247,12 +234,7 @@ func TestQueryConverter_Convert(t *testing.T) {
 			r := require.New(t)
 			ctrl := gomock.NewController(t)
 			storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-			queryConverter := NewQueryConverter(
-				storeQCMock,
-				testNamespaceName,
-				searchattribute.TestNameTypeMap(),
-				&searchattribute.TestMapper{},
-			)
+			queryConverter := newTestQueryConverter(storeQCMock)
 
 			if tc.setupMocks != nil {
 				tc.setupMocks(storeQCMock)
@@ -381,12 +363,7 @@ func TestQueryConverter_ConvertWhereString(t *testing.T) {
 			r := require.New(t)
 			ctrl := gomock.NewController(t)
 			storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-			queryConverter := NewQueryConverter(
-				storeQCMock,
-				testNamespaceName,
-				searchattribute.TestNameTypeMap(),
-				&searchattribute.TestMapper{},
-			)
+			queryConverter := newTestQueryConverter(storeQCMock)
 
 			if tc.setupMocks != nil {
 				tc.setupMocks(storeQCMock)
@@ -554,12 +531,7 @@ func TestQueryConverter_ConvertSelectStmt(t *testing.T) {
 			r := require.New(t)
 			ctrl := gomock.NewController(t)
 			storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-			queryConverter := NewQueryConverter(
-				storeQCMock,
-				testNamespaceName,
-				searchattribute.TestNameTypeMap(),
-				&searchattribute.TestMapper{},
-			)
+			queryConverter := newTestQueryConverter(storeQCMock)
 
 			if tc.setupMocks != nil {
 				tc.setupMocks(storeQCMock)
@@ -824,12 +796,7 @@ func TestQueryConverter_ConvertWhereExpr(t *testing.T) {
 			r := require.New(t)
 			ctrl := gomock.NewController(t)
 			storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-			queryConverter := NewQueryConverter(
-				storeQCMock,
-				testNamespaceName,
-				searchattribute.TestNameTypeMap(),
-				&searchattribute.TestMapper{},
-			)
+			queryConverter := newTestQueryConverter(storeQCMock)
 
 			if tc.setupMocks != nil {
 				tc.setupMocks(storeQCMock)
@@ -914,12 +881,7 @@ func TestQueryConverter_ConvertParenExpr(t *testing.T) {
 			r := require.New(t)
 			ctrl := gomock.NewController(t)
 			storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-			queryConverter := NewQueryConverter(
-				storeQCMock,
-				testNamespaceName,
-				searchattribute.TestNameTypeMap(),
-				&searchattribute.TestMapper{},
-			)
+			queryConverter := newTestQueryConverter(storeQCMock)
 
 			if tc.setupMocks != nil {
 				tc.setupMocks(storeQCMock)
@@ -994,12 +956,7 @@ func TestQueryConverter_ConvertNotExpr(t *testing.T) {
 			r := require.New(t)
 			ctrl := gomock.NewController(t)
 			storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-			queryConverter := NewQueryConverter(
-				storeQCMock,
-				testNamespaceName,
-				searchattribute.TestNameTypeMap(),
-				&searchattribute.TestMapper{},
-			)
+			queryConverter := newTestQueryConverter(storeQCMock)
 
 			if tc.setupMocks != nil {
 				tc.setupMocks(storeQCMock)
@@ -1103,12 +1060,7 @@ func TestQueryConverter_ConvertAndExpr(t *testing.T) {
 			r := require.New(t)
 			ctrl := gomock.NewController(t)
 			storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-			queryConverter := NewQueryConverter(
-				storeQCMock,
-				testNamespaceName,
-				searchattribute.TestNameTypeMap(),
-				&searchattribute.TestMapper{},
-			)
+			queryConverter := newTestQueryConverter(storeQCMock)
 
 			if tc.setupMocks != nil {
 				tc.setupMocks(storeQCMock)
@@ -1212,12 +1164,7 @@ func TestQueryConverter_ConvertOrExpr(t *testing.T) {
 			r := require.New(t)
 			ctrl := gomock.NewController(t)
 			storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-			queryConverter := NewQueryConverter(
-				storeQCMock,
-				testNamespaceName,
-				searchattribute.TestNameTypeMap(),
-				&searchattribute.TestMapper{},
-			)
+			queryConverter := newTestQueryConverter(storeQCMock)
 
 			if tc.setupMocks != nil {
 				tc.setupMocks(storeQCMock)
@@ -1334,12 +1281,7 @@ func TestQueryConverter_ConvertComparisonExprStoreQueryConverterCalled(t *testin
 			r := require.New(t)
 			ctrl := gomock.NewController(t)
 			storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-			queryConverter := NewQueryConverter(
-				storeQCMock,
-				testNamespaceName,
-				searchattribute.TestNameTypeMap(),
-				&searchattribute.TestMapper{},
-			)
+			queryConverter := newTestQueryConverter(storeQCMock)
 			storeQCMock.EXPECT().GetDatetimeFormat().Return(time.RFC3339Nano).AnyTimes()
 
 			input := &sqlparser.ComparisonExpr{
@@ -1427,12 +1369,7 @@ func TestQueryConverter_ConvertComparisonExprFail(t *testing.T) {
 			r := require.New(t)
 			ctrl := gomock.NewController(t)
 			storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-			queryConverter := NewQueryConverter(
-				storeQCMock,
-				testNamespaceName,
-				searchattribute.TestNameTypeMap(),
-				&searchattribute.TestMapper{},
-			)
+			queryConverter := newTestQueryConverter(storeQCMock)
 
 			inExpr := parseWhereString(tc.in).(*sqlparser.ComparisonExpr)
 			_, err := queryConverter.convertComparisonExpr(inExpr)
@@ -1522,12 +1459,7 @@ func TestQueryConverter_ConvertRangeCond(t *testing.T) {
 			r := require.New(t)
 			ctrl := gomock.NewController(t)
 			storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-			queryConverter := NewQueryConverter(
-				storeQCMock,
-				testNamespaceName,
-				searchattribute.TestNameTypeMap(),
-				&searchattribute.TestMapper{},
-			)
+			queryConverter := newTestQueryConverter(storeQCMock)
 
 			if tc.setupMocks != nil {
 				tc.setupMocks(storeQCMock)
@@ -1659,12 +1591,7 @@ func TestQueryConverter_ConvertIsExpr(t *testing.T) {
 			r := require.New(t)
 			ctrl := gomock.NewController(t)
 			storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-			queryConverter := NewQueryConverter(
-				storeQCMock,
-				testNamespaceName,
-				searchattribute.TestNameTypeMap(),
-				&searchattribute.TestMapper{},
-			)
+			queryConverter := newTestQueryConverter(storeQCMock)
 
 			if tc.setupMocks != nil {
 				tc.setupMocks(storeQCMock)
@@ -1764,12 +1691,7 @@ func TestQueryConverter_ConvertColName(t *testing.T) {
 			r := require.New(t)
 			ctrl := gomock.NewController(t)
 			storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-			queryConverter := NewQueryConverter(
-				storeQCMock,
-				testNamespaceName,
-				searchattribute.TestNameTypeMap(),
-				&searchattribute.TestMapper{},
-			)
+			queryConverter := newTestQueryConverter(storeQCMock)
 
 			out, err := queryConverter.convertColName(tc.in)
 			if tc.err != "" {
@@ -1927,6 +1849,7 @@ func TestQueryConverter_ResolveSearchAttributeAlias(t *testing.T) {
 				&searchattribute.TestMapper{
 					WithCustomScheduleID: tc.withCustomScheduleID,
 				},
+				log.NewNoopLogger(),
 			)
 
 			if tc.useNoopMapper {
@@ -2065,12 +1988,7 @@ func TestQueryConverter_ParseValueExpr(t *testing.T) {
 			r := require.New(t)
 			ctrl := gomock.NewController(t)
 			storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-			queryConverter := NewQueryConverter(
-				storeQCMock,
-				testNamespaceName,
-				searchattribute.TestNameTypeMap(),
-				&searchattribute.TestMapper{},
-			)
+			queryConverter := newTestQueryConverter(storeQCMock)
 
 			out, err := queryConverter.parseValueExpr(tc.expr, tc.alias, tc.field, tc.saType)
 			if tc.err != "" {
@@ -2188,12 +2106,7 @@ func TestQueryConverter_ParseSQLVal(t *testing.T) {
 			r := require.New(t)
 			ctrl := gomock.NewController(t)
 			storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-			queryConverter := NewQueryConverter(
-				storeQCMock,
-				testNamespaceName,
-				searchattribute.TestNameTypeMap(),
-				&searchattribute.TestMapper{},
-			)
+			queryConverter := newTestQueryConverter(storeQCMock)
 			storeQCMock.EXPECT().GetDatetimeFormat().Return(time.RFC3339Nano).AnyTimes()
 
 			out, err := queryConverter.parseSQLVal(tc.expr, tc.saName, tc.saFieldName, tc.saType)
@@ -2405,12 +2318,7 @@ func TestQueryConverter_ValidateValueType(t *testing.T) {
 			r := require.New(t)
 			ctrl := gomock.NewController(t)
 			storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-			queryConverter := NewQueryConverter(
-				storeQCMock,
-				testNamespaceName,
-				searchattribute.TestNameTypeMap(),
-				&searchattribute.TestMapper{},
-			)
+			queryConverter := newTestQueryConverter(storeQCMock)
 			storeQCMock.EXPECT().GetDatetimeFormat().Return(time.RFC3339Nano).AnyTimes()
 
 			out, err := queryConverter.validateValueType(tc.saName, tc.saType, tc.value)
@@ -2566,12 +2474,7 @@ func TestQueryConverter_WithChasmMapper(t *testing.T) {
 		},
 	)
 
-	c := NewQueryConverter(
-		storeQCMock,
-		testNamespaceName,
-		searchattribute.TestNameTypeMap(),
-		&searchattribute.TestMapper{},
-	)
+	c := newTestQueryConverter(storeQCMock)
 	r.Nil(c.chasmMapper)
 
 	c = c.WithChasmMapper(chasmMapper)
@@ -2587,12 +2490,7 @@ func TestQueryConverter_WithArchetypeID(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
 
-	c := NewQueryConverter(
-		storeQCMock,
-		testNamespaceName,
-		searchattribute.TestNameTypeMap(),
-		&searchattribute.TestMapper{},
-	)
+	c := newTestQueryConverter(storeQCMock)
 	r.Equal(chasm.UnspecifiedArchetypeID, c.archetypeID)
 
 	c = c.WithArchetypeID(123)
@@ -2610,12 +2508,8 @@ func TestQueryConverter_TemporalSystemExecutionStatus(t *testing.T) {
 	// Test that TemporalSystemExecutionStatus maps to ExecutionStatus only for SchedulerArchetypeID
 	t.Run("with SchedulerArchetypeID", func(t *testing.T) {
 		r := require.New(t)
-		queryConverter := NewQueryConverter(
-			storeQCMock,
-			testNamespaceName,
-			searchattribute.TestNameTypeMap(),
-			&searchattribute.TestMapper{},
-		).WithArchetypeID(chasm.SchedulerArchetypeID)
+		queryConverter := newTestQueryConverter(storeQCMock).
+			WithArchetypeID(chasm.SchedulerArchetypeID)
 
 		in := &sqlparser.ColName{
 			Name: sqlparser.NewColIdent("TemporalSystemExecutionStatus"),
@@ -2631,12 +2525,7 @@ func TestQueryConverter_TemporalSystemExecutionStatus(t *testing.T) {
 
 	t.Run("without SchedulerArchetypeID", func(t *testing.T) {
 		r := require.New(t)
-		queryConverter := NewQueryConverter(
-			storeQCMock,
-			testNamespaceName,
-			searchattribute.TestNameTypeMap(),
-			&searchattribute.TestMapper{},
-		)
+		queryConverter := newTestQueryConverter(storeQCMock)
 
 		in := &sqlparser.ColName{
 			Name: sqlparser.NewColIdent("TemporalSystemExecutionStatus"),
@@ -2663,12 +2552,8 @@ func TestQueryConverter_ResolveSearchAttributeAlias_WithChasmMapper(t *testing.T
 		},
 	)
 
-	queryConverter := NewQueryConverter(
-		storeQCMock,
-		testNamespaceName,
-		searchattribute.TestNameTypeMap(),
-		&searchattribute.TestMapper{},
-	).WithChasmMapper(chasmMapper)
+	queryConverter := newTestQueryConverter(storeQCMock).
+		WithChasmMapper(chasmMapper)
 
 	testCases := []struct {
 		name                    string
@@ -2723,4 +2608,43 @@ func TestQueryConverter_ResolveSearchAttributeAlias_WithChasmMapper(t *testing.T
 			}
 		})
 	}
+}
+
+func TestQueryConverter_CapturePanic(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+	ctrl := gomock.NewController(t)
+	logger := log.NewMockLogger(ctrl)
+	storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
+	queryConverter := newTestQueryConverter(storeQCMock)
+	queryConverter.logger = logger
+
+	keywordCol := NewSAColumn(
+		"AliasForKeyword01",
+		"Keyword01",
+		enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+	)
+
+	logger.EXPECT().Error("Panic is captured", gomock.Any(), gomock.Any()).Return()
+	storeQCMock.EXPECT().ConvertKeywordComparisonExpr(sqlparser.EqualStr, keywordCol, "foo").
+		DoAndReturn(
+			func(operator string, col *SAColumn, value any) (sqlparser.Expr, error) {
+				panic("random")
+			},
+		)
+	out, err := queryConverter.Convert("AliasForKeyword01 = 'foo'")
+	r.ErrorContains(err, "panic: random")
+	r.Nil(out)
+}
+
+func newTestQueryConverter(
+	storeQC StoreQueryConverter[sqlparser.Expr],
+) *QueryConverter[sqlparser.Expr] {
+	return NewQueryConverter(
+		storeQC,
+		testNamespaceName,
+		searchattribute.TestNameTypeMap(),
+		&searchattribute.TestMapper{},
+		log.NewNoopLogger(),
+	)
 }

--- a/common/persistence/visibility/store/query/converter_test.go
+++ b/common/persistence/visibility/store/query/converter_test.go
@@ -12,6 +12,7 @@ import (
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/searchattribute/sadefs"
@@ -1849,6 +1850,7 @@ func TestQueryConverter_ResolveSearchAttributeAlias(t *testing.T) {
 				&searchattribute.TestMapper{
 					WithCustomScheduleID: tc.withCustomScheduleID,
 				},
+				metrics.NewMockHandler(ctrl),
 				log.NewNoopLogger(),
 			)
 
@@ -2614,10 +2616,12 @@ func TestQueryConverter_CapturePanic(t *testing.T) {
 	t.Parallel()
 	r := require.New(t)
 	ctrl := gomock.NewController(t)
-	logger := log.NewMockLogger(ctrl)
+	metricsHandlerMock := metrics.NewMockHandler(ctrl)
+	loggerMock := log.NewMockLogger(ctrl)
 	storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
 	queryConverter := newTestQueryConverter(storeQCMock)
-	queryConverter.logger = logger
+	queryConverter.metricsHandler = metricsHandlerMock
+	queryConverter.logger = loggerMock
 
 	keywordCol := NewSAColumn(
 		"AliasForKeyword01",
@@ -2625,7 +2629,10 @@ func TestQueryConverter_CapturePanic(t *testing.T) {
 		enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 	)
 
-	logger.EXPECT().Error("Panic is captured", gomock.Any(), gomock.Any()).Return()
+	counterMock := metrics.NewMockCounterIface(ctrl)
+	counterMock.EXPECT().Record(int64(1))
+	metricsHandlerMock.EXPECT().Counter(metrics.ServicePanic.Name()).Return(counterMock)
+	loggerMock.EXPECT().Error("Panic is captured", gomock.Any(), gomock.Any()).Return()
 	storeQCMock.EXPECT().ConvertKeywordComparisonExpr(sqlparser.EqualStr, keywordCol, "foo").
 		DoAndReturn(
 			func(operator string, col *SAColumn, value any) (sqlparser.Expr, error) {
@@ -2645,6 +2652,7 @@ func newTestQueryConverter(
 		testNamespaceName,
 		searchattribute.TestNameTypeMap(),
 		&searchattribute.TestMapper{},
+		nil, // metricsHandler
 		log.NewNoopLogger(),
 	)
 }

--- a/common/persistence/visibility/store/query/interceptors_test.go
+++ b/common/persistence/visibility/store/query/interceptors_test.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/searchattribute"
+	"go.uber.org/mock/gomock"
 )
 
 type testSearchAttributeInterceptor struct {
@@ -25,12 +27,14 @@ func (t *testSearchAttributeInterceptor) Intercept(col *SAColumn) error {
 
 func TestSearchAttributeInterceptor(t *testing.T) {
 	t.Parallel()
+	ctrl := gomock.NewController(t)
 
 	interceptor := &testSearchAttributeInterceptor{}
 	c := NewNilQueryConverter(
 		"",
 		searchattribute.TestNameTypeMap(),
 		&searchattribute.TestMapper{},
+		metrics.NewMockHandler(ctrl),
 		log.NewNoopLogger(),
 	).WithSearchAttributeInterceptor(interceptor)
 

--- a/common/persistence/visibility/store/query/interceptors_test.go
+++ b/common/persistence/visibility/store/query/interceptors_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/searchattribute"
 )
 
@@ -30,6 +31,7 @@ func TestSearchAttributeInterceptor(t *testing.T) {
 		"",
 		searchattribute.TestNameTypeMap(),
 		&searchattribute.TestMapper{},
+		log.NewNoopLogger(),
 	).WithSearchAttributeInterceptor(interceptor)
 
 	_, err := c.Convert("ExecutionStatus='Running' order by StartTime")

--- a/common/persistence/visibility/store/query/nil_converter.go
+++ b/common/persistence/visibility/store/query/nil_converter.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/searchattribute"
 )
@@ -84,6 +85,7 @@ func NewNilQueryConverter(
 	namespaceName namespace.Name,
 	saTypeMap searchattribute.NameTypeMap,
 	saMapper searchattribute.Mapper,
+	metricsHandler metrics.Handler,
 	logger log.Logger,
 ) NilQueryConverter {
 	return NewQueryConverter(
@@ -91,6 +93,7 @@ func NewNilQueryConverter(
 		namespaceName,
 		saTypeMap,
 		saMapper,
+		metricsHandler,
 		logger,
 	)
 }

--- a/common/persistence/visibility/store/query/nil_converter.go
+++ b/common/persistence/visibility/store/query/nil_converter.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/searchattribute"
 )
@@ -83,11 +84,13 @@ func NewNilQueryConverter(
 	namespaceName namespace.Name,
 	saTypeMap searchattribute.NameTypeMap,
 	saMapper searchattribute.Mapper,
+	logger log.Logger,
 ) NilQueryConverter {
 	return NewQueryConverter(
 		&nilStoreQueryConverter{},
 		namespaceName,
 		saTypeMap,
 		saMapper,
+		logger,
 	)
 }

--- a/common/persistence/visibility/store/query/nil_converter_test.go
+++ b/common/persistence/visibility/store/query/nil_converter_test.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/searchattribute"
+	"go.uber.org/mock/gomock"
 )
 
 func TestNilStoreQueryConverter_GetDatetimeFormat(t *testing.T) {
@@ -96,6 +98,13 @@ func TestNilStoreQueryConverter_ConvertIsExpr(t *testing.T) {
 
 func TestNewNilQueryConverter(t *testing.T) {
 	t.Parallel()
-	c := NewNilQueryConverter("", searchattribute.TestNameTypeMap(), nil, log.NewNoopLogger())
+	ctrl := gomock.NewController(t)
+	c := NewNilQueryConverter(
+		"",
+		searchattribute.TestNameTypeMap(),
+		nil, // saMapper
+		metrics.NewMockHandler(ctrl),
+		log.NewNoopLogger(),
+	)
 	require.Equal(t, &nilStoreQueryConverter{}, c.storeQC)
 }

--- a/common/persistence/visibility/store/query/nil_converter_test.go
+++ b/common/persistence/visibility/store/query/nil_converter_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/searchattribute"
 )
 
@@ -95,6 +96,6 @@ func TestNilStoreQueryConverter_ConvertIsExpr(t *testing.T) {
 
 func TestNewNilQueryConverter(t *testing.T) {
 	t.Parallel()
-	c := NewNilQueryConverter("", searchattribute.TestNameTypeMap(), nil)
+	c := NewNilQueryConverter("", searchattribute.TestNameTypeMap(), nil, log.NewNoopLogger())
 	require.Equal(t, &nilStoreQueryConverter{}, c.storeQC)
 }

--- a/common/persistence/visibility/store/sql/visibility_store.go
+++ b/common/persistence/visibility/store/sql/visibility_store.go
@@ -275,6 +275,7 @@ func (s *VisibilityStore) countChasmExecutions(
 		saMapper,
 		mapper,
 		request.ArchetypeId,
+		s.metricsHandler,
 		s.logger,
 	)
 	if err != nil {
@@ -386,6 +387,7 @@ func (s *VisibilityStore) listExecutionsInternal(
 		saMapper,
 		request.ChasmMapper,
 		request.ArchetypeID,
+		s.metricsHandler,
 		s.logger,
 	)
 	if err != nil {
@@ -619,6 +621,7 @@ func (s *VisibilityStore) countWorkflowExecutions(
 		saMapper,
 		nil,
 		chasm.UnspecifiedArchetypeID,
+		s.metricsHandler,
 		s.logger,
 	)
 	if err != nil {
@@ -932,9 +935,10 @@ func buildQueryParams(
 	saMapper searchattribute.Mapper,
 	chasmMapper *chasm.VisibilitySearchAttributesMapper,
 	archetypeID chasm.ArchetypeID,
+	metricsHandler metrics.Handler,
 	logger log.Logger,
 ) (*query.QueryParams[sqlparser.Expr], error) {
-	c := query.NewQueryConverter(sqlQC, namespaceName, saTypeMap, saMapper, logger).
+	c := query.NewQueryConverter(sqlQC, namespaceName, saTypeMap, saMapper, metricsHandler, logger).
 		WithChasmMapper(chasmMapper).
 		WithArchetypeID(archetypeID)
 

--- a/common/persistence/visibility/store/sql/visibility_store.go
+++ b/common/persistence/visibility/store/sql/visibility_store.go
@@ -275,6 +275,7 @@ func (s *VisibilityStore) countChasmExecutions(
 		saMapper,
 		mapper,
 		request.ArchetypeId,
+		s.logger,
 	)
 	if err != nil {
 		if converterErr, ok := errors.AsType[*query.ConverterError](err); ok {
@@ -385,6 +386,7 @@ func (s *VisibilityStore) listExecutionsInternal(
 		saMapper,
 		request.ChasmMapper,
 		request.ArchetypeID,
+		s.logger,
 	)
 	if err != nil {
 		// Convert ConverterError to InvalidArgument and pass through all other errors (which should be
@@ -617,6 +619,7 @@ func (s *VisibilityStore) countWorkflowExecutions(
 		saMapper,
 		nil,
 		chasm.UnspecifiedArchetypeID,
+		s.logger,
 	)
 	if err != nil {
 		// Convert ConverterError to InvalidArgument and pass through all other errors (which should be
@@ -929,8 +932,9 @@ func buildQueryParams(
 	saMapper searchattribute.Mapper,
 	chasmMapper *chasm.VisibilitySearchAttributesMapper,
 	archetypeID chasm.ArchetypeID,
+	logger log.Logger,
 ) (*query.QueryParams[sqlparser.Expr], error) {
-	c := query.NewQueryConverter(sqlQC, namespaceName, saTypeMap, saMapper).
+	c := query.NewQueryConverter(sqlQC, namespaceName, saTypeMap, saMapper, logger).
 		WithChasmMapper(chasmMapper).
 		WithArchetypeID(archetypeID)
 

--- a/common/persistence/visibility/store/sql/visibility_store_test.go
+++ b/common/persistence/visibility/store/sql/visibility_store_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/temporalio/sqlparser"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin/mysql"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin/postgresql"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin/sqlite"
@@ -77,6 +78,7 @@ func TestBuildQueryParams(t *testing.T) {
 					&searchattribute.TestMapper{},
 					nil,
 					chasm.UnspecifiedArchetypeID,
+					log.NewNoopLogger(),
 				)
 				if tc.err != "" {
 					r.Error(err)

--- a/common/persistence/visibility/store/sql/visibility_store_test.go
+++ b/common/persistence/visibility/store/sql/visibility_store_test.go
@@ -8,10 +8,12 @@ import (
 	"github.com/temporalio/sqlparser"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin/mysql"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin/postgresql"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin/sqlite"
 	"go.temporal.io/server/common/searchattribute"
+	"go.uber.org/mock/gomock"
 )
 
 var pluginNames = []string{
@@ -66,6 +68,7 @@ func TestBuildQueryParams(t *testing.T) {
 			tcName := fmt.Sprintf("%s/%s", pluginName, tc.name)
 			t.Run(tcName, func(t *testing.T) {
 				r := require.New(t)
+				ctrl := gomock.NewController(t)
 				sqlQC, err := NewSQLQueryConverter(pluginName)
 				r.NoError(err)
 
@@ -76,8 +79,9 @@ func TestBuildQueryParams(t *testing.T) {
 					sqlQC,
 					searchattribute.TestNameTypeMap(),
 					&searchattribute.TestMapper{},
-					nil,
+					nil, // chasmMapper
 					chasm.UnspecifiedArchetypeID,
+					metrics.NewMockHandler(ctrl),
 					log.NewNoopLogger(),
 				)
 				if tc.err != "" {

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -5229,6 +5229,7 @@ func (wh *WorkflowHandler) prepareSchedulerQuery(
 			chasmMapper,
 			wh.config.VisibilityEnableUnifiedQueryConverter,
 			query,
+			wh.logger,
 		); err != nil {
 			return "", err
 		}

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -5176,17 +5176,23 @@ func (wh *WorkflowHandler) ListSchedules(
 		return nil, errListNotAllowed
 	}
 
+	metricsHandler := wh.metricsScope(ctx).WithTags(metrics.HeaderCallsiteTag("ListSchedules"))
 	chasmEnabled := wh.chasmSchedulerEnabled(ctx, namespaceName.String())
-	query, err := wh.prepareSchedulerQuery(chasmEnabled, request.Query, namespaceName)
+	schedulerQuery, err := wh.prepareSchedulerQuery(
+		chasmEnabled,
+		request.Query,
+		namespaceName,
+		metricsHandler,
+	)
 	if err != nil {
 		return nil, err
 	}
 
 	if chasmEnabled {
 		// CHASM ListSchedules will include schedules created in the V1/workflow stack.
-		return wh.listSchedulesChasm(ctx, request, namespaceName, namespaceID, query)
+		return wh.listSchedulesChasm(ctx, request, namespaceName, namespaceID, schedulerQuery)
 	}
-	return wh.listSchedulesWorkflow(ctx, request, namespaceName, namespaceID, query)
+	return wh.listSchedulesWorkflow(ctx, request, namespaceName, namespaceID, schedulerQuery)
 }
 
 // prepareSchedulerQuery validates a scheduler RPC's query argument, and wraps it
@@ -5195,6 +5201,7 @@ func (wh *WorkflowHandler) prepareSchedulerQuery(
 	chasmEnabled bool,
 	query string,
 	namespaceName namespace.Name,
+	metricsHandler metrics.Handler,
 ) (string, error) {
 	// Use different base queries based on code path:
 	// - CHASM path uses TemporalSystemExecutionStatus (translated via archetype ID)
@@ -5229,6 +5236,7 @@ func (wh *WorkflowHandler) prepareSchedulerQuery(
 			chasmMapper,
 			wh.config.VisibilityEnableUnifiedQueryConverter,
 			query,
+			metricsHandler,
 			wh.logger,
 		); err != nil {
 			return "", err
@@ -5366,17 +5374,23 @@ func (wh *WorkflowHandler) CountSchedules(
 		return nil, errListNotAllowed
 	}
 
+	metricsHandler := wh.metricsScope(ctx).WithTags(metrics.HeaderCallsiteTag("CountSchedules"))
 	chasmEnabled := wh.chasmSchedulerEnabled(ctx, namespaceName.String())
-	query, err := wh.prepareSchedulerQuery(chasmEnabled, request.Query, namespaceName)
+	schedulerQuery, err := wh.prepareSchedulerQuery(
+		chasmEnabled,
+		request.Query,
+		namespaceName,
+		metricsHandler,
+	)
 	if err != nil {
 		return nil, err
 	}
 
 	// Route to CHASM or V1 based on config (same pattern as ListSchedules)
 	if chasmEnabled {
-		return wh.countSchedulesChasm(ctx, namespaceID, namespaceName, query)
+		return wh.countSchedulesChasm(ctx, namespaceID, namespaceName, schedulerQuery)
 	}
-	return wh.countSchedulesWorkflow(ctx, namespaceID, namespaceName, query)
+	return wh.countSchedulesWorkflow(ctx, namespaceID, namespaceName, schedulerQuery)
 }
 
 // countSchedulesChasm counts schedules using CHASM APIs

--- a/service/worker/scheduler/query.go
+++ b/service/worker/scheduler/query.go
@@ -7,6 +7,7 @@ import (
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence/visibility/store/elasticsearch"
 	"go.temporal.io/server/common/persistence/visibility/store/query"
@@ -72,6 +73,7 @@ func ValidateVisibilityQuery(
 	chasmMapper *chasm.VisibilitySearchAttributesMapper,
 	enableUnifiedQueryConverter dynamicconfig.BoolPropertyFn,
 	queryString string,
+	logger log.Logger,
 ) error {
 	var fields []string
 	var err error
@@ -82,6 +84,7 @@ func ValidateVisibilityQuery(
 			saMapperProvider,
 			chasmMapper,
 			queryString,
+			logger,
 		)
 	} else {
 		fields, err = getQueryFieldsLegacy(namespaceName, saNameType, saMapperProvider, chasmMapper, queryString)
@@ -105,6 +108,7 @@ func getQueryFields(
 	saMapperProvider searchattribute.MapperProvider,
 	chasmMapper *chasm.VisibilitySearchAttributesMapper,
 	queryString string,
+	logger log.Logger,
 ) ([]string, error) {
 	saMapper, err := saMapperProvider.GetMapper(namespaceName)
 	if err != nil {
@@ -115,6 +119,7 @@ func getQueryFields(
 		namespaceName,
 		saNameType,
 		saMapper,
+		logger,
 	).WithChasmMapper(chasmMapper).WithSearchAttributeInterceptor(saInterceptor)
 	_, err = queryConverter.Convert(queryString)
 	if err != nil {

--- a/service/worker/scheduler/query.go
+++ b/service/worker/scheduler/query.go
@@ -8,6 +8,7 @@ import (
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence/visibility/store/elasticsearch"
 	"go.temporal.io/server/common/persistence/visibility/store/query"
@@ -73,6 +74,7 @@ func ValidateVisibilityQuery(
 	chasmMapper *chasm.VisibilitySearchAttributesMapper,
 	enableUnifiedQueryConverter dynamicconfig.BoolPropertyFn,
 	queryString string,
+	metricsHandler metrics.Handler,
 	logger log.Logger,
 ) error {
 	var fields []string
@@ -84,6 +86,7 @@ func ValidateVisibilityQuery(
 			saMapperProvider,
 			chasmMapper,
 			queryString,
+			metricsHandler,
 			logger,
 		)
 	} else {
@@ -108,6 +111,7 @@ func getQueryFields(
 	saMapperProvider searchattribute.MapperProvider,
 	chasmMapper *chasm.VisibilitySearchAttributesMapper,
 	queryString string,
+	metricsHandler metrics.Handler,
 	logger log.Logger,
 ) ([]string, error) {
 	saMapper, err := saMapperProvider.GetMapper(namespaceName)
@@ -119,6 +123,7 @@ func getQueryFields(
 		namespaceName,
 		saNameType,
 		saMapper,
+		metricsHandler,
 		logger,
 	).WithChasmMapper(chasmMapper).WithSearchAttributeInterceptor(saInterceptor)
 	_, err = queryConverter.Convert(queryString)

--- a/service/worker/scheduler/query_test.go
+++ b/service/worker/scheduler/query_test.go
@@ -8,10 +8,12 @@ import (
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence/visibility/store/query"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/searchattribute/sadefs"
+	"go.uber.org/mock/gomock"
 )
 
 const (
@@ -257,12 +259,14 @@ func TestGetQueryFields(t *testing.T) {
 			tc.name,
 			func(t *testing.T) {
 				s := require.New(t)
+				ctrl := gomock.NewController(t)
 				fields, err := getQueryFields(
 					testNamespace,
 					searchattribute.TestNameTypeMap(),
 					searchattribute.NewTestMapperProvider(&searchattribute.TestMapper{}),
-					nil,
+					nil, // chasmMapper
 					tc.input,
+					metrics.NewMockHandler(ctrl),
 					log.NewNoopLogger(),
 				)
 				if tc.expectedErrMsg == "" {
@@ -339,6 +343,7 @@ func TestValidateVisibilityQuery(t *testing.T) {
 			tc.name,
 			func(t *testing.T) {
 				s := require.New(t)
+				ctrl := gomock.NewController(t)
 				err := ValidateVisibilityQuery(
 					testNamespace,
 					searchattribute.TestNameTypeMap(),
@@ -346,6 +351,7 @@ func TestValidateVisibilityQuery(t *testing.T) {
 					nil,
 					dynamicconfig.GetBoolPropertyFn(true),
 					tc.input,
+					metrics.NewMockHandler(ctrl),
 					log.NewNoopLogger(),
 				)
 				if tc.expectedErrMsg == "" {

--- a/service/worker/scheduler/query_test.go
+++ b/service/worker/scheduler/query_test.go
@@ -7,6 +7,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence/visibility/store/query"
 	"go.temporal.io/server/common/searchattribute"
@@ -262,6 +263,7 @@ func TestGetQueryFields(t *testing.T) {
 					searchattribute.NewTestMapperProvider(&searchattribute.TestMapper{}),
 					nil,
 					tc.input,
+					log.NewNoopLogger(),
 				)
 				if tc.expectedErrMsg == "" {
 					s.NoError(err)
@@ -344,6 +346,7 @@ func TestValidateVisibilityQuery(t *testing.T) {
 					nil,
 					dynamicconfig.GetBoolPropertyFn(true),
 					tc.input,
+					log.NewNoopLogger(),
 				)
 				if tc.expectedErrMsg == "" {
 					s.NoError(err)


### PR DESCRIPTION
## What changed?
Capture any panics in Visibility query converter.

## Why?
Visibility query converter is complex, and at times might make assumptions that might not hold (due to bugs in the store query converter implementation for example). Capturing at top level, and returning an error instead.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
