### PR TITLE
WIP: Use sync match rate for the poller scaling ratio check, behind dynamic config

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1570,6 +1570,15 @@ dispatch rate above which a decision to scale up the number of pollers will be i
 metric describing why pollers are scaled up, down, or held for a physical task queue. This is opt-in and can be
 scoped by namespace and/or task queue.`,
 	)
+	MatchingUseImprovedSignalsForPollerScaling = NewTaskQueueBoolSetting(
+		"matching.useImprovedSignalsForPollerScaling",
+		false,
+		`MatchingUseImprovedSignalsForPollerScaling, when enabled, uses the physical queue's sync match rate instead of
+its total dispatch rate as the denominator of the poller scaling add-to-dispatch ratio check. The total dispatch rate
+includes tasks dispatched from the backlog, which makes it track the add rate closely and so masks a poor sync match
+rate. Both signals are always evaluated and compared via the poller_scale_signal_comparison metric; this setting only
+controls which one drives the decision.`,
+	)
 	MatchingUseNewMatcher = NewTaskQueueTypedSettingWithConverter(
 		"matching.useNewMatcher",
 		ConvertGradualChange(true),

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1563,6 +1563,18 @@ second per poller by one physical queue manager`,
 		`MatchingPollerScalingTaskAddToDispatchRatio is the ratio of task add rate to task
 dispatch rate above which a decision to scale up the number of pollers will be issued`,
 	)
+	MatchingPollerScalingSyncMatchRatio = NewTaskQueueFloatSetting(
+		"matching.pollerScalingSyncMatchRatio",
+		1.2,
+		`MatchingPollerScalingSyncMatchRatio is the ratio of task add rate to task sync match rate above which a
+decision to scale up the number of pollers will be issued, when matching.useImprovedSignalsForPollerScaling is
+enabled. This is deliberately a separate setting from matching.pollerScalingTaskAddToDispatchRatio even though the
+defaults match, because the two ratios have different natural scales: add rate and total dispatch rate are equal in
+steady state, so that ratio is centered on 1.0, whereas add rate over sync match rate is the reciprocal of the
+sync-matched fraction and so is always at least 1.0. At the 1.2 default this signal fires once the sync-matched
+fraction drops below roughly 83%. Keeping the knobs separate also means shadow-mode data can be re-collected at a
+different threshold without perturbing the signal it is being compared against.`,
+	)
 	MatchingEnablePollerScalingDecisionMetrics = NewTaskQueueBoolSetting(
 		"matching.enablePollerScalingDecisionMetrics",
 		false,
@@ -1576,8 +1588,9 @@ scoped by namespace and/or task queue.`,
 		`MatchingUseImprovedSignalsForPollerScaling, when enabled, uses the physical queue's sync match rate instead of
 its total dispatch rate as the denominator of the poller scaling add-to-dispatch ratio check. The total dispatch rate
 includes tasks dispatched from the backlog, which makes it track the add rate closely and so masks a poor sync match
-rate. Both signals are always evaluated and compared via the poller_scale_signal_comparison metric; this setting only
-controls which one drives the decision.`,
+rate. Whenever a scaling decision reaches the ratio check, both signals are evaluated and compared via the
+poller_scale_signal_comparison metric; this setting only controls which one drives the decision. The improved signal
+is thresholded by matching.pollerScalingSyncMatchRatio rather than matching.pollerScalingTaskAddToDispatchRatio.`,
 	)
 	MatchingUseNewMatcher = NewTaskQueueTypedSettingWithConverter(
 		"matching.useNewMatcher",

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1407,10 +1407,12 @@ var (
 	PollerScaleSignalComparisonCounter = NewCounterDef(
 		"poller_scale_signal_comparison",
 		WithDescription(
-			"Compares the old and improved poller scaling signals in shadow mode. Emitted on every scaling decision "+
-				"where at least one of the two signals fires. Dimensions: namespace, taskqueue, task_type, partition, "+
-				"signal (ratio), result (both/new_only/old_only). Gated by "+
-				"matching.enablePollerScalingDecisionMetrics."),
+			"Compares the old and improved poller scaling signals in shadow mode. Only emitted when a scaling "+
+				"decision actually reaches the add-to-dispatch ratio check and at least one of the two signals "+
+				"fires, so it does not cover decisions settled earlier by the scale-down, rate-limit, or backlog "+
+				"branches, nor non-root normal partitions, which never reach the ratio check at all. Dimensions: "+
+				"namespace, taskqueue, task_type, partition, signal (ratio), result (both/new_only/old_only). "+
+				"Gated by matching.enablePollerScalingDecisionMetrics."),
 	)
 	// ----------------------------------------------------------------------------------------------------------------
 

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1404,6 +1404,14 @@ var (
 				"dynamic config matching.enablePollerScalingDecisionMetrics is enabled. Dimensions: namespace, taskqueue, "+
 				"task_type, partition, decision (scale_up/scale_down/hold), reason (idle/backlog/task_rate/rate_limited)"),
 	)
