### PR TITLE
Populate identity for child workflows

### DIFF
--- a/service/history/interfaces/mutable_state.go
+++ b/service/history/interfaces/mutable_state.go
@@ -168,6 +168,7 @@ type (
 		GetRequesteCancelExternalInitiatedEvent(context.Context, int64) (*historypb.HistoryEvent, error)
 		GetChildExecutionInfo(int64) (*persistencespb.ChildExecutionInfo, bool)
 		GetChildExecutionInitiatedEvent(context.Context, int64) (*historypb.HistoryEvent, error)
+		GetWorkflowTaskCompletedEvent(ctx context.Context, workflowTaskCompletedEventID int64) (*historypb.HistoryEvent, error)
 		GetCompletionEvent(context.Context) (*historypb.HistoryEvent, error)
 		GetWorkflowCloseTime(ctx context.Context) (time.Time, error)
 		GetWorkflowExecutionDuration(ctx context.Context) (time.Duration, error)

--- a/service/history/interfaces/mutable_state_mock.go
+++ b/service/history/interfaces/mutable_state_mock.go
@@ -2954,6 +2954,21 @@ func (mr *MockMutableStateMockRecorder) GetWorkflowTaskByID(scheduledEventID any
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflowTaskByID", reflect.TypeOf((*MockMutableState)(nil).GetWorkflowTaskByID), scheduledEventID)
 }
 
+// GetWorkflowTaskCompletedEvent mocks base method.
+func (m *MockMutableState) GetWorkflowTaskCompletedEvent(ctx context.Context, workflowTaskCompletedEventID int64) (*history.HistoryEvent, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWorkflowTaskCompletedEvent", ctx, workflowTaskCompletedEventID)
+	ret0, _ := ret[0].(*history.HistoryEvent)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetWorkflowTaskCompletedEvent indicates an expected call of GetWorkflowTaskCompletedEvent.
+func (mr *MockMutableStateMockRecorder) GetWorkflowTaskCompletedEvent(ctx, workflowTaskCompletedEventID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflowTaskCompletedEvent", reflect.TypeOf((*MockMutableState)(nil).GetWorkflowTaskCompletedEvent), ctx, workflowTaskCompletedEventID)
+}
+
 // GetWorkflowTaskScheduleToStartTimeoutTask mocks base method.
 func (m *MockMutableState) GetWorkflowTaskScheduleToStartTimeoutTask() *tasks.WorkflowTaskTimeoutTask {
 	m.ctrl.T.Helper()

--- a/service/history/transfer_queue_active_task_executor.go
+++ b/service/history/transfer_queue_active_task_executor.go
@@ -925,6 +925,17 @@ func (t *transferQueueActiveTaskExecutor) processStartChildExecution(
 	}
 	attributes := initiatedEvent.GetStartChildWorkflowExecutionInitiatedEventAttributes()
 
+	// The initiated event does not carry the identity of the worker that reported the
+	// StartChildWorkflowExecution command, so look it up from the WorkflowTaskCompleted event
+	// it was reported with. This is best-effort: if the event can't be located, proceed with an
+	// empty identity rather than failing to start the child workflow.
+	var identity string
+	if wtCompletedEvent, err := mutableState.GetWorkflowTaskCompletedEvent(ctx, attributes.GetWorkflowTaskCompletedEventId()); err != nil {
+		t.logger.Warn("Unable to load workflow task completed event for child workflow identity", tag.Error(err))
+	} else {
+		identity = wtCompletedEvent.GetWorkflowTaskCompletedEventAttributes().GetIdentity()
+	}
+
 	var parentNamespaceName namespace.Name
 	if namespaceEntry, err := t.registry.GetNamespaceByID(namespace.ID(task.NamespaceID)); err != nil {
 		if _, isNotFound := err.(*serviceerror.NamespaceNotFound); !isNotFound {
@@ -1109,6 +1120,7 @@ func (t *transferQueueActiveTaskExecutor) processStartChildExecution(
 		inheritedPinnedVersion,
 		priorities.Merge(mutableState.GetExecutionInfo().Priority, attributes.Priority),
 		inheritedAutoUpgradeInfo,
+		identity,
 	)
 	if err != nil {
 		t.logger.Debug("Failed to start child workflow execution", tag.Error(err))
@@ -1688,6 +1700,7 @@ func (t *transferQueueActiveTaskExecutor) startChildWorkflow(
 	inheritedPinnedVersion *deploymentpb.WorkerDeploymentVersion,
 	priority *commonpb.Priority,
 	inheritedAutoUpgradeInfo *deploymentpb.InheritedAutoUpgradeInfo,
+	identity string,
 ) (string, *clockspb.VectorClock, error) {
 	versioningOverride := inheritedVersioningOverride
 	if attributes.GetVersioningOverride() != nil {
@@ -1704,6 +1717,7 @@ func (t *transferQueueActiveTaskExecutor) startChildWorkflow(
 		WorkflowExecutionTimeout: attributes.WorkflowExecutionTimeout,
 		WorkflowRunTimeout:       attributes.WorkflowRunTimeout,
 		WorkflowTaskTimeout:      attributes.WorkflowTaskTimeout,
+		Identity:                 identity,
 
 		// Use the same request ID to dedupe StartWorkflowExecution calls
 		RequestId:                childRequestID,

--- a/service/history/transfer_queue_active_task_executor_test.go
+++ b/service/history/transfer_queue_active_task_executor_test.go
@@ -2113,6 +2113,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_Su
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.NewString())
 	wt.StartedEventID = event.GetEventId()
 	event = addWorkflowTaskCompletedEvent(&s.Suite, mutableState, wt.ScheduledEventID, wt.StartedEventID, "some random identity")
+	s.cacheWorkflowTaskCompletedEvent(execution, event)
 
 	taskID := s.mustGenerateTaskID()
 
@@ -2193,6 +2194,93 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_Su
 	s.NoError(resp.ExecutionErr)
 }
 
+// TestProcessStartChildExecution_MissingWorkflowTaskCompletedEvent verifies that the child
+// workflow is still started, with an empty identity, if the parent's WorkflowTaskCompleted event
+// (used to populate the child's start identity) can't be loaded from history.
+func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_MissingWorkflowTaskCompletedEvent() {
+	execution := &commonpb.WorkflowExecution{
+		WorkflowId: "some random workflow ID",
+		RunId:      uuid.NewString(),
+	}
+	workflowType := "some random workflow type"
+	taskQueueName := "some random task queue"
+
+	childWorkflowID := "some random child workflow ID"
+	childRunID := uuid.NewString()
+	childWorkflowType := "some random child workflow type"
+	childTaskQueueName := "some random child task queue"
+
+	mutableState := workflow.TestGlobalMutableState(s.mockShard, s.mockShard.GetEventsCache(), s.logger, s.version, execution.GetWorkflowId(), execution.GetRunId())
+	_, err := mutableState.AddWorkflowExecutionStartedEvent(
+		execution,
+		&historyservice.StartWorkflowExecutionRequest{
+			Attempt:     1,
+			NamespaceId: s.namespaceID.String(),
+			StartRequest: &workflowservice.StartWorkflowExecutionRequest{
+				WorkflowId:               execution.WorkflowId,
+				WorkflowType:             &commonpb.WorkflowType{Name: workflowType},
+				TaskQueue:                &taskqueuepb.TaskQueue{Name: taskQueueName},
+				WorkflowExecutionTimeout: durationpb.New(2 * time.Second),
+				WorkflowTaskTimeout:      durationpb.New(1 * time.Second),
+			},
+		},
+	)
+	s.NoError(err)
+
+	wt := addWorkflowTaskScheduledEvent(mutableState)
+	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.NewString())
+	wt.StartedEventID = event.GetEventId()
+	event = addWorkflowTaskCompletedEvent(&s.Suite, mutableState, wt.ScheduledEventID, wt.StartedEventID, "some random identity")
+	// Deliberately do not warm the events cache for the WorkflowTaskCompleted event, and make the
+	// history store lookup fail, to simulate it being unavailable (e.g. evicted from cache).
+	s.mockExecutionMgr.EXPECT().ReadHistoryBranch(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewUnavailable("simulated history read failure"))
+
+	taskID := s.mustGenerateTaskID()
+
+	event, _ = addStartChildWorkflowExecutionInitiatedEvent(
+		mutableState,
+		event.GetEventId(),
+		s.childNamespace,
+		s.childNamespaceID,
+		childWorkflowID,
+		childWorkflowType,
+		childTaskQueueName,
+		nil,
+		1*time.Second,
+		1*time.Second,
+		1*time.Second,
+		enumspb.PARENT_CLOSE_POLICY_TERMINATE,
+	)
+
+	transferTask := &tasks.StartChildExecutionTask{
+		WorkflowKey: definition.NewWorkflowKey(
+			s.namespaceID.String(),
+			execution.GetWorkflowId(),
+			execution.GetRunId(),
+		),
+		Version:             s.version,
+		TaskID:              taskID,
+		InitiatedEventID:    event.GetEventId(),
+		VisibilityTimestamp: time.Now().UTC(),
+	}
+
+	childClock := vclock.NewVectorClock(rand.Int63(), rand.Int31(), rand.Int63())
+	persistenceMutableState := s.createPersistenceMutableState(mutableState, event.GetEventId(), event.GetVersion())
+	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
+	s.mockHistoryClient.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, request *historyservice.StartWorkflowExecutionRequest, _ ...grpc.CallOption) (*historyservice.StartWorkflowExecutionResponse, error) {
+			s.Empty(request.StartRequest.GetIdentity())
+			return &historyservice.StartWorkflowExecutionResponse{RunId: childRunID, Clock: childClock}, nil
+		},
+	)
+	s.mockExecutionMgr.EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).Return(tests.UpdateWorkflowExecutionResponse, nil)
+	s.mockClusterMetadata.EXPECT().ClusterNameForFailoverVersion(s.namespaceEntry.IsGlobalNamespace(), s.version).Return(cluster.TestCurrentClusterName).AnyTimes()
+	s.mockHistoryClient.EXPECT().ScheduleWorkflowTask(gomock.Any(), gomock.Any()).Return(&historyservice.ScheduleWorkflowTaskResponse{}, nil)
+
+	resp := s.transferQueueActiveTaskExecutor.Execute(context.Background(), s.newTaskExecutable(transferTask))
+	s.NoError(resp.ExecutionErr)
+}
+
 func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_InheritsPendingOneTimeOverride() {
 	execution := &commonpb.WorkflowExecution{
 		WorkflowId: "some random workflow ID",
@@ -2237,6 +2325,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_In
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.NewString())
 	wt.StartedEventID = event.GetEventId()
 	event = addWorkflowTaskCompletedEvent(&s.Suite, mutableState, wt.ScheduledEventID, wt.StartedEventID, "some random identity")
+	s.cacheWorkflowTaskCompletedEvent(execution, event)
 
 	_, err = mutableState.AddWorkflowExecutionOptionsUpdatedEvent(
 		versioningOverride, false, "", nil, nil, uuid.NewString(), nil, nil, false, nil)
@@ -2342,6 +2431,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_Wo
 	wftStartedevent := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.NewString())
 	wt.StartedEventID = wftStartedevent.GetEventId()
 	wftCompletedEvent := addWorkflowTaskCompletedEvent(&s.Suite, mutableState, wt.ScheduledEventID, wt.StartedEventID, "some random identity")
+	s.cacheWorkflowTaskCompletedEvent(execution, wftCompletedEvent)
 
 	taskID := s.mustGenerateTaskID()
 
@@ -2573,6 +2663,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_Fa
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.NewString())
 	wt.StartedEventID = event.GetEventId()
 	event = addWorkflowTaskCompletedEvent(&s.Suite, mutableState, wt.ScheduledEventID, wt.StartedEventID, "some random identity")
+	s.cacheWorkflowTaskCompletedEvent(execution, event)
 
 	taskID := s.mustGenerateTaskID()
 
@@ -2672,6 +2763,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_Fa
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.NewString())
 	wt.StartedEventID = event.GetEventId()
 	event = addWorkflowTaskCompletedEvent(&s.Suite, mutableState, wt.ScheduledEventID, wt.StartedEventID, "some random identity")
+	s.cacheWorkflowTaskCompletedEvent(execution, event)
 
 	taskID := s.mustGenerateTaskID()
 
@@ -2774,6 +2866,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_Fa
 	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduledEventID, taskQueueName, uuid.NewString())
 	wt.StartedEventID = event.GetEventId()
 	event = addWorkflowTaskCompletedEvent(&s.Suite, mutableState, wt.ScheduledEventID, wt.StartedEventID, "some random identity")
