### PR TITLE
Capture panic in ServiceErrorInterceptor

### DIFF
--- a/common/rpc/interceptor/mask_internal_error_test.go
+++ b/common/rpc/interceptor/mask_internal_error_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/common"
@@ -52,9 +52,9 @@ func testMaskUnknownOrInternalErrors(t *testing.T, st *status.Status, expectRepl
 			errorHash,
 		)
 
-		assert.Equal(t, expectedMessage, gotError.Error())
+		require.Equal(t, expectedMessage, gotError.Error())
 	} else {
-		assert.Equal(t, err, gotError)
+		require.Equal(t, err, gotError)
 	}
 }
 
@@ -70,18 +70,18 @@ func TestMaskInternalErrorDetailsInterceptor(t *testing.T) {
 	test_namespace := "test-namespace"
 	req := &workflowservice.StartWorkflowExecutionRequest{Namespace: test_namespace}
 	mockRegistry.EXPECT().GetNamespace(namespace.Name(test_namespace)).Return(&namespace.Namespace{}, nil).AnyTimes()
-	assert.True(t, errorMask.shouldMaskErrors(req))
+	require.True(t, errorMask.shouldMaskErrors(req))
 
 	namespace_not_found := "namespace-not-found"
 	req = &workflowservice.StartWorkflowExecutionRequest{Namespace: namespace_not_found}
 	mockRegistry.EXPECT().GetNamespace(namespace.Name(namespace_not_found)).Return(nil, serviceerror.NewNamespaceNotFound("missing-namespace"))
-	assert.False(t, errorMask.shouldMaskErrors(req))
+	require.False(t, errorMask.shouldMaskErrors(req))
 
 	empty_namespace := ""
 	req = &workflowservice.StartWorkflowExecutionRequest{Namespace: empty_namespace}
 	mockRegistry.EXPECT().GetNamespace(namespace.Name(empty_namespace)).Return(nil, serviceerror.NewNamespaceNotFound("missing-namespace"))
-	assert.False(t, errorMask.shouldMaskErrors(req))
+	require.False(t, errorMask.shouldMaskErrors(req))
 
 	var ei any
-	assert.False(t, errorMask.shouldMaskErrors(ei))
+	require.False(t, errorMask.shouldMaskErrors(ei))
 }

--- a/common/rpc/interceptor/mask_internal_error_test.go
+++ b/common/rpc/interceptor/mask_internal_error_test.go
@@ -17,18 +17,20 @@ import (
 )
 
 func TestMaskUnknownOrInternalErrors(t *testing.T) {
-
 	statusOk := status.New(codes.OK, "OK")
 	testMaskUnknownOrInternalErrors(t, statusOk, false)
 
-	statusUnknown := status.New(codes.Unknown, "Unknown")
+	statusCanceled := status.New(codes.Canceled, "Canceled message")
+	testMaskUnknownOrInternalErrors(t, statusCanceled, false)
+
+	statusUnknown := status.New(codes.Unknown, "Unknown message")
 	testMaskUnknownOrInternalErrors(t, statusUnknown, true)
 
-	statusInternal := status.New(codes.Internal, "Internal")
+	statusInternal := status.New(codes.Internal, "Internal message")
 	testMaskUnknownOrInternalErrors(t, statusInternal, true)
 }
 
