### PR TITLE
Add failure capability to Nexus cancellation requests

### DIFF
--- a/chasm/lib/nexusoperation/cancellation_tasks.go
+++ b/chasm/lib/nexusoperation/cancellation_tasks.go
@@ -16,6 +16,7 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/nexus/nexusrpc"
 	queueserrors "go.temporal.io/server/service/history/queues/errors"
 	"go.uber.org/fx"
 )
@@ -159,8 +160,15 @@ func (h *cancellationInvocationTaskHandler) Execute(
 	if err != nil {
 		return fmt.Errorf("failed to construct invocation: %w", err)
 	}
+	header := nexus.Header(args.headers)
+	if h.config.UseNewFailureWireFormat(ns.Name().String()) {
+		if header == nil {
+			header = make(nexus.Header, 1)
+		}
+		header.Set(nexusrpc.HeaderTemporalNexusFailureSupport, "true")
+	}
 	startTime := time.Now() // nolint:forbidigo // Time can be used for timing metrics.
-	callErr := inv.Cancel(callCtx, args, nexus.CancelOperationOptions{Header: nexus.Header(args.headers)})
+	callErr := inv.Cancel(callCtx, args, nexus.CancelOperationOptions{Header: header})
 	failureSource := failureSourceFromContext(callCtx)
 
 	h.recordCallOutcome(endpoint, cancelCallOutcomeTag(callCtx, callErr), callErr, time.Since(startTime), failureSource, traceCtx)

--- a/chasm/lib/nexusoperation/cancellation_tasks.go
+++ b/chasm/lib/nexusoperation/cancellation_tasks.go
@@ -160,11 +160,9 @@ func (h *cancellationInvocationTaskHandler) Execute(
 	if err != nil {
 		return fmt.Errorf("failed to construct invocation: %w", err)
 	}
-	header := nexus.Header(args.headers)
+	header := buildRequestHeader(args.headers)
+	// If this request is handled by a newer server that supports Nexus failure serialization, trigger that behavior.
 	if h.config.UseNewFailureWireFormat(ns.Name().String()) {
-		if header == nil {
-			header = make(nexus.Header, 1)
-		}
 		header.Set(nexusrpc.HeaderTemporalNexusFailureSupport, "true")
 	}
 	startTime := time.Now() // nolint:forbidigo // Time can be used for timing metrics.

--- a/chasm/lib/nexusoperation/cancellation_tasks_test.go
+++ b/chasm/lib/nexusoperation/cancellation_tasks_test.go
@@ -305,16 +305,17 @@ func TestCancellationLoadArgs_StandaloneFallsBackToRequestData(t *testing.T) {
 
 func TestCancellationInvocationTaskHandler_HTTP(t *testing.T) {
 	cases := []struct {
-		name                  string
-		header                map[string]string
-		onCancelOperation     func(ctx context.Context, service, operation, token string, options nexus.CancelOperationOptions) error
-		expectedMetricOutcome string
-		checkOutcome          func(t *testing.T, c *Cancellation)
-		requestTimeout        time.Duration
-		schedToCloseTimeout   time.Duration
-		startToCloseTimeout   time.Duration
-		destinationDown       bool
-		endpointNotFound      bool
+		name                        string
+		header                      map[string]string
+		onCancelOperation           func(ctx context.Context, service, operation, token string, options nexus.CancelOperationOptions) error
+		expectedMetricOutcome       string
+		checkOutcome                func(t *testing.T, c *Cancellation)
+		requestTimeout              time.Duration
+		schedToCloseTimeout         time.Duration
+		startToCloseTimeout         time.Duration
+		destinationDown             bool
+		endpointNotFound            bool
+		disableNewFailureWireFormat bool
 	}{
 		{
 			name: "failure",
@@ -351,11 +352,33 @@ func TestCancellationInvocationTaskHandler_HTTP(t *testing.T) {
 			},
 		},
 		{
-			name:   "success with headers",
+			name:   "success with temporal failure capability and user headers",
 			header: map[string]string{"key": "value"},
 			onCancelOperation: func(ctx context.Context, service, operation, token string, options nexus.CancelOperationOptions) error {
 				if options.Header["key"] != "value" {
 					return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, `"key" header is not equal to "value"`)
+				}
+				if options.Header.Get(nexusrpc.HeaderTemporalNexusFailureSupport) != "true" {
+					return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "temporal failure capability is not enabled")
+				}
+				return nil
+			},
+			expectedMetricOutcome: "successful",
+			checkOutcome: func(t *testing.T, c *Cancellation) {
+				require.Equal(t, nexusoperationpb.CANCELLATION_STATUS_SUCCEEDED, c.Status)
+				require.Nil(t, c.LastAttemptFailure)
+			},
+		},
+		{
+			name:                        "success without temporal failure capability",
+			header:                      map[string]string{"key": "value"},
+			disableNewFailureWireFormat: true,
+			onCancelOperation: func(ctx context.Context, service, operation, token string, options nexus.CancelOperationOptions) error {
+				if options.Header["key"] != "value" {
+					return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, `"key" header is not equal to "value"`)
+				}
+				if options.Header.Get(nexusrpc.HeaderTemporalNexusFailureSupport) != "" {
+					return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "temporal failure capability is enabled")
 				}
 				return nil
 			},
@@ -555,6 +578,7 @@ func TestCancellationInvocationTaskHandler_HTTP(t *testing.T) {
 					Header: tc.header,
 				},
 				endpointReg, clientProvider, metricsHandler, cmp.Or(tc.requestTimeout, time.Hour))
+			env.handler.config.UseNewFailureWireFormat = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(!tc.disableNewFailureWireFormat)
 
 			env.setupReadComponent()
 			env.setupUpdateComponent()

--- a/chasm/lib/nexusoperation/config.go
+++ b/chasm/lib/nexusoperation/config.go
@@ -236,7 +236,7 @@ Uses Go's len() function to determine the length.`,
 var UseNewFailureWireFormat = dynamicconfig.NewNamespaceBoolSetting(
 	"nexusoperation.useNewFailureWireFormat",
 	true,
-	`Controls whether to use the new failure wire format via an HTTP header that is attached to StartOperation requests.
+	`Controls whether to use the new failure wire format via an HTTP header that is attached to Nexus operation requests.
 Added for safety. Defaults to true. Likely to be removed in future server versions.`,
 )
 

--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -773,8 +773,15 @@ func (e taskExecutor) executeCancelationTask(ctx context.Context, env hsm.Enviro
 			}
 		}
 
+		header := nexus.Header(args.headers)
+		if e.Config.UseNewFailureWireFormat(ns.Name().String()) {
+			if header == nil {
+				header = make(nexus.Header, 1)
+			}
+			header.Set(nexusrpc.HeaderTemporalNexusFailureSupport, "true")
+		}
 		startTime = time.Now()
-		callErr = handle.Cancel(callCtx, nexus.CancelOperationOptions{Header: nexus.Header(args.headers)})
+		callErr = handle.Cancel(callCtx, nexus.CancelOperationOptions{Header: header})
 	}
 	failureSource := failureSourceFromContext(callCtx)
 	methodTag := metrics.NexusMethodTag("CancelOperation")

--- a/components/nexusoperations/executors_test.go
+++ b/components/nexusoperations/executors_test.go
@@ -973,16 +973,17 @@ func TestProcessStartToCloseTimeoutTask(t *testing.T) {
 
 func TestProcessCancelationTask(t *testing.T) {
 	cases := []struct {
-		name                  string
-		endpointNotFound      bool
-		onCancelOperation     func(ctx context.Context, service, operation, token string, options nexus.CancelOperationOptions) error
-		expectedMetricOutcome string
-		checkOutcome          func(t *testing.T, op nexusoperations.Cancelation)
-		requestTimeout        time.Duration
-		schedToCloseTimeout   time.Duration
-		startToCloseTimeout   time.Duration
-		destinationDown       bool
-		header                map[string]string
+		name                        string
+		endpointNotFound            bool
+		onCancelOperation           func(ctx context.Context, service, operation, token string, options nexus.CancelOperationOptions) error
+		expectedMetricOutcome       string
+		checkOutcome                func(t *testing.T, op nexusoperations.Cancelation)
+		requestTimeout              time.Duration
+		schedToCloseTimeout         time.Duration
+		startToCloseTimeout         time.Duration
+		destinationDown             bool
+		header                      map[string]string
+		disableNewFailureWireFormat bool
 	}{
 		{
 			name:            "failure",
@@ -1017,13 +1018,36 @@ func TestProcessCancelationTask(t *testing.T) {
 			},
 		},
 		{
-			name:            "success with headers",
+			name:            "success with temporal failure capability and user headers",
 			requestTimeout:  time.Hour,
 			destinationDown: false,
 			header:          map[string]string{"key": "value"},
 			onCancelOperation: func(ctx context.Context, service, operation, token string, options nexus.CancelOperationOptions) error {
 				if options.Header["key"] != "value" {
 					return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, `"key" header is not equal to "value"`)
+				}
+				if options.Header.Get(nexusrpc.HeaderTemporalNexusFailureSupport) != "true" {
+					return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "temporal failure capability is not enabled")
+				}
+				return nil
+			},
+			expectedMetricOutcome: "successful",
+			checkOutcome: func(t *testing.T, c nexusoperations.Cancelation) {
+				require.Equal(t, enumspb.NEXUS_OPERATION_CANCELLATION_STATE_SUCCEEDED, c.State())
+				require.Nil(t, c.LastAttemptFailure.GetApplicationFailureInfo())
+			},
+		},
+		{
+			name:                        "success without temporal failure capability",
+			requestTimeout:              time.Hour,
+			header:                      map[string]string{"key": "value"},
+			disableNewFailureWireFormat: true,
+			onCancelOperation: func(ctx context.Context, service, operation, token string, options nexus.CancelOperationOptions) error {
+				if options.Header["key"] != "value" {
+					return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, `"key" header is not equal to "value"`)
+				}
+				if options.Header.Get(nexusrpc.HeaderTemporalNexusFailureSupport) != "" {
+					return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "temporal failure capability is enabled")
 				}
 				return nil
 			},
@@ -1182,7 +1206,7 @@ func TestProcessCancelationTask(t *testing.T) {
 					RequestTimeout:                      dynamicconfig.GetDurationPropertyFnFilteredByDestination(tc.requestTimeout),
 					MinRequestTimeout:                   dynamicconfig.GetDurationPropertyFnFilteredByNamespace(time.Millisecond),
 					RecordCancelRequestCompletionEvents: dynamicconfig.GetBoolPropertyFn(true),
-					UseNewFailureWireFormat:             dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true),
+					UseNewFailureWireFormat:             dynamicconfig.GetBoolPropertyFnFilteredByNamespace(!tc.disableNewFailureWireFormat),
 					RetryPolicy: func() backoff.RetryPolicy {
 						return backoff.NewExponentialRetryPolicy(time.Second)
 					},

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -96,6 +96,9 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelation(chasmEnabled bool
 			return &nexus.HandlerStartOperationResultAsync{OperationToken: "test"}, nil
 		},
 		OnCancelOperation: func(ctx context.Context, service, operation, token string, options nexus.CancelOperationOptions) error {
+			if options.Header.Get(nexusrpc.HeaderTemporalNexusFailureSupport) != "true" {
+				return errors.New("expected Temporal failure response capability header")
+			}
 			if !firstCancelSeen {
 				// Fail cancel request once to test NexusOperationCancelRequestFailed event is recorded and request is retried.
 				firstCancelSeen = true
@@ -270,102 +273,6 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelation(chasmEnabled bool
 	})
 	s.RequireHistoryEvent(hist, enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_FAILED)
 	s.RequireHistoryEvent(hist, enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_COMPLETED)
-}
-
-func (s *NexusWorkflowTestSuite) TestNexusOperationCancelationEnablesTemporalFailureCapability(chasmEnabled bool) {
-	env := s.newTestEnv(chasmEnabled)
-	ctx := s.Context()
-	workflowTaskQueue := testcore.RandomizeStr(s.T().Name() + "-workflow")
-	nexusTaskQueue := testcore.RandomizeStr(s.T().Name() + "-nexus")
-	// A worker endpoint exposes the server-generated Nexus requests through PollNexusTaskQueue so the test can inspect
-	// the exact capabilities delivered to an SDK worker.
-	endpoint := env.createNexusEndpoint(ctx, s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), nexusTaskQueue)
-
-	run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
-		TaskQueue: workflowTaskQueue,
-	}, "workflow")
-	s.Require().NoError(err)
-
-	pollResp, err := env.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
-		Namespace: env.Namespace().String(),
-		TaskQueue: &taskqueuepb.TaskQueue{
-			Name: workflowTaskQueue,
-			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
-		},
-		Identity: "test",
-	})
-	s.Require().NoError(err)
-
-	// Complete the start request asynchronously so the operation remains available for cancellation.
-	startPoller := env.nexusTaskPoller(ctx, s.T(), nexusTaskQueue, func(_ *testing.T, task *workflowservice.PollNexusTaskQueueResponse) (*nexusTaskResponse, error) {
-		if task.Request.GetStartOperation() == nil {
-			return nil, errors.New("expected start operation request")
-		}
-		return &nexusTaskResponse{
-			StartResult: &nexus.HandlerStartOperationResultAsync{OperationToken: "test"},
-		}, nil
-	})
-	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
-		Identity:  "test",
-		TaskToken: pollResp.TaskToken,
-		Commands: []*commandpb.Command{
-			{
-				CommandType: enumspb.COMMAND_TYPE_SCHEDULE_NEXUS_OPERATION,
-				Attributes: &commandpb.Command_ScheduleNexusOperationCommandAttributes{
-					ScheduleNexusOperationCommandAttributes: &commandpb.ScheduleNexusOperationCommandAttributes{
-						Endpoint:  endpoint.Spec.Name,
-						Service:   "test-service",
-						Operation: "test-operation",
-						Input:     testcore.MustToPayload(s.T(), "input"),
-					},
-				},
-			},
-		},
-	})
-	s.Require().NoError(err)
-	s.Require().NoError(await.Rcv(s.T(), startPoller))
-
-	pollResp, err = env.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
-		Namespace: env.Namespace().String(),
-		TaskQueue: &taskqueuepb.TaskQueue{
-			Name: workflowTaskQueue,
-			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
-		},
-		Identity: "test",
-	})
-	s.Require().NoError(err)
-	s.RequireHistoryEvent(pollResp.History.Events, enumspb.EVENT_TYPE_NEXUS_OPERATION_STARTED)
-	scheduledEvent := s.RequireHistoryEvent(pollResp.History.Events, enumspb.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED)
-
-	// Inspect the raw worker task because this capability controls how the SDK serializes a cancel handler failure.
-	cancelPoller := env.nexusTaskPoller(ctx, s.T(), nexusTaskQueue, func(_ *testing.T, task *workflowservice.PollNexusTaskQueueResponse) (*nexusTaskResponse, error) {
-		if task.Request.GetCancelOperation() == nil {
-			return nil, errors.New("expected cancel operation request")
-		}
-		if !task.Request.GetCapabilities().GetTemporalFailureResponses() {
-			return nil, errors.New("expected Temporal failure responses capability")
-		}
-		return &nexusTaskResponse{CancelResult: &struct{}{}}, nil
-	})
-	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
-		Identity:  "test",
-		TaskToken: pollResp.TaskToken,
-		Commands: []*commandpb.Command{
-			{
-				CommandType: enumspb.COMMAND_TYPE_REQUEST_CANCEL_NEXUS_OPERATION,
-				Attributes: &commandpb.Command_RequestCancelNexusOperationCommandAttributes{
-					RequestCancelNexusOperationCommandAttributes: &commandpb.RequestCancelNexusOperationCommandAttributes{
-						ScheduledEventId: scheduledEvent.EventId,
-					},
-				},
-			},
-		},
-	})
-	s.Require().NoError(err)
-	s.Require().NoError(await.Rcv(s.T(), cancelPoller))
-
-	err = env.SdkClient().TerminateWorkflow(ctx, run.GetID(), run.GetRunID(), "test")
-	s.Require().NoError(err)
 }
 
 // TestNexusOperationCancellationCrossTree verifies that a RequestCancelNexusOperation command is routed to the tree

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -272,6 +272,102 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationCancelation(chasmEnabled bool
 	s.RequireHistoryEvent(hist, enumspb.EVENT_TYPE_NEXUS_OPERATION_CANCEL_REQUEST_COMPLETED)
 }
 
+func (s *NexusWorkflowTestSuite) TestNexusOperationCancelationEnablesTemporalFailureCapability(chasmEnabled bool) {
+	env := s.newTestEnv(chasmEnabled)
+	ctx := s.Context()
+	workflowTaskQueue := testcore.RandomizeStr(s.T().Name() + "-workflow")
+	nexusTaskQueue := testcore.RandomizeStr(s.T().Name() + "-nexus")
+	// A worker endpoint exposes the server-generated Nexus requests through PollNexusTaskQueue so the test can inspect
+	// the exact capabilities delivered to an SDK worker.
+	endpoint := env.createNexusEndpoint(ctx, s.T(), testcore.RandomizedNexusEndpoint(s.T().Name()), nexusTaskQueue)
+
+	run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		TaskQueue: workflowTaskQueue,
+	}, "workflow")
+	s.Require().NoError(err)
+
+	pollResp, err := env.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
+		Namespace: env.Namespace().String(),
+		TaskQueue: &taskqueuepb.TaskQueue{
+			Name: workflowTaskQueue,
+			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
+		},
+		Identity: "test",
+	})
+	s.Require().NoError(err)
+
+	// Complete the start request asynchronously so the operation remains available for cancellation.
+	startPoller := env.nexusTaskPoller(ctx, s.T(), nexusTaskQueue, func(_ *testing.T, task *workflowservice.PollNexusTaskQueueResponse) (*nexusTaskResponse, error) {
+		if task.Request.GetStartOperation() == nil {
+			return nil, errors.New("expected start operation request")
+		}
+		return &nexusTaskResponse{
+			StartResult: &nexus.HandlerStartOperationResultAsync{OperationToken: "test"},
+		}, nil
+	})
+	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+		Identity:  "test",
+		TaskToken: pollResp.TaskToken,
+		Commands: []*commandpb.Command{
+			{
+				CommandType: enumspb.COMMAND_TYPE_SCHEDULE_NEXUS_OPERATION,
+				Attributes: &commandpb.Command_ScheduleNexusOperationCommandAttributes{
+					ScheduleNexusOperationCommandAttributes: &commandpb.ScheduleNexusOperationCommandAttributes{
+						Endpoint:  endpoint.Spec.Name,
+						Service:   "test-service",
+						Operation: "test-operation",
+						Input:     testcore.MustToPayload(s.T(), "input"),
+					},
+				},
+			},
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().NoError(await.Rcv(s.T(), startPoller))
+
+	pollResp, err = env.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
+		Namespace: env.Namespace().String(),
+		TaskQueue: &taskqueuepb.TaskQueue{
+			Name: workflowTaskQueue,
+			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
+		},
+		Identity: "test",
+	})
+	s.Require().NoError(err)
+	s.RequireHistoryEvent(pollResp.History.Events, enumspb.EVENT_TYPE_NEXUS_OPERATION_STARTED)
+	scheduledEvent := s.RequireHistoryEvent(pollResp.History.Events, enumspb.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED)
+
+	// Inspect the raw worker task because this capability controls how the SDK serializes a cancel handler failure.
+	cancelPoller := env.nexusTaskPoller(ctx, s.T(), nexusTaskQueue, func(_ *testing.T, task *workflowservice.PollNexusTaskQueueResponse) (*nexusTaskResponse, error) {
+		if task.Request.GetCancelOperation() == nil {
+			return nil, errors.New("expected cancel operation request")
+		}
+		if !task.Request.GetCapabilities().GetTemporalFailureResponses() {
+			return nil, errors.New("expected Temporal failure responses capability")
+		}
+		return &nexusTaskResponse{CancelResult: &struct{}{}}, nil
+	})
+	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+		Identity:  "test",
+		TaskToken: pollResp.TaskToken,
+		Commands: []*commandpb.Command{
+			{
+				CommandType: enumspb.COMMAND_TYPE_REQUEST_CANCEL_NEXUS_OPERATION,
+				Attributes: &commandpb.Command_RequestCancelNexusOperationCommandAttributes{
+					RequestCancelNexusOperationCommandAttributes: &commandpb.RequestCancelNexusOperationCommandAttributes{
+						ScheduledEventId: scheduledEvent.EventId,
+					},
+				},
+			},
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().NoError(await.Rcv(s.T(), cancelPoller))
+
+	err = env.SdkClient().TerminateWorkflow(ctx, run.GetID(), run.GetRunID(), "test")
+	s.Require().NoError(err)
+}
+
 // TestNexusOperationCancellationCrossTree verifies that a RequestCancelNexusOperation command is routed to the tree
 // that actually holds the operation, not to the tree implied by the current enableChasmWorkflowOperations flag.
 // An operation's tree is fixed when it is scheduled, so flipping the flag (a downgrade or an upgrade) must not cause


### PR DESCRIPTION
## What changed?

- Add the Temporal failure response capability header to Nexus cancellation requests in both HSM and CHASM executors.
- Respect the `nexusoperation.useNewFailureWireFormat` dynamic config when adding the header to cancellation requests.

## Why?

Nexus start requests explicitly advertise support for Temporal failure responses, but cancellation requests relied on the request header map being mutated elsewhere.

[#10720](https://github.com/temporalio/temporal/pull/10720) and [#10746](https://github.com/temporalio/temporal/pull/10746) introduced defensive copies of Nexus request headers. That exposed the missing capability header on cancellation requests, causing SDK workers to use the legacy failure wire format for cancel handler failures.

## How did you test it?

- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)

## Potential risks

Cancellation requests now advertise support for Temporal failure responses by default. The existing dynamic config can disable the behavior if needed.