+	s.cacheWorkflowTaskCompletedEvent(execution, event)
 
 	taskID := s.mustGenerateTaskID()
 
@@ -3344,6 +3437,26 @@ func (s *transferQueueActiveTaskExecutorSuite) createSignalWorkflowExecutionRequ
 	}
 }
 
+// cacheWorkflowTaskCompletedEvent warms the shard's events cache with a WorkflowTaskCompleted
+// event. Production code doesn't proactively cache these events (unlike start/completion events),
+// so processStartChildExecution's identity lookup would otherwise fall through to a
+// ReadHistoryBranch call that these tests don't stub.
+func (s *transferQueueActiveTaskExecutorSuite) cacheWorkflowTaskCompletedEvent(
+	execution *commonpb.WorkflowExecution,
+	event *historypb.HistoryEvent,
+) {
+	s.mockShard.GetEventsCache().PutEvent(
+		events.EventKey{
+			NamespaceID: s.namespaceID,
+			WorkflowID:  execution.GetWorkflowId(),
+			RunID:       execution.GetRunId(),
+			EventID:     event.GetEventId(),
+			Version:     event.GetVersion(),
+		},
+		event,
+	)
+}
+
 func (s *transferQueueActiveTaskExecutorSuite) createChildWorkflowExecutionRequest(
 	childNamespace namespace.Name,
 	task *tasks.StartChildExecutionTask,
@@ -3355,6 +3468,8 @@ func (s *transferQueueActiveTaskExecutorSuite) createChildWorkflowExecutionReque
 	event, err := mutableState.GetChildExecutionInitiatedEvent(context.Background(), task.InitiatedEventID)
 	s.NoError(err)
 	attributes := event.GetStartChildWorkflowExecutionInitiatedEventAttributes()
+	wtCompletedEvent, err := mutableState.GetWorkflowTaskCompletedEvent(context.Background(), attributes.GetWorkflowTaskCompletedEventId())
+	s.NoError(err)
 	execution := &commonpb.WorkflowExecution{
 		WorkflowId: task.WorkflowID,
 		RunId:      task.RunID,
@@ -3372,6 +3487,7 @@ func (s *transferQueueActiveTaskExecutorSuite) createChildWorkflowExecutionReque
 			WorkflowExecutionTimeout: attributes.WorkflowExecutionTimeout,
 			WorkflowRunTimeout:       attributes.WorkflowRunTimeout,
 			WorkflowTaskTimeout:      attributes.WorkflowTaskTimeout,
+			Identity:                 wtCompletedEvent.GetWorkflowTaskCompletedEventAttributes().GetIdentity(),
 			// Use the same request ID to dedupe StartWorkflowExecution calls
 			RequestId:                ci.CreateRequestId,
 			WorkflowIdReusePolicy:    attributes.WorkflowIdReusePolicy,

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -114,6 +114,8 @@ var (
 	ErrMissingActivityScheduledEvent = serviceerror.NewInternal("unable to get activity scheduled event")
 	// ErrMissingChildWorkflowInitiatedEvent indicates missing child workflow initiated event
 	ErrMissingChildWorkflowInitiatedEvent = serviceerror.NewInternal("unable to get child workflow initiated event")
+	// ErrMissingWorkflowTaskCompletedEvent indicates missing workflow task completed event
+	ErrMissingWorkflowTaskCompletedEvent = serviceerror.NewInternal("unable to get workflow task completed event")
 	// ErrMissingSignalInitiatedEvent indicates missing workflow signal initiated event
 	ErrMissingSignalInitiatedEvent = serviceerror.NewInternal("unable to get signal initiated event")
 	// ErrPinnedWorkflowCannotTransition indicates attempt to start a transition on a pinned workflow
@@ -1712,6 +1714,42 @@ func (ms *MutableStateImpl) GetChildExecutionInitiatedEvent(
 			// since original error of type NotFound
 			// can cause task processing side to fail silently
 			return nil, ErrMissingChildWorkflowInitiatedEvent
+		}
+		return nil, err
+	}
+	return event, nil
+}
+
+// GetWorkflowTaskCompletedEvent returns the WORKFLOW_TASK_COMPLETED event identified by
+// workflowTaskCompletedEventID, e.g. to look up the identity of the worker that reported the
+// commands recorded after it (such as a StartChildWorkflowExecution command).
+func (ms *MutableStateImpl) GetWorkflowTaskCompletedEvent(
+	ctx context.Context,
+	workflowTaskCompletedEventID int64,
+) (*historypb.HistoryEvent, error) {
+	currentBranchToken, version, err := ms.getCurrentBranchTokenAndEventVersion(workflowTaskCompletedEventID)
+	if err != nil {
+		return nil, err
+	}
+	event, err := ms.eventsCache.GetEvent(
+		ctx,
+		ms.shard.GetShardID(),
+		events.EventKey{
+			NamespaceID: namespace.ID(ms.executionInfo.NamespaceId),
+			WorkflowID:  ms.executionInfo.WorkflowId,
+			RunID:       ms.executionState.RunId,
+			EventID:     workflowTaskCompletedEventID,
+			Version:     version,
+		},
+		workflowTaskCompletedEventID,
+		currentBranchToken,
+	)
+	if err != nil {
+		if common.IsNotFoundError(err) {
+			// do not return the original error
+			// since original error of type NotFound
+			// can cause task processing side to fail silently
+			return nil, ErrMissingWorkflowTaskCompletedEvent
 		}
 		return nil, err
 	}

--- a/tests/child_workflow_test.go
+++ b/tests/child_workflow_test.go
@@ -358,6 +358,127 @@ func (s *ChildWorkflowSuite) TestChildWorkflowExecution() {
 	s.Equal("Child Done", childResult)
 }
 
+// TestChildWorkflowExecution_Identity verifies that a child workflow's WorkflowExecutionStarted.identity
+// is populated from the identity of the worker that completed the parent's workflow task which issued the
+// StartChildWorkflowExecution command, not from whichever worker happens to poll the child's task queue.
+func (s *ChildWorkflowSuite) TestChildWorkflowExecution_Identity() {
+	env := testcore.NewEnv(s.T())
+	tvParent := env.Tv().Sub("parent")
+	tvChild := env.Tv().Sub("child")
+
+	_, err := env.FrontendClient().StartWorkflowExecution(s.Context(), &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:           tvParent.RequestID(),
+		Namespace:           env.Namespace().String(),
+		WorkflowId:          tvParent.WorkflowID(),
+		WorkflowType:        tvParent.WorkflowType(),
+		TaskQueue:           tvParent.TaskQueue(),
+		WorkflowRunTimeout:  durationpb.New(100 * time.Second),
+		WorkflowTaskTimeout: durationpb.New(10 * time.Second),
+		Identity:            tvParent.WorkerIdentity(),
+	})
+	s.NoError(err)
+
+	childExecutionStarted := false
+	var childCompletedEventFromParent *historypb.HistoryEvent
+	wtHandlerParent := func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*commandpb.Command, error) {
+		if !childExecutionStarted {
+			childExecutionStarted = true
+			return []*commandpb.Command{{
+				CommandType: enumspb.COMMAND_TYPE_START_CHILD_WORKFLOW_EXECUTION,
+				Attributes: &commandpb.Command_StartChildWorkflowExecutionCommandAttributes{
+					StartChildWorkflowExecutionCommandAttributes: &commandpb.StartChildWorkflowExecutionCommandAttributes{
+						WorkflowId:          tvChild.WorkflowID(),
+						WorkflowType:        tvChild.WorkflowType(),
+						TaskQueue:           tvChild.TaskQueue(),
+						Input:               payloads.EncodeString("child-workflow-input"),
+						WorkflowRunTimeout:  durationpb.New(100 * time.Second),
+						WorkflowTaskTimeout: durationpb.New(10 * time.Second),
+					},
+				},
+			}}, nil
+		}
+		if task.PreviousStartedEventId > 0 {
+			for _, event := range task.History.Events[task.PreviousStartedEventId:] {
+				if event.GetEventType() == enumspb.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_STARTED {
+					// no-op: just acknowledge, keep waiting for the child to complete.
+					return []*commandpb.Command{}, nil
+				}
+				if event.GetEventType() == enumspb.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_COMPLETED {
+					childCompletedEventFromParent = event
+					return []*commandpb.Command{{
+						CommandType: enumspb.COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION,
+						Attributes: &commandpb.Command_CompleteWorkflowExecutionCommandAttributes{
+							CompleteWorkflowExecutionCommandAttributes: &commandpb.CompleteWorkflowExecutionCommandAttributes{
+								Result: payloads.EncodeString("Done"),
+							},
+						},
+					}}, nil
+				}
+			}
+		}
+		return nil, nil
+	}
+
+	var childStartedEvent *historypb.HistoryEvent
+	wtHandlerChild := func(task *workflowservice.PollWorkflowTaskQueueResponse) ([]*commandpb.Command, error) {
+		if task.PreviousStartedEventId <= 0 {
+			childStartedEvent = task.History.Events[0]
+		}
+		return []*commandpb.Command{{
+			CommandType: enumspb.COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION,
+			Attributes: &commandpb.Command_CompleteWorkflowExecutionCommandAttributes{
+				CompleteWorkflowExecutionCommandAttributes: &commandpb.CompleteWorkflowExecutionCommandAttributes{
+					Result: payloads.EncodeString("Child Done"),
+				},
+			},
+		}}, nil
+	}
+
+	pollerParent := taskpoller.New(s.T(), env.FrontendClient(), env.Namespace().String())
+	pollerChild := taskpoller.New(s.T(), env.FrontendClient(), env.Namespace().String())
+
+	// First workflow task: parent issues StartChildWorkflowExecution.
+	_, err = pollerParent.PollAndHandleWorkflowTask(tvParent, func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		cmds, err := wtHandlerParent(task)
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{Commands: cmds}, err
+	})
+	s.NoError(err)
+	s.True(childExecutionStarted)
+
+	// Second parent workflow task: acknowledge ChildWorkflowExecutionStarted, keep waiting.
+	_, err = pollerParent.PollAndHandleWorkflowTask(tvParent, func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		cmds, err := wtHandlerParent(task)
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{Commands: cmds}, err
+	})
+	s.NoError(err)
+
+	// Child's first (and only) workflow task carries its WorkflowExecutionStarted event, and
+	// completes the child. Note the child poller uses its own identity (tvChild.WorkerIdentity()),
+	// distinct from the parent's, to prove the started event's identity doesn't just leak in from
+	// whoever happens to poll/complete the child's own workflow task.
+	_, err = pollerChild.PollAndHandleWorkflowTask(tvChild, func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		cmds, err := wtHandlerChild(task)
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{Commands: cmds}, err
+	})
+	s.NoError(err)
+	s.NotNil(childStartedEvent)
+	childStartedEventAttrs := childStartedEvent.GetWorkflowExecutionStartedEventAttributes()
+	s.Equal(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED, childStartedEvent.GetEventType())
+	// The child's start identity should come from the parent's WorkflowTaskCompleted event
+	// (i.e. whoever issued the StartChildWorkflowExecution command), not from the worker that
+	// happens to poll the child's task queue.
+	s.Equal(tvParent.WorkerIdentity(), childStartedEventAttrs.GetIdentity())
+	s.NotEqual(tvChild.WorkerIdentity(), childStartedEventAttrs.GetIdentity())
+
+	// Third parent workflow task: process ChildWorkflowExecutionCompleted and complete the parent.
+	_, err = pollerParent.PollAndHandleWorkflowTask(tvParent, func(task *workflowservice.PollWorkflowTaskQueueResponse) (*workflowservice.RespondWorkflowTaskCompletedRequest, error) {
+		cmds, err := wtHandlerParent(task)
+		return &workflowservice.RespondWorkflowTaskCompletedRequest{Commands: cmds}, err
+	})
+	s.NoError(err)
+	s.NotNil(childCompletedEventFromParent)
+}
+
 func (s *ChildWorkflowSuite) TestCronChildWorkflowExecution() {
 	env := testcore.NewEnv(s.T())
 


### PR DESCRIPTION
## What changed?

`StartChildWorkflowExecutionInitiatedEventAttributes` doesn't carry the identity of the worker that issued the `StartChildWorkflowExecution` command, so a child workflow's `WorkflowExecutionStarted.identity` was always left empty, even though normal (non-child) workflow starts populate it from the client identity.

This adds `MutableState.GetWorkflowTaskCompletedEvent`, and uses it in `processStartChildExecution` to look up the parent's `WorkflowTaskCompleted` event referenced by `workflow_task_completed_event_id` on the initiated event, then uses that event's `identity` when starting the child. This matches what SDKs already set on the corresponding `StartWorkflowExecutionRequest.identity`, so a parent and its child started by the same SDK client end up with the same identity.

The lookup is best-effort: if the event can't be loaded (e.g. evicted from the events cache and the history read fails), we log a warning and proceed with an empty identity rather than failing to start the child workflow.

## Why?

Fixes #2687. Without this, it's hard to trace which worker/client started a given child workflow, which came up when debugging issues from a specific SDK client.

There was earlier work on this in #5564, where @mfateev pointed out that the identity should come from the parent's `WorkflowTaskCompleted` event (reached via `parent_initiated_event_id` -> `workflow_task_completed_event_id`) rather than the parent's own start event, to correctly reflect the worker that issued the child-start command even if it differs from whoever started the parent. That PR implemented this correctly but went stale without being merged, so this PR reimplements it fresh against current `main` with updated tests.

## How did you test it?

- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)