-func testMaskUnknownOrInternalErrors(t *testing.T, st *status.Status, expectRelpace bool) {
+func testMaskUnknownOrInternalErrors(t *testing.T, st *status.Status, expectReplace bool) {
 	controller := gomock.NewController(t)
 	mockRegistry := namespace.NewMockRegistry(controller)
 	mockLogger := log.NewMockLogger(controller)
@@ -36,27 +38,27 @@ func testMaskUnknownOrInternalErrors(t *testing.T, st *status.Status, expectRelp
 	errorMaskInterceptor := NewMaskInternalErrorDetailsInterceptor(
 		dynamicconfig.FrontendMaskInternalErrorDetails.Get(dc), mockRegistry, mockLogger)
 
-	err := serviceerror.FromStatus(st)
-	if expectRelpace {
+	err := st.Err()
+	if expectReplace {
 		mockLogger.EXPECT().Error(gomock.Any(), gomock.Any()).Times(1)
 	}
-	errorMessage := errorMaskInterceptor.maskUnknownOrInternalErrors(nil, "test", err)
-	if expectRelpace {
+	gotError := errorMaskInterceptor.maskUnknownOrInternalErrors(nil, "test", err)
+	if expectReplace {
 		errorHash := common.ErrorHash(err)
-		expectedMessage := fmt.Sprintf("rpc error: code = %s desc = %s (%s)", st.Message(), errorFrontendMasked, errorHash)
+		expectedMessage := fmt.Sprintf(
+			"rpc error: code = %s desc = %s (%s)",
+			st.Code(),
+			errorFrontendMasked,
+			errorHash,
+		)
 
-		assert.Equal(t, expectedMessage, errorMessage.Error())
+		assert.Equal(t, expectedMessage, gotError.Error())
 	} else {
-		if err == nil {
-			assert.Equal(t, errorMessage, nil)
-		} else {
-			assert.Equal(t, errorMessage.Error(), st.Message())
-		}
+		assert.Equal(t, err, gotError)
 	}
 }
 
 func TestMaskInternalErrorDetailsInterceptor(t *testing.T) {
-
 	controller := gomock.NewController(t)
 	mockRegistry := namespace.NewMockRegistry(controller)
 	dc := dynamicconfig.NewNoopCollection()

--- a/common/rpc/interceptor/service_error_interceptor.go
+++ b/common/rpc/interceptor/service_error_interceptor.go
@@ -7,6 +7,7 @@ import (
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/util"
 	"google.golang.org/grpc"
@@ -18,17 +19,20 @@ const truncatedSuffix = "... <truncated>"
 type ServiceErrorInterceptor struct {
 	maxMessageLength dynamicconfig.IntPropertyFn
 
-	logger log.Logger
+	metricsHandler metrics.Handler
+	logger         log.Logger
 }
 
 func NewServiceErrorInterceptor(
 	maxMessageLength dynamicconfig.IntPropertyFn,
+	metricsHandler metrics.Handler,
 	logger log.Logger,
 ) *ServiceErrorInterceptor {
 	return &ServiceErrorInterceptor{
 		maxMessageLength: maxMessageLength,
 
-		logger: logger,
+		metricsHandler: metricsHandler,
+		logger:         logger,
 	}
 }
 
@@ -64,6 +68,6 @@ func (i *ServiceErrorInterceptor) capturePanicHandler(
 	req any,
 	handler grpc.UnaryHandler,
 ) (_ any, retError error) {
-	defer log.CapturePanic(i.logger, &retError)
+	defer metrics.CapturePanic(i.logger, i.metricsHandler, &retError)
 	return handler(ctx, req)
 }

--- a/common/rpc/interceptor/service_error_interceptor.go
+++ b/common/rpc/interceptor/service_error_interceptor.go
@@ -6,6 +6,7 @@ import (
 
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/util"
 	"google.golang.org/grpc"
@@ -16,13 +17,18 @@ const truncatedSuffix = "... <truncated>"
 
 type ServiceErrorInterceptor struct {
 	maxMessageLength dynamicconfig.IntPropertyFn
+
+	logger log.Logger
 }
 
 func NewServiceErrorInterceptor(
 	maxMessageLength dynamicconfig.IntPropertyFn,
+	logger log.Logger,
 ) *ServiceErrorInterceptor {
 	return &ServiceErrorInterceptor{
 		maxMessageLength: maxMessageLength,
+
+		logger: logger,
 	}
 }
 
@@ -32,7 +38,7 @@ func (i *ServiceErrorInterceptor) Intercept(
 	_ *grpc.UnaryServerInfo,
 	handler grpc.UnaryHandler,
 ) (any, error) {
-	resp, err := handler(ctx, req)
+	resp, err := i.capturePanicHandler(ctx, req, handler)
 
 	var deserializationError *serialization.DeserializationError
 	var serializationError *serialization.SerializationError
@@ -51,4 +57,13 @@ func (i *ServiceErrorInterceptor) Intercept(
 	}
 
 	return resp, st.Err()
+}
+
+func (i *ServiceErrorInterceptor) capturePanicHandler(
+	ctx context.Context,
+	req any,
+	handler grpc.UnaryHandler,
+) (_ any, retError error) {
+	defer log.CapturePanic(i.logger, &retError)
+	return handler(ctx, req)
 }

--- a/common/rpc/interceptor/service_error_interceptor_test.go
+++ b/common/rpc/interceptor/service_error_interceptor_test.go
@@ -2,6 +2,8 @@ package interceptor
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -9,7 +11,10 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/persistence/serialization"
+	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -31,7 +36,10 @@ func (e *ErrorWithoutStatus) Error() string {
 
 // Error returns string message.
 func TestServiceErrorInterceptorUnknown(t *testing.T) {
-	interceptor := NewServiceErrorInterceptor(dynamicconfig.GetIntPropertyFn(testMaxMessageLength))
+	interceptor := NewServiceErrorInterceptor(
+		dynamicconfig.GetIntPropertyFn(testMaxMessageLength),
+		log.NewTestLogger(),
+	)
 
 	_, err := interceptor.Intercept(t.Context(), nil, nil,
 		func(ctx context.Context, req any) (any, error) {
@@ -54,7 +62,10 @@ func TestServiceErrorInterceptorUnknown(t *testing.T) {
 }
 
 func TestServiceErrorInterceptorSer(t *testing.T) {
-	interceptor := NewServiceErrorInterceptor(dynamicconfig.GetIntPropertyFn(testMaxMessageLength))
+	interceptor := NewServiceErrorInterceptor(
+		dynamicconfig.GetIntPropertyFn(testMaxMessageLength),
+		log.NewTestLogger(),
+	)
 	serErrors := []error{
 		serialization.NewDeserializationError(enumspb.ENCODING_TYPE_PROTO3, nil),
 		serialization.NewSerializationError(enumspb.ENCODING_TYPE_PROTO3, nil),
@@ -69,7 +80,10 @@ func TestServiceErrorInterceptorSer(t *testing.T) {
 }
 
 func TestServiceErrorInterceptorTruncation(t *testing.T) {
-	interceptor := NewServiceErrorInterceptor(dynamicconfig.GetIntPropertyFn(testMaxMessageLength))
+	interceptor := NewServiceErrorInterceptor(
+		dynamicconfig.GetIntPropertyFn(testMaxMessageLength),
+		log.NewTestLogger(),
+	)
 
 	t.Run("nil error is not affected", func(t *testing.T) {
 		_, err := interceptor.Intercept(t.Context(), nil, nil,
@@ -145,4 +159,89 @@ func TestServiceErrorInterceptorTruncation(t *testing.T) {
 			require.Equal(t, '€', r)
 		}
 	})
+}
+
+func TestServiceErrorInterceptorPanic(t *testing.T) {
+	testCases := []struct {
+		name       string
+		panicObj   any
+		errMessage string
+	}{
+		{
+			name:       "panic with error is converted to internal error",
+			panicObj:   errors.New("panic error message"),
+			errMessage: "panic error message",
+		},
+		{
+			name:       "panic with non-error value is converted to internal error",
+			panicObj:   "something went wrong",
+			errMessage: "panic: something went wrong",
+		},
+		{
+			name:       "panic with service error is still converted to internal error",
+			panicObj:   serviceerror.NewNotFound("not found message"),
+			errMessage: "not found message",
+		},
+		{
+			name:       "captured panic message is truncated",
+			panicObj:   errors.New(strings.Repeat("a", testMaxMessageLength+100)),
+			errMessage: strings.Repeat("a", testMaxMessageLength-len(truncatedSuffix)) + truncatedSuffix,
+		},
+		{
+			name:       "no panic does not log",
+			panicObj:   nil,
+			errMessage: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			mockLogger := log.NewMockLogger(controller)
+			interceptor := NewServiceErrorInterceptor(
+				dynamicconfig.GetIntPropertyFn(testMaxMessageLength),
+				mockLogger,
+			)
+
+			var loggedTags []tag.Tag
+			if tc.panicObj != nil {
+				mockLogger.EXPECT().Error("Panic is captured", gomock.Any(), gomock.Any()).
+					Do(func(_ string, tags ...tag.Tag) {
+						loggedTags = tags
+					}).
+					Times(1)
+			}
+
+			resp, err := interceptor.Intercept(t.Context(), nil, nil,
+				func(_ context.Context, _ any) (any, error) {
+					if tc.panicObj != nil {
+						panic(tc.panicObj)
+					}
+					return "ok", nil
+				})
+
+			if tc.panicObj != nil {
+				expectedMessage := fmt.Sprintf(
+					"rpc error: code = Internal desc = %s",
+					tc.errMessage,
+				)
+				require.Nil(t, resp)
+				require.Error(t, err)
+				require.Equal(t, codes.Internal, status.Code(err))
+				require.Equal(t, expectedMessage, err.Error())
+
+				// Logs contains the stack trace
+				tagsByKey := make(map[string]tag.Tag, len(loggedTags))
+				for _, tg := range loggedTags {
+					tagsByKey[tg.Key()] = tg
+				}
+				require.Contains(t, tagsByKey, "sys-stack-trace")
+				require.Contains(t, tagsByKey["sys-stack-trace"].Value(), "service_error_interceptor_test.go")
+				require.Contains(t, tagsByKey, "error")
+			} else {
+				require.Equal(t, "ok", resp)
+				require.Nil(t, err)
+			}
+		})
+	}
 }

--- a/common/rpc/interceptor/service_error_interceptor_test.go
+++ b/common/rpc/interceptor/service_error_interceptor_test.go
@@ -13,6 +13,7 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence/serialization"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/codes"
@@ -36,8 +37,10 @@ func (e *ErrorWithoutStatus) Error() string {
 
 // Error returns string message.
 func TestServiceErrorInterceptorUnknown(t *testing.T) {
+	ctrl := gomock.NewController(t)
 	interceptor := NewServiceErrorInterceptor(
 		dynamicconfig.GetIntPropertyFn(testMaxMessageLength),
+		metrics.NewMockHandler(ctrl),
 		log.NewTestLogger(),
 	)
 
@@ -62,8 +65,10 @@ func TestServiceErrorInterceptorUnknown(t *testing.T) {
 }
 
 func TestServiceErrorInterceptorSer(t *testing.T) {
+	ctrl := gomock.NewController(t)
 	interceptor := NewServiceErrorInterceptor(
 		dynamicconfig.GetIntPropertyFn(testMaxMessageLength),
+		metrics.NewMockHandler(ctrl),
 		log.NewTestLogger(),
 	)
 	serErrors := []error{
@@ -80,8 +85,10 @@ func TestServiceErrorInterceptorSer(t *testing.T) {
 }
 
 func TestServiceErrorInterceptorTruncation(t *testing.T) {
+	ctrl := gomock.NewController(t)
 	interceptor := NewServiceErrorInterceptor(
 		dynamicconfig.GetIntPropertyFn(testMaxMessageLength),
+		metrics.NewMockHandler(ctrl),
 		log.NewTestLogger(),
 	)
 
@@ -196,16 +203,21 @@ func TestServiceErrorInterceptorPanic(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			controller := gomock.NewController(t)
-			mockLogger := log.NewMockLogger(controller)
+			ctrl := gomock.NewController(t)
+			metricsHandlerMock := metrics.NewMockHandler(ctrl)
+			loggerMock := log.NewMockLogger(ctrl)
 			interceptor := NewServiceErrorInterceptor(
 				dynamicconfig.GetIntPropertyFn(testMaxMessageLength),
-				mockLogger,
+				metricsHandlerMock,
+				loggerMock,
 			)
 
 			var loggedTags []tag.Tag
 			if tc.panicObj != nil {
-				mockLogger.EXPECT().Error("Panic is captured", gomock.Any(), gomock.Any()).
+				counterMock := metrics.NewMockCounterIface(ctrl)
+				counterMock.EXPECT().Record(int64(1))
+				metricsHandlerMock.EXPECT().Counter(metrics.ServicePanic.Name()).Return(counterMock)
+				loggerMock.EXPECT().Error("Panic is captured", gomock.Any(), gomock.Any()).
 					Do(func(_ string, tags ...tag.Tag) {
 						loggedTags = tags
 					}).
@@ -240,7 +252,7 @@ func TestServiceErrorInterceptorPanic(t *testing.T) {
 				require.Contains(t, tagsByKey, "error")
 			} else {
 				require.Equal(t, "ok", resp)
-				require.Nil(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -362,9 +362,11 @@ func ConfigProvider(
 
 func ServiceErrorInterceptorProvider(
 	dc *dynamicconfig.Collection,
+	logger log.Logger,
 ) *interceptor.ServiceErrorInterceptor {
 	return interceptor.NewServiceErrorInterceptor(
 		dynamicconfig.MaxServiceErrorMessageLength.Get(dc),
+		logger,
 	)
 }
 

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -362,10 +362,12 @@ func ConfigProvider(
 
 func ServiceErrorInterceptorProvider(
 	dc *dynamicconfig.Collection,
+	metricsHandler metrics.Handler,
 	logger log.Logger,
 ) *interceptor.ServiceErrorInterceptor {
 	return interceptor.NewServiceErrorInterceptor(
 		dynamicconfig.MaxServiceErrorMessageLength.Get(dc),
+		metricsHandler,
 		logger,
 	)
 }

--- a/service/frontend/fx_test.go
+++ b/service/frontend/fx_test.go
@@ -208,6 +208,7 @@ func TestRateLimitInterceptorProvider(t *testing.T) {
 
 			serviceErrorInterceptor := interceptor.NewServiceErrorInterceptor(
 				dynamicconfig.GetIntPropertyFn(4000),
+				log.NewTestLogger(),
 			)
 
 			// Create a rate limit interceptor which uses the per-instance and global RPS limits from the test case.
@@ -576,6 +577,7 @@ func TestNamespaceRateLimitInterceptorProvider(t *testing.T) {
 
 			serviceErrorInterceptor := interceptor.NewServiceErrorInterceptor(
 				dynamicconfig.GetIntPropertyFn(4000),
+				log.NewTestLogger(),
 			)
 
 			// Create a rate limit interceptor.
@@ -779,6 +781,7 @@ func TestNamespaceRateLimitMetrics(t *testing.T) {
 
 			serviceErrorInterceptor := interceptor.NewServiceErrorInterceptor(
 				dynamicconfig.GetIntPropertyFn(4000),
+				log.NewTestLogger(),
 			)
 
 			// Create a rate limit interceptor which uses the per-instance and global RPS limits from the test case.

--- a/service/frontend/fx_test.go
+++ b/service/frontend/fx_test.go
@@ -33,6 +33,8 @@ type rateLimitInterceptorTestCase struct {
 	name string
 	// t is the test object
 	t *testing.T
+	// ctrl is the mock controller
+	ctrl *gomock.Controller
 	// globalRPSLimit is the global RPS limit for all frontend hosts
 	globalRPSLimit int
 	// perInstanceRPSLimit is the RPS limit for each frontend host
@@ -183,7 +185,7 @@ func TestRateLimitInterceptorProvider(t *testing.T) {
 				tc.perInstanceRPSLimit = highPerInstanceRPSLimit
 				tc.operatorRPSRatio = operatorRPSRatio
 				tc.expectRateLimit = false
-				serviceResolver := membership.NewMockServiceResolver(gomock.NewController(tc.t))
+				serviceResolver := membership.NewMockServiceResolver(tc.ctrl)
 				serviceResolver.EXPECT().AvailableMemberCount().Return(0).AnyTimes()
 				tc.serviceResolver = serviceResolver
 			},
@@ -196,11 +198,11 @@ func TestRateLimitInterceptorProvider(t *testing.T) {
 
 			tc.numRequests = 10
 			tc.t = t
+			tc.ctrl = gomock.NewController(t)
 			{
 				// Create a mock service resolver which returns the number of frontend hosts.
 				// This may be overridden by the test case.
-				ctrl := gomock.NewController(t)
-				serviceResolver := membership.NewMockServiceResolver(ctrl)
+				serviceResolver := membership.NewMockServiceResolver(tc.ctrl)
 				serviceResolver.EXPECT().AvailableMemberCount().Return(numHosts).AnyTimes()
 				tc.serviceResolver = serviceResolver
 			}
@@ -208,6 +210,7 @@ func TestRateLimitInterceptorProvider(t *testing.T) {
 
 			serviceErrorInterceptor := interceptor.NewServiceErrorInterceptor(
 				dynamicconfig.GetIntPropertyFn(4000),
+				metrics.NewMockHandler(tc.ctrl),
 				log.NewTestLogger(),
 			)
 
@@ -566,17 +569,19 @@ func TestNamespaceRateLimitInterceptorProvider(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			ctrl := gomock.NewController(t)
 
 			namespaceName := "test-namespace"
-			mockRegistry := namespace.NewMockRegistry(gomock.NewController(t))
+			mockRegistry := namespace.NewMockRegistry(ctrl)
 			mockRegistry.EXPECT().GetNamespace(namespace.Name(namespaceName)).Return(&namespace.Namespace{}, nil).AnyTimes()
-			serviceResolver := membership.NewMockServiceResolver(gomock.NewController(t))
+			serviceResolver := membership.NewMockServiceResolver(ctrl)
 			serviceResolver.EXPECT().AvailableMemberCount().Return(tc.frontendServiceCount).AnyTimes()
 
 			config := getTestConfig(tc)
 
 			serviceErrorInterceptor := interceptor.NewServiceErrorInterceptor(
 				dynamicconfig.GetIntPropertyFn(4000),
+				metrics.NewMockHandler(ctrl),
 				log.NewTestLogger(),
 			)
 
@@ -754,11 +759,12 @@ func TestNamespaceRateLimitMetrics(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			ctrl := gomock.NewController(t)
 
 			testNS := "test_namespace"
-			mockRegistry := namespace.NewMockRegistry(gomock.NewController(t))
+			mockRegistry := namespace.NewMockRegistry(ctrl)
 			mockRegistry.EXPECT().GetNamespace(namespace.Name(testNS)).Return(&namespace.Namespace{}, nil).AnyTimes()
-			serviceResolver := membership.NewMockServiceResolver(gomock.NewController(t))
+			serviceResolver := membership.NewMockServiceResolver(ctrl)
 			serviceResolver.EXPECT().AvailableMemberCount().Return(tc.frontendServiceCount).AnyTimes()
 			metricsHandler := metricstest.NewCaptureHandler()
 			capture := metricsHandler.StartCapture()
@@ -781,6 +787,7 @@ func TestNamespaceRateLimitMetrics(t *testing.T) {
 
 			serviceErrorInterceptor := interceptor.NewServiceErrorInterceptor(
 				dynamicconfig.GetIntPropertyFn(4000),
+				metrics.NewMockHandler(ctrl),
 				log.NewTestLogger(),
 			)
 

--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -249,9 +249,11 @@ func ConfigProvider(
 
 func ServiceErrorInterceptorProvider(
 	dc *dynamicconfig.Collection,
+	logger log.Logger,
 ) *interceptor.ServiceErrorInterceptor {
 	return interceptor.NewServiceErrorInterceptor(
 		dynamicconfig.MaxServiceErrorMessageLength.Get(dc),
+		logger,
 	)
 }
 

--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -249,10 +249,12 @@ func ConfigProvider(
 
 func ServiceErrorInterceptorProvider(
 	dc *dynamicconfig.Collection,
+	metricsHandler metrics.Handler,
 	logger log.Logger,
 ) *interceptor.ServiceErrorInterceptor {
 	return interceptor.NewServiceErrorInterceptor(
 		dynamicconfig.MaxServiceErrorMessageLength.Get(dc),
+		metricsHandler,
 		logger,
 	)
 }

--- a/service/matching/fx.go
+++ b/service/matching/fx.go
@@ -71,10 +71,12 @@ func ConfigProvider(
 
 func ServiceErrorInterceptorProvider(
 	dc *dynamicconfig.Collection,
+	metricsHandler metrics.Handler,
 	logger log.Logger,
 ) *interceptor.ServiceErrorInterceptor {
 	return interceptor.NewServiceErrorInterceptor(
 		dynamicconfig.MaxServiceErrorMessageLength.Get(dc),
+		metricsHandler,
 		logger,
 	)
 }

--- a/service/matching/fx.go
+++ b/service/matching/fx.go
@@ -71,9 +71,11 @@ func ConfigProvider(
 
 func ServiceErrorInterceptorProvider(
 	dc *dynamicconfig.Collection,
+	logger log.Logger,
 ) *interceptor.ServiceErrorInterceptor {
 	return interceptor.NewServiceErrorInterceptor(
 		dynamicconfig.MaxServiceErrorMessageLength.Get(dc),
+		logger,
 	)
 }
 


### PR DESCRIPTION
## What changed?
Capture panic in `ServiceErrorInterceptor`

## Why?
`ServiceErrorInterceptor` is a top-level interceptor for frontend, history and matching. Capturing panics to make sure unhandled panics won't crash the service.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
