### PR TITLE
Fix Nexus start-operation retry classification for wrapped service errors

### DIFF
--- a/chasm/lib/nexusoperation/task_handler_helpers.go
+++ b/chasm/lib/nexusoperation/task_handler_helpers.go
@@ -141,7 +141,7 @@ func cancelCallOutcomeTag(callCtx context.Context, callErr error) string {
 // Always returns a non-nil failure.
 func callErrorToFailure(callErr error) (*failurepb.Failure, bool, error) {
 	if serviceErr, ok := errors.AsType[serviceerror.ServiceError](callErr); ok {
-		retryable := common.IsRetryableRPCError(callErr)
+		retryable := common.IsRetryableRPCError(serviceErr)
 		failure := &failurepb.Failure{
 			Message: fmt.Sprintf("%s: %s", strings.Replace(fmt.Sprintf("%T", serviceErr), "*serviceerror.", "", 1), serviceErr.Error()),
 			FailureInfo: &failurepb.Failure_ServerFailureInfo{
@@ -233,7 +233,7 @@ func newInvocationResult(
 	}
 
 	if serviceErr, ok := errors.AsType[serviceerror.ServiceError](callErr); ok {
-		retryable := common.IsRetryableRPCError(callErr)
+		retryable := common.IsRetryableRPCError(serviceErr)
 		failure := &failurepb.Failure{
 			Message: fmt.Sprintf("%s: %s", strings.Replace(fmt.Sprintf("%T", serviceErr), "*serviceerror.", "", 1), serviceErr.Error()),
 			FailureInfo: &failurepb.Failure_ServerFailureInfo{

--- a/chasm/lib/nexusoperation/task_handler_helpers_test.go
+++ b/chasm/lib/nexusoperation/task_handler_helpers_test.go
@@ -6,12 +6,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/api/serviceerror"
-	"go.temporal.io/server/common"
 )
 
-// wrappedUnavailable mirrors how net/http.Client.Do wraps a RoundTripper error:
-// the underlying serviceerror.Unavailable (e.g. returned by a membership-resolver
-// RoundTripper when no frontend host is available) is only reachable via Unwrap().
+// wrappedUnavailable returns a transient serviceerror reachable only via Unwrap,
+// as an HTTP client wraps transport errors.
 func wrappedUnavailable() error {
 	return &url.Error{
 		Op:  "Post",
@@ -20,7 +18,6 @@ func wrappedUnavailable() error {
 	}
 }
 
-// a wrapped transient serviceerror must still be retried.
 func TestCallErrorToFailure_RetriesTransientServiceErrorEvenWhenWrapped(t *testing.T) {
 	failure, retryable, err := callErrorToFailure(wrappedUnavailable())
 	require.NoError(t, err)
@@ -33,14 +30,4 @@ func TestNewInvocationResult_RetriesTransientServiceErrorEvenWhenWrapped(t *test
 	require.NoError(t, err)
 	require.IsType(t, invocationResultRetry{}, result,
 		"wrapped Unavailable must produce a retry result, not a terminal failure")
-}
-
-func TestIsRetryableRPCError_RequiresUnwrappedServiceError(t *testing.T) {
-	wrapped := wrappedUnavailable()
-	unwrapped := serviceerror.NewUnavailable("no frontend host to route request to")
-
-	require.False(t, common.IsRetryableRPCError(wrapped),
-		"sanity check: the wrapped error alone can't be classified")
-	require.True(t, common.IsRetryableRPCError(unwrapped),
-		"the unwrapped serviceerror must be classified as retryable")
 }

--- a/chasm/lib/nexusoperation/task_handler_helpers_test.go
+++ b/chasm/lib/nexusoperation/task_handler_helpers_test.go
@@ -12,7 +12,9 @@ import (
 // wrappedUnavailable mirrors how net/http.Client.Do wraps a RoundTripper error:
 // the underlying serviceerror.Unavailable (e.g. returned by a membership-resolver
 // RoundTripper when no frontend host is available) is only reachable via Unwrap(),
-// not via a direct type assertion or a gRPC status.
+// not via a direct type assertion or a gRPC status. IsRetryableRPCError can't see
+// through that wrapping, so callers must pass the already-unwrapped serviceerror
+// (e.g. from errors.AsType), not the original wrapped error.
 func wrappedUnavailable() error {
 	return &url.Error{
 		Op:  "Post",
@@ -21,12 +23,7 @@ func wrappedUnavailable() error {
 	}
 }
 
-// TestCallErrorToFailure_RetriesTransientServiceErrorEvenWhenWrapped guards against a
-// regression where the retryability decision was made on the wrapped call error
-// (which IsRetryableRPCError cannot classify) instead of the unwrapped serviceerror
-// that errors.AsType already extracted. A transient Unavailable must stay retryable
-// regardless of how many layers wrap it, or a benign frontend blip is escalated into a
-// terminal, non-retryable operation failure.
+// Regression: a wrapped transient serviceerror must still be retried.
 func TestCallErrorToFailure_RetriesTransientServiceErrorEvenWhenWrapped(t *testing.T) {
 	failure, retryable, err := callErrorToFailure(wrappedUnavailable())
 	require.NoError(t, err)
@@ -41,11 +38,6 @@ func TestNewInvocationResult_RetriesTransientServiceErrorEvenWhenWrapped(t *test
 		"wrapped Unavailable must produce a retry result, not a terminal failure")
 }
 
-// TestIsRetryableRPCError_RequiresUnwrappedServiceError documents the exact mechanism:
-// IsRetryableRPCError only recognizes a serviceerror via a direct (non-unwrapping) type
-// assertion or a gRPC status; it cannot see through wrapping on its own. Callers that
-// already have the unwrapped serviceerror (e.g. from errors.AsType) must pass that value,
-// not the original wrapped error.
 func TestIsRetryableRPCError_RequiresUnwrappedServiceError(t *testing.T) {
 	wrapped := wrappedUnavailable()
 	unwrapped := serviceerror.NewUnavailable("no frontend host to route request to")

--- a/chasm/lib/nexusoperation/task_handler_helpers_test.go
+++ b/chasm/lib/nexusoperation/task_handler_helpers_test.go
@@ -1,0 +1,57 @@
+package nexusoperation
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/common"
+)
+
+// wrappedUnavailable mirrors how net/http.Client.Do wraps a RoundTripper error:
+// the underlying serviceerror.Unavailable (e.g. returned by a membership-resolver
+// RoundTripper when no frontend host is available) is only reachable via Unwrap(),
+// not via a direct type assertion or a gRPC status.
+func wrappedUnavailable() error {
+	return &url.Error{
+		Op:  "Post",
+		URL: "https://internal",
+		Err: serviceerror.NewUnavailable("no frontend host to route request to"),
+	}
+}
+
+// TestCallErrorToFailure_RetriesTransientServiceErrorEvenWhenWrapped guards against a
+// regression where the retryability decision was made on the wrapped call error
+// (which IsRetryableRPCError cannot classify) instead of the unwrapped serviceerror
+// that errors.AsType already extracted. A transient Unavailable must stay retryable
+// regardless of how many layers wrap it, or a benign frontend blip is escalated into a
+// terminal, non-retryable operation failure.
+func TestCallErrorToFailure_RetriesTransientServiceErrorEvenWhenWrapped(t *testing.T) {
+	failure, retryable, err := callErrorToFailure(wrappedUnavailable())
+	require.NoError(t, err)
+	require.True(t, retryable, "wrapped Unavailable must be classified as retryable")
+	require.False(t, failure.GetServerFailureInfo().GetNonRetryable())
+}
+
+func TestNewInvocationResult_RetriesTransientServiceErrorEvenWhenWrapped(t *testing.T) {
+	result, err := newInvocationResult(nil, wrappedUnavailable())
+	require.NoError(t, err)
+	require.IsType(t, invocationResultRetry{}, result,
+		"wrapped Unavailable must produce a retry result, not a terminal failure")
+}
+
+// TestIsRetryableRPCError_RequiresUnwrappedServiceError documents the exact mechanism:
+// IsRetryableRPCError only recognizes a serviceerror via a direct (non-unwrapping) type
+// assertion or a gRPC status; it cannot see through wrapping on its own. Callers that
+// already have the unwrapped serviceerror (e.g. from errors.AsType) must pass that value,
+// not the original wrapped error.
+func TestIsRetryableRPCError_RequiresUnwrappedServiceError(t *testing.T) {
+	wrapped := wrappedUnavailable()
+	unwrapped := serviceerror.NewUnavailable("no frontend host to route request to")
+
+	require.False(t, common.IsRetryableRPCError(wrapped),
+		"sanity check: the wrapped error alone can't be classified")
+	require.True(t, common.IsRetryableRPCError(unwrapped),
+		"the unwrapped serviceerror must be classified as retryable")
+}

--- a/chasm/lib/nexusoperation/task_handler_helpers_test.go
+++ b/chasm/lib/nexusoperation/task_handler_helpers_test.go
@@ -11,10 +11,7 @@ import (
 
 // wrappedUnavailable mirrors how net/http.Client.Do wraps a RoundTripper error:
 // the underlying serviceerror.Unavailable (e.g. returned by a membership-resolver
-// RoundTripper when no frontend host is available) is only reachable via Unwrap(),
-// not via a direct type assertion or a gRPC status. IsRetryableRPCError can't see
-// through that wrapping, so callers must pass the already-unwrapped serviceerror
-// (e.g. from errors.AsType), not the original wrapped error.
+// RoundTripper when no frontend host is available) is only reachable via Unwrap().
 func wrappedUnavailable() error {
 	return &url.Error{
 		Op:  "Post",
@@ -23,7 +20,7 @@ func wrappedUnavailable() error {
 	}
 }
 
-// Regression: a wrapped transient serviceerror must still be retried.
+// a wrapped transient serviceerror must still be retried.
 func TestCallErrorToFailure_RetriesTransientServiceErrorEvenWhenWrapped(t *testing.T) {
 	failure, retryable, err := callErrorToFailure(wrappedUnavailable())
 	require.NoError(t, err)

--- a/chasm/lib/nexusoperation/task_handler_helpers_test.go
+++ b/chasm/lib/nexusoperation/task_handler_helpers_test.go
@@ -19,6 +19,8 @@ func wrappedUnavailable() error {
 }
 
 func TestCallErrorToFailure_RetriesTransientServiceErrorEvenWhenWrapped(t *testing.T) {
+	t.Parallel()
+
 	failure, retryable, err := callErrorToFailure(wrappedUnavailable())
 	require.NoError(t, err)
 	require.True(t, retryable, "wrapped Unavailable must be classified as retryable")
@@ -26,6 +28,8 @@ func TestCallErrorToFailure_RetriesTransientServiceErrorEvenWhenWrapped(t *testi
 }
 
 func TestNewInvocationResult_RetriesTransientServiceErrorEvenWhenWrapped(t *testing.T) {
+	t.Parallel()
+
 	result, err := newInvocationResult(nil, wrappedUnavailable())
 	require.NoError(t, err)
 	require.IsType(t, invocationResultRetry{}, result,

--- a/common/util.go
+++ b/common/util.go
@@ -763,6 +763,9 @@ func getFieldNameFromStruct(structPtr any, fieldPtr any) (string, error) {
 }
 
 // IsRetryableRPCError checks if the error is a retryable gRPC error.
+//
+// This does not unwrap err: If err may be wrapped (e.g. by an HTTP client, which wraps
+// RoundTripper errors in *url.Error), unwrap it yourself and pass the unwrapped error here.
 func IsRetryableRPCError(err error) bool {
 	var st *status.Status
 	stGetter, ok := err.(interface{ Status() *status.Status })

--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -535,7 +535,7 @@ func (e taskExecutor) handleStartOperationError(env hsm.Environment, node *hsm.N
 
 	switch {
 	case errors.As(callErr, &serviceErr):
-		if !common.IsRetryableRPCError(callErr) {
+		if !common.IsRetryableRPCError(serviceErr) {
 			return handleNonRetryableStartOperationError(node, operation, callErr)
 		}
 		// Fall through all uncaught errors to retryable

--- a/components/nexusoperations/executors_test.go
+++ b/components/nexusoperations/executors_test.go
@@ -101,7 +101,9 @@ func TestProcessInvocationTask(t *testing.T) {
 		startToCloseTimeout        time.Duration
 		schedToStartTimeout        time.Duration
 		destinationDown            bool
-		httpCallerErr              error
+		// httpCallerErr, when set, fails the outbound HTTP call with this error instead of
+		// performing a real request.
+		httpCallerErr error
 	}{
 		{
 			name:            "async start",
@@ -385,8 +387,6 @@ func TestProcessInvocationTask(t *testing.T) {
 		{
 			name:           "transient service error wrapped by HTTP caller",
 			requestTimeout: time.Hour,
-			// httpCallerErr, when set, makes the outbound HTTP caller fail with this error instead of
-			// performing a real request.
 			httpCallerErr: &url.Error{
 				Op:  "Post",
 				URL: "http://unavailable",

--- a/components/nexusoperations/executors_test.go
+++ b/components/nexusoperations/executors_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
@@ -99,6 +101,10 @@ func TestProcessInvocationTask(t *testing.T) {
 		startToCloseTimeout        time.Duration
 		schedToStartTimeout        time.Duration
 		destinationDown            bool
+		// httpCallerErr, when set, makes the outbound HTTP caller fail with this error instead of
+		// performing a real request. Mirrors how net/http.Client.Do wraps a RoundTripper error in
+		// *url.Error before returning it.
+		httpCallerErr error
 	}{
 		{
 			name:            "async start",
@@ -380,6 +386,25 @@ func TestProcessInvocationTask(t *testing.T) {
 			},
 		},
 		{
+			// Regression test: the HTTP caller fails before reaching the handler (as it does when
+			// net/http.Client.Do wraps a RoundTripper error in *url.Error), so callErr here is a
+			// wrapped, not a direct, serviceerror.ServiceError. The operation must still back off.
+			name:           "transient service error wrapped by HTTP caller",
+			requestTimeout: time.Hour,
+			httpCallerErr: &url.Error{
+				Op:  "Post",
+				URL: "http://unavailable",
+				Err: serviceerror.NewUnavailable("no frontend host to route request to"),
+			},
+			expectedMetricOutcome: "service-error:Unavailable",
+			checkOutcome: func(t *testing.T, op nexusoperations.Operation, events []*historypb.HistoryEvent) {
+				require.Equal(t, enumsspb.NEXUS_OPERATION_STATE_BACKING_OFF, op.State())
+				require.False(t, op.LastAttemptFailure.GetServerFailureInfo().GetNonRetryable())
+				require.Contains(t, op.LastAttemptFailure.Message, "Unavailable")
+				require.Empty(t, events)
+			},
+		},
+		{
 			name:                  "invocation timeout by request timeout",
 			requestTimeout:        2 * time.Millisecond,
 			schedToCloseTimeout:   time.Hour,
@@ -655,11 +680,17 @@ func TestProcessInvocationTask(t *testing.T) {
 				Logger:                 log.NewNoopLogger(),
 				EndpointRegistry:       endpointReg,
 				ClientProvider: func(ctx context.Context, namespaceID string, entry *persistencespb.NexusEndpointEntry, service string) (*nexusrpc.HTTPClient, error) {
-					return nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{
+					options := nexusrpc.HTTPClientOptions{
 						BaseURL:    "http://" + listenAddr,
 						Service:    service,
 						Serializer: commonnexus.PayloadSerializer,
-					})
+					}
+					if tc.httpCallerErr != nil {
+						options.HTTPCaller = func(*http.Request) (*http.Response, error) {
+							return nil, tc.httpCallerErr
+						}
+					}
+					return nexusrpc.NewHTTPClient(options)
 				},
 			}))
 

--- a/components/nexusoperations/executors_test.go
+++ b/components/nexusoperations/executors_test.go
@@ -101,10 +101,7 @@ func TestProcessInvocationTask(t *testing.T) {
 		startToCloseTimeout        time.Duration
 		schedToStartTimeout        time.Duration
 		destinationDown            bool
-		// httpCallerErr, when set, makes the outbound HTTP caller fail with this error instead of
-		// performing a real request. Mirrors how net/http.Client.Do wraps a RoundTripper error in
-		// *url.Error before returning it.
-		httpCallerErr error
+		httpCallerErr              error
 	}{
 		{
 			name:            "async start",
@@ -386,11 +383,10 @@ func TestProcessInvocationTask(t *testing.T) {
 			},
 		},
 		{
-			// Regression test: the HTTP caller fails before reaching the handler (as it does when
-			// net/http.Client.Do wraps a RoundTripper error in *url.Error), so callErr here is a
-			// wrapped, not a direct, serviceerror.ServiceError. The operation must still back off.
 			name:           "transient service error wrapped by HTTP caller",
 			requestTimeout: time.Hour,
+			// httpCallerErr, when set, makes the outbound HTTP caller fail with this error instead of
+			// performing a real request.
 			httpCallerErr: &url.Error{
 				Op:  "Post",
 				URL: "http://unavailable",


### PR DESCRIPTION
## What changed?
`handleStartOperationError` (`components/nexusoperations/executors.go`), `callErrorToFailure`, and `newInvocationResult` (`chasm/lib/nexusoperation/task_handler_helpers.go`) all unwrap `callErr` into a typed `serviceerror.ServiceError` via `errors.As`/`errors.AsType`, then pass the *original wrapped* `callErr` — not the unwrapped `serviceErr` — to `common.IsRetryableRPCError`.

Fix: pass the already-unwrapped `serviceErr` to `IsRetryableRPCError` at all three call sites — in both the workflow-based (`components/nexusoperations`) and CHASM standalone (`chasm/lib/nexusoperation`) Nexus operation state machines. These were the only call sites of `IsRetryableRPCError` outside its own definition/tests.

## Why?
`IsRetryableRPCError` only recognizes a service error via a direct (non-unwrapping) type assertion or a gRPC status; neither sees through wrapping. So whenever the transport wraps the service error (e.g. `net/http.Client.Do` wraps `RoundTripper` errors in `*url.Error`), a transient error like `Unavailable` is always misclassified as non-retryable, permanently failing the Nexus operation instead of retrying it.

Observed in practice: a Nexus `cancel` operation dispatched during a brief window where the internal service resolver had zero available frontend members failed with `Unavailable: no frontend host to route request to`. That error was wrapped by the HTTP round-tripper, misclassified as non-retryable, and permanently failed the operation — with ~19 of its 20-minute `scheduleToCloseTimeout` still unused, while sibling operations dispatched moments later succeeded normally. A single retry would have resolved it.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
Low risk: the change only affects the retryability decision for the `serviceerror` branch of Nexus start-operation error handling, and only for errors that were previously misclassified (wrapped service errors). Correctly-classified cases (direct/unwrapped service errors, gRPC status errors) are unaffected since `serviceErr` and `callErr` resolve to the same classification for those.