Details:
- Added `MutableState.GetWorkflowTaskCompletedEvent` (mirroring the existing `GetStartEvent`/`GetChildExecutionInitiatedEvent` patterns) and regenerated the mock.
- Updated `transferQueueActiveTaskExecutorSuite`'s shared `createChildWorkflowExecutionRequest` test helper to assert the identity dynamically, which extends coverage across all existing `TestProcessStartChildExecution_*` tests.
- Added `TestProcessStartChildExecution_MissingWorkflowTaskCompletedEvent` (unit) covering the graceful-degradation path when the event can't be loaded.
- Added `TestChildWorkflowExecution_Identity` (functional, `tests/child_workflow_test.go`), which runs against a real in-process test cluster: starts a parent and child workflow with distinct poller identities and asserts the child's `WorkflowExecutionStarted.identity` matches the parent's, not the child's own poller identity. Verified this test fails without the fix (reverted the production change locally and confirmed the assertion fails) and passes with it.
- Manually ran a real `temporal-server` (sqlite) locally with a real Go SDK worker/client executing an actual parent+child workflow, and confirmed via `GetWorkflowHistory` that the child's `WorkflowExecutionStarted.identity` was populated with the worker's identity (previously empty).
- Ran `go build ./...`, the full `service/history/...` and `tests/...` (`ChildWorkflowSuite`) test suites, `make lint-code-fast` (0 issues), and `gofmt -l` (clean).

## Potential risks

Starting a child workflow now does an additional lookup for the parent's `WorkflowTaskCompleted` event, which is not proactively cached (unlike start/completion events), so it will typically incur one extra small point-read (`ReadHistoryBranch`, `MinEventID == MaxEventID - 1`) against the history store per child workflow start. This mirrors the design discussed in #5564 and is scoped to the async transfer-task path, not the caller's synchronous request. On lookup failure, we fall back to an empty identity rather than failing the task.

Made with [Cursor](https://cursor.com)