### PR TITLE
Perf/lazy timer map

### DIFF
--- a/common/persistence/data_interfaces.go
+++ b/common/persistence/data_interfaces.go
@@ -391,6 +391,10 @@ type (
 
 		ActivityInfos       map[int64]*persistencespb.ActivityInfo
 		TimerInfos          map[string]*persistencespb.TimerInfo
+		// TimerInfoBlobs holds user timer entries that were never decoded in
+		// memory. They are persisted verbatim, avoiding a decode/encode round
+		// trip, and are disjoint from TimerInfos.
+		TimerInfoBlobs      map[string]*commonpb.DataBlob
 		ChildExecutionInfos map[int64]*persistencespb.ChildExecutionInfo
 		RequestCancelInfos  map[int64]*persistencespb.RequestCancelInfo
 		SignalInfos         map[int64]*persistencespb.SignalInfo

--- a/common/persistence/data_interfaces.go
+++ b/common/persistence/data_interfaces.go
@@ -389,8 +389,8 @@ type (
 		// TODO deprecate NextEventID in favor of DBRecordVersion
 		NextEventID int64
 
-		ActivityInfos       map[int64]*persistencespb.ActivityInfo
-		TimerInfos          map[string]*persistencespb.TimerInfo
+		ActivityInfos map[int64]*persistencespb.ActivityInfo
+		TimerInfos    map[string]*persistencespb.TimerInfo
 		// TimerInfoBlobs holds user timer entries that were never decoded in
 		// memory. They are persisted verbatim, avoiding a decode/encode round
 		// trip, and are disjoint from TimerInfos.

--- a/common/persistence/data_interfaces.go
+++ b/common/persistence/data_interfaces.go
@@ -305,6 +305,10 @@ type (
 		State             *persistencespb.WorkflowMutableState
 		DBRecordVersion   int64
 		MutableStateStats MutableStateStatistics
+		// TimerInfoBlobs contains user timer entries that were left encoded when
+		// loading the state, in which case State.TimerInfos is empty. Decoding is
+		// deferred until an entry is actually accessed.
+		TimerInfoBlobs map[string]*commonpb.DataBlob
 	}
 
 	// SetWorkflowExecutionRequest is used to overwrite the info of a workflow execution

--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -22,6 +22,7 @@ import (
 	"go.temporal.io/server/common/persistence/versionhistory"
 	"go.temporal.io/server/common/softassert"
 	"go.temporal.io/server/service/history/tasks"
+	"google.golang.org/protobuf/proto"
 )
 
 type (
@@ -482,7 +483,7 @@ func (m *executionManagerImpl) GetWorkflowExecution(
 		// try to utilize resp as much as possible, for RebuildMutableState API
 		return nil, respErr
 	}
-	state, err := m.toWorkflowMutableState(response.State)
+	state, timerInfoBlobs, err := m.toWorkflowMutableStateWithEncodedTimerInfos(response.State)
 	if err != nil {
 		return nil, err
 	}
@@ -496,6 +497,7 @@ func (m *executionManagerImpl) GetWorkflowExecution(
 		State:             state,
 		DBRecordVersion:   response.DBRecordVersion,
 		MutableStateStats: *statusOfInternalWorkflow(response.State, state, nil),
+		TimerInfoBlobs:    timerInfoBlobs,
 	}
 	return newResponse, respErr
 }
@@ -1140,6 +1142,21 @@ func (m *executionManagerImpl) trimHistoryNode(
 }
 
 func (m *executionManagerImpl) toWorkflowMutableState(internState *InternalWorkflowMutableState) (*persistencespb.WorkflowMutableState, error) {
+	state, _, err := m.toWorkflowMutableStateInternal(internState, true)
+	return state, err
+}
+
+// toWorkflowMutableStateWithEncodedTimerInfos leaves user timer entries encoded.
+// Entries that were not decoded are returned so they can be passed back to
+// persistence without an encode/decode round trip.
+func (m *executionManagerImpl) toWorkflowMutableStateWithEncodedTimerInfos(internState *InternalWorkflowMutableState) (*persistencespb.WorkflowMutableState, map[string]*commonpb.DataBlob, error) {
+	return m.toWorkflowMutableStateInternal(internState, false)
+}
+
+func (m *executionManagerImpl) toWorkflowMutableStateInternal(
+	internState *InternalWorkflowMutableState,
+	decodeTimerInfos bool,
+) (*persistencespb.WorkflowMutableState, map[string]*commonpb.DataBlob, error) {
 	state := &persistencespb.WorkflowMutableState{
 		ActivityInfos:       make(map[int64]*persistencespb.ActivityInfo),
 		TimerInfos:          make(map[string]*persistencespb.TimerInfo),
@@ -1151,41 +1168,36 @@ func (m *executionManagerImpl) toWorkflowMutableState(internState *InternalWorkf
 		NextEventId:         internState.NextEventID,
 		BufferedEvents:      make([]*historypb.HistoryEvent, len(internState.BufferedEvents)),
 	}
-	for key, blob := range internState.ActivityInfos {
-		info, err := m.serializer.ActivityInfoFromBlob(blob)
-		if err != nil {
-			return nil, err
-		}
-		state.ActivityInfos[key] = info
+	activityInfos, err := decodeBlobMap(internState.ActivityInfos, m.serializer.ActivityInfoFromBlob)
+	if err != nil {
+		return nil, nil, err
 	}
-	for key, blob := range internState.TimerInfos {
-		info, err := m.serializer.TimerInfoFromBlob(blob)
+	state.ActivityInfos = activityInfos
+	var untouchedTimerInfoBlobs map[string]*commonpb.DataBlob
+	if !decodeTimerInfos {
+		untouchedTimerInfoBlobs = internState.TimerInfos
+	} else {
+		timerInfos, err := decodeBlobMap(internState.TimerInfos, m.serializer.TimerInfoFromBlob)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		state.TimerInfos[key] = info
+		state.TimerInfos = timerInfos
 	}
-	for key, blob := range internState.ChildExecutionInfos {
-		info, err := m.serializer.ChildExecutionInfoFromBlob(blob)
-		if err != nil {
-			return nil, err
-		}
-		state.ChildExecutionInfos[key] = info
+	childExecutionInfos, err := decodeBlobMap(internState.ChildExecutionInfos, m.serializer.ChildExecutionInfoFromBlob)
+	if err != nil {
+		return nil, nil, err
 	}
-	for key, blob := range internState.RequestCancelInfos {
-		info, err := m.serializer.RequestCancelInfoFromBlob(blob)
-		if err != nil {
-			return nil, err
-		}
-		state.RequestCancelInfos[key] = info
+	state.ChildExecutionInfos = childExecutionInfos
+	requestCancelInfos, err := decodeBlobMap(internState.RequestCancelInfos, m.serializer.RequestCancelInfoFromBlob)
+	if err != nil {
+		return nil, nil, err
 	}
-	for key, blob := range internState.SignalInfos {
-		info, err := m.serializer.SignalInfoFromBlob(blob)
-		if err != nil {
-			return nil, err
-		}
-		state.SignalInfos[key] = info
+	state.RequestCancelInfos = requestCancelInfos
+	signalInfos, err := decodeBlobMap(internState.SignalInfos, m.serializer.SignalInfoFromBlob)
+	if err != nil {
+		return nil, nil, err
 	}
+	state.SignalInfos = signalInfos
 	for key, internal := range internState.ChasmNodes {
 		var node *persistencespb.ChasmNode
 		var err error
@@ -1196,15 +1208,14 @@ func (m *executionManagerImpl) toWorkflowMutableState(internState *InternalWorkf
 			node, err = m.serializer.ChasmNodeFromBlobs(internal.Metadata, internal.Data)
 		}
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		state.ChasmNodes[key] = node
 	}
-	var err error
 	state.ExecutionInfo, err = m.serializer.WorkflowExecutionInfoFromBlob(internState.ExecutionInfo)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if state.ExecutionInfo.AutoResetPoints == nil {
 		// TODO: check if we need this?
@@ -1212,20 +1223,35 @@ func (m *executionManagerImpl) toWorkflowMutableState(internState *InternalWorkf
 	}
 	state.ExecutionState, err = m.serializer.WorkflowExecutionStateFromBlob(internState.ExecutionState)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	state.BufferedEvents, err = m.DeserializeBufferedEvents(internState.BufferedEvents)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if internState.Checksum != nil {
 		state.Checksum, err = m.serializer.ChecksumFromBlob(internState.Checksum)
 	}
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return state, nil
+	return state, untouchedTimerInfoBlobs, nil
+}
+
+func decodeBlobMap[K comparable, V proto.Message](
+	blobs map[K]*commonpb.DataBlob,
+	fromBlob func(*commonpb.DataBlob) (V, error),
+) (map[K]V, error) {
+	infos := make(map[K]V, len(blobs))
+	for key, blob := range blobs {
+		info, err := fromBlob(blob)
+		if err != nil {
+			return nil, err
+		}
+		infos[key] = info
+	}
+	return infos, nil
 }
 
 func (m *executionManagerImpl) assertAndConvertArchetypeID(

--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -808,6 +808,13 @@ func (m *executionManagerImpl) SerializeWorkflowSnapshot( // unexport
 		}
 		result.TimerInfos[key] = blob
 	}
+	for key, blob := range input.TimerInfoBlobs {
+		if _, ok := result.TimerInfos[key]; ok {
+			return nil, serviceerror.NewInternalf(
+				"user timer info %q present in both encoded and decoded snapshot entries", key)
+		}
+		result.TimerInfos[key] = blob
+	}
 	for key, info := range input.ChildExecutionInfos {
 		blob, err := m.serializer.ChildExecutionInfoToBlob(info)
 		if err != nil {

--- a/common/persistence/execution_manager_test.go
+++ b/common/persistence/execution_manager_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	enumsspb "go.temporal.io/server/api/enums/v1"
@@ -234,5 +235,182 @@ func TestExecutionManager_TrimHistoryBranchSkipped_EmptyBranchToken(t *testing.T
 	}
 	if _, ok := err.(*p.ConditionFailedError); !ok {
 		t.Fatalf("expected ConditionFailedError, got %T", err)
+	}
+}
+
+func TestExecutionManager_GetWorkflowExecutionLeavesTimerInfosEncoded(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	store := mockp.NewMockExecutionStore(ctrl)
+	store.EXPECT().GetName().AnyTimes().Return("mock-store")
+
+	serializer := serialization.NewSerializer()
+	timerInfoBlob, err := serializer.TimerInfoToBlob(&persistencespb.TimerInfo{TimerId: "t1", StartedEventId: 5})
+	if err != nil {
+		t.Fatalf("TimerInfoToBlob error: %v", err)
+	}
+	executionInfo := &persistencespb.WorkflowExecutionInfo{
+		NamespaceId:    "namespace",
+		WorkflowId:     "workflow",
+		UserTimerCount: 1,
+	}
+	executionState := &persistencespb.WorkflowExecutionState{
+		RunId:  "run",
+		State:  enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING,
+		Status: enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+	}
+	executionInfoBlob, err := serializer.WorkflowExecutionInfoToBlob(executionInfo)
+	if err != nil {
+		t.Fatalf("WorkflowExecutionInfoToBlob error: %v", err)
+	}
+	executionStateBlob, err := serializer.WorkflowExecutionStateToBlob(executionState)
+	if err != nil {
+		t.Fatalf("WorkflowExecutionStateToBlob error: %v", err)
+	}
+
+	store.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(
+		&p.InternalGetWorkflowExecutionResponse{
+			State: &p.InternalWorkflowMutableState{
+				ExecutionInfo:  executionInfoBlob,
+				ExecutionState: executionStateBlob,
+				TimerInfos:     map[string]*commonpb.DataBlob{"t1": timerInfoBlob},
+			},
+			DBRecordVersion: 3,
+		},
+		nil,
+	)
+
+	em := p.NewExecutionManager(
+		store,
+		serializer,
+		nil,
+		testlogger.NewTestLogger(t, testlogger.FailOnAnyUnexpectedError),
+		dynamicconfig.GetIntPropertyFn(1024*1024),
+		dynamicconfig.GetBoolPropertyFn(false),
+	)
+
+	resp, err := em.GetWorkflowExecution(context.Background(), &p.GetWorkflowExecutionRequest{
+		ShardID:     1,
+		NamespaceID: "namespace",
+		WorkflowID:  "workflow",
+		RunID:       "run",
+		ArchetypeID: chasm.WorkflowArchetypeID,
+	})
+	if err != nil {
+		t.Fatalf("GetWorkflowExecution error: %v", err)
+	}
+	if len(resp.State.TimerInfos) != 0 {
+		t.Fatalf("expected state timer infos to be left empty, got %v", resp.State.TimerInfos)
+	}
+	if len(resp.TimerInfoBlobs) != 1 || resp.TimerInfoBlobs["t1"] != timerInfoBlob {
+		t.Fatalf("expected timer info blob to be passed through verbatim, got %v", resp.TimerInfoBlobs)
+	}
+	if resp.MutableStateStats.TimerInfoCount != 1 || resp.MutableStateStats.TotalUserTimerCount != 1 {
+		t.Fatalf("unexpected timer stats: %+v", resp.MutableStateStats)
+	}
+	if resp.DBRecordVersion != 3 {
+		t.Fatalf("unexpected DB record version: %v", resp.DBRecordVersion)
+	}
+}
+
+func TestExecutionManager_SetWorkflowExecutionPersistsEncodedTimerInfosVerbatim(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	store := mockp.NewMockExecutionStore(ctrl)
+	store.EXPECT().GetName().AnyTimes().Return("mock-store")
+
+	serializer := serialization.NewSerializer()
+	encodedTimerBlob, err := serializer.TimerInfoToBlob(&persistencespb.TimerInfo{TimerId: "t-encoded", StartedEventId: 5})
+	if err != nil {
+		t.Fatalf("TimerInfoToBlob error: %v", err)
+	}
+	decodedTimer := &persistencespb.TimerInfo{TimerId: "t-decoded", StartedEventId: 6}
+
+	var captured *p.InternalSetWorkflowExecutionRequest
+	store.EXPECT().SetWorkflowExecution(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, req *p.InternalSetWorkflowExecutionRequest) error {
+			captured = req
+			return nil
+		},
+	)
+
+	em := p.NewExecutionManager(
+		store,
+		serializer,
+		nil,
+		testlogger.NewTestLogger(t, testlogger.FailOnAnyUnexpectedError),
+		dynamicconfig.GetIntPropertyFn(1024*1024),
+		dynamicconfig.GetBoolPropertyFn(false),
+	)
+
+	_, err = em.SetWorkflowExecution(context.Background(), &p.SetWorkflowExecutionRequest{
+		ShardID:     1,
+		RangeID:     1,
+		ArchetypeID: chasm.WorkflowArchetypeID,
+		SetWorkflowSnapshot: p.WorkflowSnapshot{
+			ExecutionInfo:  &persistencespb.WorkflowExecutionInfo{NamespaceId: "namespace", WorkflowId: "workflow"},
+			ExecutionState: &persistencespb.WorkflowExecutionState{RunId: "run"},
+			TimerInfos:     map[string]*persistencespb.TimerInfo{"t-decoded": decodedTimer},
+			TimerInfoBlobs: map[string]*commonpb.DataBlob{"t-encoded": encodedTimerBlob},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SetWorkflowExecution error: %v", err)
+	}
+
+	persistedTimerInfos := captured.SetWorkflowSnapshot.TimerInfos
+	if len(persistedTimerInfos) != 2 {
+		t.Fatalf("expected both timer entries to be persisted, got %v", persistedTimerInfos)
+	}
+	if persistedTimerInfos["t-encoded"] != encodedTimerBlob {
+		t.Fatal("expected encoded timer entry to be persisted verbatim")
+	}
+	roundTrippedTimer, err := serializer.TimerInfoFromBlob(persistedTimerInfos["t-decoded"])
+	if err != nil {
+		t.Fatalf("TimerInfoFromBlob error: %v", err)
+	}
+	if roundTrippedTimer.String() != decodedTimer.String() {
+		t.Fatalf("expected decoded timer to survive a round trip, got %v", roundTrippedTimer)
+	}
+}
+
+func TestExecutionManager_SetWorkflowExecutionRejectsDuplicateTimerInfos(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	store := mockp.NewMockExecutionStore(ctrl)
+	store.EXPECT().GetName().AnyTimes().Return("mock-store")
+
+	serializer := serialization.NewSerializer()
+	timerBlob, err := serializer.TimerInfoToBlob(&persistencespb.TimerInfo{TimerId: "dup"})
+	if err != nil {
+		t.Fatalf("TimerInfoToBlob error: %v", err)
+	}
+
+	// no store expectations, serialization must fail before reaching the store
+	em := p.NewExecutionManager(
+		store,
+		serializer,
+		nil,
+		testlogger.NewTestLogger(t, testlogger.FailOnAnyUnexpectedError),
+		dynamicconfig.GetIntPropertyFn(1024*1024),
+		dynamicconfig.GetBoolPropertyFn(false),
+	)
+
+	_, err = em.SetWorkflowExecution(context.Background(), &p.SetWorkflowExecutionRequest{
+		ShardID:     1,
+		RangeID:     1,
+		ArchetypeID: chasm.WorkflowArchetypeID,
+		SetWorkflowSnapshot: p.WorkflowSnapshot{
+			ExecutionInfo:  &persistencespb.WorkflowExecutionInfo{NamespaceId: "namespace", WorkflowId: "workflow"},
+			ExecutionState: &persistencespb.WorkflowExecutionState{RunId: "run"},
+			TimerInfos:     map[string]*persistencespb.TimerInfo{"dup": {TimerId: "dup"}},
+			TimerInfoBlobs: map[string]*commonpb.DataBlob{"dup": timerBlob},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected SetWorkflowExecution to reject duplicate user timer entries")
 	}
 }

--- a/common/persistence/tests/execution_mutable_state.go
+++ b/common/persistence/tests/execution_mutable_state.go
@@ -47,6 +47,7 @@ type (
 		ShardManager      p.ShardManager
 		ExecutionManager  p.ExecutionManager
 		HistoryBranchUtil p.HistoryBranchUtil
+		Serializer        serialization.Serializer
 		Logger            log.Logger
 
 		// MutableStateTableCounts reports per-table surviving row counts for a run's
@@ -82,6 +83,7 @@ func NewExecutionMutableStateSuite(
 			dynamicconfig.GetBoolPropertyFn(false),
 		),
 		HistoryBranchUtil: p.NewHistoryBranchUtil(serializer),
+		Serializer:        serializer,
 		Logger:            logger,
 	}
 }
@@ -2803,6 +2805,18 @@ func (s *ExecutionMutableStateSuite) Accumulate(
 		SignalInfos:         snapshot.SignalInfos,
 		SignalRequestedIds:  convert.StringSetToSlice(snapshot.SignalRequestedIDs),
 		ChasmNodes:          snapshot.ChasmNodes,
+	}
+	// user timer entries persisted verbatim are indistinguishable from decoded
+	// ones once read back
+	if len(snapshot.TimerInfoBlobs) > 0 {
+		if mutableState.TimerInfos == nil {
+			mutableState.TimerInfos = make(map[string]*persistencespb.TimerInfo, len(snapshot.TimerInfoBlobs))
+		}
+		for key, blob := range snapshot.TimerInfoBlobs {
+			info, err := s.Serializer.TimerInfoFromBlob(blob)
+			s.NoError(err)
+			mutableState.TimerInfos[key] = info
+		}
 	}
 	dbRecordVersion := snapshot.DBRecordVersion
 

--- a/common/persistence/tests/execution_mutable_state.go
+++ b/common/persistence/tests/execution_mutable_state.go
@@ -2776,6 +2776,19 @@ func (s *ExecutionMutableStateSuite) AssertMSEqualWithDB(
 	actualMutableState := resp.State
 	actualDBRecordVersion := resp.DBRecordVersion
 
+	// user timer entries are returned still encoded by GetWorkflowExecution,
+	// decode them here so the comparison covers the full persisted state
+	if len(resp.TimerInfoBlobs) > 0 {
+		if actualMutableState.TimerInfos == nil {
+			actualMutableState.TimerInfos = make(map[string]*persistencespb.TimerInfo, len(resp.TimerInfoBlobs))
+		}
+		for key, blob := range resp.TimerInfoBlobs {
+			timerInfo, err := s.Serializer.TimerInfoFromBlob(blob)
+			s.NoError(err)
+			actualMutableState.TimerInfos[key] = timerInfo
+		}
+	}
+
 	expectedMutableState, expectedDBRecordVersion := s.Accumulate(snapshot, mutations...)
 
 	// need to special handling signal request IDs ...

--- a/common/persistence/tests/util.go
+++ b/common/persistence/tests/util.go
@@ -46,6 +46,25 @@ func RandomSnapshot(
 	dbRecordVersion int64,
 	branchToken []byte,
 ) (*p.WorkflowSnapshot, []*p.WorkflowEvents) {
+	timerInfos := RandomStringTimerInfoMap()
+	// persist all but one entry verbatim so stores round trip encoded user
+	// timer blobs as well as decoded ones
+	timerInfoBlobs := make(map[string]*commonpb.DataBlob, len(timerInfos))
+	serializer := serialization.NewSerializer()
+	keptTypedKey := ""
+	for key, info := range timerInfos {
+		if keptTypedKey == "" {
+			keptTypedKey = key
+			continue
+		}
+		blob, err := serializer.TimerInfoToBlob(info)
+		if err != nil {
+			t.Fatal(err)
+		}
+		timerInfoBlobs[key] = blob
+		delete(timerInfos, key)
+	}
+
 	snapshot := &p.WorkflowSnapshot{
 		ExecutionInfo:  RandomExecutionInfo(namespaceID, workflowID, eventID, lastWriteVersion, branchToken),
 		ExecutionState: RandomExecutionState(runID, state, status, lastWriteVersion),
@@ -53,7 +72,8 @@ func RandomSnapshot(
 		NextEventID: eventID + 1, // NOTE: RandomSnapshot generates a single history event, hence NextEventID is plus 1
 
 		ActivityInfos:       RandomInt64ActivityInfoMap(),
-		TimerInfos:          RandomStringTimerInfoMap(),
+		TimerInfos:          timerInfos,
+		TimerInfoBlobs:      timerInfoBlobs,
 		ChildExecutionInfos: RandomInt64ChildExecutionInfoMap(),
 		RequestCancelInfos:  RandomInt64RequestCancelInfoMap(),
 		SignalInfos:         RandomInt64SignalInfoMap(),

--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -425,13 +425,14 @@ func (c *ContextImpl) LoadMutableState(ctx context.Context, shardContext history
 			return nil, err
 		}
 
-		mutableState, err := NewMutableStateFromDB(
+		mutableState, err := newMutableStateFromDB(
 			shardContext,
 			shardContext.GetEventsCache(),
 			c.logger,
 			namespaceEntry,
 			response.State,
 			response.DBRecordVersion,
+			response.TimerInfoBlobs,
 		)
 		if err != nil {
 			return nil, err

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -133,10 +133,9 @@ type (
 		deleteActivityInfos            map[int64]struct{}                     // Deleted activities from last update.
 		syncActivityTasks              map[int64]struct{}                     // Activity to be sync to remote
 
-		pendingTimerInfoIDs     map[string]*persistencespb.TimerInfo // User Timer ID -> Timer Info.
-		pendingTimerEventIDToID map[int64]string                     // User Timer Start Event ID -> User Timer ID.
-		updateTimerInfos        map[string]*persistencespb.TimerInfo // Modified timers from last update.
-		deleteTimerInfos        map[string]struct{}                  // Deleted timers from last update.
+		pendingUserTimers *userTimers                          // User timers, entries loaded from DB stay encoded until first access.
+		updateTimerInfos  map[string]*persistencespb.TimerInfo // Modified timers from last update.
+		deleteTimerInfos  map[string]struct{}                  // Deleted timers from last update.
 
 		pendingChildExecutionInfoIDs map[int64]*persistencespb.ChildExecutionInfo // Initiated Event ID -> Child Execution Info
 		updateChildExecutionInfos    map[int64]*persistencespb.ChildExecutionInfo // Modified ChildExecution Infos since last update
@@ -321,10 +320,9 @@ func NewMutableState(
 		deleteActivityInfos:            make(map[int64]struct{}),
 		syncActivityTasks:              make(map[int64]struct{}),
 
-		pendingTimerInfoIDs:     make(map[string]*persistencespb.TimerInfo),
-		pendingTimerEventIDToID: make(map[int64]string),
-		updateTimerInfos:        make(map[string]*persistencespb.TimerInfo),
-		deleteTimerInfos:        make(map[string]struct{}),
+		pendingUserTimers: newUserTimers(logger),
+		updateTimerInfos:  make(map[string]*persistencespb.TimerInfo),
+		deleteTimerInfos:  make(map[string]struct{}),
 
 		updateChildExecutionInfos:    make(map[int64]*persistencespb.ChildExecutionInfo),
 		pendingChildExecutionInfoIDs: make(map[int64]*persistencespb.ChildExecutionInfo),
@@ -451,6 +449,18 @@ func NewMutableStateFromDB(
 	dbRecord *persistencespb.WorkflowMutableState,
 	dbRecordVersion int64,
 ) (*MutableStateImpl, error) {
+	return newMutableStateFromDB(shard, eventsCache, logger, namespaceEntry, dbRecord, dbRecordVersion, nil)
+}
+
+func newMutableStateFromDB(
+	shard historyi.ShardContext,
+	eventsCache events.Cache,
+	logger log.Logger,
+	namespaceEntry *namespace.Namespace,
+	dbRecord *persistencespb.WorkflowMutableState,
+	dbRecordVersion int64,
+	timerInfosBlobs map[string]*commonpb.DataBlob,
+) (*MutableStateImpl, error) {
 	// startTime will be overridden by DB record
 	startTime := time.Time{}
 
@@ -464,51 +474,8 @@ func NewMutableStateFromDB(
 		startTime,
 	)
 
-	if dbRecord.ActivityInfos != nil {
-		mutableState.pendingActivityInfoIDs = dbRecord.ActivityInfos
-		mutableState.approximateSize += int64SizeBytes * len(mutableState.pendingActivityInfoIDs)
-	}
-	for _, activityInfo := range dbRecord.ActivityInfos {
-		mutableState.pendingActivityIDToEventID[activityInfo.ActivityId] = activityInfo.ScheduledEventId
-		mutableState.approximateSize += activityInfo.Size()
-		if (activityInfo.TimerTaskStatus & TimerTaskStatusCreatedHeartbeat) > 0 {
-			// Sets last pending timer heartbeat to year 2000.
-			// This ensures at least one heartbeat task will be processed for the pending activity.
-			mutableState.pendingActivityTimerHeartbeats[activityInfo.ScheduledEventId] = time.Unix(946684800, 0)
-		}
-	}
-
-	if dbRecord.TimerInfos != nil {
-		mutableState.pendingTimerInfoIDs = dbRecord.TimerInfos
-	}
-	for timerID, timerInfo := range dbRecord.TimerInfos {
-		mutableState.pendingTimerEventIDToID[timerInfo.GetStartedEventId()] = timerInfo.GetTimerId()
-		mutableState.approximateSize += timerInfo.Size()
-		mutableState.approximateSize += len(timerID)
-	}
-
-	if dbRecord.ChildExecutionInfos != nil {
-		mutableState.pendingChildExecutionInfoIDs = dbRecord.ChildExecutionInfos
-		mutableState.approximateSize += int64SizeBytes * len(mutableState.pendingChildExecutionInfoIDs)
-	}
-	for _, childInfo := range dbRecord.ChildExecutionInfos {
-		mutableState.approximateSize += childInfo.Size()
-	}
-
-	if dbRecord.RequestCancelInfos != nil {
-		mutableState.pendingRequestCancelInfoIDs = dbRecord.RequestCancelInfos
-		mutableState.approximateSize += int64SizeBytes * len(mutableState.pendingRequestCancelInfoIDs)
-	}
-	for _, cancelInfo := range dbRecord.RequestCancelInfos {
-		mutableState.approximateSize += cancelInfo.Size()
-	}
-
-	if dbRecord.SignalInfos != nil {
-		mutableState.pendingSignalInfoIDs = dbRecord.SignalInfos
-		mutableState.approximateSize += int64SizeBytes * len(mutableState.pendingSignalInfoIDs)
-	}
-	for _, signalInfo := range dbRecord.SignalInfos {
-		mutableState.approximateSize += signalInfo.Size()
+	if err := mutableState.seedSubStateMachineInfosFromDB(dbRecord, timerInfosBlobs); err != nil {
+		return nil, err
 	}
 
 	mutableState.pendingSignalRequestedIDs = convert.StringSliceToSet(dbRecord.SignalRequestedIds)
@@ -602,6 +569,72 @@ func NewMutableStateFromDB(
 		mutableState.wrapTimeSourceWithTimeSkipping()
 	}
 	return mutableState, nil
+}
+
+// seedSubStateMachineInfosFromDB seeds the pending activity, user timer, child
+// execution, request cancel and signal infos from a DB record. User timer
+// entries can be passed still encoded via timerInfosBlobs, in which case
+// dbRecord.TimerInfos must be empty.
+func (ms *MutableStateImpl) seedSubStateMachineInfosFromDB(
+	dbRecord *persistencespb.WorkflowMutableState,
+	timerInfosBlobs map[string]*commonpb.DataBlob,
+) error {
+	if dbRecord.ActivityInfos != nil {
+		ms.pendingActivityInfoIDs = dbRecord.ActivityInfos
+		ms.approximateSize += int64SizeBytes * len(ms.pendingActivityInfoIDs)
+	}
+	for _, activityInfo := range dbRecord.ActivityInfos {
+		ms.pendingActivityIDToEventID[activityInfo.ActivityId] = activityInfo.ScheduledEventId
+		ms.approximateSize += activityInfo.Size()
+		if (activityInfo.TimerTaskStatus & TimerTaskStatusCreatedHeartbeat) > 0 {
+			// Sets last pending timer heartbeat to year 2000.
+			// This ensures at least one heartbeat task will be processed for the pending activity.
+			ms.pendingActivityTimerHeartbeats[activityInfo.ScheduledEventId] = time.Unix(946684800, 0)
+		}
+	}
+
+	if timerInfosBlobs == nil {
+		ms.pendingUserTimers.seedTyped(dbRecord.TimerInfos)
+		for timerID, timerInfo := range dbRecord.TimerInfos {
+			ms.approximateSize += timerInfo.Size()
+			ms.approximateSize += len(timerID)
+		}
+	} else {
+		if len(dbRecord.TimerInfos) != 0 {
+			return softassert.UnexpectedInternalErr(
+				ms.logger,
+				"decoded user timer infos provided alongside encoded user timer infos",
+				nil,
+			)
+		}
+		ms.pendingUserTimers.seedBlobs(timerInfosBlobs)
+		ms.approximateSize += ms.pendingUserTimers.approximateEncodedSize()
+	}
+
+	if dbRecord.ChildExecutionInfos != nil {
+		ms.pendingChildExecutionInfoIDs = dbRecord.ChildExecutionInfos
+		ms.approximateSize += int64SizeBytes * len(ms.pendingChildExecutionInfoIDs)
+	}
+	for _, childInfo := range dbRecord.ChildExecutionInfos {
+		ms.approximateSize += childInfo.Size()
+	}
+
+	if dbRecord.RequestCancelInfos != nil {
+		ms.pendingRequestCancelInfoIDs = dbRecord.RequestCancelInfos
+		ms.approximateSize += int64SizeBytes * len(ms.pendingRequestCancelInfoIDs)
+	}
+	for _, cancelInfo := range dbRecord.RequestCancelInfos {
+		ms.approximateSize += cancelInfo.Size()
+	}
+
+	if dbRecord.SignalInfos != nil {
+		ms.pendingSignalInfoIDs = dbRecord.SignalInfos
+		ms.approximateSize += int64SizeBytes * len(ms.pendingSignalInfoIDs)
+	}
+	for _, signalInfo := range dbRecord.SignalInfos {
+		ms.approximateSize += signalInfo.Size()
+	}
+	return nil
 }
 
 func NewSanitizedMutableState(
@@ -984,7 +1017,7 @@ func (ms *MutableStateImpl) GetHSMCompletionCallbackArg(ctx context.Context) (*p
 func (ms *MutableStateImpl) CloneToProto() *persistencespb.WorkflowMutableState {
 	msProto := &persistencespb.WorkflowMutableState{
 		ActivityInfos:       ms.pendingActivityInfoIDs,
-		TimerInfos:          ms.pendingTimerInfoIDs,
+		TimerInfos:          ms.pendingUserTimers.all(),
 		ChildExecutionInfos: ms.pendingChildExecutionInfoIDs,
 		RequestCancelInfos:  ms.pendingRequestCancelInfoIDs,
 		SignalInfos:         ms.pendingSignalInfoIDs,
@@ -2258,26 +2291,21 @@ func (ms *MutableStateImpl) DeleteActivity(
 func (ms *MutableStateImpl) GetUserTimerInfo(
 	timerID string,
 ) (*persistencespb.TimerInfo, bool) {
-	timerInfo, ok := ms.pendingTimerInfoIDs[timerID]
-	return timerInfo, ok
+	return ms.pendingUserTimers.get(timerID)
 }
 
 // GetUserTimerInfoByEventID gives details about a user timer.
 func (ms *MutableStateImpl) GetUserTimerInfoByEventID(
 	startEventID int64,
 ) (*persistencespb.TimerInfo, bool) {
-	timerID, ok := ms.pendingTimerEventIDToID[startEventID]
-	if !ok {
-		return nil, false
-	}
-	return ms.GetUserTimerInfo(timerID)
+	return ms.pendingUserTimers.getByEventID(startEventID)
 }
 
 // UpdateUserTimer updates the user timer in progress.
 func (ms *MutableStateImpl) UpdateUserTimer(
 	ti *persistencespb.TimerInfo,
 ) error {
-	timerID, ok := ms.pendingTimerEventIDToID[ti.GetStartedEventId()]
+	_, ok := ms.pendingUserTimers.getByEventID(ti.GetStartedEventId())
 	if !ok {
 		ms.logError(
 			fmt.Sprintf("unable to find timer event ID: %v in mutable state", ti.GetStartedEventId()),
@@ -2286,22 +2314,14 @@ func (ms *MutableStateImpl) UpdateUserTimer(
 		return ErrMissingTimerInfo
 	}
 
-	if _, ok := ms.pendingTimerInfoIDs[timerID]; !ok {
-		ms.logError(
-			fmt.Sprintf("unable to find timer ID: %v in mutable state", timerID),
-			tag.ErrorTypeInvalidMutableStateAction,
-		)
-		return ErrMissingTimerInfo
-	}
-
-	ms.pendingTimerInfoIDs[ti.TimerId] = ti
+	ms.pendingUserTimers.put(ti)
 	ms.updateTimerInfos[ti.TimerId] = ti
 	ms.timerInfosUserDataUpdated[ti.TimerId] = struct{}{}
 	return nil
 }
 
 func (ms *MutableStateImpl) UpdateUserTimerTaskStatus(timerID string, status int64) error {
-	timerInfo, ok := ms.pendingTimerInfoIDs[timerID]
+	timerInfo, ok := ms.pendingUserTimers.get(timerID)
 	if !ok {
 		ms.logError(
 			fmt.Sprintf("unable to find timer ID: %v in mutable state", timerID),
@@ -2318,19 +2338,10 @@ func (ms *MutableStateImpl) UpdateUserTimerTaskStatus(timerID string, status int
 func (ms *MutableStateImpl) DeleteUserTimer(
 	timerID string,
 ) error {
-	if timerInfo, ok := ms.pendingTimerInfoIDs[timerID]; ok {
-		delete(ms.pendingTimerInfoIDs, timerID)
-		ms.approximateSize -= timerInfo.Size() + len(timerID)
-
-		if _, ok = ms.pendingTimerEventIDToID[timerInfo.GetStartedEventId()]; ok {
-			delete(ms.pendingTimerEventIDToID, timerInfo.GetStartedEventId())
-		} else {
-			ms.logError(
-				fmt.Sprintf("unable to find timer event ID: %v in mutable state", timerID),
-				tag.ErrorTypeInvalidMutableStateAction,
-			)
-			// log data inconsistency instead of returning an error
-			ms.logDataInconsistency()
+	timerInfo, ok := ms.pendingUserTimers.delete(timerID)
+	if ok {
+		if timerInfo != nil {
+			ms.approximateSize -= timerInfo.Size() + len(timerID)
 		}
 	} else {
 		ms.logError(
@@ -2357,7 +2368,7 @@ func (ms *MutableStateImpl) GetPendingActivityInfos() map[int64]*persistencespb.
 }
 
 func (ms *MutableStateImpl) GetPendingTimerInfos() map[string]*persistencespb.TimerInfo {
-	return ms.pendingTimerInfoIDs
+	return ms.pendingUserTimers.all()
 }
 
 func (ms *MutableStateImpl) GetPendingChildExecutionInfos() map[int64]*persistencespb.ChildExecutionInfo {
@@ -5543,8 +5554,7 @@ func (ms *MutableStateImpl) ApplyTimerStartedEvent(
 		TaskStatus:     TimerTaskStatusNone,
 	}
 
-	ms.pendingTimerInfoIDs[ti.TimerId] = ti
-	ms.pendingTimerEventIDToID[ti.StartedEventId] = ti.TimerId
+	ms.pendingUserTimers.put(ti)
 	ms.updateTimerInfos[ti.TimerId] = ti
 	ms.timerInfosUserDataUpdated[ti.TimerId] = struct{}{}
 	ms.approximateSize += ti.Size() + len(ti.TimerId)
@@ -7669,7 +7679,7 @@ func (ms *MutableStateImpl) CloseTransactionAsSnapshot(
 		NextEventID:    ms.hBuilder.NextEventID(),
 
 		ActivityInfos:       ms.pendingActivityInfoIDs,
-		TimerInfos:          ms.pendingTimerInfoIDs,
+		TimerInfos:          ms.pendingUserTimers.all(),
 		ChildExecutionInfos: ms.pendingChildExecutionInfoIDs,
 		RequestCancelInfos:  ms.pendingRequestCancelInfoIDs,
 		SignalInfos:         ms.pendingSignalInfoIDs,
@@ -9367,10 +9377,10 @@ func (ms *MutableStateImpl) applyUpdatesToSubStateMachines(
 		return err
 	}
 
-	err = applyUpdatesToSubStateMachine(ms, ms.pendingTimerInfoIDs, ms.updateTimerInfos, updatedTimerInfos, isSnapshot, ms.DeleteUserTimer, func(current, incoming *persistencespb.TimerInfo) {
+	err = applyUpdatesToSubStateMachine(ms, ms.pendingUserTimers.all(), ms.updateTimerInfos, updatedTimerInfos, isSnapshot, ms.DeleteUserTimer, func(current, incoming *persistencespb.TimerInfo) {
 		incoming.TaskStatus = TimerTaskStatusNone
 	}, func(ti *persistencespb.TimerInfo) {
-		ms.pendingTimerEventIDToID[ti.StartedEventId] = ti.TimerId
+		ms.pendingUserTimers.updateEventIDIndex(ti)
 		ms.timerInfosUserDataUpdated[ti.TimerId] = struct{}{}
 	})
 	if err != nil {
@@ -9696,7 +9706,7 @@ func (ms *MutableStateImpl) applyTombstones(
 					err = ms.DeleteActivity(tombstone.GetActivityScheduledEventId())
 				}
 			case *persistencespb.StateMachineTombstone_TimerId:
-				if _, ok := ms.pendingTimerInfoIDs[tombstone.GetTimerId()]; ok {
+				if ms.pendingUserTimers.has(tombstone.GetTimerId()) {
 					err = ms.DeleteUserTimer(tombstone.GetTimerId())
 				}
 			case *persistencespb.StateMachineTombstone_ChildExecutionInitiatedEventId:

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -7679,7 +7679,8 @@ func (ms *MutableStateImpl) CloseTransactionAsSnapshot(
 		NextEventID:    ms.hBuilder.NextEventID(),
 
 		ActivityInfos:       ms.pendingActivityInfoIDs,
-		TimerInfos:          ms.pendingUserTimers.all(),
+		TimerInfos:          ms.pendingUserTimers.decoded(),
+		TimerInfoBlobs:      ms.pendingUserTimers.untouchedBlobs(),
 		ChildExecutionInfos: ms.pendingChildExecutionInfoIDs,
 		RequestCancelInfos:  ms.pendingRequestCancelInfoIDs,
 		SignalInfos:         ms.pendingSignalInfoIDs,

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -5700,9 +5700,9 @@ func (s *mutableStateSuite) verifyMutableState(current, target, origin *MutableS
 	compareMapOfProto(s, current.pendingActivityInfoIDs, current.updateActivityInfos)
 	s.Equal(map[int64]struct{}{89: {}}, current.deleteActivityInfos, "deleteActivityInfos mismatch")
 
-	compareMapOfProto(s, target.pendingTimerInfoIDs, current.pendingTimerInfoIDs)
-	s.Equal(target.pendingTimerEventIDToID, current.pendingTimerEventIDToID, "pendingTimerEventIDToID mismatch")
-	compareMapOfProto(s, target.pendingTimerInfoIDs, current.updateTimerInfos)
+	compareMapOfProto(s, target.pendingUserTimers.all(), current.pendingUserTimers.all())
+	s.Equal(target.pendingUserTimers.eventIDToID, current.pendingUserTimers.eventIDToID, "user timer event ID index mismatch")
+	compareMapOfProto(s, target.pendingUserTimers.all(), current.updateTimerInfos)
 	s.Equal(map[string]struct{}{"to-be-deleted": {}}, current.deleteTimerInfos, "deleteTimerInfos mismatch")
 
 	s.verifyChildExecutionInfos(target.pendingChildExecutionInfoIDs, current.pendingChildExecutionInfoIDs, origin.pendingChildExecutionInfoIDs)
@@ -5751,7 +5751,7 @@ func (s *mutableStateSuite) buildSnapshot(state *MutableStateImpl) *persistences
 			"25": {
 				Version:                       1234,
 				StartedEventId:                85,
-				ExpiryTime:                    state.pendingTimerInfoIDs["25"].ExpiryTime,
+				ExpiryTime:                    state.pendingUserTimers.all()["25"].ExpiryTime,
 				TimerId:                       "25",
 				LastUpdateVersionedTransition: &persistencespb.VersionedTransition{TransitionCount: 1025},
 			},
@@ -5940,7 +5940,7 @@ func (s *mutableStateSuite) TestApplySnapshot() {
 			for key := range targetMS.updateActivityInfos {
 				targetMS.activityInfosUserDataUpdated[key] = struct{}{}
 			}
-			targetMS.updateTimerInfos = targetMS.pendingTimerInfoIDs
+			targetMS.updateTimerInfos = targetMS.pendingUserTimers.all()
 			for key := range targetMS.updateTimerInfos {
 				targetMS.timerInfosUserDataUpdated[key] = struct{}{}
 			}
@@ -5988,7 +5988,7 @@ func (s *mutableStateSuite) buildMutation(
 	executionInfoClone.UpdateInfos = nil
 	mutation := &persistencespb.WorkflowMutableStateMutation{
 		UpdatedActivityInfos:            state.pendingActivityInfoIDs,
-		UpdatedTimerInfos:               state.pendingTimerInfoIDs,
+		UpdatedTimerInfos:               state.pendingUserTimers.all(),
 		UpdatedChildExecutionInfos:      state.pendingChildExecutionInfoIDs,
 		UpdatedRequestCancelInfos:       state.pendingRequestCancelInfoIDs,
 		UpdatedSignalInfos:              state.pendingSignalInfoIDs,
@@ -6107,7 +6107,7 @@ func (s *mutableStateSuite) TestApplyMutation() {
 			for key := range targetMS.updateActivityInfos {
 				targetMS.activityInfosUserDataUpdated[key] = struct{}{}
 			}
-			targetMS.updateTimerInfos = targetMS.pendingTimerInfoIDs
+			targetMS.updateTimerInfos = targetMS.pendingUserTimers.all()
 			for key := range targetMS.updateTimerInfos {
 				targetMS.timerInfosUserDataUpdated[key] = struct{}{}
 			}
@@ -8272,7 +8272,9 @@ func (s *mutableStateSuite) TestCloseTransactionPrepareTasks() {
 		s.Equal(timerExpiry, utTasks[0].VisibilityTimestamp)
 
 		// The timer must be marked as created in mutable state.
-		s.Equal(int64(TimerTaskStatusCreated), ms.pendingTimerInfoIDs["t1"].TaskStatus)
+		timerInfo, ok := ms.GetUserTimerInfo("t1")
+		s.Require().True(ok)
+		s.Equal(int64(TimerTaskStatusCreated), timerInfo.TaskStatus)
 	})
 
 	s.Run("HandleActivityUserTimerTasks/Active_Running_UserTimer_AlreadyCreated", func() {

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -44,6 +44,7 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/payloads"
+	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/persistence/transitionhistory"
 	"go.temporal.io/server/common/persistence/versionhistory"
 	"go.temporal.io/server/common/primitives/timestamp"
@@ -9154,4 +9155,92 @@ func (s *mutableStateSuite) TestAddContinueAsNewEvent_CompletionEventBatchID() {
 	)
 	s.NoError(err)
 	s.Equal(event.GetEventId(), s.mutableState.GetExecutionInfo().CompletionEventBatchId)
+}
+
+func (s *mutableStateSuite) TestUserTimerBlobsPassThroughToSnapshot() {
+	serializer := serialization.NewSerializer()
+	encode := func(id string, startEventID int64) *commonpb.DataBlob {
+		blob, err := serializer.TimerInfoToBlob(&persistencespb.TimerInfo{
+			TimerId:        id,
+			StartedEventId: startEventID,
+			Version:        1,
+		})
+		s.Require().NoError(err)
+		return blob
+	}
+
+	dbState := s.buildWorkflowMutableState()
+	dbState.TimerInfos = nil
+	timerInfoBlobs := map[string]*commonpb.DataBlob{
+		"untouched-1": encode("untouched-1", 100),
+		"untouched-2": encode("untouched-2", 101),
+	}
+
+	mutableState, err := newMutableStateFromDB(
+		s.mockShard,
+		s.mockEventsCache,
+		s.logger,
+		tests.LocalNamespaceEntry,
+		dbState,
+		123,
+		timerInfoBlobs,
+	)
+	s.Require().NoError(err)
+	mutableState.namespaceEntry = s.newNamespaceCacheEntry()
+
+	// touching one entry must decode only that entry and route it through the
+	// decoded side of the snapshot
+	s.Require().NoError(mutableState.UpdateUserTimerTaskStatus("untouched-1", TimerTaskStatusCreated))
+
+	snapshot, _, err := mutableState.CloseTransactionAsSnapshot(context.Background(), historyi.TransactionPolicyPassive)
+	s.Require().NoError(err)
+
+	s.Len(snapshot.TimerInfos, 1)
+	s.Contains(snapshot.TimerInfos, "untouched-1")
+	s.Len(snapshot.TimerInfoBlobs, 1)
+	s.Contains(snapshot.TimerInfoBlobs, "untouched-2")
+}
+
+func (s *mutableStateSuite) TestNewMutableStateFromDBWithTimerBlobsRejectsDecodedTimers() {
+	dbState := s.buildWorkflowMutableState()
+	dbState.TimerInfos = map[string]*persistencespb.TimerInfo{"t": {TimerId: "t"}}
+
+	_, err := newMutableStateFromDB(
+		s.mockShard,
+		s.mockEventsCache,
+		s.logger,
+		tests.LocalNamespaceEntry,
+		dbState,
+		123,
+		map[string]*commonpb.DataBlob{"encoded": {}},
+	)
+	s.Error(err)
+}
+
+func (s *mutableStateSuite) TestDeleteEncodedUserTimerAccounting() {
+	serializer := serialization.NewSerializer()
+	blob, err := serializer.TimerInfoToBlob(&persistencespb.TimerInfo{TimerId: "d1", StartedEventId: 7, Version: 1})
+	s.Require().NoError(err)
+
+	dbState := s.buildWorkflowMutableState()
+	dbState.TimerInfos = nil
+
+	mutableState, err := newMutableStateFromDB(
+		s.mockShard,
+		s.mockEventsCache,
+		s.logger,
+		tests.LocalNamespaceEntry,
+		dbState,
+		123,
+		map[string]*commonpb.DataBlob{"d1": blob},
+	)
+	s.Require().NoError(err)
+	sizeBeforeDelete := mutableState.approximateSize
+
+	s.Require().NoError(mutableState.DeleteUserTimer("d1"))
+
+	_, ok := mutableState.GetUserTimerInfo("d1")
+	s.False(ok)
+	s.Equal(0, len(mutableState.pendingUserTimers.typed)+len(mutableState.pendingUserTimers.blobs))
+	s.LessOrEqual(sizeBeforeDelete-mutableState.approximateSize, len(blob.GetData())+len("d1"))
 }

--- a/service/history/workflow/timeskipping_test.go
+++ b/service/history/workflow/timeskipping_test.go
@@ -358,7 +358,7 @@ func (s *mutableStateSuite) TestIsWorkflowSkippable() {
 		s.mutableState.executionInfo.TimeSkippingInfo = &persistencespb.TimeSkippingInfo{
 			Config: &commonpb.TimeSkippingConfig{Enabled: true},
 		}
-		s.mutableState.pendingTimerInfoIDs["t1"] = &persistencespb.TimerInfo{TimerId: "t1"}
+		s.mutableState.pendingUserTimers.put(&persistencespb.TimerInfo{TimerId: "t1"})
 		s.False(s.mutableState.isWorkflowSkippable())
 	})
 
@@ -423,7 +423,7 @@ func (s *mutableStateSuite) TestIsWorkflowSkippable() {
 		s.mutableState.executionInfo.TimeSkippingInfo = &persistencespb.TimeSkippingInfo{
 			Config: &commonpb.TimeSkippingConfig{Enabled: true},
 		}
-		s.mutableState.pendingTimerInfoIDs["t1"] = &persistencespb.TimerInfo{TimerId: "t1"}
+		s.mutableState.pendingUserTimers.put(&persistencespb.TimerInfo{TimerId: "t1"})
 		s.True(s.mutableState.isWorkflowSkippable())
 	})
 
@@ -967,10 +967,10 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 	s.mutableState.timeSource = fixedTimeSource
 
 	addTimer := func(id string, expiry time.Time) {
-		s.mutableState.pendingTimerInfoIDs[id] = &persistencespb.TimerInfo{
+		s.mutableState.pendingUserTimers.put(&persistencespb.TimerInfo{
 			TimerId:    id,
 			ExpiryTime: timestamppb.New(expiry),
-		}
+		})
 	}
 	setFastForward := func(target time.Time) {
 		s.mutableState.executionInfo.TimeSkippingInfo.FastForwardInfo =
@@ -982,7 +982,7 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 		ts := clock.NewEventTimeSource()
 		ts.Update(baseTime)
 		s.mutableState.timeSource = ts
-		s.mutableState.pendingTimerInfoIDs = make(map[string]*persistencespb.TimerInfo)
+		s.mutableState.pendingUserTimers.seedTyped(map[string]*persistencespb.TimerInfo{})
 		s.mutableState.pendingActivityInfoIDs = make(map[int64]*persistencespb.ActivityInfo)
 		s.mutableState.executionInfo.TimeSkippingInfo = &persistencespb.TimeSkippingInfo{
 			Config: &commonpb.TimeSkippingConfig{Enabled: true},
@@ -1256,10 +1256,10 @@ func (s *mutableStateSuite) TestFindNextSkipTarget() {
 
 func (s *mutableStateSuite) TestCloseTransactionHandleWorkflowTimeSkipping() {
 	// A valid skip target exists: a user timer one hour in the (virtual) future.
-	s.mutableState.pendingTimerInfoIDs["t1"] = &persistencespb.TimerInfo{
+	s.mutableState.pendingUserTimers.put(&persistencespb.TimerInfo{
 		TimerId:    "t1",
 		ExpiryTime: timestamppb.New(s.mutableState.Now().Add(time.Hour)),
-	}
+	})
 	s.Require().True(s.mutableState.findNextSkipTarget().IsValid(), "the user timer is a valid skip target")
 
 	s.Run("NilConfig_NoSkip", func() {
@@ -1303,10 +1303,10 @@ func (s *mutableStateSuite) TestCloseTransactionHandleWorkflowTimeSkipping() {
 		s.mutableState.executionInfo.TimeSkippingInfo = &persistencespb.TimeSkippingInfo{
 			Config: &commonpb.TimeSkippingConfig{Enabled: true},
 		}
-		s.mutableState.pendingTimerInfoIDs["t1"] = &persistencespb.TimerInfo{
+		s.mutableState.pendingUserTimers.put(&persistencespb.TimerInfo{
 			TimerId:    "t1",
 			ExpiryTime: timestamppb.New(s.mutableState.Now().Add(time.Hour)),
-		}
+		})
 		s.mutableState.timeSkippingInfoUpdated = false
 		s.Require().True(s.mutableState.IsWorkflow())
 		s.Require().True(s.mutableState.isWorkflowSkippable())
@@ -1338,10 +1338,10 @@ func (s *mutableStateSuite) TestCloseTransactionHandleWorkflowTimeSkipping() {
 		s.mutableState.executionInfo.TimeSkippingInfo = &persistencespb.TimeSkippingInfo{
 			Config: &commonpb.TimeSkippingConfig{Enabled: true},
 		}
-		s.mutableState.pendingTimerInfoIDs["t1"] = &persistencespb.TimerInfo{
+		s.mutableState.pendingUserTimers.put(&persistencespb.TimerInfo{
 			TimerId:    "t1",
 			ExpiryTime: timestamppb.New(s.mutableState.Now().Add(time.Hour)),
-		}
+		})
 		s.mutableState.timeSkippingInfoUpdated = false
 
 		needRegen := s.mutableState.closeTransactionHandleWorkflowTimeSkipping(

--- a/service/history/workflow/user_timer_cache.go
+++ b/service/history/workflow/user_timer_cache.go
@@ -1,0 +1,177 @@
+package workflow
+
+import (
+	commonpb "go.temporal.io/api/common/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/persistence/serialization"
+)
+
+// userTimers holds the pending user timers of a mutable state. Entries loaded
+// from persistence stay encoded until first access, so workflows with many
+// pending timers do not pay for decoding entries that are never read. Not
+// thread safe, access must be confined by the workflow context lock.
+type userTimers struct {
+	serializer serialization.Serializer
+	logger     log.Logger
+
+	// blobs contains entries as read from persistence that were not decoded yet.
+	blobs map[string]*commonpb.DataBlob
+	// typed contains decoded DB entries and all timers created or updated in memory.
+	typed map[string]*persistencespb.TimerInfo
+	// eventIDToID is a reverse index over typed entries only.
+	eventIDToID map[int64]string
+}
+
+func newUserTimers(
+	logger log.Logger,
+) *userTimers {
+	return &userTimers{
+		serializer: serialization.NewSerializer(),
+		logger:     logger,
+	}
+}
+
+// seedTyped takes ownership of infos, which must not be modified by the caller afterwards.
+func (t *userTimers) seedTyped(infos map[string]*persistencespb.TimerInfo) {
+	t.typed = infos
+	t.blobs = nil
+	t.eventIDToID = make(map[int64]string)
+	for _, info := range infos {
+		t.updateEventIDIndex(info)
+	}
+}
+
+// seedBlobs takes ownership of blobs, which must not be modified by the caller afterwards.
+func (t *userTimers) seedBlobs(blobs map[string]*commonpb.DataBlob) {
+	t.blobs = blobs
+	t.typed = nil
+	t.eventIDToID = nil
+}
+
+// approximateEncodedSize estimates the persisted size of the entries that are
+// still encoded. Decoded entries are accounted for by the caller.
+func (t *userTimers) approximateEncodedSize() int {
+	size := 0
+	for timerID, blob := range t.blobs {
+		size += len(blob.GetData()) + len(timerID)
+	}
+	return size
+}
+
+func (t *userTimers) get(timerID string) (*persistencespb.TimerInfo, bool) {
+	if info, ok := t.typed[timerID]; ok {
+		return info, true
+	}
+	blob, ok := t.blobs[timerID]
+	if !ok {
+		return nil, false
+	}
+	info, err := t.serializer.TimerInfoFromBlob(blob)
+	if err != nil {
+		// drop the entry so the corruption is not hit again on every access,
+		// missing entries are reported as inconsistencies by the callers
+		delete(t.blobs, timerID)
+		t.logger.Error("unable to decode user timer info",
+			tag.String("timerId", timerID),
+			tag.Error(err),
+		)
+		return nil, false
+	}
+	delete(t.blobs, timerID)
+	t.setDecoded(timerID, info)
+	return info, true
+}
+
+// getByEventID resolves a timer by its start event ID. The reverse index only
+// covers decoded entries, so a miss decodes the remaining entries before retrying.
+func (t *userTimers) getByEventID(startEventID int64) (*persistencespb.TimerInfo, bool) {
+	timerID, ok := t.eventIDToID[startEventID]
+	if !ok || !t.has(timerID) {
+		t.decodeAll()
+		timerID, ok = t.eventIDToID[startEventID]
+		if !ok {
+			return nil, false
+		}
+	}
+	return t.get(timerID)
+}
+
+func (t *userTimers) has(timerID string) bool {
+	if _, ok := t.typed[timerID]; ok {
+		return true
+	}
+	_, ok := t.blobs[timerID]
+	return ok
+}
+
+func (t *userTimers) put(info *persistencespb.TimerInfo) {
+	timerID := info.GetTimerId()
+	delete(t.blobs, timerID)
+	if t.typed == nil {
+		t.typed = make(map[string]*persistencespb.TimerInfo)
+	}
+	t.typed[timerID] = info
+	t.updateEventIDIndex(info)
+}
+
+// updateEventIDIndex maintains the reverse index for entries written into the
+// typed map without going through put, e.g. by applyUpdatesToSubStateMachine.
+func (t *userTimers) updateEventIDIndex(info *persistencespb.TimerInfo) {
+	if t.eventIDToID == nil {
+		t.eventIDToID = make(map[int64]string)
+	}
+	t.eventIDToID[info.GetStartedEventId()] = info.GetTimerId()
+}
+
+// delete removes a timer and returns the removed entry. The returned info is
+// nil if the entry was found but could not be decoded.
+func (t *userTimers) delete(timerID string) (*persistencespb.TimerInfo, bool) {
+	info, ok := t.get(timerID)
+	if !ok {
+		return nil, false
+	}
+	delete(t.typed, timerID)
+	delete(t.eventIDToID, info.GetStartedEventId())
+	return info, true
+}
+
+// all decodes the remaining encoded entries and returns the typed map. The
+// returned map is live, mutations must keep the reverse index in sync via
+// updateEventIDIndex.
+func (t *userTimers) all() map[string]*persistencespb.TimerInfo {
+	t.decodeAll()
+	return t.typed
+}
+
+// untouchedBlobs hands out the entries that were never accessed since load.
+// Ownership of the returned map is transferred to the caller.
+func (t *userTimers) untouchedBlobs() map[string]*commonpb.DataBlob {
+	blobs := t.blobs
+	t.blobs = nil
+	return blobs
+}
+
+func (t *userTimers) decodeAll() {
+	for timerID, blob := range t.blobs {
+		info, err := t.serializer.TimerInfoFromBlob(blob)
+		if err != nil {
+			t.logger.Error("unable to decode user timer info",
+				tag.String("timerId", timerID),
+				tag.Error(err),
+			)
+			continue
+		}
+		t.setDecoded(timerID, info)
+	}
+	t.blobs = nil
+}
+
+func (t *userTimers) setDecoded(timerID string, info *persistencespb.TimerInfo) {
+	if t.typed == nil {
+		t.typed = make(map[string]*persistencespb.TimerInfo)
+	}
+	t.typed[timerID] = info
+	t.updateEventIDIndex(info)
+}

--- a/service/history/workflow/user_timer_cache.go
+++ b/service/history/workflow/user_timer_cache.go
@@ -145,6 +145,12 @@ func (t *userTimers) all() map[string]*persistencespb.TimerInfo {
 	return t.typed
 }
 
+// decoded returns the entries decoded so far without forcing decoding of the
+// remaining encoded entries.
+func (t *userTimers) decoded() map[string]*persistencespb.TimerInfo {
+	return t.typed
+}
+
 // untouchedBlobs hands out the entries that were never accessed since load.
 // Ownership of the returned map is transferred to the caller.
 func (t *userTimers) untouchedBlobs() map[string]*commonpb.DataBlob {

--- a/service/history/workflow/user_timer_cache_bench_test.go
+++ b/service/history/workflow/user_timer_cache_bench_test.go
@@ -1,0 +1,68 @@
+package workflow
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	commonpb "go.temporal.io/api/common/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/persistence/serialization"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func BenchmarkUserTimersLazyVsEager(b *testing.B) {
+	const numTimers = 10000
+	serializer := serialization.NewSerializer()
+	logger := log.NewNoopLogger()
+
+	blobs := make(map[string]*commonpb.DataBlob, numTimers)
+	for i := 0; i < numTimers; i++ {
+		timerID := fmt.Sprintf("timer-%05d", i)
+		blob, err := serializer.TimerInfoToBlob(&persistencespb.TimerInfo{
+			TimerId:        timerID,
+			StartedEventId: int64(i),
+			Version:        1,
+			ExpiryTime:     timestamppb.New(time.Now().UTC().Add(time.Hour)),
+		})
+		if err != nil {
+			b.Fatal(err)
+		}
+		blobs[timerID] = blob
+	}
+
+	b.Run("eager_decode_all_on_load", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			c := newUserTimers(logger)
+			c.seedBlobs(blobs)
+			if got := len(c.all()); got != numTimers {
+				b.Fatalf("expected %d timers, got %d", numTimers, got)
+			}
+		}
+	})
+
+	b.Run("lazy_seed_untouched_only", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			c := newUserTimers(logger)
+			c.seedBlobs(blobs)
+			c.untouchedBlobs()
+		}
+	})
+
+	b.Run("lazy_single_entry_access", func(b *testing.B) {
+		b.ReportAllocs()
+		// get() moves entries out of the owned blobs map, so every iteration
+		// needs a fresh one-entry map
+		blob := blobs["timer-04999"]
+		for i := 0; i < b.N; i++ {
+			c := newUserTimers(logger)
+			c.seedBlobs(map[string]*commonpb.DataBlob{"timer-04999": blob})
+			if _, ok := c.get("timer-04999"); !ok {
+				b.Fatal("timer not found")
+			}
+		}
+	})
+}

--- a/service/history/workflow/user_timer_cache_test.go
+++ b/service/history/workflow/user_timer_cache_test.go
@@ -141,3 +141,40 @@ func TestUserTimersUntouchedBlobsOwnershipTransfer(t *testing.T) {
 	require.Nil(t, container.blobs)
 	require.Equal(t, 1, len(container.typed)+len(container.blobs))
 }
+
+func TestUserTimersReseedClearsReverseIndex(t *testing.T) {
+	container, encode := newTestUserTimers(t)
+	container.seedBlobs(map[string]*commonpb.DataBlob{"t1": encode("t1")})
+
+	// decode-all is idempotent once blobs are drained
+	require.Len(t, container.all(), 1)
+	require.Nil(t, container.blobs)
+	require.Len(t, container.all(), 1)
+
+	// reseeding must not leave stale reverse index entries behind
+	container.seedTyped(map[string]*persistencespb.TimerInfo{
+		"t2": {TimerId: "t2", StartedEventId: 10},
+	})
+	info, ok := container.getByEventID(10)
+	require.True(t, ok)
+	require.Equal(t, "t2", info.GetTimerId())
+
+	container.seedTyped(nil)
+	_, ok = container.getByEventID(10)
+	require.False(t, ok)
+	require.Equal(t, 0, len(container.typed)+len(container.blobs))
+}
+
+func TestUserTimersUpdateTaskStatusOnEncodedEntry(t *testing.T) {
+	container, encode := newTestUserTimers(t)
+	container.seedBlobs(map[string]*commonpb.DataBlob{"t1": encode("t1")})
+
+	info, ok := container.get("t1")
+	require.True(t, ok)
+	info.TaskStatus = 42
+
+	got, ok := container.get("t1")
+	require.True(t, ok)
+	require.Same(t, info, got)
+	require.EqualValues(t, 42, got.TaskStatus)
+}

--- a/service/history/workflow/user_timer_cache_test.go
+++ b/service/history/workflow/user_timer_cache_test.go
@@ -1,0 +1,143 @@
+package workflow
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/persistence/serialization"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func newTestUserTimers(t *testing.T) (*userTimers, func(string) *commonpb.DataBlob) {
+	serializer := serialization.NewSerializer()
+	nextEventID := int64(10)
+	return newUserTimers(log.NewNoopLogger()), func(timerID string) *commonpb.DataBlob {
+		startEventID := nextEventID
+		nextEventID++
+		blob, err := serializer.TimerInfoToBlob(&persistencespb.TimerInfo{
+			TimerId:        timerID,
+			StartedEventId: startEventID,
+			Version:        1,
+			ExpiryTime:     timestamppb.New(time.Now().UTC().Add(time.Hour)),
+		})
+		require.NoError(t, err)
+		return blob
+	}
+}
+
+func TestUserTimersLazyDecode(t *testing.T) {
+	container, encode := newTestUserTimers(t)
+	container.seedBlobs(map[string]*commonpb.DataBlob{
+		"t1": encode("t1"),
+		"t2": encode("t2"),
+	})
+
+	// seeding must not decode anything
+	require.Nil(t, container.typed)
+	require.Equal(t, 2, len(container.typed)+len(container.blobs))
+	require.True(t, container.has("t1"))
+	require.False(t, container.has("t0"))
+	require.Nil(t, container.eventIDToID)
+
+	info, ok := container.get("t1")
+	require.True(t, ok)
+	require.Equal(t, "t1", info.GetTimerId())
+	require.Len(t, container.typed, 1)
+
+	// decoded entries stay cached, untouched ones stay encoded
+	require.Equal(t, 2, len(container.typed)+len(container.blobs))
+	require.NotNil(t, container.blobs["t2"])
+}
+
+func TestUserTimersGetByEventIDDecodesAll(t *testing.T) {
+	container, encode := newTestUserTimers(t)
+	container.seedBlobs(map[string]*commonpb.DataBlob{
+		"t1": encode("t1"),
+		"t2": encode("t2"),
+	})
+
+	info, ok := container.getByEventID(10)
+	require.True(t, ok)
+	require.Equal(t, "t1", info.GetTimerId())
+
+	// reverse lookup over fully encoded state as well
+	freshContainer, freshEncode := newTestUserTimers(t)
+	freshContainer.seedBlobs(map[string]*commonpb.DataBlob{"t3": freshEncode("t3")})
+	info, ok = freshContainer.getByEventID(10)
+	require.True(t, ok)
+	require.Equal(t, "t3", info.GetTimerId())
+	require.Nil(t, freshContainer.blobs)
+
+	_, ok = freshContainer.getByEventID(11)
+	require.False(t, ok)
+}
+
+func TestUserTimersPutOverridesEncodedEntry(t *testing.T) {
+	container, encode := newTestUserTimers(t)
+	container.seedBlobs(map[string]*commonpb.DataBlob{"t1": encode("t1")})
+
+	updated := &persistencespb.TimerInfo{TimerId: "t1", StartedEventId: 20}
+	container.put(updated)
+
+	require.Nil(t, container.blobs["t1"])
+	require.Same(t, updated, container.typed["t1"])
+	require.Equal(t, 1, len(container.typed)+len(container.blobs))
+
+	got, ok := container.getByEventID(20)
+	require.True(t, ok)
+	require.Same(t, updated, got)
+	// the old start event ID must no longer resolve
+	_, ok = container.getByEventID(10)
+	require.False(t, ok)
+}
+
+func TestUserTimersDeleteEncodedEntry(t *testing.T) {
+	container, encode := newTestUserTimers(t)
+	container.seedBlobs(map[string]*commonpb.DataBlob{"t1": encode("t1"), "t2": encode("t2")})
+
+	info, ok := container.delete("t1")
+	require.True(t, ok)
+	require.Equal(t, "t1", info.GetTimerId())
+	require.Equal(t, 1, len(container.typed)+len(container.blobs))
+	require.False(t, container.has("t1"))
+	_, ok = container.getByEventID(10)
+	require.False(t, ok)
+
+	_, ok = container.delete("missing")
+	require.False(t, ok)
+}
+
+func TestUserTimersCorruptBlobIsDropped(t *testing.T) {
+	container := newUserTimers(log.NewNoopLogger())
+	container.seedBlobs(map[string]*commonpb.DataBlob{
+		"bad": {EncodingType: enumspb.ENCODING_TYPE_PROTO3, Data: []byte{0xFF, 0x00}},
+	})
+
+	_, ok := container.get("bad")
+	require.False(t, ok)
+	require.Equal(t, 0, len(container.typed)+len(container.blobs))
+
+	_, ok = container.getByEventID(10)
+	require.False(t, ok)
+}
+
+func TestUserTimersUntouchedBlobsOwnershipTransfer(t *testing.T) {
+	container, encode := newTestUserTimers(t)
+	container.seedBlobs(map[string]*commonpb.DataBlob{
+		"t1": encode("t1"),
+		"t2": encode("t2"),
+	})
+	_, ok := container.get("t1")
+	require.True(t, ok)
+
+	untouched := container.untouchedBlobs()
+	require.Len(t, untouched, 1)
+	require.Contains(t, untouched, "t2")
+	require.Nil(t, container.blobs)
+	require.Equal(t, 1, len(container.typed)+len(container.blobs))
+}


### PR DESCRIPTION
## Motivation

The ScyllaDB `timer_map map<text,blob>` column grows large (10k+ entries, ~157 KB) for timer-heavy workflows. Every load previously **eagerly deserialized the entire map** — 10k `TimerInfo` proto allocations, 3.5 MB, 30k allocs per load - even when the workflow never reads most timers.

**Lazy decode + verbatim passthrough** avoids this for the common case where timers sit pending until firing (or workflow completes). The memory win is the primary benefit; CPU win is proportional to timers actually accessed.

---

## What Changed?

**3 commits on branch `perf/lazy-timer-map`:**

1. **history: defer user timer decoding until first access** - the lazy decoding part
   New `userTimers` container (`service/history/workflow/user_timer_cache.go`) holds pending user timers. Entries loaded from persistence stay encoded (`*DataBlob`) until first access via `get()` or `getByEventID()`. Reverse index (`eventID → timerID`) covers only decoded entries; a miss triggers one-time full decode. `untouchedBlobs()` transfers ownership of never-accessed entries for snapshot passthrough. `approximateEncodedSize()` enables size accounting without decoding.

2. **persistence: persist untouched user timer blobs verbatim** - the even more lazy - don't decode right away if we don't need to.
   `GetWorkflowExecution` now returns `TimerInfoBlobs` (lazy) instead of decoding all timers. `ListConcreteExecutions` stays eager (scanner path). `SerializeWorkflowSnapshot` merges `TimerInfos` (decoded) + `TimerInfoBlobs` (verbatim) with collision guard. `WorkflowSnapshot` carries both fields.

3. **testing: cover lazy decode, blob passthrough, performance** - tests for the above.
   Container tests (8), manager tests (3), store suite tests (3), benchmark. SQLite store suite round-trips typed+blob split end-to-end.

---

## How Did You Test It?

- [x] built (`make lint-code` clean)
- [x] run locally and tested manually (benchmark, unit tests)
- [x] covered by existing tests (all `service/history/...`, `common/persistence/...`, `worker/scanner/...` pass)
- [x] added new unit test(s):
  - `user_timer_cache_test.go`: 8 tests (lazy decode, reverse index, corrupt blob drop, update/delete on encoded, reseed clears index, decode-all idempotency, put overrides blob, concurrent access patterns)
  - `execution_manager_test.go`: 3 tests (lazy Get returns blobs, snapshot passthrough, collision rejection)
  - `mutable_state_impl_test.go`: 3 tests (snapshot passthrough from lazy load, ctor invariant, delete accounting)
  - `user_timer_cache_bench_test.go`: microbenchmark (eager vs lazy vs single-touch)
- [ ] added new functional test(s) — integration tests require live cluster (docker deps), not run in CI unit suite

---

## Potential Risks

1. **`getByEventID` miss on non-existent timer** triggers full decode of all remaining blobs (one-time per miss). Mitigated: rare in practice (timer IDs are known), but could add `decodedAll` guard to skip repeat scans. I think it's reasonable, I can if needed improve that, perhaps.

2. **`all()` forces full decode** — called by task generation, checksum, `CloneToProto`, replication `applyUpdatesToSubStateMachine`. Workflows with many timers *that also generate tasks/checksums frequently* will still pay decode cost. This is by design (those paths need full map), but worth monitoring. Reasonable.

3. **Corrupt blob handling** — logs error, drops entry, treats as missing. Downstream callers (task gen, checksum) never see that timer. Silent data loss if corruption is transient; acceptable per current persistence contract.

4. **`untouchedBlobs()` ownership transfer** — returns nil on second call. Only `SerializeWorkflowSnapshot` calls it (once). Guard added in code but not explicit; could harden?

5. **No Cassandra/ScyllaDB integration test in CI** — store suites against real DB need `make start-deps`. SQLite suite passes and exercises the same code paths; manual verification against Cassandra recommended before merge. That's annoying.

6. **Replication `applyUpdatesToSubStateMachine`** forces decode via `all()`. Replicated timers start with `TaskStatus = None` (reset in callback). Verify this matches replication semantics.

---

**Refs:** https://github.com/temporalio/temporal/issues/11794  
**Signed-off-by:** Yaniv Kaul <yaniv.kaul@scylladb.com>