+	PollerScaleSignalComparisonCounter = NewCounterDef(
+		"poller_scale_signal_comparison",
+		WithDescription(
+			"Compares the old and improved poller scaling signals in shadow mode. Emitted on every scaling decision "+
+				"where at least one of the two signals fires. Dimensions: namespace, taskqueue, task_type, partition, "+
+				"signal (ratio), result (both/new_only/old_only). Gated by "+
+				"matching.enablePollerScalingDecisionMetrics."),
+	)
 	// ----------------------------------------------------------------------------------------------------------------
 
 	PartitionCacheSize = NewGaugeDef(

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -30,6 +30,8 @@ const (
 	forwardedTag            = "forwarded"
 	pollResultTagName       = "poll_result"
 	pollerScaleDecisionTag  = "decision"
+	pollerScaleSignalTag    = "signal"
+	pollerScaleResultTag    = "result"
 	fromCluster             = "from_cluster"
 	toCluster               = "to_cluster"
 	taskQueue               = "taskqueue"
@@ -348,10 +350,34 @@ const (
 	PollerScaleReasonTaskQueueRateLimited ReasonString = "task_queue_rate_limited"
 )
 
+// PollerScaleSignalRatio names the add-to-dispatch ratio scale-up signal in the "signal" tag of
+// metrics.PollerScaleSignalComparisonCounter.
+const PollerScaleSignalRatio = "ratio"
+
+// Values for the "result" tag of metrics.PollerScaleSignalComparisonCounter, describing which of
+// the old and improved signals fired.
+const (
+	PollerScaleComparisonBoth    = "both"
+	PollerScaleComparisonNewOnly = "new_only"
+	PollerScaleComparisonOldOnly = "old_only"
+)
+
 // PollerScaleDecisionTag records the direction of a poller scaling decision (scale up, scale
 // down, or hold). Pair it with ReasonTag for the cause. See metrics.PollerScaleDecisionCounter.
 func PollerScaleDecisionTag(decision string) Tag {
 	return Tag{Key: pollerScaleDecisionTag, Value: decision}
+}
+
+// PollerScaleSignalTag records which scale-up signal a shadow-mode comparison is about. Pair it
+// with PollerScaleComparisonResultTag. See metrics.PollerScaleSignalComparisonCounter.
+func PollerScaleSignalTag(signal string) Tag {
+	return Tag{Key: pollerScaleSignalTag, Value: signal}
+}
+
+// PollerScaleComparisonResultTag records which of the old and improved signals fired.
+// See metrics.PollerScaleSignalComparisonCounter.
+func PollerScaleComparisonResultTag(result string) Tag {
+	return Tag{Key: pollerScaleResultTag, Value: result}
 }
 
 func MatchingTaskPriorityTag(value int32) Tag {

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -137,6 +137,7 @@ type (
 		PollerScalingWaitTime               dynamicconfig.DurationPropertyFnWithTaskQueueFilter
 		PollerScalingDecisionsPerSecond     dynamicconfig.FloatPropertyFnWithTaskQueueFilter
 		PollerScalingTaskAddToDispatchRatio dynamicconfig.FloatPropertyFnWithTaskQueueFilter
+		PollerScalingSyncMatchRatio         dynamicconfig.FloatPropertyFnWithTaskQueueFilter
 		EnablePollerScalingDecisionMetrics  dynamicconfig.BoolPropertyFnWithTaskQueueFilter
 		UseImprovedSignalsForPollerScaling  dynamicconfig.BoolPropertyFnWithTaskQueueFilter
 
@@ -232,6 +233,7 @@ type (
 		PollerScalingWaitTime               func() time.Duration
 		PollerScalingDecisionsPerSecond     func() float64
 		PollerScalingTaskAddToDispatchRatio func() float64
+		PollerScalingSyncMatchRatio         func() float64
 		EnablePollerScalingDecisionMetrics  func() bool
 		UseImprovedSignalsForPollerScaling  func() bool
 
@@ -386,6 +388,7 @@ func NewConfig(
 		PollerScalingWaitTime:               dynamicconfig.MatchingPollerScalingWaitTime.Get(dc),
 		PollerScalingDecisionsPerSecond:     dynamicconfig.MatchingPollerScalingDecisionsPerSecond.Get(dc),
 		PollerScalingTaskAddToDispatchRatio: dynamicconfig.MatchingPollerScalingTaskAddToDispatchRatio.Get(dc),
+		PollerScalingSyncMatchRatio:         dynamicconfig.MatchingPollerScalingSyncMatchRatio.Get(dc),
 		EnablePollerScalingDecisionMetrics:  dynamicconfig.MatchingEnablePollerScalingDecisionMetrics.Get(dc),
 		UseImprovedSignalsForPollerScaling:  dynamicconfig.MatchingUseImprovedSignalsForPollerScaling.Get(dc),
 
@@ -563,6 +566,9 @@ func newTaskQueueConfig(tq *tqid.TaskQueue, config *Config, ns namespace.Name) *
 		},
 		PollerScalingTaskAddToDispatchRatio: func() float64 {
 			return config.PollerScalingTaskAddToDispatchRatio(ns.String(), taskQueueName, taskType)
+		},
+		PollerScalingSyncMatchRatio: func() float64 {
+			return config.PollerScalingSyncMatchRatio(ns.String(), taskQueueName, taskType)
 		},
 		EnablePollerScalingDecisionMetrics: func() bool {
 			return config.EnablePollerScalingDecisionMetrics(ns.String(), taskQueueName, taskType)

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -138,6 +138,7 @@ type (
 		PollerScalingDecisionsPerSecond     dynamicconfig.FloatPropertyFnWithTaskQueueFilter
 		PollerScalingTaskAddToDispatchRatio dynamicconfig.FloatPropertyFnWithTaskQueueFilter
 		EnablePollerScalingDecisionMetrics  dynamicconfig.BoolPropertyFnWithTaskQueueFilter
+		UseImprovedSignalsForPollerScaling  dynamicconfig.BoolPropertyFnWithTaskQueueFilter
 
 		FairnessCounter               dynamicconfig.TypedPropertyFnWithTaskQueueFilter[counter.CounterParams]
 		FairnessPassDither            dynamicconfig.BoolPropertyFnWithTaskQueueFilter
@@ -232,6 +233,7 @@ type (
 		PollerScalingDecisionsPerSecond     func() float64
 		PollerScalingTaskAddToDispatchRatio func() float64
 		EnablePollerScalingDecisionMetrics  func() bool
+		UseImprovedSignalsForPollerScaling  func() bool
 
 		FairnessCounter               func() counter.CounterParams
 		FairnessPassDither            func() bool
@@ -385,6 +387,7 @@ func NewConfig(
 		PollerScalingDecisionsPerSecond:     dynamicconfig.MatchingPollerScalingDecisionsPerSecond.Get(dc),
 		PollerScalingTaskAddToDispatchRatio: dynamicconfig.MatchingPollerScalingTaskAddToDispatchRatio.Get(dc),
 		EnablePollerScalingDecisionMetrics:  dynamicconfig.MatchingEnablePollerScalingDecisionMetrics.Get(dc),
+		UseImprovedSignalsForPollerScaling:  dynamicconfig.MatchingUseImprovedSignalsForPollerScaling.Get(dc),
 
 		FairnessCounter:               dynamicconfig.MatchingFairnessCounter.Get(dc),
 		FairnessPassDither:            dynamicconfig.MatchingFairnessPassDither.Get(dc),
@@ -563,6 +566,9 @@ func newTaskQueueConfig(tq *tqid.TaskQueue, config *Config, ns namespace.Name) *
 		},
 		EnablePollerScalingDecisionMetrics: func() bool {
 			return config.EnablePollerScalingDecisionMetrics(ns.String(), taskQueueName, taskType)
+		},
+		UseImprovedSignalsForPollerScaling: func() bool {
+			return config.UseImprovedSignalsForPollerScaling(ns.String(), taskQueueName, taskType)
 		},
 		FairnessCounter: func() counter.CounterParams {
 			return config.FairnessCounter(ns.String(), taskQueueName, taskType)

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -95,6 +95,9 @@ type (
 		taskTrackerLock sync.Mutex
 		tasksAdded      map[priorityKey]*taskTracker
 		tasksDispatched map[priorityKey]*taskTracker
+		// tasksSyncMatched tracks the subset of tasksDispatched that were matched to a waiting
+		// poller instead of being read back from the backlog. Used only by poller scaling.
+		tasksSyncMatched map[priorityKey]*taskTracker
 		// tasksRateLimited tracks rate-limit events in a sliding window for stats reporting.
 		tasksRateLimited *taskTracker
 	}
@@ -162,6 +165,7 @@ func newPhysicalTaskQueueManager(
 		metricsHandler:           taggedMetricsHandler,
 		tasksAdded:               make(map[priorityKey]*taskTracker),
 		tasksDispatched:          make(map[priorityKey]*taskTracker),
+		tasksSyncMatched:         make(map[priorityKey]*taskTracker),
 		tasksRateLimited:         e.newTaskTracker(),
 		pollerScalingRateLimiter: quotas.NewDefaultOutgoingRateLimiter(pollerScalingRateLimitFn),
 		deploymentRegistrationCh: make(chan struct{}, 1),
@@ -530,7 +534,17 @@ func (c *physicalTaskQueueManagerImpl) PollTask(
 		task.backlogCountHint = c.backlogCountHint
 
 		if pollMetadata.forwardedFrom == "" { // track the task on the child, not where a poll was forwarded to
-			c.incTaskTracker(c.tasksDispatched, priorityKey(task.getPriority().GetPriorityKey()), 1)
+			pri := priorityKey(task.getPriority().GetPriorityKey())
+			c.incTaskTracker(c.tasksDispatched, pri, 1)
+			// A task that still carries its history source was matched to a poller directly rather
+			// than read back from the backlog, i.e. it was sync matched. Query and Nexus tasks are
+			// also sourced from history and are never backlogged, so they count as sync matches too.
+			// Tasks whose source was lost (a "started" task handed back by a forwarded poll) are
+			// deliberately not counted; only root and sticky queues consume this rate, and neither
+			// forwards polls.
+			if task.source == enumsspb.TASK_SOURCE_HISTORY {
+				c.incTaskTracker(c.tasksSyncMatched, pri, 1)
+			}
 		}
 		return task, nil
 	}
@@ -937,9 +951,38 @@ func (c *physicalTaskQueueManagerImpl) makePollerScalingDecisionImpl(
 		// as they have only 1 partition.
 		return nil
 	} else {
-		if float64(stats.GetTasksAddRate())/float64(stats.GetTasksDispatchRate()) > c.partitionMgr.config.PollerScalingTaskAddToDispatchRatio() {
-			// Increase if we're adding tasks faster than we're dispatching them. Particularly useful for Nexus tasks,
-			// since those (currently) don't get backlogged.
+		// Increase if we're adding tasks faster than we're draining them. Particularly useful for
+		// Nexus tasks, since those (currently) don't get backlogged.
+		//
+		// Two signals are evaluated on every decision so they can be compared in shadow mode:
+		//
+		//   old: add rate / total dispatch rate, both taken from the adjusted queue stats.
+		//   new: add rate / sync match rate, both taken from this queue's own trackers.
+		//
+		// The old denominator counts tasks dispatched from the backlog, so under sustained backlog
+		// pressure it tracks the add rate closely and the ratio sits near 1 no matter how badly
+		// pollers are keeping up. The sync match rate excludes backlog dispatches, so it only
+		// measures work that found a poller waiting.
+		//
+		// The new signal deliberately does not reuse stats.GetTasksAddRate(): the partition manager
+		// re-attributes rates across the unversioned queue and the current/ramping version queues
+		// before returning them, so pairing that numerator with this queue's own sync match rate
+		// would compare two different populations. During a version rollout that skew is severe --
+		// a version's queue can be attributed the whole unversioned add rate while having no sync
+		// matches of its own, which would peg the ratio at +Inf and scale up forever.
+		threshold := c.partitionMgr.config.PollerScalingTaskAddToDispatchRatio()
+		oldRatioFires := ratioExceeds(float64(stats.GetTasksAddRate()), float64(stats.GetTasksDispatchRate()), threshold)
+
+		localAddRate, localSyncMatchedRate := c.getLocalAddAndSyncMatchedRates()
+		newRatioFires := ratioExceeds(float64(localAddRate), float64(localSyncMatchedRate), threshold)
+
+		c.recordPollerScaleSignalComparison(metrics.PollerScaleSignalRatio, oldRatioFires, newRatioFires)
+
+		scaleUpByRatio := oldRatioFires
+		if c.partitionMgr.config.UseImprovedSignalsForPollerScaling() {
+			scaleUpByRatio = newRatioFires
+		}
+		if scaleUpByRatio {
 			delta = 1
 			reason = metrics.PollerScaleReasonTaskRate
 		}
@@ -964,6 +1007,65 @@ func (c *physicalTaskQueueManagerImpl) recordPollerScaleDecision(decision string
 	}
 	c.metricsHandler.Counter(metrics.PollerScaleDecisionCounter.Name()).
 		Record(1, metrics.PollerScaleDecisionTag(decision), metrics.ReasonTag(reason))
+}
+
+// recordPollerScaleSignalComparison emits the poller_scale_signal_comparison metric comparing the
+// old and improved scale-up signals. Emitted only when at least one of the two fires, so the
+// counter stays quiet on idle queues. Gated by the same opt-in dynamic config as the poller scaling
+// decision metrics.
+func (c *physicalTaskQueueManagerImpl) recordPollerScaleSignalComparison(signal string, oldFires, newFires bool) {
+	if !oldFires && !newFires {
+		return
+	}
+	if !c.partitionMgr.config.EnablePollerScalingDecisionMetrics() {
+		return
+	}
+	var result string
+	switch {
+	case oldFires && newFires:
+		result = metrics.PollerScaleComparisonBoth
+	case newFires:
+		result = metrics.PollerScaleComparisonNewOnly
+	default:
+		result = metrics.PollerScaleComparisonOldOnly
+	}
+	c.metricsHandler.Counter(metrics.PollerScaleSignalComparisonCounter.Name()).
+		Record(1, metrics.PollerScaleSignalTag(signal), metrics.PollerScaleComparisonResultTag(result))
+}
+
+// ratioExceeds reports whether numerator/denominator is above threshold, without producing NaN or
+// +Inf for a zero denominator. Nothing arriving is never a reason to scale up; something arriving
+// while nothing drains is the strongest reason there is.
+func ratioExceeds(numerator, denominator, threshold float64) bool {
+	if numerator <= 0 {
+		return false
+	}
+	if denominator <= 0 {
+		return true
+	}
+	return numerator/denominator > threshold
+}
+
+// getLocalAddAndSyncMatchedRates returns this physical queue's own add and sync match rates,
+// aggregated over priorities. Both are read under one lock so they cover the same window.
+//
+// These are the raw tracker rates, not the rates in TaskQueueStats: the latter are re-attributed
+// across the unversioned and versioned queues by the partition manager, which would make the two
+// sides of the ratio incomparable. They are also kept out of GetStatsByPriority because
+// TaskQueueStats is a public API proto and the sync match rate is only used internally for scaling
+// decisions. If we ever want to expose it in metrics or DescribeTaskQueue, move it into
+// GetStatsByPriority and add a proto field.
+func (c *physicalTaskQueueManagerImpl) getLocalAddAndSyncMatchedRates() (addRate, syncMatchedRate float32) {
+	c.taskTrackerLock.Lock()
+	defer c.taskTrackerLock.Unlock()
+
+	for _, tt := range c.tasksAdded {
+		addRate += tt.rate()
+	}
+	for _, tt := range c.tasksSyncMatched {
+		syncMatchedRate += tt.rate()
+	}
+	return addRate, syncMatchedRate
 }
 
 func (c *physicalTaskQueueManagerImpl) UpdateRemotePriorityBacklogs(backlogs remotePriorityBacklogSet) {
@@ -995,6 +1097,7 @@ func (c *physicalTaskQueueManagerImpl) incTaskTracker(
 		// Initialize all task trackers together; or the timeframes won't line up.
 		c.tasksAdded[priorityKey] = c.partitionMgr.engine.newTaskTracker()
 		c.tasksDispatched[priorityKey] = c.partitionMgr.engine.newTaskTracker()
+		c.tasksSyncMatched[priorityKey] = c.partitionMgr.engine.newTaskTracker()
 		tracker = intervals[priorityKey]
 	}
 	tracker.inc(n)

--- a/service/matching/physical_task_queue_manager.go
+++ b/service/matching/physical_task_queue_manager.go
@@ -933,7 +933,15 @@ func (c *physicalTaskQueueManagerImpl) makePollerScalingDecisionImpl(
 
 	delta := int32(0)
 	var reason metrics.ReasonString
+	// Without stats we can't tell whether dispatch is rate limited or the backlog is growing, so
+	// don't guess. This matters more than it looks: the improved ratio signal below reads this
+	// queue's own trackers rather than these stats, so it would otherwise keep suggesting scale-ups
+	// right through a Describe outage, with the rate-limit check below silently skipped.
 	stats := statsFn()
+	if stats == nil {
+		return nil
+	}
+
 	// If dispatch is bottlenecked by a task queue rate limit, adding pollers won't help.
 	if stats.GetRateLimitingActive() {
 		c.recordPollerScaleDecision(metrics.PollerScaleDecisionHold, metrics.PollerScaleReasonTaskQueueRateLimited)
@@ -970,11 +978,25 @@ func (c *physicalTaskQueueManagerImpl) makePollerScalingDecisionImpl(
 		// would compare two different populations. During a version rollout that skew is severe --
 		// a version's queue can be attributed the whole unversioned add rate while having no sync
 		// matches of its own, which would peg the ratio at +Inf and scale up forever.
-		threshold := c.partitionMgr.config.PollerScalingTaskAddToDispatchRatio()
-		oldRatioFires := ratioExceeds(float64(stats.GetTasksAddRate()), float64(stats.GetTasksDispatchRate()), threshold)
+		// The two ratios get separate thresholds because they have different natural scales. Add
+		// rate and total dispatch rate are equal in steady state, so the old ratio is centered on
+		// 1.0 and its threshold reads as "adding this much faster than we drain". Add rate over
+		// sync match rate is the reciprocal of the sync-matched fraction, so it is always at least
+		// 1.0 and the same numeric threshold instead reads as "sync-matched fraction below 1/x".
+		// Sharing one knob would also mean retuning the improved signal perturbed the signal it is
+		// being compared against.
+		oldRatioFires := ratioExceeds(
+			float64(stats.GetTasksAddRate()),
+			float64(stats.GetTasksDispatchRate()),
+			c.partitionMgr.config.PollerScalingTaskAddToDispatchRatio(),
+		)
 
 		localAddRate, localSyncMatchedRate := c.getLocalAddAndSyncMatchedRates()
-		newRatioFires := ratioExceeds(float64(localAddRate), float64(localSyncMatchedRate), threshold)
+		newRatioFires := ratioExceeds(
+			float64(localAddRate),
+			float64(localSyncMatchedRate),
+			c.partitionMgr.config.PollerScalingSyncMatchRatio(),
+		)
 
 		c.recordPollerScaleSignalComparison(metrics.PollerScaleSignalRatio, oldRatioFires, newRatioFires)
 
@@ -1035,7 +1057,15 @@ func (c *physicalTaskQueueManagerImpl) recordPollerScaleSignalComparison(signal 
 
 // ratioExceeds reports whether numerator/denominator is above threshold, without producing NaN or
 // +Inf for a zero denominator. Nothing arriving is never a reason to scale up; something arriving
-// while nothing drains is the strongest reason there is.
+// while nothing drains is the strongest reason there is, so a zero denominator fires regardless of
+// threshold.
+//
+// Note that a zero denominator is far more common for the sync match rate than it ever was for the
+// total dispatch rate: a queue served entirely from its backlog has no sync matches at all. Such a
+// queue reaches this check only when its backlog is too young to have already triggered the backlog
+// branch, and raising the threshold will not damp it, because no threshold applies. That is
+// deliberate -- zero sync matches means no poll was ever waiting when a task arrived -- but it is
+// the main reason the improved signal wants shadow-mode validation before being enabled anywhere.
 func ratioExceeds(numerator, denominator, threshold float64) bool {
 	if numerator <= 0 {
 		return false

--- a/service/matching/physical_task_queue_manager_test.go
+++ b/service/matching/physical_task_queue_manager_test.go
@@ -18,6 +18,7 @@ import (
 	"go.temporal.io/server/api/matchingservicemock/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/goro"
@@ -835,4 +836,227 @@ func TestDrainCompletionNoReloadDraining(t *testing.T) {
 	// verify no new persistence calls on pri queue
 	assert.Equal(t, prevPriStats.updateCount, priQueueData.persistenceStats().updateCount,
 		"no new UpdateTaskQueue calls should be made to drained table after reload")
+}
+
+// setLocalRateTrackers replaces this queue's own add and sync-match trackers with ones driven by a
+// fake clock advanced exactly one second, so getLocalAddAndSyncMatchedRates returns the given
+// per-second rates exactly. Both trackers share the clock, matching the production invariant that
+// they are created together so their windows line up.
+func (s *PhysicalTaskQueueManagerTestSuite) setLocalRateTrackers(addRate, syncMatchedRate int) {
+	timeSource := clock.NewEventTimeSource()
+	timeSource.Update(time.Now())
+
+	added := newTaskTracker(timeSource, 5*time.Second, 30*time.Second)
+	syncMatched := newTaskTracker(timeSource, 5*time.Second, 30*time.Second)
+	added.inc(addRate)
+	syncMatched.inc(syncMatchedRate)
+	timeSource.Advance(time.Second)
+
+	pri := s.tqMgr.config.DefaultPriorityKey
+	s.tqMgr.taskTrackerLock.Lock()
+	defer s.tqMgr.taskTrackerLock.Unlock()
+	s.tqMgr.tasksAdded[pri] = added
+	s.tqMgr.tasksSyncMatched[pri] = syncMatched
+}
+
+func (s *PhysicalTaskQueueManagerTestSuite) allowAllScalingDecisions() {
+	rl := quotas.NewMockRateLimiter(s.controller)
+	rl.EXPECT().AllowN(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+	s.tqMgr.pollerScalingRateLimiter = rl
+}
+
+func (s *PhysicalTaskQueueManagerTestSuite) TestGetLocalAddAndSyncMatchedRates() {
+	s.tqMgr.taskTrackerLock.Lock()
+	s.Empty(s.tqMgr.tasksSyncMatched)
+	s.tqMgr.taskTrackerLock.Unlock()
+
+	// Incrementing any one tracker map must initialize all three for that priority, or the rates
+	// would be measured over windows that don't line up.
+	s.tqMgr.incTaskTracker(s.tqMgr.tasksDispatched, 1, 1)
+	s.tqMgr.taskTrackerLock.Lock()
+	s.Contains(s.tqMgr.tasksAdded, priorityKey(1))
+	s.Contains(s.tqMgr.tasksDispatched, priorityKey(1))
+	s.Contains(s.tqMgr.tasksSyncMatched, priorityKey(1))
+	s.tqMgr.taskTrackerLock.Unlock()
+
+	// Rates aggregate across priorities.
+	s.setLocalRateTrackers(100, 40)
+	addRate, syncMatchedRate := s.tqMgr.getLocalAddAndSyncMatchedRates()
+	s.InEpsilon(float32(100), addRate, 0.001)
+	s.InEpsilon(float32(40), syncMatchedRate, 0.001)
+}
+
+func TestRatioExceeds(t *testing.T) {
+	// Nothing arriving is never a reason to scale up, whatever the denominator.
+	assert.False(t, ratioExceeds(0, 0, 1.2))
+	assert.False(t, ratioExceeds(0, 10, 1.2))
+	// Tasks arriving with nothing draining is the strongest reason to scale up.
+	assert.True(t, ratioExceeds(1, 0, 1.2))
+	assert.True(t, ratioExceeds(100, 0, 1e9))
+	// Ordinary comparisons.
+	assert.False(t, ratioExceeds(110, 100, 1.2))
+	assert.True(t, ratioExceeds(130, 100, 1.2))
+	assert.False(t, ratioExceeds(100, 100, 1.2))
+}
+
+// TestPollScalingRatioImprovedSignalFiresOnZeroSyncMatch covers the case the improved signal
+// exists for: tasks are arriving and the total dispatch rate keeps up because the backlog is being
+// drained, but nothing is being sync matched, so pollers are not actually keeping up.
+func (s *PhysicalTaskQueueManagerTestSuite) TestPollScalingRatioImprovedSignalFiresOnZeroSyncMatch() {
+	s.allowAllScalingDecisions()
+	s.tqMgr.partitionMgr.config.UseImprovedSignalsForPollerScaling = func() bool { return true }
+
+	// Old signal: 100/100 = 1.0, below the 1.2 default, does not fire.
+	fakeStats := &taskqueuepb.TaskQueueStats{TasksAddRate: 100, TasksDispatchRate: 100}
+	// New signal: tasks arriving, nothing sync matched.
+	s.setLocalRateTrackers(100, 0)
+
+	decision := s.tqMgr.makePollerScalingDecisionImpl(time.Now(), enumsspb.TASK_SOURCE_HISTORY, func() *taskqueuepb.TaskQueueStats { return fakeStats })
+	s.Require().NotNil(decision)
+	s.Equal(int32(1), decision.PollRequestDeltaSuggestion)
+}
+
+// TestPollScalingRatioImprovedSignalHoldsWhenSyncMatchingKeepsUp is the converse: the old signal
+// fires but the improved one does not, so with the flag on there must be no scale-up.
+func (s *PhysicalTaskQueueManagerTestSuite) TestPollScalingRatioImprovedSignalHoldsWhenSyncMatchingKeepsUp() {
+	s.allowAllScalingDecisions()
+	s.tqMgr.partitionMgr.config.UseImprovedSignalsForPollerScaling = func() bool { return true }
+
+	// Old signal: 100/10 = 10, well above the 1.2 default, would fire.
+	fakeStats := &taskqueuepb.TaskQueueStats{TasksAddRate: 100, TasksDispatchRate: 10}
+	// New signal: 100/100 = 1.0, below the default.
+	s.setLocalRateTrackers(100, 100)
+
+	decision := s.tqMgr.makePollerScalingDecisionImpl(time.Now(), enumsspb.TASK_SOURCE_HISTORY, func() *taskqueuepb.TaskQueueStats { return fakeStats })
+	s.Nil(decision)
+}
+
+// TestPollScalingRatioFlagOffKeepsOldSignal pins that the improved signal is inert while the flag
+// is off, in both directions, so shadow mode cannot change behavior.
+func (s *PhysicalTaskQueueManagerTestSuite) TestPollScalingRatioFlagOffKeepsOldSignal() {
+	s.allowAllScalingDecisions()
+	s.tqMgr.partitionMgr.config.UseImprovedSignalsForPollerScaling = func() bool { return false }
+
+	// Old fires, new would not: still scales up.
+	s.setLocalRateTrackers(100, 100)
+	oldFiresStats := &taskqueuepb.TaskQueueStats{TasksAddRate: 100, TasksDispatchRate: 10}
+	decision := s.tqMgr.makePollerScalingDecisionImpl(time.Now(), enumsspb.TASK_SOURCE_HISTORY, func() *taskqueuepb.TaskQueueStats { return oldFiresStats })
+	s.Require().NotNil(decision)
+	s.Equal(int32(1), decision.PollRequestDeltaSuggestion)
+
+	// New would fire, old does not: still no scale-up.
+	s.setLocalRateTrackers(100, 0)
+	newFiresStats := &taskqueuepb.TaskQueueStats{TasksAddRate: 100, TasksDispatchRate: 100}
+	decision = s.tqMgr.makePollerScalingDecisionImpl(time.Now(), enumsspb.TASK_SOURCE_HISTORY, func() *taskqueuepb.TaskQueueStats { return newFiresStats })
+	s.Nil(decision)
+}
+
+// TestPollScalingRatioUsesLocalAddRate pins that the improved signal pairs this queue's own add
+// rate with its own sync match rate. Reusing the add rate from TaskQueueStats would compare two
+// differently-attributed populations: a version's queue can be credited the whole unversioned add
+// rate while having no sync matches of its own, which would peg the ratio at +Inf forever.
+func (s *PhysicalTaskQueueManagerTestSuite) TestPollScalingRatioUsesLocalAddRate() {
+	s.allowAllScalingDecisions()
+	s.tqMgr.partitionMgr.config.UseImprovedSignalsForPollerScaling = func() bool { return true }
+
+	// Stats credit this queue with a large add rate, but nothing has actually flowed through it.
+	fakeStats := &taskqueuepb.TaskQueueStats{TasksAddRate: 1000, TasksDispatchRate: 1000}
+	s.setLocalRateTrackers(0, 0)
+
+	decision := s.tqMgr.makePollerScalingDecisionImpl(time.Now(), enumsspb.TASK_SOURCE_HISTORY, func() *taskqueuepb.TaskQueueStats { return fakeStats })
+	s.Nil(decision)
+}
+
+func (s *PhysicalTaskQueueManagerTestSuite) TestPollScalingSignalComparisonMetric() {
+	testCases := []struct {
+		name            string
+		addRate         float32
+		dispatchRate    float32
+		localAddRate    int
+		localSyncMatchd int
+		wantResult      string // empty means nothing should be emitted
+	}{
+		{
+			name: "both fire",
+			// old: 100/10 = 10; new: 100/10 = 10.
+			addRate: 100, dispatchRate: 10, localAddRate: 100, localSyncMatchd: 10,
+			wantResult: metrics.PollerScaleComparisonBoth,
+		},
+		{
+			name: "only the improved signal fires",
+			// old: 100/100 = 1.0; new: 100/0 = unbounded.
+			addRate: 100, dispatchRate: 100, localAddRate: 100, localSyncMatchd: 0,
+			wantResult: metrics.PollerScaleComparisonNewOnly,
+		},
+		{
+			name: "only the old signal fires",
+			// old: 100/10 = 10; new: 100/100 = 1.0.
+			addRate: 100, dispatchRate: 10, localAddRate: 100, localSyncMatchd: 100,
+			wantResult: metrics.PollerScaleComparisonOldOnly,
+		},
+		{
+			name: "neither fires",
+			// old: 10/100 = 0.1; new: 10/100 = 0.1.
+			addRate: 10, dispatchRate: 100, localAddRate: 10, localSyncMatchd: 100,
+			wantResult: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			s.SetupTest()
+			s.allowAllScalingDecisions()
+			handler := s.enablePollerScaleDecisionMetrics()
+			capture := handler.StartCapture()
+			defer handler.StopCapture(capture)
+
+			s.setLocalRateTrackers(tc.localAddRate, tc.localSyncMatchd)
+			fakeStats := &taskqueuepb.TaskQueueStats{TasksAddRate: tc.addRate, TasksDispatchRate: tc.dispatchRate}
+			s.tqMgr.makePollerScalingDecisionImpl(time.Now(), enumsspb.TASK_SOURCE_HISTORY, func() *taskqueuepb.TaskQueueStats { return fakeStats })
+
+			recordings := capture.Snapshot()[metrics.PollerScaleSignalComparisonCounter.Name()]
+			if tc.wantResult == "" {
+				s.Empty(recordings)
+				return
+			}
+			s.Require().Len(recordings, 1)
+			s.Equal(int64(1), recordings[0].Value)
+			s.Equal(metrics.PollerScaleSignalRatio, recordings[0].Tags[metrics.PollerScaleSignalTag("").Key])
+			s.Equal(tc.wantResult, recordings[0].Tags[metrics.PollerScaleComparisonResultTag("").Key])
+		})
+	}
+}
+
+func (s *PhysicalTaskQueueManagerTestSuite) TestPollScalingSignalComparisonMetricDisabledByDefault() {
+	s.allowAllScalingDecisions()
+	// The opt-in metrics config defaults to false; the comparison rides on the same gate.
+	handler := metricstest.NewCaptureHandler()
+	s.tqMgr.metricsHandler = handler
+	capture := handler.StartCapture()
+	defer handler.StopCapture(capture)
+
+	s.setLocalRateTrackers(100, 0)
+	fakeStats := &taskqueuepb.TaskQueueStats{TasksAddRate: 100, TasksDispatchRate: 10}
+	s.tqMgr.makePollerScalingDecisionImpl(time.Now(), enumsspb.TASK_SOURCE_HISTORY, func() *taskqueuepb.TaskQueueStats { return fakeStats })
+	s.Empty(capture.Snapshot()[metrics.PollerScaleSignalComparisonCounter.Name()])
+}
+
+// TestPollScalingSignalComparisonNotEvaluatedOnBacklogScaleUp pins that the ratio comparison is
+// only evaluated when the decision actually reaches the ratio check. A backlog scale-up short
+// circuits it, so shadow data isn't skewed by decisions the ratio never influenced.
+func (s *PhysicalTaskQueueManagerTestSuite) TestPollScalingSignalComparisonNotEvaluatedOnBacklogScaleUp() {
+	s.allowAllScalingDecisions()
+	handler := s.enablePollerScaleDecisionMetrics()
+	capture := handler.StartCapture()
+	defer handler.StopCapture(capture)
+
+	s.setLocalRateTrackers(100, 0) // would fire the improved ratio signal
+	fakeStats := &taskqueuepb.TaskQueueStats{
+		ApproximateBacklogCount: 100,
+		ApproximateBacklogAge:   durationpb.New(1 * time.Minute),
+	}
+	s.tqMgr.makePollerScalingDecisionImpl(time.Now(), enumsspb.TASK_SOURCE_HISTORY, func() *taskqueuepb.TaskQueueStats { return fakeStats })
+
+	s.assertPollerScaleDecision(capture, metrics.PollerScaleDecisionUp, metrics.PollerScaleReasonBacklog)
+	s.Empty(capture.Snapshot()[metrics.PollerScaleSignalComparisonCounter.Name()])
 }

--- a/service/matching/physical_task_queue_manager_test.go
+++ b/service/matching/physical_task_queue_manager_test.go
@@ -847,6 +847,7 @@ func (s *PhysicalTaskQueueManagerTestSuite) setLocalRateTrackers(addRate, syncMa
 	timeSource.Update(time.Now())
 
 	added := newTaskTracker(timeSource, 5*time.Second, 30*time.Second)
+	dispatched := newTaskTracker(timeSource, 5*time.Second, 30*time.Second)
 	syncMatched := newTaskTracker(timeSource, 5*time.Second, 30*time.Second)
 	added.inc(addRate)
 	syncMatched.inc(syncMatchedRate)
@@ -856,6 +857,10 @@ func (s *PhysicalTaskQueueManagerTestSuite) setLocalRateTrackers(addRate, syncMa
 	s.tqMgr.taskTrackerLock.Lock()
 	defer s.tqMgr.taskTrackerLock.Unlock()
 	s.tqMgr.tasksAdded[pri] = added
+	// Populate all three maps even though only two are read here: incTaskTracker keys its
+	// "initialize together" branch off whichever map it is handed, so leaving tasksDispatched
+	// unset would let a later increment silently re-create all three and wipe these rates.
+	s.tqMgr.tasksDispatched[pri] = dispatched
 	s.tqMgr.tasksSyncMatched[pri] = syncMatched
 }
 
@@ -1059,4 +1064,83 @@ func (s *PhysicalTaskQueueManagerTestSuite) TestPollScalingSignalComparisonNotEv
 
 	s.assertPollerScaleDecision(capture, metrics.PollerScaleDecisionUp, metrics.PollerScaleReasonBacklog)
 	s.Empty(capture.Snapshot()[metrics.PollerScaleSignalComparisonCounter.Name()])
+}
+
+// TestPollScalingRatioThresholdsAreIndependent pins that the improved signal is thresholded by
+// matching.pollerScalingSyncMatchRatio, not by the old add-to-dispatch threshold. The two ratios
+// have different natural scales, and sharing a knob would mean retuning one perturbed the other.
+func (s *PhysicalTaskQueueManagerTestSuite) TestPollScalingRatioThresholdsAreIndependent() {
+	s.allowAllScalingDecisions()
+	s.tqMgr.partitionMgr.config.UseImprovedSignalsForPollerScaling = func() bool { return true }
+
+	// New ratio is 100/50 = 2.0. Raising only the sync-match threshold above it must suppress the
+	// scale-up, even though the old threshold stays at its default.
+	s.setLocalRateTrackers(100, 50)
+	s.tqMgr.partitionMgr.config.PollerScalingSyncMatchRatio = func() float64 { return 3.0 }
+	fakeStats := &taskqueuepb.TaskQueueStats{TasksAddRate: 100, TasksDispatchRate: 100}
+	decision := s.tqMgr.makePollerScalingDecisionImpl(time.Now(), enumsspb.TASK_SOURCE_HISTORY, func() *taskqueuepb.TaskQueueStats { return fakeStats })
+	s.Nil(decision)
+
+	// Lowering it back below the ratio brings the scale-up back.
+	s.setLocalRateTrackers(100, 50)
+	s.tqMgr.partitionMgr.config.PollerScalingSyncMatchRatio = func() float64 { return 1.5 }
+	decision = s.tqMgr.makePollerScalingDecisionImpl(time.Now(), enumsspb.TASK_SOURCE_HISTORY, func() *taskqueuepb.TaskQueueStats { return fakeStats })
+	s.Require().NotNil(decision)
+	s.Equal(int32(1), decision.PollRequestDeltaSuggestion)
+}
+
+// TestPollScalingRatioOldThresholdDoesNotGateImprovedSignal is the converse: moving the old
+// threshold must not change what the improved signal decides.
+func (s *PhysicalTaskQueueManagerTestSuite) TestPollScalingRatioOldThresholdDoesNotGateImprovedSignal() {
+	s.allowAllScalingDecisions()
+	s.tqMgr.partitionMgr.config.UseImprovedSignalsForPollerScaling = func() bool { return true }
+	// Absurdly high old threshold: nothing could ever fire the old signal.
+	s.tqMgr.partitionMgr.config.PollerScalingTaskAddToDispatchRatio = func() float64 { return 1e9 }
+
+	s.setLocalRateTrackers(100, 10) // new ratio 10, above the 1.2 sync-match default
+	fakeStats := &taskqueuepb.TaskQueueStats{TasksAddRate: 100, TasksDispatchRate: 100}
+	decision := s.tqMgr.makePollerScalingDecisionImpl(time.Now(), enumsspb.TASK_SOURCE_HISTORY, func() *taskqueuepb.TaskQueueStats { return fakeStats })
+	s.Require().NotNil(decision)
+	s.Equal(int32(1), decision.PollRequestDeltaSuggestion)
+}
+
+// TestPollScalingNilStatsHolds pins that an unavailable stats read produces no decision. The
+// improved signal reads local trackers rather than stats, so without this guard a Describe outage
+// would let it keep suggesting scale-ups with the rate-limit check skipped.
+func (s *PhysicalTaskQueueManagerTestSuite) TestPollScalingNilStatsHolds() {
+	s.allowAllScalingDecisions()
+	s.setLocalRateTrackers(100, 0) // would otherwise fire the improved ratio signal
+
+	for _, improved := range []bool{false, true} {
+		s.tqMgr.partitionMgr.config.UseImprovedSignalsForPollerScaling = func() bool { return improved }
+		decision := s.tqMgr.makePollerScalingDecisionImpl(time.Now(), enumsspb.TASK_SOURCE_HISTORY, func() *taskqueuepb.TaskQueueStats { return nil })
+		s.Nil(decision, "improved signals enabled: %v", improved)
+	}
+}
+
+// TestPollScalingNilStatsEmitsNoComparison pins that a stats outage doesn't pollute the shadow-mode
+// comparison data with samples the ratio check never actually evaluated.
+func (s *PhysicalTaskQueueManagerTestSuite) TestPollScalingNilStatsEmitsNoComparison() {
+	s.allowAllScalingDecisions()
+	handler := s.enablePollerScaleDecisionMetrics()
+	capture := handler.StartCapture()
+	defer handler.StopCapture(capture)
+
+	s.setLocalRateTrackers(100, 0)
+	s.tqMgr.makePollerScalingDecisionImpl(time.Now(), enumsspb.TASK_SOURCE_HISTORY, func() *taskqueuepb.TaskQueueStats { return nil })
+
+	s.Empty(capture.Snapshot()[metrics.PollerScaleSignalComparisonCounter.Name()])
+	s.Empty(capture.Snapshot()[metrics.PollerScaleDecisionCounter.Name()])
+}
+
+// TestSetLocalRateTrackersSurvivesIncTaskTracker guards the test helper itself: seeded rates must
+// not be silently reset by a subsequent tracker increment on any of the three maps.
+func (s *PhysicalTaskQueueManagerTestSuite) TestSetLocalRateTrackersSurvivesIncTaskTracker() {
+	s.setLocalRateTrackers(100, 40)
+	pri := s.tqMgr.config.DefaultPriorityKey
+	s.tqMgr.incTaskTracker(s.tqMgr.tasksDispatched, pri, 1)
+
+	addRate, syncMatchedRate := s.tqMgr.getLocalAddAndSyncMatchedRates()
+	s.InEpsilon(float32(100), addRate, 0.001)
+	s.InEpsilon(float32(40), syncMatchedRate, 0.001)
 }


### PR DESCRIPTION
## What changed?

The poller autoscaling add-to-dispatch ratio check divides the task add rate by the **total** dispatch rate. This adds `matching.useImprovedSignalsForPollerScaling` (task-queue scoped, **default false**) to switch that denominator to the physical queue's **sync match rate**.

Both signals are evaluated on every decision that reaches the ratio check and compared through a new `poller_scale_signal_comparison` counter — tags `signal=ratio` and `result=both|new_only|old_only` — gated by the existing `matching.enablePollerScalingDecisionMetrics` opt-in. So the new signal can be validated in shadow mode on real traffic before it drives anything, and the flag flips which one decides.

Supporting pieces: a `tasksSyncMatched` tracker map alongside `tasksAdded`/`tasksDispatched`, incremented in `PollTask` for tasks that still carry `TASK_SOURCE_HISTORY`.

## Why?

The total dispatch rate counts tasks dispatched from the backlog. Under sustained backlog pressure it therefore tracks the add rate closely, and the ratio sits near 1 no matter how badly pollers are keeping up — masking the exact condition the check exists to detect. The sync match rate counts only tasks that found a poller already waiting, so it measures whether poller capacity is actually adequate.

This is signal #1 of two from the prototype in `kannan/improved-scaling-signals`. The backlog-age signal is deliberately **not** included here, so the `MakePollerScalingDecision` signature is unchanged and the interface, generated mock, and partition manager are untouched.

Two intentional departures from that prototype:

**1. The improved signal reads both sides from this queue's own trackers** rather than reusing `TaskQueueStats.TasksAddRate`.

`GetPhysicalQueueAdjustedStats` → `Describe` re-attributes rates across the unversioned queue and the current/ramping version queues before returning them. The old signal is immune to this: numerator and denominator are scaled by the same factor, so the ratio is invariant. A local denominator paired with that adjusted numerator is not. During a version rollout where traffic still lands on the unversioned queue, a version's physical queue is credited the entire unversioned add rate while having zero sync matches of its own — pegging the ratio at `+Inf` and suggesting scale-up on every decision indefinitely. `getLocalAddAndSyncMatchedRates` reads both rates under one lock so they cover the same window.

**2. Both ratios go through `ratioExceeds`**, which handles a zero denominator explicitly instead of relying on `NaN`/`+Inf` comparison semantics. Verified behavior-preserving for the old signal in every case (`0/0` → NaN → false; `n/0` → +Inf → true).

## How did you test it?
- [x] built
- [x] covered by existing tests
- [x] added new unit test(s)

All 19 existing poll-scaling tests are unmodified and still pass. New coverage (× the 3 suite variants — classic, pri, fair): both toggle directions, all four comparison-metric result combinations, the disabled-by-default gate, short-circuiting when a backlog scale-up wins first, and a regression test pinning that the improved signal uses the *local* add rate. Rate trackers are seeded through a fake clock so the ratios are exact rather than wall-clock dependent.

Note: full-package runs of `service/matching` flake intermittently on clean `main` as well (observed `TestMultipleWorkersLesserNumberOfPollersThanTasksNoDBErrors` on main and `TestTaskAddHooks_AddHookSyncMatch` once on this branch, both passing on re-run and under isolated stress). Pre-existing and unrelated to this change.

## Potential risks

Low. The dynamic config defaults to false, so the decision path is byte-for-byte unchanged unless it is turned on per namespace/task queue. The comparison metric rides the existing opt-in metrics gate and is off by default.

Two things worth a reviewer's eye:

- **Zero sync match rate scales up.** With tasks arriving and nothing sync matched, `ratioExceeds` returns true regardless of threshold. That is the intended reading of the signal, and it is why departure #1 matters — the local pairing confines it to genuine cases. Worth confirming in shadow-mode data before enabling anywhere.
- **`TASK_SOURCE_HISTORY` as the sync-match proxy.** Query and Nexus tasks are also constructed with this source and are never backlogged, so they count as sync matches — intended, since Nexus is the ratio check's original motivation. Forwarded "started" tasks lose their source and go uncounted; only root and sticky queues consume this rate and neither forwards polls, so this does not affect the decision path.
