### PR TITLE
Fixes to Visibility SQL query converter

### DIFF
--- a/common/persistence/visibility/store/elasticsearch/query_converter.go
+++ b/common/persistence/visibility/store/elasticsearch/query_converter.go
@@ -6,25 +6,29 @@ import (
 
 	"github.com/olivere/elastic/v7"
 	"github.com/temporalio/sqlparser"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence/visibility/store/query"
+	"go.temporal.io/server/common/searchattribute"
 )
 
-type queryConverter struct{}
+type esQueryConverter struct{}
 
-var _ query.StoreQueryConverter[elastic.Query] = (*queryConverter)(nil)
+var _ query.StoreQueryConverter[elastic.Query] = (*esQueryConverter)(nil)
 
-func (c *queryConverter) GetDatetimeFormat() string {
+func (c *esQueryConverter) GetDatetimeFormat() string {
 	return time.RFC3339Nano
 }
 
-func (c *queryConverter) BuildParenExpr(expr elastic.Query) (elastic.Query, error) {
+func (c *esQueryConverter) BuildParenExpr(expr elastic.Query) (elastic.Query, error) {
 	if expr == nil {
 		return nil, nil
 	}
 	return expr, nil
 }
 
-func (c *queryConverter) BuildNotExpr(expr elastic.Query) (elastic.Query, error) {
+func (c *esQueryConverter) BuildNotExpr(expr elastic.Query) (elastic.Query, error) {
 	if expr == nil {
 		return nil, nil
 	}
@@ -37,7 +41,7 @@ func (c *queryConverter) BuildNotExpr(expr elastic.Query) (elastic.Query, error)
 	return newBoolQuery().MustNot(expr), nil
 }
 
-func (c *queryConverter) BuildAndExpr(exprs ...elastic.Query) (elastic.Query, error) {
+func (c *esQueryConverter) BuildAndExpr(exprs ...elastic.Query) (elastic.Query, error) {
 	var reusableBoolQuery *boolQuery
 	validExprs := make([]elastic.Query, 0, len(exprs))
 	for _, e := range exprs {
@@ -65,7 +69,7 @@ func (c *queryConverter) BuildAndExpr(exprs ...elastic.Query) (elastic.Query, er
 	return newBoolQuery().Filter(validExprs...), nil
 }
 
-func (c *queryConverter) BuildOrExpr(exprs ...elastic.Query) (elastic.Query, error) {
+func (c *esQueryConverter) BuildOrExpr(exprs ...elastic.Query) (elastic.Query, error) {
 	var reusableBoolQuery *boolQuery
 	validExprs := make([]elastic.Query, 0, len(exprs))
 	for _, e := range exprs {
@@ -93,7 +97,7 @@ func (c *queryConverter) BuildOrExpr(exprs ...elastic.Query) (elastic.Query, err
 	return newBoolQuery().Should(validExprs...).MinimumNumberShouldMatch(1), nil
 }
 
-func (c *queryConverter) ConvertComparisonExpr(
+func (c *esQueryConverter) ConvertComparisonExpr(
 	operator string,
 	col *query.SAColumn,
 	value any,
@@ -126,7 +130,7 @@ func (c *queryConverter) ConvertComparisonExpr(
 	return res, nil
 }
 
-func (c *queryConverter) ConvertKeywordComparisonExpr(
+func (c *esQueryConverter) ConvertKeywordComparisonExpr(
 	operator string,
 	col *query.SAColumn,
 	value any,
@@ -152,7 +156,7 @@ func (c *queryConverter) ConvertKeywordComparisonExpr(
 	}
 }
 
-func (c *queryConverter) ConvertKeywordListComparisonExpr(
+func (c *esQueryConverter) ConvertKeywordListComparisonExpr(
 	operator string,
 	col *query.SAColumn,
 	value any,
@@ -160,7 +164,7 @@ func (c *queryConverter) ConvertKeywordListComparisonExpr(
 	return c.ConvertKeywordComparisonExpr(operator, col, value)
 }
 
-func (c *queryConverter) ConvertTextComparisonExpr(
+func (c *esQueryConverter) ConvertTextComparisonExpr(
 	operator string,
 	col *query.SAColumn,
 	value any,
@@ -176,7 +180,7 @@ func (c *queryConverter) ConvertTextComparisonExpr(
 	}
 }
 
-func (c *queryConverter) ConvertRangeExpr(
+func (c *esQueryConverter) ConvertRangeExpr(
 	operator string,
 	col *query.SAColumn,
 	from, to any,
@@ -198,7 +202,7 @@ func (c *queryConverter) ConvertRangeExpr(
 	}
 }
 
-func (c *queryConverter) ConvertIsExpr(
+func (c *esQueryConverter) ConvertIsExpr(
 	operator string,
 	col *query.SAColumn,
 ) (elastic.Query, error) {
@@ -216,4 +220,21 @@ func (c *queryConverter) ConvertIsExpr(
 			query.InvalidExpressionErrMessage,
 		)
 	}
+}
+
+func NewQueryConverter(
+	namespaceName namespace.Name,
+	saTypeMap searchattribute.NameTypeMap,
+	saMapper searchattribute.Mapper,
+	metricsHandler metrics.Handler,
+	logger log.Logger,
+) *query.QueryConverter[elastic.Query] {
+	return query.NewQueryConverter(
+		&esQueryConverter{},
+		namespaceName,
+		saTypeMap,
+		saMapper,
+		metricsHandler,
+		logger,
+	)
 }

--- a/common/persistence/visibility/store/elasticsearch/query_converter_test.go
+++ b/common/persistence/visibility/store/elasticsearch/query_converter_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestQueryConverter_GetDatetimeFormat(t *testing.T) {
-	qc := &queryConverter{}
+	qc := &esQueryConverter{}
 	require.Equal(t, time.RFC3339Nano, qc.GetDatetimeFormat())
 }
 
@@ -43,7 +43,7 @@ func TestQueryConverter_BuildParenExpr(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := require.New(t)
-			qc := &queryConverter{}
+			qc := &esQueryConverter{}
 			out, err := qc.BuildParenExpr(tc.in)
 			r.NoError(err)
 			r.Equal(tc.out, out)
@@ -88,7 +88,7 @@ func TestQueryConverter_BuildNotExpr(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := require.New(t)
-			qc := &queryConverter{}
+			qc := &esQueryConverter{}
 			out, err := qc.BuildNotExpr(tc.in)
 			r.NoError(err)
 			r.Equal(tc.out, out)
@@ -169,7 +169,7 @@ func TestQueryConverter_BuildAndExpr(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := require.New(t)
-			qc := &queryConverter{}
+			qc := &esQueryConverter{}
 			out, err := qc.BuildAndExpr(tc.in...)
 			r.NoError(err)
 			r.Equal(tc.out, out)
@@ -250,7 +250,7 @@ func TestQueryConverter_BuildOrExpr(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := require.New(t)
-			qc := &queryConverter{}
+			qc := &esQueryConverter{}
 			out, err := qc.BuildOrExpr(tc.in...)
 			r.NoError(err)
 			r.Equal(tc.out, out)
@@ -346,7 +346,7 @@ func TestQueryConverter_ConvertComparisonExpr(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := require.New(t)
-			qc := &queryConverter{}
+			qc := &esQueryConverter{}
 			out, err := qc.ConvertComparisonExpr(tc.operator, tc.col, tc.value)
 			if tc.err != "" {
 				r.Error(err)
@@ -483,7 +483,7 @@ func TestQueryConverter_ConvertKeywordComparisonExpr(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := require.New(t)
-			qc := &queryConverter{}
+			qc := &esQueryConverter{}
 			out, err := qc.ConvertKeywordComparisonExpr(tc.operator, tc.col, tc.value)
 			if tc.err != "" {
 				r.Error(err)
@@ -558,7 +558,7 @@ func TestQueryConverter_ConvertKeywordListComparisonExpr(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := require.New(t)
-			qc := &queryConverter{}
+			qc := &esQueryConverter{}
 			out, err := qc.ConvertKeywordListComparisonExpr(tc.operator, tc.col, tc.value)
 			if tc.err != "" {
 				r.Error(err)
@@ -617,7 +617,7 @@ func TestQueryConverter_ConvertTextComparisonExpr(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := require.New(t)
-			qc := &queryConverter{}
+			qc := &esQueryConverter{}
 			out, err := qc.ConvertTextComparisonExpr(tc.operator, tc.col, tc.value)
 			if tc.err != "" {
 				r.Error(err)
@@ -681,7 +681,7 @@ func TestQueryConverter_ConvertRangeExpr(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := require.New(t)
-			qc := &queryConverter{}
+			qc := &esQueryConverter{}
 			out, err := qc.ConvertRangeExpr(tc.operator, tc.col, tc.from, tc.to)
 			if tc.err != "" {
 				r.Error(err)
@@ -736,7 +736,7 @@ func TestQueryConverter_ConvertIsExpr(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := require.New(t)
-			qc := &queryConverter{}
+			qc := &esQueryConverter{}
 			out, err := qc.ConvertIsExpr(tc.operator, tc.col)
 			if tc.err != "" {
 				r.Error(err)

--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -763,14 +763,8 @@ func (s *VisibilityStore) convertQuery(
 		return nil, err
 	}
 
-	c := query.NewQueryConverter(
-		&queryConverter{},
-		namespaceName,
-		saTypeMap,
-		saMapper,
-		s.metricsHandler,
-		s.logger,
-	).WithChasmMapper(chasmMapper).
+	c := NewQueryConverter(namespaceName, saTypeMap, saMapper, s.metricsHandler, s.logger).
+		WithChasmMapper(chasmMapper).
 		WithArchetypeID(archetypeID)
 
 	queryParams, err := c.Convert(queryString)

--- a/common/persistence/visibility/store/query/converter.go
+++ b/common/persistence/visibility/store/query/converter.go
@@ -595,8 +595,7 @@ func (c *QueryConverter[ExprT]) parseValueExpr(
 		}
 		return value, nil
 	case sqlparser.BoolVal:
-		// no-op: no validation needed
-		return bool(e), nil
+		return c.validateValueType(saName, saType, bool(e))
 	case sqlparser.ValTuple:
 		// This is "in (1,2,3)" case.
 		values := make([]any, 0, len(e))
@@ -608,6 +607,35 @@ func (c *QueryConverter[ExprT]) parseValueExpr(
 			values = append(values, item)
 		}
 		return values, nil
+	case *sqlparser.UnaryExpr:
+		// Negative value may be parsed as UnaryExpr
+		if e.Operator != sqlparser.UPlusStr && e.Operator != sqlparser.UMinusStr {
+			return nil, NewConverterError(
+				"%s: unary operator %q",
+				NotSupportedErrMessage,
+				e.Operator,
+			)
+		}
+		value, err := c.parseValueExpr(e.Expr, saName, saFieldName, saType)
+		if err != nil {
+			return nil, err
+		}
+		if e.Operator == sqlparser.UMinusStr {
+			switch v := value.(type) {
+			case int64:
+				value = -v
+			case float64:
+				value = -v
+			default:
+				// This catches some weird cases like `CustomKeyword = -'foo'`
+				return nil, NewConverterError(
+					"%s: unary operator not supported in %q",
+					InvalidExpressionErrMessage,
+					sqlparser.String(expr),
+				)
+			}
+		}
+		return value, nil
 	case *sqlparser.GroupConcatExpr:
 		return nil, NewConverterError("%s: 'group_concat'", NotSupportedErrMessage)
 	case *sqlparser.FuncExpr:
@@ -713,10 +741,20 @@ func (c *QueryConverter[ExprT]) validateValueType(
 		}
 		return tm.UTC().Format(c.storeQC.GetDatetimeFormat()), nil
 	case enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-		enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST,
-		enumspb.INDEXED_VALUE_TYPE_TEXT:
+		enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST:
 		if _, ok := value.(string); !ok {
 			return nil, valueTypeErr
+		}
+		return value, nil
+	case enumspb.INDEXED_VALUE_TYPE_TEXT:
+		if v, ok := value.(string); !ok {
+			return nil, valueTypeErr
+		} else if strings.TrimSpace(v) == "" {
+			return nil, NewConverterError(
+				"%s: no tokens found filtering on Text type search attribute %s",
+				InvalidExpressionErrMessage,
+				saName,
+			)
 		}
 		return value, nil
 	default:

--- a/common/persistence/visibility/store/query/converter.go
+++ b/common/persistence/visibility/store/query/converter.go
@@ -616,24 +616,33 @@ func (c *QueryConverter[ExprT]) parseValueExpr(
 				e.Operator,
 			)
 		}
+		if value, ok := e.Expr.(*sqlparser.SQLVal); !ok || value.Type == sqlparser.StrVal {
+			return nil, NewConverterError(
+				"%s: unary operator not supported in %q",
+				InvalidExpressionErrMessage,
+				sqlparser.String(expr),
+			)
+		}
 		value, err := c.parseValueExpr(e.Expr, saName, saFieldName, saType)
 		if err != nil {
 			return nil, err
 		}
-		if e.Operator == sqlparser.UMinusStr {
-			switch v := value.(type) {
-			case int64:
+		switch v := value.(type) {
+		case int64:
+			if e.Operator == sqlparser.UMinusStr {
 				value = -v
-			case float64:
-				value = -v
-			default:
-				// This catches some weird cases like `CustomKeyword = -'foo'`
-				return nil, NewConverterError(
-					"%s: unary operator not supported in %q",
-					InvalidExpressionErrMessage,
-					sqlparser.String(expr),
-				)
 			}
+		case float64:
+			if e.Operator == sqlparser.UMinusStr {
+				value = -v
+			}
+		default:
+			// This should never happen, but here to catch any unexpected case.
+			return nil, NewConverterError(
+				"%s: unary expression %q",
+				InvalidExpressionErrMessage,
+				sqlparser.String(expr),
+			)
 		}
 		return value, nil
 	case *sqlparser.GroupConcatExpr:
@@ -694,6 +703,16 @@ func (c *QueryConverter[ExprT]) parseSQLVal(
 	}
 }
 
+// validateValueType validates a single value type against the search attribute type,
+// and returns the value formatted if needed.
+// If search attribute type is:
+//   - Int, Double: value type must be int64 or float64 and returns the input value;
+//   - Bool: value type must be bool and returns the input value;
+//   - Keyword, KeywordList: value type must be string and returns the input value;
+//   - Text: value type must be string with a valid token (empty string or string
+//     with only spaces are not valid) and returns the input value;
+//   - Datetime: value type must be int64 (Unix nanos) or string and returns datetime
+//     formated based on storeQC.GetDatetimeFormat() value.
 func (c *QueryConverter[ExprT]) validateValueType(
 	saName string,
 	saType enumspb.IndexedValueType,

--- a/common/persistence/visibility/store/sql/query_converter.go
+++ b/common/persistence/visibility/store/sql/query_converter.go
@@ -263,15 +263,15 @@ func (c *SQLQueryConverter) ConvertIsExpr(
 }
 
 func (c *SQLQueryConverter) buildValueExpr(name string, value any) (sqlparser.Expr, error) {
-	// ExecutionStatus is stored as an integer in SQL database.
-	if name == sadefs.ExecutionStatus {
-		// Query converter already validates the value, so there should not be any errors here.
-		status, _ := enumspb.WorkflowExecutionStatusFromString(value.(string))
-		return sqlparser.NewIntVal([]byte(strconv.FormatInt(int64(status), 10))), nil
-	}
-
 	switch v := value.(type) {
 	case string:
+		// ExecutionStatus is stored as an integer in SQL database.
+		if name == sadefs.ExecutionStatus {
+			// Query converter already validates the value, so there should not be any errors here.
+			status, _ := enumspb.WorkflowExecutionStatusFromString(value.(string))
+			return sqlparser.NewIntVal([]byte(strconv.FormatInt(int64(status), 10))), nil
+		}
+
 		// escape strings for safety
 		replacer := strings.NewReplacer(escapeCharMap...)
 		return query.NewUnsafeSQLString(replacer.Replace(v)), nil

--- a/common/persistence/visibility/store/tests/query_converter_test.go
+++ b/common/persistence/visibility/store/tests/query_converter_test.go
@@ -206,6 +206,11 @@ var queryConverterTestCases = []queryConverterTestCase{
 		err:  `invalid expression: unary operator not supported in "-'foo'"`,
 	},
 	{
+		name: "Keyword with positive value",
+		in:   "AliasForKeyword01 = +'foo'",
+		err:  `invalid expression: unary operator not supported in "+'foo'"`,
+	},
+	{
 		name: "Keyword unsupported operator",
 		in:   "AliasForKeyword01 LIKE 'foo%'",
 		err:  "operation is not supported: operator 'LIKE' not supported for Keyword type search attribute 'AliasForKeyword01'",
@@ -247,10 +252,16 @@ var queryConverterTestCases = []queryConverterTestCase{
 		es:   `{"bool":{"filter":{"term":{"Int01":-10}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
 	},
 	{
+		name: "Int positive sign value",
+		in:   "AliasForInt01 = +10",
+		sql:  "TemporalNamespaceDivision is null and Int01 = 10",
+		es:   `{"bool":{"filter":{"term":{"Int01":10}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
 		// Only a literal value can be negated, not an arbitrary expression.
 		name: "Int negative parenthesized value",
 		in:   "AliasForInt01 = -(10)",
-		err:  "invalid expression: unexpected value type *sqlparser.ParenExpr",
+		err:  `invalid expression: unary operator not supported in "-(10)"`,
 	},
 	{
 		name: "Int greater than",
@@ -301,6 +312,31 @@ var queryConverterTestCases = []queryConverterTestCase{
 		es:   `{"bool":{"filter":{"term":{"Int01":1.5}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
 	},
 	{
+		name: "Int with negative float value",
+		in:   "AliasForInt01 = -1.5",
+		sql:  "TemporalNamespaceDivision is null and Int01 = -1.5",
+		es:   `{"bool":{"filter":{"term":{"Int01":-1.5}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Int with positive sign float value",
+		in:   "AliasForInt01 = +1.5",
+		sql:  "TemporalNamespaceDivision is null and Int01 = 1.5",
+		es:   `{"bool":{"filter":{"term":{"Int01":1.5}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		// negative int is parsed as SQLVal, and sqlparser reduces inline
+		name: "Int negative negative int value",
+		in:   "AliasForInt01 = - -10",
+		sql:  "TemporalNamespaceDivision is null and Int01 = 10",
+		es:   `{"bool":{"filter":{"term":{"Int01":10}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		// negative float is parsed as UnaryExpr, and nested unary expressions is not allowed
+		name: "Int negative negative float value",
+		in:   "AliasForInt01 = - -1.0",
+		err:  `invalid expression: unary operator not supported in "- -1.0"`,
+	},
+	{
 		name: "Int invalid value type",
 		in:   "HistoryLength = 'foo'",
 		err:  `invalid expression: invalid value type for search attribute HistoryLength of type Int: "foo" (type: string)`,
@@ -324,12 +360,6 @@ var queryConverterTestCases = []queryConverterTestCase{
 		es:   `{"bool":{"filter":{"term":{"Double01":1.5}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
 	},
 	{
-		name: "Double with int value",
-		in:   "AliasForDouble01 = 1",
-		sql:  "TemporalNamespaceDivision is null and Double01 = 1",
-		es:   `{"bool":{"filter":{"term":{"Double01":1}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
-	},
-	{
 		// Unlike negative integers, negative floats are parsed as an unary expression.
 		name: "Double negative value",
 		in:   "AliasForDouble01 >= -1.5",
@@ -341,6 +371,37 @@ var queryConverterTestCases = []queryConverterTestCase{
 		in:   "AliasForDouble01 = +1.5",
 		sql:  "TemporalNamespaceDivision is null and Double01 = 1.5",
 		es:   `{"bool":{"filter":{"term":{"Double01":1.5}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Double with int value",
+		in:   "AliasForDouble01 = 1",
+		sql:  "TemporalNamespaceDivision is null and Double01 = 1",
+		es:   `{"bool":{"filter":{"term":{"Double01":1}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Double with negative int value",
+		in:   "AliasForDouble01 = -1",
+		sql:  "TemporalNamespaceDivision is null and Double01 = -1",
+		es:   `{"bool":{"filter":{"term":{"Double01":-1}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Double with positive sign int value",
+		in:   "AliasForDouble01 = +1",
+		sql:  "TemporalNamespaceDivision is null and Double01 = 1",
+		es:   `{"bool":{"filter":{"term":{"Double01":1}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		// negative int is parsed as SQLVal, and sqlparser reduces inline
+		name: "Double negative negative int value",
+		in:   "AliasForDouble01 = - -10",
+		sql:  "TemporalNamespaceDivision is null and Double01 = 10",
+		es:   `{"bool":{"filter":{"term":{"Double01":10}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		// negative float is parsed as UnaryExpr, and nested unary expressions is not allowed
+		name: "Double negative negative float value",
+		in:   "AliasForDouble01 = - -1.0",
+		err:  `invalid expression: unary operator not supported in "- -1.0"`,
 	},
 	{
 		name: "Double invalid value type",
@@ -376,6 +437,16 @@ var queryConverterTestCases = []queryConverterTestCase{
 		name: "Bool range condition not supported",
 		in:   "AliasForBool01 BETWEEN false AND true",
 		err:  "invalid expression: cannot do range condition on search attribute 'AliasForBool01' of type Bool",
+	},
+	{
+		name: "Bool invalid unary negative value type",
+		in:   "AliasForBool01 = -true",
+		err:  `invalid expression: unary operator not supported in "-true"`,
+	},
+	{
+		name: "Bool invalid unary positive value type",
+		in:   "AliasForBool01 = +true",
+		err:  `invalid expression: unary operator not supported in "+true"`,
 	},
 
 	// Datetime type search attributes.
@@ -440,6 +511,16 @@ var queryConverterTestCases = []queryConverterTestCase{
 		name: "Datetime with bool value",
 		in:   "StartTime = true",
 		err:  "invalid expression: invalid value type for search attribute StartTime of type Datetime: true (type: bool)",
+	},
+	{
+		name: "Datetime invalid unary negative value type",
+		in:   "StartTime = -'2020-01-02T15:04:05Z'",
+		err:  `invalid expression: unary operator not supported in "-'2020-01-02T15:04:05Z'"`,
+	},
+	{
+		name: "Datetime invalid unary positive value type",
+		in:   "StartTime = +'2020-01-02T15:04:05Z'",
+		err:  `invalid expression: unary operator not supported in "+'2020-01-02T15:04:05Z'"`,
 	},
 
 	// ExecutionStatus search attribute.
@@ -546,6 +627,13 @@ var queryConverterTestCases = []queryConverterTestCase{
 		es:   `{"bool":{"filter":{"range":{"ExecutionDuration":{"from":630000000000,"include_lower":false,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
 	},
 	{
+		// negative zero hours works because -0 = 0, it does not negate the duration (bug?)
+		name: "ExecutionDuration negative 00:mm:ss",
+		in:   "ExecutionDuration > '-00:10:30'",
+		sql:  "TemporalNamespaceDivision is null and execution_duration > 630000000000",
+		es:   `{"bool":{"filter":{"range":{"ExecutionDuration":{"from":630000000000,"include_lower":false,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
 		name: "ExecutionDuration between",
 		in:   "ExecutionDuration BETWEEN '1s' AND '1m'",
 		sql:  "TemporalNamespaceDivision is null and execution_duration between 1000000000 and 60000000000",
@@ -561,6 +649,49 @@ var queryConverterTestCases = []queryConverterTestCase{
 		in:   "ExecutionDuration > -1000",
 		sql:  "TemporalNamespaceDivision is null and execution_duration > -1000",
 		es:   `{"bool":{"filter":{"range":{"ExecutionDuration":{"from":-1000,"include_lower":false,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "ExecutionDuration positive sign value",
+		in:   "ExecutionDuration > +1000",
+		sql:  "TemporalNamespaceDivision is null and execution_duration > 1000",
+		es:   `{"bool":{"filter":{"range":{"ExecutionDuration":{"from":1000,"include_lower":false,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "ExecutionDuration golang negative duration",
+		in:   "ExecutionDuration > '-10s'",
+		sql:  "TemporalNamespaceDivision is null and execution_duration > -10000000000",
+		es:   `{"bool":{"filter":{"range":{"ExecutionDuration":{"from":-10000000000,"include_lower":false,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "ExecutionDuration golang positive sign duration",
+		in:   "ExecutionDuration > '+10s'",
+		sql:  "TemporalNamespaceDivision is null and execution_duration > 10000000000",
+		es:   `{"bool":{"filter":{"range":{"ExecutionDuration":{"from":10000000000,"include_lower":false,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "ExecutionDuration negative golang duration",
+		in:   "ExecutionDuration > -'10s'",
+		err:  `invalid expression: unary operator not supported in "-'10s'"`,
+	},
+	{
+		name: "ExecutionDuration positive sign golang duration",
+		in:   "ExecutionDuration > +'10s'",
+		err:  `invalid expression: unary operator not supported in "+'10s'"`,
+	},
+	{
+		name: "ExecutionDuration negative hh:mm:ss",
+		in:   "ExecutionDuration > '-01:10:30'",
+		err:  "invalid expression: invalid duration value for search attribute ExecutionDuration: -01:10:30",
+	},
+	{
+		name: "ExecutionDuration unary negative hh:mm:ss",
+		in:   "ExecutionDuration > -'00:10:30'",
+		err:  `invalid expression: unary operator not supported in "-'00:10:30'"`,
+	},
+	{
+		name: "ExecutionDuration unary positive hh:mm:ss",
+		in:   "ExecutionDuration > +'00:10:30'",
+		err:  `invalid expression: unary operator not supported in "+'00:10:30'"`,
 	},
 	{
 		name: "ExecutionDuration with bool value",
@@ -630,6 +761,36 @@ var queryConverterTestCases = []queryConverterTestCase{
 		in:   "AliasForKeywordList01 = 123",
 		err:  "invalid expression: invalid value type for search attribute AliasForKeywordList01 of type KeywordList: 123 (type: int64)",
 	},
+	{
+		name: "KeywordList with negative value",
+		in:   "AliasForKeywordList01 = -'foo'",
+		err:  `invalid expression: unary operator not supported in "-'foo'"`,
+	},
+	{
+		name: "KeywordList with positive value",
+		in:   "AliasForKeywordList01 = +'foo'",
+		err:  `invalid expression: unary operator not supported in "+'foo'"`,
+	},
+	{
+		name: "KeywordList in with negative value",
+		in:   "AliasForKeywordList01 IN ('foo', -'bar')",
+		err:  `invalid expression: unary operator not supported in "-'bar'"`,
+	},
+	{
+		name: "KeywordList in with positive value",
+		in:   "AliasForKeywordList01 IN ('foo', +'bar')",
+		err:  `invalid expression: unary operator not supported in "+'bar'"`,
+	},
+	{
+		name: "KeywordList not in with negative value",
+		in:   "AliasForKeywordList01 NOT IN ('foo', -'bar')",
+		err:  `invalid expression: unary operator not supported in "-'bar'"`,
+	},
+	{
+		name: "KeywordList not in with positive value",
+		in:   "AliasForKeywordList01 NOT IN ('foo', +'bar')",
+		err:  `invalid expression: unary operator not supported in "+'bar'"`,
+	},
 
 	// Text type search attributes.
 	{
@@ -687,6 +848,16 @@ var queryConverterTestCases = []queryConverterTestCase{
 		name: "Text invalid value type",
 		in:   "AliasForText01 = 123",
 		err:  "invalid expression: invalid value type for search attribute AliasForText01 of type Text: 123 (type: int64)",
+	},
+	{
+		name: "Text with negative value",
+		in:   "AliasForText01 = -'foo'",
+		err:  `invalid expression: unary operator not supported in "-'foo'"`,
+	},
+	{
+		name: "Text with positive value",
+		in:   "AliasForText01 = +'foo'",
+		err:  `invalid expression: unary operator not supported in "+'foo'"`,
 	},
 
 	// Search attribute name resolution.

--- a/common/persistence/visibility/store/tests/query_converter_test.go
+++ b/common/persistence/visibility/store/tests/query_converter_test.go
@@ -1,0 +1,1122 @@
+package tests
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/olivere/elastic/v7"
+	"github.com/stretchr/testify/require"
+	"github.com/temporalio/sqlparser"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/persistence/sql"
+	"go.temporal.io/server/common/persistence/visibility/store/elasticsearch"
+	"go.temporal.io/server/common/persistence/visibility/store/query"
+	vissql "go.temporal.io/server/common/persistence/visibility/store/sql"
+	"go.temporal.io/server/common/searchattribute"
+)
+
+const (
+	testNamespaceName = namespace.Name("test-namespace")
+
+	mysqlStore    = "mysql8"
+	postgresStore = "postgres12"
+	sqliteStore   = "sqlite"
+	esStore       = "elasticsearch"
+)
+
+var sqlPlugins = []string{mysqlStore, postgresStore, sqliteStore}
+
+type queryConverterTestCase struct {
+	name string
+	in   string
+
+	// out is the expected converted query: `sql` is the WHERE clause expected for every SQL
+	// plugin, and `mysql`, `postgres` and `sqlite` override it for the plugins whose output
+	// differs (mostly Text and KeywordList types); `es` is the expected Elasticsearch query.
+	sql      string
+	mysql    string
+	postgres string
+	sqlite   string
+	es       string
+
+	// err is the expected error message for every store: most errors come from the shared
+	// front-end converter. When only some stores fail, use the store specific fields
+	// instead: sqlErr for every SQL plugin, and mysqlErr, postgresErr, sqliteErr and esErr
+	// for a single store.
+	err         string
+	sqlErr      string
+	mysqlErr    string
+	postgresErr string
+	sqliteErr   string
+	esErr       string
+
+	// groupBy is the expected list of GROUP BY search attribute field names.
+	groupBy []string
+	// orderBy is the expected ORDER BY clause.
+	orderBy string
+}
+
+func (tc *queryConverterTestCase) expected(store string) (out string, errMsg string) {
+	if tc.err != "" {
+		return "", tc.err
+	}
+	if store == esStore {
+		return tc.es, tc.esErr
+	}
+
+	var outOverride, errOverride string
+	switch store {
+	case mysqlStore:
+		outOverride, errOverride = tc.mysql, tc.mysqlErr
+	case postgresStore:
+		outOverride, errOverride = tc.postgres, tc.postgresErr
+	case sqliteStore:
+		outOverride, errOverride = tc.sqlite, tc.sqliteErr
+	default:
+		// no-op
+	}
+
+	if errOverride != "" {
+		return "", errOverride
+	}
+	if outOverride != "" {
+		return outOverride, ""
+	}
+	return tc.sql, tc.sqlErr
+}
+
+var queryConverterTestCases = []queryConverterTestCase{
+	{
+		name: "empty query",
+		in:   "",
+		sql:  "TemporalNamespaceDivision is null",
+		es:   `{"bool":{"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "blank query",
+		in:   "   ",
+		sql:  "TemporalNamespaceDivision is null",
+		es:   `{"bool":{"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	// Keyword type search attributes.
+	{
+		name: "Keyword equal",
+		in:   "WorkflowId = 'wid'",
+		sql:  "TemporalNamespaceDivision is null and workflow_id = 'wid'",
+		es:   `{"bool":{"filter":{"term":{"WorkflowId":"wid"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Keyword not equal",
+		in:   "WorkflowId != 'wid'",
+		sql:  "TemporalNamespaceDivision is null and workflow_id != 'wid'",
+		es:   `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"term":{"WorkflowId":"wid"}}]}}`,
+	},
+	{
+		name: "Keyword in",
+		in:   "WorkflowType IN ('foo', 'bar')",
+		sql:  "TemporalNamespaceDivision is null and workflow_type_name in ('foo', 'bar')",
+		es:   `{"bool":{"filter":{"terms":{"WorkflowType":["foo","bar"]}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Keyword not in",
+		in:   "WorkflowType NOT IN ('foo', 'bar')",
+		sql:  "TemporalNamespaceDivision is null and workflow_type_name not in ('foo', 'bar')",
+		es:   `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"terms":{"WorkflowType":["foo","bar"]}}]}}`,
+	},
+	{
+		name: "Keyword starts with",
+		in:   "TaskQueue STARTS_WITH 'foo'",
+		sql:  "TemporalNamespaceDivision is null and task_queue like 'foo%' escape '!'",
+		es:   `{"bool":{"filter":{"prefix":{"TaskQueue":"foo"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Keyword not starts with",
+		in:   "TaskQueue NOT STARTS_WITH 'foo'",
+		sql:  "TemporalNamespaceDivision is null and task_queue not like 'foo%' escape '!'",
+		es:   `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"prefix":{"TaskQueue":"foo"}}]}}`,
+	},
+	{
+		name: "Keyword starts with special chars",
+		in:   "AliasForKeyword01 STARTS_WITH 'a%b_c!d'",
+		sql:  "TemporalNamespaceDivision is null and Keyword01 like 'a!%b!_c!!d%' escape '!'",
+		es:   `{"bool":{"filter":{"prefix":{"Keyword01":"a%b_c!d"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Keyword starts with non string value",
+		in:   "AliasForKeyword01 STARTS_WITH 123",
+		err:  "invalid expression: invalid value type for search attribute AliasForKeyword01 of type Keyword: 123 (type: int64)",
+	},
+	{
+		name: "Keyword greater than",
+		in:   "AliasForKeyword01 > 'foo'",
+		sql:  "TemporalNamespaceDivision is null and Keyword01 > 'foo'",
+		es:   `{"bool":{"filter":{"range":{"Keyword01":{"from":"foo","include_lower":false,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Keyword between",
+		in:   "AliasForKeyword01 BETWEEN 'a' AND 'b'",
+		sql:  "TemporalNamespaceDivision is null and Keyword01 between 'a' and 'b'",
+		es:   `{"bool":{"filter":{"range":{"Keyword01":{"from":"a","include_lower":true,"include_upper":true,"to":"b"}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Keyword is null",
+		in:   "AliasForKeyword01 IS NULL",
+		sql:  "TemporalNamespaceDivision is null and Keyword01 is null",
+		es:   `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"exists":{"field":"Keyword01"}}]}}`,
+	},
+	{
+		name: "Keyword is not null",
+		in:   "AliasForKeyword01 IS NOT NULL",
+		sql:  "TemporalNamespaceDivision is null and Keyword01 is not null",
+		es:   `{"bool":{"filter":{"exists":{"field":"Keyword01"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Keyword empty string",
+		in:   "AliasForKeyword01 = ''",
+		sql:  "TemporalNamespaceDivision is null and Keyword01 = ''",
+		es:   `{"bool":{"filter":{"term":{"Keyword01":""}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Keyword value with quote",
+		in:   "AliasForKeyword01 = 'foo''s bar'",
+		sql:  "TemporalNamespaceDivision is null and Keyword01 = 'foo''s bar'",
+		es:   `{"bool":{"filter":{"term":{"Keyword01":"foo's bar"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Keyword value with backslash",
+		in:   "AliasForKeyword01 = 'foo\\\\bar'",
+		sql:  "TemporalNamespaceDivision is null and Keyword01 = 'foo\\\\bar'",
+		es:   `{"bool":{"filter":{"term":{"Keyword01":"foo\\bar"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Keyword invalid value type",
+		in:   "AliasForKeyword01 = 123",
+		err:  "invalid expression: invalid value type for search attribute AliasForKeyword01 of type Keyword: 123 (type: int64)",
+	},
+	{
+		name: "Keyword with bool value",
+		in:   "AliasForKeyword01 = true",
+		err:  "invalid expression: invalid value type for search attribute AliasForKeyword01 of type Keyword: true (type: bool)",
+	},
+	{
+		name: "Keyword with negative value",
+		in:   "AliasForKeyword01 = -'foo'",
+		err:  `invalid expression: unary operator not supported in "-'foo'"`,
+	},
+	{
+		name: "Keyword unsupported operator",
+		in:   "AliasForKeyword01 LIKE 'foo%'",
+		err:  "operation is not supported: operator 'LIKE' not supported for Keyword type search attribute 'AliasForKeyword01'",
+	},
+	{
+		name: "Keyword value with escaped chars",
+		in:   "AliasForKeyword01 = 'foo\\nbar\\ttail'",
+		sql:  "TemporalNamespaceDivision is null and Keyword01 = 'foo\\nbar\\ttail'",
+		es:   `{"bool":{"filter":{"term":{"Keyword01":"foo\nbar\ttail"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Keyword single value in list",
+		in:   "WorkflowId IN ('wid')",
+		sql:  "TemporalNamespaceDivision is null and workflow_id in ('wid')",
+		es:   `{"bool":{"filter":{"terms":{"WorkflowId":["wid"]}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Keyword empty list",
+		in:   "WorkflowId IN ()",
+		err:  "malformed SQL query: syntax error at position 44",
+	},
+	{
+		name: "search attribute name is case sensitive",
+		in:   "workflowid = 'wid'",
+		err:  "invalid expression: column name 'workflowid' is not a valid search attribute",
+	},
+
+	// Int type search attributes.
+	{
+		name: "Int equal",
+		in:   "HistoryLength = 10",
+		sql:  "TemporalNamespaceDivision is null and history_length = 10",
+		es:   `{"bool":{"filter":{"term":{"HistoryLength":10}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Int negative value",
+		in:   "AliasForInt01 = -10",
+		sql:  "TemporalNamespaceDivision is null and Int01 = -10",
+		es:   `{"bool":{"filter":{"term":{"Int01":-10}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		// Only a literal value can be negated, not an arbitrary expression.
+		name: "Int negative parenthesized value",
+		in:   "AliasForInt01 = -(10)",
+		err:  "invalid expression: unexpected value type *sqlparser.ParenExpr",
+	},
+	{
+		name: "Int greater than",
+		in:   "HistoryLength > 10",
+		sql:  "TemporalNamespaceDivision is null and history_length > 10",
+		es:   `{"bool":{"filter":{"range":{"HistoryLength":{"from":10,"include_lower":false,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Int greater equal",
+		in:   "HistoryLength >= 10",
+		sql:  "TemporalNamespaceDivision is null and history_length >= 10",
+		es:   `{"bool":{"filter":{"range":{"HistoryLength":{"from":10,"include_lower":true,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Int less than",
+		in:   "StateTransitionCount < 10",
+		sql:  "TemporalNamespaceDivision is null and state_transition_count < 10",
+		es:   `{"bool":{"filter":{"range":{"StateTransitionCount":{"from":null,"include_lower":true,"include_upper":false,"to":10}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Int less equal",
+		in:   "StateTransitionCount <= 10",
+		sql:  "TemporalNamespaceDivision is null and state_transition_count <= 10",
+		es:   `{"bool":{"filter":{"range":{"StateTransitionCount":{"from":null,"include_lower":true,"include_upper":true,"to":10}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Int in",
+		in:   "HistorySizeBytes IN (1, 2, 3)",
+		sql:  "TemporalNamespaceDivision is null and history_size_bytes in (1, 2, 3)",
+		es:   `{"bool":{"filter":{"terms":{"HistorySizeBytes":[1,2,3]}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Int between",
+		in:   "HistoryLength BETWEEN 1 AND 10",
+		sql:  "TemporalNamespaceDivision is null and history_length between 1 and 10",
+		es:   `{"bool":{"filter":{"range":{"HistoryLength":{"from":1,"include_lower":true,"include_upper":true,"to":10}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Int not between",
+		in:   "HistoryLength NOT BETWEEN 1 AND 10",
+		sql:  "TemporalNamespaceDivision is null and history_length not between 1 and 10",
+		es:   `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"range":{"HistoryLength":{"from":1,"include_lower":true,"include_upper":true,"to":10}}}]}}`,
+	},
+	{
+		name: "Int with float value",
+		in:   "AliasForInt01 = 1.5",
+		sql:  "TemporalNamespaceDivision is null and Int01 = 1.5",
+		es:   `{"bool":{"filter":{"term":{"Int01":1.5}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Int invalid value type",
+		in:   "HistoryLength = 'foo'",
+		err:  `invalid expression: invalid value type for search attribute HistoryLength of type Int: "foo" (type: string)`,
+	},
+	{
+		name: "Int unsupported operator",
+		in:   "HistoryLength STARTS_WITH 1",
+		err:  "operation is not supported: operator 'STARTS_WITH' not supported for Int type search attribute 'HistoryLength'",
+	},
+	{
+		name: "Int mixed types in list",
+		in:   "AliasForInt01 IN (1, 'foo')",
+		err:  `invalid expression: invalid value type for search attribute AliasForInt01 of type Int: "foo" (type: string)`,
+	},
+
+	// Double type search attributes.
+	{
+		name: "Double equal",
+		in:   "AliasForDouble01 = 1.5",
+		sql:  "TemporalNamespaceDivision is null and Double01 = 1.5",
+		es:   `{"bool":{"filter":{"term":{"Double01":1.5}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Double with int value",
+		in:   "AliasForDouble01 = 1",
+		sql:  "TemporalNamespaceDivision is null and Double01 = 1",
+		es:   `{"bool":{"filter":{"term":{"Double01":1}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		// Unlike negative integers, negative floats are parsed as an unary expression.
+		name: "Double negative value",
+		in:   "AliasForDouble01 >= -1.5",
+		sql:  "TemporalNamespaceDivision is null and Double01 >= -1.5",
+		es:   `{"bool":{"filter":{"range":{"Double01":{"from":-1.5,"include_lower":true,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Double positive sign value",
+		in:   "AliasForDouble01 = +1.5",
+		sql:  "TemporalNamespaceDivision is null and Double01 = 1.5",
+		es:   `{"bool":{"filter":{"term":{"Double01":1.5}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Double invalid value type",
+		in:   "AliasForDouble01 = 'foo'",
+		err:  `invalid expression: invalid value type for search attribute AliasForDouble01 of type Double: "foo" (type: string)`,
+	},
+
+	// Bool type search attributes.
+	{
+		name: "Bool true",
+		in:   "AliasForBool01 = true",
+		sql:  "TemporalNamespaceDivision is null and Bool01 = true",
+		es:   `{"bool":{"filter":{"term":{"Bool01":true}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Bool false",
+		in:   "TemporalSchedulePaused = false",
+		sql:  "TemporalNamespaceDivision is null and TemporalSchedulePaused = false",
+		es:   `{"bool":{"filter":{"term":{"TemporalSchedulePaused":false}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Bool not equal",
+		in:   "AliasForBool01 != true",
+		sql:  "TemporalNamespaceDivision is null and Bool01 != true",
+		es:   `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"term":{"Bool01":true}}]}}`,
+	},
+	{
+		name: "Bool invalid value type",
+		in:   "AliasForBool01 = 'true'",
+		err:  `invalid expression: invalid value type for search attribute AliasForBool01 of type Bool: "true" (type: string)`,
+	},
+	{
+		name: "Bool range condition not supported",
+		in:   "AliasForBool01 BETWEEN false AND true",
+		err:  "invalid expression: cannot do range condition on search attribute 'AliasForBool01' of type Bool",
+	},
+
+	// Datetime type search attributes.
+	{
+		name:     "Datetime equal",
+		in:       "StartTime = '2020-01-02T15:04:05Z'",
+		mysql:    "TemporalNamespaceDivision is null and start_time = '2020-01-02 15:04:05'",
+		postgres: "TemporalNamespaceDivision is null and start_time = '2020-01-02 15:04:05'",
+		sqlite:   "TemporalNamespaceDivision is null and start_time = '2020-01-02 15:04:05+00:00'",
+		es:       `{"bool":{"filter":{"term":{"StartTime":"2020-01-02T15:04:05Z"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name:     "Datetime with nanoseconds and offset",
+		in:       "StartTime > '2020-01-02T15:04:05.123456789-07:00'",
+		mysql:    "TemporalNamespaceDivision is null and start_time > '2020-01-02 22:04:05.123456'",
+		postgres: "TemporalNamespaceDivision is null and start_time > '2020-01-02 22:04:05.123456'",
+		sqlite:   "TemporalNamespaceDivision is null and start_time > '2020-01-02 22:04:05.123456+00:00'",
+		es:       `{"bool":{"filter":{"range":{"StartTime":{"from":"2020-01-02T22:04:05.123456789Z","include_lower":false,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name:     "Datetime with unix nanoseconds",
+		in:       "StartTime > 1577977445000000000",
+		mysql:    "TemporalNamespaceDivision is null and start_time > '2020-01-02 15:04:05'",
+		postgres: "TemporalNamespaceDivision is null and start_time > '2020-01-02 15:04:05'",
+		sqlite:   "TemporalNamespaceDivision is null and start_time > '2020-01-02 15:04:05+00:00'",
+		es:       `{"bool":{"filter":{"range":{"StartTime":{"from":"2020-01-02T15:04:05Z","include_lower":false,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name:     "Datetime between",
+		in:       "CloseTime BETWEEN '2020-01-02T15:04:05Z' AND '2020-01-03T15:04:05Z'",
+		mysql:    "TemporalNamespaceDivision is null and close_time between '2020-01-02 15:04:05' and '2020-01-03 15:04:05'",
+		postgres: "TemporalNamespaceDivision is null and close_time between '2020-01-02 15:04:05' and '2020-01-03 15:04:05'",
+		sqlite:   "TemporalNamespaceDivision is null and close_time between '2020-01-02 15:04:05+00:00' and '2020-01-03 15:04:05+00:00'",
+		es:       `{"bool":{"filter":{"range":{"CloseTime":{"from":"2020-01-02T15:04:05Z","include_lower":true,"include_upper":true,"to":"2020-01-03T15:04:05Z"}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Datetime is null",
+		in:   "CloseTime IS NULL",
+		sql:  "TemporalNamespaceDivision is null and close_time is null",
+		es:   `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"exists":{"field":"CloseTime"}}]}}`,
+	},
+	{
+		name: "Datetime is not null",
+		in:   "CloseTime IS NOT NULL",
+		sql:  "TemporalNamespaceDivision is null and close_time is not null",
+		es:   `{"bool":{"filter":{"exists":{"field":"CloseTime"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name:     "Datetime custom search attribute",
+		in:       "AliasForDatetime01 <= '2020-01-02T15:04:05Z'",
+		mysql:    "TemporalNamespaceDivision is null and Datetime01 <= '2020-01-02 15:04:05'",
+		postgres: "TemporalNamespaceDivision is null and Datetime01 <= '2020-01-02 15:04:05'",
+		sqlite:   "TemporalNamespaceDivision is null and Datetime01 <= '2020-01-02 15:04:05+00:00'",
+		es:       `{"bool":{"filter":{"range":{"Datetime01":{"from":null,"include_lower":true,"include_upper":true,"to":"2020-01-02T15:04:05Z"}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Datetime invalid value",
+		in:   "StartTime = 'foo'",
+		err:  "invalid expression: unable to parse datetime 'foo'",
+	},
+	{
+		name: "Datetime with bool value",
+		in:   "StartTime = true",
+		err:  "invalid expression: invalid value type for search attribute StartTime of type Datetime: true (type: bool)",
+	},
+
+	// ExecutionStatus search attribute.
+	{
+		name: "ExecutionStatus equal",
+		in:   "ExecutionStatus = 'Running'",
+		sql:  "TemporalNamespaceDivision is null and status = 1",
+		es:   `{"bool":{"filter":{"term":{"ExecutionStatus":"Running"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "ExecutionStatus equal code",
+		in:   "ExecutionStatus = 1",
+		sql:  "TemporalNamespaceDivision is null and status = 1",
+		es:   `{"bool":{"filter":{"term":{"ExecutionStatus":"Running"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "ExecutionStatus not equal",
+		in:   "ExecutionStatus != 'Completed'",
+		sql:  "TemporalNamespaceDivision is null and status != 2",
+		es:   `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"term":{"ExecutionStatus":"Completed"}}]}}`,
+	},
+	{
+		name: "ExecutionStatus in",
+		in:   "ExecutionStatus IN ('Running', 'Completed')",
+		sql:  "TemporalNamespaceDivision is null and status in (1, 2)",
+		es:   `{"bool":{"filter":{"terms":{"ExecutionStatus":["Running","Completed"]}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "ExecutionStatus in code",
+		in:   "ExecutionStatus IN (1, 2)",
+		sql:  "TemporalNamespaceDivision is null and status in (1, 2)",
+		es:   `{"bool":{"filter":{"terms":{"ExecutionStatus":["Running","Completed"]}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "ExecutionStatus not in",
+		in:   "ExecutionStatus NOT IN ('Running', 'Completed')",
+		sql:  "TemporalNamespaceDivision is null and status not in (1, 2)",
+		es:   `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"terms":{"ExecutionStatus":["Running","Completed"]}}]}}`,
+	},
+	{
+		name: "ExecutionStatus unspecified",
+		in:   "ExecutionStatus = 'Unspecified'",
+		sql:  "TemporalNamespaceDivision is null and status = 0",
+		es:   `{"bool":{"filter":{"term":{"ExecutionStatus":"Unspecified"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "ExecutionStatus invalid name",
+		in:   "ExecutionStatus = 'Foo'",
+		err:  "invalid expression: invalid ExecutionStatus value 'Foo'",
+	},
+	{
+		name: "ExecutionStatus invalid code",
+		in:   "ExecutionStatus = 42",
+		err:  "invalid expression: invalid ExecutionStatus value 42",
+	},
+	{
+		name: "ExecutionStatus invalid value type",
+		in:   "ExecutionStatus = 1.5",
+		err:  "invalid expression: unexpected value type float64 for search attribute ExecutionStatus",
+	},
+	{
+		name: "ExecutionStatus invalid value in list",
+		in:   "ExecutionStatus IN ('Running', 'Foo')",
+		err:  "invalid expression: invalid ExecutionStatus value 'Foo'",
+	},
+	{
+		name: "ExecutionStatus is null",
+		in:   "ExecutionStatus IS NULL",
+		sql:  "TemporalNamespaceDivision is null and status is null",
+		es:   `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"exists":{"field":"ExecutionStatus"}}]}}`,
+	},
+	{
+		// ExecutionStatus is stored as an integer in SQL databases, thus a prefix search
+		// is only possible in Elasticsearch.
+		name:   "ExecutionStatus starts with",
+		in:     "ExecutionStatus STARTS_WITH 'Running'",
+		sqlErr: `invalid expression: right-hand side of "starts_with" operator must be a literal string (got: Running)`,
+		es:     `{"bool":{"filter":{"prefix":{"ExecutionStatus":"Running"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+
+	// ExecutionDuration search attribute.
+	{
+		name: "ExecutionDuration nanoseconds",
+		in:   "ExecutionDuration > 1000000",
+		sql:  "TemporalNamespaceDivision is null and execution_duration > 1000000",
+		es:   `{"bool":{"filter":{"range":{"ExecutionDuration":{"from":1000000,"include_lower":false,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "ExecutionDuration golang duration",
+		in:   "ExecutionDuration > '10s'",
+		sql:  "TemporalNamespaceDivision is null and execution_duration > 10000000000",
+		es:   `{"bool":{"filter":{"range":{"ExecutionDuration":{"from":10000000000,"include_lower":false,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "ExecutionDuration days",
+		in:   "ExecutionDuration > '2d'",
+		sql:  "TemporalNamespaceDivision is null and execution_duration > 172800000000000",
+		es:   `{"bool":{"filter":{"range":{"ExecutionDuration":{"from":172800000000000,"include_lower":false,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "ExecutionDuration hh:mm:ss",
+		in:   "ExecutionDuration > '00:10:30'",
+		sql:  "TemporalNamespaceDivision is null and execution_duration > 630000000000",
+		es:   `{"bool":{"filter":{"range":{"ExecutionDuration":{"from":630000000000,"include_lower":false,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "ExecutionDuration between",
+		in:   "ExecutionDuration BETWEEN '1s' AND '1m'",
+		sql:  "TemporalNamespaceDivision is null and execution_duration between 1000000000 and 60000000000",
+		es:   `{"bool":{"filter":{"range":{"ExecutionDuration":{"from":1000000000,"include_lower":true,"include_upper":true,"to":60000000000}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "ExecutionDuration invalid value",
+		in:   "ExecutionDuration > 'foo'",
+		err:  "invalid expression: invalid duration value for search attribute ExecutionDuration: foo",
+	},
+	{
+		name: "ExecutionDuration negative value",
+		in:   "ExecutionDuration > -1000",
+		sql:  "TemporalNamespaceDivision is null and execution_duration > -1000",
+		es:   `{"bool":{"filter":{"range":{"ExecutionDuration":{"from":-1000,"include_lower":false,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "ExecutionDuration with bool value",
+		in:   "ExecutionDuration > true",
+		err:  "invalid expression: invalid value type for search attribute ExecutionDuration of type Int: true (type: bool)",
+	},
+
+	// KeywordList type search attributes.
+	{
+		name:     "KeywordList equal",
+		in:       "AliasForKeywordList01 = 'foo'",
+		mysql:    "TemporalNamespaceDivision is null and 'foo' member of (KeywordList01)",
+		postgres: "TemporalNamespaceDivision is null and KeywordList01 @> jsonb_build_array('foo')",
+		sqlite:   `TemporalNamespaceDivision is null and rowid in (select rowid from executions_visibility_fts_keyword_list where executions_visibility_fts_keyword_list = 'KeywordList01 : ("foo")')`,
+		es:       `{"bool":{"filter":{"term":{"KeywordList01":"foo"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name:     "KeywordList not equal",
+		in:       "AliasForKeywordList01 != 'foo'",
+		mysql:    "TemporalNamespaceDivision is null and (not 'foo' member of (KeywordList01))",
+		postgres: "TemporalNamespaceDivision is null and (not KeywordList01 @> jsonb_build_array('foo'))",
+		sqlite:   `TemporalNamespaceDivision is null and rowid not in (select rowid from executions_visibility_fts_keyword_list where executions_visibility_fts_keyword_list = 'KeywordList01 : ("foo")')`,
+		es:       `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"term":{"KeywordList01":"foo"}}]}}`,
+	},
+	{
+		name:     "KeywordList in",
+		in:       "AliasForKeywordList01 IN ('foo', 'bar')",
+		mysql:    `TemporalNamespaceDivision is null and json_overlaps(KeywordList01, cast('["foo","bar"]' as json))`,
+		postgres: "TemporalNamespaceDivision is null and (KeywordList01 @> jsonb_build_array('foo') or KeywordList01 @> jsonb_build_array('bar'))",
+		sqlite:   `TemporalNamespaceDivision is null and rowid in (select rowid from executions_visibility_fts_keyword_list where executions_visibility_fts_keyword_list = 'KeywordList01 : ("foo" OR "bar")')`,
+		es:       `{"bool":{"filter":{"terms":{"KeywordList01":["foo","bar"]}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name:     "KeywordList not in",
+		in:       "AliasForKeywordList01 NOT IN ('foo', 'bar')",
+		mysql:    `TemporalNamespaceDivision is null and (not json_overlaps(KeywordList01, cast('["foo","bar"]' as json)))`,
+		postgres: "TemporalNamespaceDivision is null and (not (KeywordList01 @> jsonb_build_array('foo') or KeywordList01 @> jsonb_build_array('bar')))",
+		sqlite:   `TemporalNamespaceDivision is null and rowid not in (select rowid from executions_visibility_fts_keyword_list where executions_visibility_fts_keyword_list = 'KeywordList01 : ("foo" OR "bar")')`,
+		es:       `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"terms":{"KeywordList01":["foo","bar"]}}]}}`,
+	},
+	{
+		name:     "KeywordList predefined search attribute",
+		in:       "TemporalChangeVersion = 'foo'",
+		mysql:    "TemporalNamespaceDivision is null and 'foo' member of (TemporalChangeVersion)",
+		postgres: "TemporalNamespaceDivision is null and TemporalChangeVersion @> jsonb_build_array('foo')",
+		sqlite:   `TemporalNamespaceDivision is null and rowid in (select rowid from executions_visibility_fts_keyword_list where executions_visibility_fts_keyword_list = 'TemporalChangeVersion : ("foo")')`,
+		es:       `{"bool":{"filter":{"term":{"TemporalChangeVersion":"foo"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "KeywordList is null",
+		in:   "AliasForKeywordList01 IS NULL",
+		sql:  "TemporalNamespaceDivision is null and KeywordList01 is null",
+		es:   `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"exists":{"field":"KeywordList01"}}]}}`,
+	},
+	{
+		name: "KeywordList unsupported operator",
+		in:   "AliasForKeywordList01 > 'foo'",
+		err:  "operation is not supported: operator '>' not supported for KeywordList type search attribute 'AliasForKeywordList01'",
+	},
+	{
+		name: "KeywordList starts with not supported",
+		in:   "AliasForKeywordList01 STARTS_WITH 'foo'",
+		err:  "operation is not supported: operator 'STARTS_WITH' not supported for KeywordList type search attribute 'AliasForKeywordList01'",
+	},
+	{
+		name: "KeywordList invalid value type",
+		in:   "AliasForKeywordList01 = 123",
+		err:  "invalid expression: invalid value type for search attribute AliasForKeywordList01 of type KeywordList: 123 (type: int64)",
+	},
+
+	// Text type search attributes.
+	{
+		name:     "Text equal",
+		in:       "AliasForText01 = 'foo bar'",
+		mysql:    "TemporalNamespaceDivision is null and match(Text01) against ('foo bar' in natural language mode)",
+		postgres: "TemporalNamespaceDivision is null and Text01 @@ 'foo | bar'::tsquery",
+		sqlite:   `TemporalNamespaceDivision is null and rowid in (select rowid from executions_visibility_fts_text where executions_visibility_fts_text = 'Text01 : ("foo" OR "bar")')`,
+		es:       `{"bool":{"filter":{"match":{"Text01":{"query":"foo bar"}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name:     "Text not equal",
+		in:       "AliasForText01 != 'foo bar'",
+		mysql:    "TemporalNamespaceDivision is null and (not match(Text01) against ('foo bar' in natural language mode))",
+		postgres: "TemporalNamespaceDivision is null and (not Text01 @@ 'foo | bar'::tsquery)",
+		sqlite:   `TemporalNamespaceDivision is null and rowid not in (select rowid from executions_visibility_fts_text where executions_visibility_fts_text = 'Text01 : ("foo" OR "bar")')`,
+		es:       `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"match":{"Text01":{"query":"foo bar"}}}]}}`,
+	},
+	{
+		name: "Text empty value",
+		in:   "AliasForText01 = ''",
+		err:  "invalid expression: no tokens found filtering on Text type search attribute AliasForText01",
+	},
+	{
+		name: "Text blank value",
+		in:   "AliasForText01 = '   '",
+		err:  "invalid expression: no tokens found filtering on Text type search attribute AliasForText01",
+	},
+	{
+		// Only blank values are rejected: the value is passed as is to the store converters,
+		// which tokenize it.
+		name:     "Text value with surrounding spaces",
+		in:       "AliasForText01 = '  foo bar  '",
+		mysql:    "TemporalNamespaceDivision is null and match(Text01) against ('  foo bar  ' in natural language mode)",
+		postgres: "TemporalNamespaceDivision is null and Text01 @@ 'foo | bar'::tsquery",
+		sqlite:   `TemporalNamespaceDivision is null and rowid in (select rowid from executions_visibility_fts_text where executions_visibility_fts_text = 'Text01 : ("foo" OR "bar")')`,
+		es:       `{"bool":{"filter":{"match":{"Text01":{"query":"  foo bar  "}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Text unsupported operator",
+		in:   "AliasForText01 > 'foo'",
+		err:  "operation is not supported: operator '>' not supported for Text type search attribute 'AliasForText01'",
+	},
+	{
+		name: "Text in not supported",
+		in:   "AliasForText01 IN ('foo', 'bar')",
+		err:  "operation is not supported: operator 'IN' not supported for Text type search attribute 'AliasForText01'",
+	},
+	{
+		name: "Text range condition not supported",
+		in:   "AliasForText01 BETWEEN 'a' AND 'b'",
+		err:  "invalid expression: cannot do range condition on search attribute 'AliasForText01' of type Text",
+	},
+	{
+		name: "Text invalid value type",
+		in:   "AliasForText01 = 123",
+		err:  "invalid expression: invalid value type for search attribute AliasForText01 of type Text: 123 (type: int64)",
+	},
+
+	// Search attribute name resolution.
+	{
+		name: "custom search attribute by field name",
+		in:   "Keyword01 = 'foo'",
+		sql:  "TemporalNamespaceDivision is null and Keyword01 = 'foo'",
+		es:   `{"bool":{"filter":{"term":{"Keyword01":"foo"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "custom search attribute with backticks",
+		in:   "`AliasForKeyword01` = 'foo'",
+		sql:  "TemporalNamespaceDivision is null and Keyword01 = 'foo'",
+		es:   `{"bool":{"filter":{"term":{"Keyword01":"foo"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "custom search attribute alias with hyphen",
+		in:   "`AliasWithHyphenFor-Keyword01` = 'foo'",
+		sql:  "TemporalNamespaceDivision is null and Keyword01 = 'foo'",
+		es:   `{"bool":{"filter":{"term":{"Keyword01":"foo"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name:     "predefined search attribute without Temporal prefix",
+		in:       "PauseInfo = 'foo'",
+		mysql:    "TemporalNamespaceDivision is null and 'foo' member of (TemporalPauseInfo)",
+		postgres: "TemporalNamespaceDivision is null and TemporalPauseInfo @> jsonb_build_array('foo')",
+		sqlite:   `TemporalNamespaceDivision is null and rowid in (select rowid from executions_visibility_fts_keyword_list where executions_visibility_fts_keyword_list = 'TemporalPauseInfo : ("foo")')`,
+		es:       `{"bool":{"filter":{"term":{"TemporalPauseInfo":"foo"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "system search attribute with Temporal prefix",
+		in:   "TemporalHistoryLength > 10",
+		sql:  "TemporalNamespaceDivision is null and history_length > 10",
+		es:   `{"bool":{"filter":{"range":{"HistoryLength":{"from":10,"include_lower":false,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "ScheduleId is mapped to WorkflowId",
+		in:   "ScheduleId = 'sched-id'",
+		sql:  "TemporalNamespaceDivision is null and workflow_id = 'sched-id'",
+		es:   `{"bool":{"filter":{"term":{"WorkflowId":"sched-id"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "TemporalScheduleId is mapped to WorkflowId",
+		in:   "TemporalScheduleId = 'sched-id'",
+		sql:  "TemporalNamespaceDivision is null and workflow_id = 'sched-id'",
+		es:   `{"bool":{"filter":{"term":{"WorkflowId":"sched-id"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "unknown search attribute",
+		in:   "Foo = 'bar'",
+		err:  "invalid expression: column name 'Foo' is not a valid search attribute",
+	},
+	{
+		name: "reserved field name is not a search attribute",
+		in:   "NamespaceId = 'foo'",
+		err:  "invalid expression: column name 'NamespaceId' is not a valid search attribute",
+	},
+
+	// Namespace division.
+	{
+		name: "explicit namespace division",
+		in:   "TemporalNamespaceDivision = 'foo'",
+		sql:  "TemporalNamespaceDivision = 'foo'",
+		es:   `{"term":{"TemporalNamespaceDivision":"foo"}}`,
+	},
+	{
+		name: "explicit namespace division is null",
+		in:   "TemporalNamespaceDivision IS NULL",
+		sql:  "TemporalNamespaceDivision is null",
+		es:   `{"bool":{"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "match any namespace division",
+		in:   "TemporalNamespaceDivision IS NULL OR TemporalNamespaceDivision IS NOT NULL",
+		sql:  "(TemporalNamespaceDivision is null or TemporalNamespaceDivision is not null)",
+		es:   `{"bool":{"minimum_should_match":"1","should":[{"bool":{"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}},{"exists":{"field":"TemporalNamespaceDivision"}}]}}`,
+	},
+	{
+		name: "namespace division in complex query",
+		in:   "WorkflowId = 'wid' AND (TemporalNamespaceDivision = 'foo' OR TemporalNamespaceDivision = 'bar')",
+		sql:  "(workflow_id = 'wid' and (TemporalNamespaceDivision = 'foo' or TemporalNamespaceDivision = 'bar'))",
+		es:   `{"bool":{"filter":[{"term":{"WorkflowId":"wid"}},{"bool":{"minimum_should_match":"1","should":[{"term":{"TemporalNamespaceDivision":"foo"}},{"term":{"TemporalNamespaceDivision":"bar"}}]}}]}}`,
+	},
+
+	// Logical operators.
+	{
+		name: "and expression",
+		in:   "WorkflowId = 'wid' AND ExecutionStatus = 'Running'",
+		sql:  "TemporalNamespaceDivision is null and (workflow_id = 'wid' and status = 1)",
+		es:   `{"bool":{"filter":[{"term":{"WorkflowId":"wid"}},{"term":{"ExecutionStatus":"Running"}}],"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "or expression",
+		in:   "WorkflowId = 'wid' OR RunId = 'rid'",
+		sql:  "TemporalNamespaceDivision is null and (workflow_id = 'wid' or run_id = 'rid')",
+		es:   `{"bool":{"filter":{"bool":{"minimum_should_match":"1","should":[{"term":{"WorkflowId":"wid"}},{"term":{"RunId":"rid"}}]}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "multiple and expressions",
+		in:   "WorkflowId = 'wid' AND RunId = 'rid' AND WorkflowType = 'wtype'",
+		sql:  "TemporalNamespaceDivision is null and ((workflow_id = 'wid' and run_id = 'rid') and workflow_type_name = 'wtype')",
+		es:   `{"bool":{"filter":[{"term":{"WorkflowId":"wid"}},{"term":{"RunId":"rid"}},{"term":{"WorkflowType":"wtype"}}],"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "multiple or expressions",
+		in:   "WorkflowId = 'wid' OR RunId = 'rid' OR WorkflowType = 'wtype'",
+		sql:  "TemporalNamespaceDivision is null and (workflow_id = 'wid' or run_id = 'rid' or workflow_type_name = 'wtype')",
+		es:   `{"bool":{"filter":{"bool":{"minimum_should_match":"1","should":[{"term":{"WorkflowId":"wid"}},{"term":{"RunId":"rid"}},{"term":{"WorkflowType":"wtype"}}]}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "and or precedence",
+		in:   "WorkflowId = 'wid' AND RunId = 'rid' OR WorkflowType = 'wtype'",
+		sql:  "TemporalNamespaceDivision is null and (workflow_id = 'wid' and run_id = 'rid' or workflow_type_name = 'wtype')",
+		es:   `{"bool":{"filter":{"bool":{"minimum_should_match":"1","should":[{"bool":{"filter":[{"term":{"WorkflowId":"wid"}},{"term":{"RunId":"rid"}}]}},{"term":{"WorkflowType":"wtype"}}]}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "parenthesized expression",
+		in:   "WorkflowId = 'wid' AND (RunId = 'rid' OR WorkflowType = 'wtype')",
+		sql:  "TemporalNamespaceDivision is null and (workflow_id = 'wid' and (run_id = 'rid' or workflow_type_name = 'wtype'))",
+		es:   `{"bool":{"filter":[{"term":{"WorkflowId":"wid"}},{"bool":{"minimum_should_match":"1","should":[{"term":{"RunId":"rid"}},{"term":{"WorkflowType":"wtype"}}]}}],"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "nested parenthesized expression",
+		in:   "((WorkflowId = 'wid'))",
+		sql:  "TemporalNamespaceDivision is null and workflow_id = 'wid'",
+		es:   `{"bool":{"filter":{"term":{"WorkflowId":"wid"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "not expression",
+		in:   "NOT WorkflowId = 'wid'",
+		sql:  "TemporalNamespaceDivision is null and (not workflow_id = 'wid')",
+		es:   `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"term":{"WorkflowId":"wid"}}]}}`,
+	},
+	{
+		name: "not parenthesized and expression",
+		in:   "NOT (WorkflowId = 'wid' AND RunId = 'rid')",
+		sql:  "TemporalNamespaceDivision is null and (not (workflow_id = 'wid' and run_id = 'rid'))",
+		es:   `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"bool":{"filter":[{"term":{"WorkflowId":"wid"}},{"term":{"RunId":"rid"}}]}}]}}`,
+	},
+	{
+		name: "not parenthesized or expression",
+		in:   "NOT (WorkflowId = 'wid' OR RunId = 'rid')",
+		sql:  "TemporalNamespaceDivision is null and (not (workflow_id = 'wid' or run_id = 'rid'))",
+		es:   `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"term":{"WorkflowId":"wid"}},{"term":{"RunId":"rid"}}]}}`,
+	},
+	{
+		name: "not is null expression",
+		in:   "NOT CloseTime IS NULL",
+		sql:  "TemporalNamespaceDivision is null and (not close_time is null)",
+		es:   `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"bool":{"must_not":{"exists":{"field":"CloseTime"}}}}]}}`,
+	},
+	{
+		name: "complex query",
+		in: "WorkflowType = 'wtype' AND ExecutionStatus IN ('Running', 'Failed') " +
+			"AND (StartTime > '2020-01-02T15:04:05Z' OR CloseTime IS NULL) " +
+			"AND NOT AliasForKeyword01 STARTS_WITH 'foo'",
+		mysql: "TemporalNamespaceDivision is null and " +
+			"(((workflow_type_name = 'wtype' and status in (1, 3)) and " +
+			"(start_time > '2020-01-02 15:04:05' or close_time is null)) and " +
+			"(not Keyword01 like 'foo%' escape '!'))",
+		postgres: "TemporalNamespaceDivision is null and " +
+			"(((workflow_type_name = 'wtype' and status in (1, 3)) and " +
+			"(start_time > '2020-01-02 15:04:05' or close_time is null)) and " +
+			"(not Keyword01 like 'foo%' escape '!'))",
+		sqlite: "TemporalNamespaceDivision is null and " +
+			"(((workflow_type_name = 'wtype' and status in (1, 3)) and " +
+			"(start_time > '2020-01-02 15:04:05+00:00' or close_time is null)) and " +
+			"(not Keyword01 like 'foo%' escape '!'))",
+		es: `{"bool":{"filter":[{"term":{"WorkflowType":"wtype"}},` +
+			`{"terms":{"ExecutionStatus":["Running","Failed"]}},` +
+			`{"bool":{"minimum_should_match":"1","should":[` +
+			`{"range":{"StartTime":{"from":"2020-01-02T15:04:05Z","include_lower":false,"include_upper":true,"to":null}}},` +
+			`{"bool":{"must_not":{"exists":{"field":"CloseTime"}}}}]}}],` +
+			`"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"prefix":{"Keyword01":"foo"}}]}}`,
+	},
+	{
+		name: "error inside and expression",
+		in:   "WorkflowId = 'wid' AND Foo = 'bar'",
+		err:  "invalid expression: column name 'Foo' is not a valid search attribute",
+	},
+	{
+		name: "error inside or expression",
+		in:   "Foo = 'bar' OR WorkflowId = 'wid'",
+		err:  "invalid expression: column name 'Foo' is not a valid search attribute",
+	},
+	{
+		name: "error inside not expression",
+		in:   "NOT Foo = 'bar'",
+		err:  "invalid expression: column name 'Foo' is not a valid search attribute",
+	},
+
+	// GROUP BY clause.
+	{
+		name:    "group by execution status",
+		in:      "GROUP BY ExecutionStatus",
+		sql:     "TemporalNamespaceDivision is null",
+		es:      `{"bool":{"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+		groupBy: []string{"ExecutionStatus"},
+	},
+	{
+		name:    "group by with where clause",
+		in:      "WorkflowType = 'wtype' GROUP BY ExecutionStatus",
+		sql:     "TemporalNamespaceDivision is null and workflow_type_name = 'wtype'",
+		es:      `{"bool":{"filter":{"term":{"WorkflowType":"wtype"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+		groupBy: []string{"ExecutionStatus"},
+	},
+	{
+		name:    "group by namespace division",
+		in:      "GROUP BY TemporalNamespaceDivision",
+		groupBy: []string{"TemporalNamespaceDivision"},
+	},
+	{
+		name: "group by unsupported search attribute",
+		in:   "GROUP BY WorkflowId",
+		err:  "operation is not supported: 'GROUP BY' clause is not supported for search attribute WorkflowId",
+	},
+	{
+		name: "group by multiple search attributes",
+		in:   "GROUP BY ExecutionStatus, TemporalNamespaceDivision",
+		err:  "operation is not supported: 'GROUP BY' clause supports only a single field",
+	},
+	{
+		name: "group by unknown search attribute",
+		in:   "GROUP BY Foo",
+		err:  "invalid expression: column name 'Foo' is not a valid search attribute",
+	},
+
+	// ORDER BY clause.
+	{
+		name:    "order by",
+		in:      "ORDER BY StartTime",
+		sql:     "TemporalNamespaceDivision is null",
+		es:      `{"bool":{"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+		orderBy: "order by start_time asc",
+	},
+	{
+		name:    "order by desc",
+		in:      "ORDER BY CloseTime DESC",
+		sql:     "TemporalNamespaceDivision is null",
+		es:      `{"bool":{"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+		orderBy: "order by close_time desc",
+	},
+	{
+		name:    "order by multiple search attributes",
+		in:      "ORDER BY StartTime DESC, RunId ASC",
+		sql:     "TemporalNamespaceDivision is null",
+		es:      `{"bool":{"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+		orderBy: "order by start_time desc, run_id asc",
+	},
+	{
+		name:    "order by with where clause",
+		in:      "WorkflowId = 'wid' ORDER BY StartTime DESC",
+		sql:     "TemporalNamespaceDivision is null and workflow_id = 'wid'",
+		es:      `{"bool":{"filter":{"term":{"WorkflowId":"wid"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+		orderBy: "order by start_time desc",
+	},
+	{
+		name:    "order by custom search attribute",
+		in:      "ORDER BY AliasForKeyword01",
+		sql:     "TemporalNamespaceDivision is null",
+		es:      `{"bool":{"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+		orderBy: "order by Keyword01 asc",
+	},
+	{
+		name: "order by text search attribute",
+		in:   "ORDER BY AliasForText01",
+		err:  "operation is not supported: unable to sort by search attribute type Text",
+	},
+	{
+		name: "order by unknown search attribute",
+		in:   "ORDER BY Foo",
+		err:  "invalid expression: column name 'Foo' is not a valid search attribute",
+	},
+
+	// Malformed and unsupported queries.
+	{
+		name: "malformed query",
+		in:   "this is not a query",
+		err:  "malformed SQL query: syntax error at position 41 near 'a'",
+	},
+	{
+		name: "missing value",
+		in:   "WorkflowId =",
+		err:  "malformed SQL query: syntax error at position 40",
+	},
+	{
+		name: "incomplete expression",
+		in:   "WorkflowId",
+		err:  "invalid expression: incomplete expression",
+	},
+	{
+		name: "column name on right hand side",
+		in:   "WorkflowId = RunId",
+		err:  `operation is not supported: column name on the right side of comparison expression (did you forget to quote "RunId"?)`,
+	},
+	{
+		name: "function expression",
+		in:   "length(WorkflowId)",
+		err:  "operation is not supported: function expression",
+	},
+	{
+		name: "function expression on left hand side",
+		in:   "length(WorkflowId) = 5",
+		err:  "invalid expression: must be a column name but was *sqlparser.FuncExpr",
+	},
+	{
+		name: "function expression on right hand side",
+		in:   "WorkflowId = length('foo')",
+		err:  "operation is not supported: nested func",
+	},
+	{
+		name: "limit clause",
+		in:   "WorkflowId = 'wid' LIMIT 10",
+		err:  "operation is not supported: 'LIMIT' clause",
+	},
+	{
+		name: "subquery",
+		in:   "WorkflowId IN (SELECT * FROM table1)",
+		err:  "invalid expression: unexpected value type *sqlparser.Subquery",
+	},
+	{
+		name: "arithmetic expression",
+		in:   "HistoryLength = 1 + 1",
+		err:  "invalid expression: unexpected value type *sqlparser.BinaryExpr",
+	},
+	{
+		name: "unsupported unary operator",
+		in:   "AliasForInt01 = ~1",
+		err:  `operation is not supported: unary operator "~"`,
+	},
+}
+
+func runQueryConverterTest[T any](
+	t *testing.T,
+	store string,
+	newQueryConverter func() *query.QueryConverter[T],
+	serialize func(T) (string, error),
+) {
+	for _, tc := range queryConverterTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := require.New(t)
+			expectedOut, expectedErr := tc.expected(store)
+			// The query converter is stateful (e.g. it tracks if the query filtered by
+			// namespace division), thus each test case requires a new instance.
+			queryParams, err := newQueryConverter().Convert(tc.in)
+			if expectedErr != "" {
+				r.Error(err)
+				r.EqualError(err, expectedErr)
+				var converterErr *query.ConverterError
+				r.ErrorAs(err, &converterErr)
+				r.Nil(queryParams)
+				return
+			}
+			r.NoError(err)
+			out, err := serialize(queryParams.QueryExpr)
+			r.NoError(err)
+			r.Equal(expectedOut, out)
+
+			var groupBy []string
+			for _, col := range queryParams.GroupBy {
+				groupBy = append(groupBy, col.FieldName)
+			}
+			r.Equal(tc.groupBy, groupBy)
+			r.Equal(tc.orderBy, strings.TrimSpace(sqlparser.String(queryParams.OrderBy)))
+		})
+	}
+}
+
+func serializeSQLQuery(expr sqlparser.Expr) (string, error) {
+	if expr == nil {
+		return "", nil
+	}
+	return sqlparser.String(expr), nil
+}
+
+func serializeESQuery(q elastic.Query) (string, error) {
+	if q == nil {
+		return "", nil
+	}
+	source, err := q.Source()
+	if err != nil {
+		return "", err
+	}
+	data, err := json.Marshal(source)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func TestSQLQueryConverter(t *testing.T) {
+	t.Parallel()
+	for _, plugin := range sqlPlugins {
+		t.Run(plugin, func(t *testing.T) {
+			t.Parallel()
+			pluginVisQC, err := sql.GetPluginVisibilityQueryConverter(plugin)
+			require.NoError(t, err)
+			runQueryConverterTest(
+				t,
+				plugin,
+				func() *query.QueryConverter[sqlparser.Expr] {
+					return query.NewQueryConverter(
+						&vissql.SQLQueryConverter{VisibilityQueryConverter: pluginVisQC},
+						testNamespaceName,
+						searchattribute.TestNameTypeMap(),
+						&searchattribute.TestMapper{},
+						nil, // metricsHandler
+						log.NewNoopLogger(),
+					)
+				},
+				serializeSQLQuery,
+			)
+		})
+	}
+}
+
+func TestElasticsearchQueryConverter(t *testing.T) {
+	t.Parallel()
+	runQueryConverterTest(
+		t,
+		esStore,
+		func() *query.QueryConverter[elastic.Query] {
+			return elasticsearch.NewQueryConverter(
+				testNamespaceName,
+				searchattribute.TestNameTypeMap(),
+				&searchattribute.TestMapper{},
+				nil, // metricsHandler
+				log.NewNoopLogger(),
+			)
+		},
+		serializeESQuery,
+	)
+}


### PR DESCRIPTION
## What changed?
- Fix parsing ExecutionStatus in tuple (eg: `ExecutionStatus IN ('Running', 'Completed')`)
- Fix parsing negative double values (eg: `CustomDouble > -1.5` was returning an error)
- Return error when comparing non-bool types with boolean value (eg: `StartTime = true` was not returning an error).
- Return error when comparing Text type search attribute with an empty string/no tokens (eg: `CustomText = ' '`). It was already returning an error with PostgreSQL and SQLite, now also returning an error with MySQL and Elasticsearch.
- Added unit tests covering all Visibility stores to make sure they all behave the same. One exception: `ExecutionStatus STARTS_WITH` works with Elasticsearch, but not with SQL. That's because in Elasticsearch we store as string, while in SQL we store as int.

## Why?
Bug fixes, and comprehensive unit tests to ensure uniform behavior.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
