### PR TITLE
Fix buffered child XDC test race

### DIFF
--- a/tests/xdc/buffered_events_replication_helpers_test.go
+++ b/tests/xdc/buffered_events_replication_helpers_test.go
@@ -3,6 +3,7 @@ package xdc
 import (
 	"context"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -46,7 +47,16 @@ import (
 
 type blockedReplicationTask struct {
 	execute func() error
-	result  chan error
+	once    sync.Once
+	done    chan struct{}
+	err     error
+}
+
+func (t *blockedReplicationTask) run() {
+	t.once.Do(func() {
+		t.err = t.execute()
+		close(t.done)
+	})
 }
 
 type bufferedEventsNamespace struct {
@@ -776,6 +786,7 @@ func (s *xdcBaseSuite) blockReplicationForWorkflow(
 	// The interceptor runs on the receiving cluster, so clusterIndex identifies the replication
 	// destination rather than the cluster that generated the task.
 	tasks := make(chan *blockedReplicationTask, 20)
+	stopped := make(chan struct{})
 	s.clusters[clusterIndex].InjectHook(
 		s.T(),
 		testhooks.NewHook(testhooks.HistoryReplicationTaskInterceptor, func(
@@ -787,13 +798,25 @@ func (s *xdcBaseSuite) blockReplicationForWorkflow(
 			}
 			blockedTask := &blockedReplicationTask{
 				execute: execute,
-				result:  make(chan error, 1),
+				done:    make(chan struct{}),
 			}
-			tasks <- blockedTask
-			return <-blockedTask.result
+			select {
+			case tasks <- blockedTask:
+			case <-stopped:
+				return execute()
+			}
+			select {
+			case <-blockedTask.done:
+			case <-stopped:
+				blockedTask.run()
+			}
+			return blockedTask.err
 		}),
 		testhooks.GlobalScope,
 	)
+	s.T().Cleanup(func() {
+		close(stopped)
+	})
 	return tasks
 }
 
@@ -821,14 +844,13 @@ func (s *xdcBaseSuite) tryReleaseReplicationTask(tasks <-chan *blockedReplicatio
 }
 
 func (s *xdcBaseSuite) executeReplicationTask(task *blockedReplicationTask) {
-	err := task.execute()
-	task.result <- err
+	task.run()
 	var duplicateError *serviceerror.AlreadyExists
 	var retryReplicationError *serviceerrors.RetryReplication
 	s.Require().True(
-		err == nil || errors.As(err, &duplicateError) || errors.As(err, &retryReplicationError),
+		task.err == nil || errors.As(task.err, &duplicateError) || errors.As(task.err, &retryReplicationError),
 		"replication task failed: %v",
-		err,
+		task.err,
 	)
 }
 

--- a/tests/xdc/buffered_events_replication_test.go
+++ b/tests/xdc/buffered_events_replication_test.go
@@ -292,11 +292,10 @@ func (s *FunctionalClustersTestSuite) TestNaturallyBufferedChildWorkflowOutcomes
 		}
 		commands = append(commands, startChildWorkflowCommand(childIDs[outcome], childQueues[outcome], runTimeout))
 	}
-	s.completeWorkflowTaskAndScheduleNext(ctx, workflowTaskCompletion{
+	heldWorkflowTask := s.completeWorkflowTaskAndReturnNext(ctx, workflowTaskCompletion{
 		Task:     firstTask,
 		Commands: commands,
 	})
-	heldWorkflowTask := s.pollBufferedEventsWorkflowTask(ctx, 0, ns, parentQueue)
 	s.Require().NotEmpty(heldWorkflowTask.TaskToken)
 
 	completedTask := s.pollBufferedEventsWorkflowTask(ctx, 0, ns, childQueues["completed"])


### PR DESCRIPTION
## What changed?

- Atomically return and hold the next parent workflow task after starting child workflows.
- Release pending intercepted replication tasks during test cleanup.
- Ensure each blocked replication task executes at most once.

## Why?

This is a follow-up to [#11789](https://github.com/temporalio/temporal/pull/11789).

The test separately scheduled and polled the next workflow task, leaving a race where a duplicate child outcome could be recorded before the parent workflow task started. When the assertion failed, blocked replication tasks were not released, potentially stalling subsequent XDC tests until CI timed out.

## How did you test it?

- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

Ran the affected test with the race detector 10 times:

```bash
go test -tags test_dep -race -count=10 ./tests/xdc \
  -run '^TestFuncClustersTestSuite$/^EnableTransitionHistory$/^TestNaturallyBufferedChildWorkflowOutcomesFlushedToLosingBranch$' \
  -args -persistenceType=sql -persistenceDriver=sqlite