### PR TITLE
Fix scheduler migration test activity panic

### DIFF
--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -2619,7 +2619,22 @@ func (s *workflowSuite) TestMigrateDynamicConfigDisabledNoMigration() {
 	CurrentTweakablePolicies.EnableCHASMMigration = false
 	defer func() { CurrentTweakablePolicies = prevTweakables }()
 
-	// No activity mock registered -- if migration is attempted, the test will fail.
+	s.env.OnActivity(new(activities).StartWorkflow, mock.Anything, mock.Anything).Maybe().Return(
+		func(context.Context, *schedulespb.StartWorkflowRequest) (*schedulespb.StartWorkflowResponse, error) {
+			return &schedulespb.StartWorkflowResponse{
+				RunId:         uuid.NewString(),
+				RealStartTime: timestamppb.New(s.env.Now()),
+			}, nil
+		})
+	s.env.OnActivity(new(activities).WatchWorkflow, mock.Anything, mock.Anything).Maybe().Return(
+		&schedulespb.WatchWorkflowResponse{Status: enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED}, nil)
+
+	migrateCalls := 0
+	s.env.OnActivity(new(activities).MigrateScheduleToChasm, mock.Anything, mock.Anything).Maybe().Return(
+		func(context.Context, *schedulerpb.CreateFromMigrationStateRequest) error {
+			migrateCalls++
+			return nil
+		})
 
 	CurrentTweakablePolicies.IterationsBeforeContinueAsNew = 3
 	s.env.SetStartTime(baseStartTime)
@@ -2643,4 +2658,5 @@ func (s *workflowSuite) TestMigrateDynamicConfigDisabledNoMigration() {
 	// Workflow should CAN normally without attempting migration.
 	s.True(s.env.IsWorkflowCompleted())
 	s.True(workflow.IsContinueAsNewError(s.env.GetWorkflowError()))
+	s.Zero(migrateCalls)
 }


### PR DESCRIPTION
## Summary
- mock the normal StartWorkflow and WatchWorkflow activities exercised by the disabled-migration test
- mock migration safely and assert that it is never invoked
- preserve the active schedule and continue-as-new behavior under test

This prevents the test environment from invoking activities through a nil receiver and logging repeated recovered panics.

## Testing
- `go test -tags test_dep -count=1 -run "^TestWorkflow$/^TestMigrateDynamicConfigDisabledNoMigration$" -v ./service/worker/scheduler`
- `go test -tags test_dep -count=1 ./service/worker/scheduler/...`
- `make GOLANGCI_LINT_BASE_REV=origin/main GOLANGCI_LINT_FIX=false LINT_CODE_TARGETS="./service/worker/scheduler" lint-code`