### PR TITLE
Await timing (2/2): Use the test context timeout

### DIFF
--- a/common/testing/await/config.go
+++ b/common/testing/await/config.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"go.temporal.io/server/common/debug"
+	"go.temporal.io/server/common/testing/testcontext"
 )
 
 const attemptTimeoutEnvVar = "TEMPORAL_AWAIT_ATTEMPT_TIMEOUT"
@@ -18,13 +19,13 @@ type config struct {
 
 func newConfig() config {
 	return config{
+		totalTimeout:   testcontext.DefaultTimeout(),
 		attemptTimeout: envDuration(attemptTimeoutEnvVar, 10*time.Second) * debug.TimeoutMultiplier,
 	}
 }
 
-func legacyConfig(timeout, pollInterval time.Duration, timeoutMsg string) config {
+func legacyConfig(pollInterval time.Duration, timeoutMsg string) config {
 	cfg := newConfig()
-	cfg.totalTimeout = timeout
 	cfg.pollInterval = pollInterval
 	cfg.timeoutMsg = timeoutMsg
 	return cfg

--- a/common/testing/await/config_test.go
+++ b/common/testing/await/config_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/server/common/debug"
+	"go.temporal.io/server/common/testing/testcontext"
 )
 
 func TestConfig_OverrideAttemptTimeout(t *testing.T) {
@@ -13,6 +14,13 @@ func TestConfig_OverrideAttemptTimeout(t *testing.T) {
 
 	cfg := newConfig()
 	require.Equal(t, 250*time.Millisecond*debug.TimeoutMultiplier, cfg.attemptTimeout)
+}
+
+func TestConfig_UsesTestContextTimeout(t *testing.T) {
+	t.Setenv("TEMPORAL_TEST_TIMEOUT", "250ms")
+
+	cfg := newConfig()
+	require.Equal(t, testcontext.DefaultTimeout(), cfg.totalTimeout)
 }
 
 func TestNextPollIntervalCapsAtMaximum(t *testing.T) {

--- a/common/testing/await/doc.go
+++ b/common/testing/await/doc.go
@@ -5,7 +5,9 @@
 // their formatted variants. By default, they enforce a 10s timeout for each
 // await attempt.
 //
-// Polling doubles from each caller-provided interval up to 2s.
+// The total wait is bounded by the test context timeout. Polling doubles from
+// each caller-provided interval up to 2s; timeout arguments remain for source
+// compatibility and are ignored.
 //
 // Improvements over testify's eventually functions:
 //

--- a/common/testing/await/require_ctx.go
+++ b/common/testing/await/require_ctx.go
@@ -79,7 +79,7 @@ func run(
 		tb.Logf("%s: skipping (test already failed)", funcName)
 		return
 	}
-	// Guard: context.WithDeadline panics on a nil parent.
+	// Guard: context.WithDeadline and testcontext.WithDeadline panic on a nil parent.
 	if parentCtx == nil {
 		tb.Fatalf("%s: nil context", funcName)
 		return
@@ -106,7 +106,7 @@ func run(
 	}
 
 	effectiveTimeout := max(0, time.Until(deadline))
-	awaitCtx, awaitCancel := context.WithDeadline(parentCtx, deadline)
+	awaitCtx, awaitCancel := testcontext.WithDeadline(parentCtx, deadline)
 	defer awaitCancel()
 
 	report := timeoutReport{
@@ -118,14 +118,9 @@ func run(
 	}
 
 	for {
-		// Parent context was canceled while we were sleeping (not our deadline).
-		if err := awaitCtx.Err(); err != nil && !deadlineReached(deadline) {
-			failContextCanceled(tb, report, funcName, err)
-			return
-		}
-		// Sleep can return at the deadline; do not start another attempt then.
-		if deadlineReached(deadline) {
-			report.reportTimeout(tb, funcName, cfg.timeoutMsg)
+		// Parent context may have been canceled while we were sleeping, or sleep
+		// may have returned at the deadline. Do not start another attempt then.
+		if failIfAwaitDone(awaitCtx, deadline, tb, report, funcName, cfg.timeoutMsg) {
 			return
 		}
 
@@ -171,15 +166,9 @@ func run(
 			return
 		}
 
-		// Parent context was canceled during the attempt (not our deadline).
-		if err := awaitCtx.Err(); err != nil && !deadlineReached(deadline) {
-			failContextCanceled(tb, report, funcName, err)
-			return
-		}
-
-		// Our deadline expired.
-		if deadlineReached(deadline) {
-			report.reportTimeout(tb, funcName, cfg.timeoutMsg)
+		// Parent context may have been canceled during the attempt, or our
+		// deadline may have expired.
+		if failIfAwaitDone(awaitCtx, deadline, tb, report, funcName, cfg.timeoutMsg) {
 			return
 		}
 
@@ -195,6 +184,42 @@ func run(
 		)
 		sleep(awaitCtx, deadline, pollInterval)
 	}
+}
+
+func failIfAwaitDone(
+	ctx context.Context,
+	deadline time.Time,
+	tb testing.TB,
+	report timeoutReport,
+	funcName string,
+	timeoutMsg string,
+) bool {
+	tb.Helper()
+	err := ctx.Err()
+	if err == nil {
+		if !deadlineReached(deadline) {
+			return false
+		}
+		// The wall clock can reach deadline just before the context timer
+		// publishes its terminal error and cause. Wait for that state so the
+		// reporter can classify the deadline by its actual owner.
+		<-ctx.Done()
+		err = ctx.Err()
+	}
+
+	if testcontext.FailIfDeadlineExceeded(
+		ctx,
+		tb,
+		report.renderSupplementalDetails(funcName, timeoutMsg),
+	) {
+		return true
+	}
+	if err == context.DeadlineExceeded {
+		report.reportTimeout(tb, funcName, timeoutMsg)
+		return true
+	}
+	failContextCanceled(tb, report, funcName, err)
+	return true
 }
 
 func failContextCanceled(tb testing.TB, report timeoutReport, funcName string, err error) {

--- a/common/testing/await/require_ctx.go
+++ b/common/testing/await/require_ctx.go
@@ -43,21 +43,24 @@ func hardDeadlockTimeout() time.Duration {
 const postAwaitTimeoutReserve = 10 * time.Second
 
 // Require polls condition until it returns without assertion failures, or
-// until ctx is canceled or timeout expires (whichever is earliest).
+// until ctx is canceled or the test context timeout expires (whichever is
+// earliest).
 //
 // Pass the *await.T to require.*/assert.* — failures cause a retry, not a
 // test failure. Use t.Context() inside the callback to honor the timeout.
-// The poll interval is the base for exponential backoff capped at 2s.
-func Require(ctx context.Context, tb testing.TB, condition func(*T), timeout, pollInterval time.Duration) {
+// The timeout argument is retained for source compatibility and ignored. The
+// poll interval is the base for exponential backoff capped at 2s.
+func Require(ctx context.Context, tb testing.TB, condition func(*T), _, pollInterval time.Duration) {
 	tb.Helper()
-	run(ctx, tb, condition, legacyConfig(timeout, pollInterval, ""), "Require", requireMisuseHint, true)
+	run(ctx, tb, condition, legacyConfig(pollInterval, ""), "Require", requireMisuseHint, true)
 }
 
 // Requiref is like [Require] but adds a formatted message to the timeout
-// failure. Its poll interval is also used as the base for exponential backoff.
-func Requiref(ctx context.Context, tb testing.TB, condition func(*T), timeout, pollInterval time.Duration, msg string, args ...any) {
+// failure. Its timeout argument is also ignored, and its poll interval is used
+// as the base for exponential backoff.
+func Requiref(ctx context.Context, tb testing.TB, condition func(*T), _, pollInterval time.Duration, msg string, args ...any) {
 	tb.Helper()
-	run(ctx, tb, condition, legacyConfig(timeout, pollInterval, fmt.Sprintf(msg, args...)), "Requiref", requireMisuseHint, true)
+	run(ctx, tb, condition, legacyConfig(pollInterval, fmt.Sprintf(msg, args...)), "Requiref", requireMisuseHint, true)
 }
 
 func run(

--- a/common/testing/await/require_ctx_test.go
+++ b/common/testing/await/require_ctx_test.go
@@ -181,6 +181,29 @@ func TestRequire_UsesRequestedPollIntervalAsAdaptiveBase(t *testing.T) {
 }
 
 func TestRequire_FailureScenarios(t *testing.T) {
+	t.Run("delegates test context deadline report", func(t *testing.T) {
+		t.Setenv("TEMPORAL_TEST_TIMEOUT", "1s")
+
+		synctest.Test(t, func(t *testing.T) {
+			tb := newRecordingTB()
+			tb.run(func() {
+				ctx := testcontext.For(tb)
+				await.Require(ctx, tb, func(t *await.T) {
+					t.Error("backlog count was 0, expected at least 24")
+					<-t.Context().Done()
+				}, time.Hour, 100*time.Millisecond)
+			})
+
+			require.Contains(t, tb.fatals(), "testcontext deadline exceeded after 1s")
+			require.Contains(t, tb.fatals(), "ctx extensions   = 1 (+10s total)")
+			require.Contains(t, tb.fatals(), "operation        = Require")
+			require.Contains(t, tb.fatals(), "attempts         = 1")
+			require.Contains(t, tb.fatals(), "attempt errors:")
+			require.Contains(t, tb.fatals(), "backlog count was 0, expected at least 24")
+			require.Empty(t, tb.errors())
+		})
+	})
+
 	t.Run("reports timeout", func(t *testing.T) {
 		t.Parallel()
 

--- a/common/testing/await/require_ctx_test.go
+++ b/common/testing/await/require_ctx_test.go
@@ -99,28 +99,28 @@ func TestRequire_PropagatesParentContextValues(t *testing.T) {
 	require.Equal(t, "value", got)
 }
 
-func TestRequire_SetsTimeoutContextDeadline(t *testing.T) {
+func TestRequire_IgnoresLegacyTimeoutArgument(t *testing.T) {
 	t.Parallel()
 
 	longCtx := testcontext.For(t)
 	longDeadline, ok := longCtx.Deadline()
 	require.True(t, ok)
 
-	shortTimeout := 1 * time.Second
+	attemptTimeout := 10 * time.Second * debug.TimeoutMultiplier
 
-	var shortCtx context.Context
+	var attemptCtx context.Context
 	await.Require(longCtx, t, func(t *await.T) {
-		shortCtx = t.Context()
-	}, shortTimeout, 100*time.Millisecond)
+		attemptCtx = t.Context()
+	}, time.Nanosecond, time.Hour)
 
-	require.NotNil(t, shortCtx)
-	require.NotSame(t, longCtx, shortCtx)
+	require.NotNil(t, attemptCtx)
+	require.NotSame(t, longCtx, attemptCtx)
 
-	shortDeadline, ok := shortCtx.Deadline()
+	attemptDeadline, ok := attemptCtx.Deadline()
 	require.True(t, ok)
-	require.True(t, shortDeadline.Before(longDeadline))
-	require.LessOrEqual(t, time.Until(shortDeadline), shortTimeout)
-	require.Greater(t, time.Until(shortDeadline), shortTimeout-200*time.Millisecond)
+	require.True(t, attemptDeadline.Before(longDeadline))
+	require.LessOrEqual(t, time.Until(attemptDeadline), attemptTimeout)
+	require.Greater(t, time.Until(attemptDeadline), attemptTimeout-200*time.Millisecond)
 }
 
 func TestRequire_ExtendsCachedTestContextPastActiveExpiration(t *testing.T) {
@@ -128,13 +128,9 @@ func TestRequire_ExtendsCachedTestContextPastActiveExpiration(t *testing.T) {
 
 	synctest.Test(t, func(t *testing.T) {
 		ctx := testcontext.For(t)
-		completeAt := time.Now().Add(testcontext.DefaultTimeout() + time.Second)
 
-		await.Require(ctx, t, func(t *await.T) {
-			if time.Now().Before(completeAt) {
-				t.Error("not ready")
-			}
-		}, testcontext.DefaultTimeout()+5*time.Second, testcontext.DefaultTimeout()+time.Second)
+		await.Require(ctx, t, func(*await.T) {}, testcontext.DefaultTimeout()+5*time.Second, testcontext.DefaultTimeout()+time.Second)
+		time.Sleep(testcontext.DefaultTimeout() + time.Second) //nolint:forbidigo // advance past the original active expiration
 
 		require.Same(t, ctx, testcontext.For(t))
 		require.NoError(t, ctx.Err())
@@ -188,7 +184,8 @@ func TestRequire_FailureScenarios(t *testing.T) {
 	t.Run("reports timeout", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := testcontext.For(t)
+		ctx, cancel := context.WithTimeout(testcontext.For(t), time.Second)
+		defer cancel()
 		tb := newRecordingTB()
 		tb.run(func() {
 			await.Require(ctx, tb, func(t *await.T) {
@@ -202,7 +199,8 @@ func TestRequire_FailureScenarios(t *testing.T) {
 	t.Run("cancels attempt context on timeout", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := testcontext.For(t)
+		ctx, cancel := context.WithTimeout(testcontext.For(t), 2*time.Second)
+		defer cancel()
 		tb := newRecordingTB()
 		tb.run(func() {
 			await.Require(ctx, tb, func(t *await.T) {
@@ -222,7 +220,9 @@ func TestRequire_FailureScenarios(t *testing.T) {
 		pollInterval := 100 * time.Millisecond
 		t.Setenv("TEMPORAL_AWAIT_ATTEMPT_TIMEOUT", attemptTimeoutEnv.String())
 
-		ctx := testcontext.For(t)
+		awaitTimeout := 2*attemptTimeout + time.Second
+		ctx, cancel := context.WithTimeout(testcontext.For(t), awaitTimeout)
+		defer cancel()
 		var attempts atomic.Int32
 		var firstAttemptRemaining time.Duration
 
@@ -234,7 +234,7 @@ func TestRequire_FailureScenarios(t *testing.T) {
 					firstAttemptRemaining = time.Until(deadline)
 				}
 				<-t.Context().Done()
-			}, 2*attemptTimeout+time.Second, pollInterval)
+			}, awaitTimeout, pollInterval)
 		})
 
 		require.True(t, tb.Failed())
@@ -247,7 +247,8 @@ func TestRequire_FailureScenarios(t *testing.T) {
 	t.Run("does not poll again after attempt consumes timeout", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := testcontext.For(t)
+		ctx, cancel := context.WithTimeout(testcontext.For(t), time.Second)
+		defer cancel()
 		var attempts atomic.Int32
 
 		tb := newRecordingTB()
@@ -312,7 +313,8 @@ func TestRequire_FailureScenarios(t *testing.T) {
 	t.Run("reports all attempt errors on timeout", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := testcontext.For(t)
+		ctx, cancel := context.WithTimeout(testcontext.For(t), time.Second)
+		defer cancel()
 		var attempts atomic.Int32
 		tb := newRecordingTB()
 		tb.run(func() {
@@ -334,7 +336,8 @@ func TestRequire_FailureScenarios(t *testing.T) {
 
 	t.Run("truncates middle attempts when many fail", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
-			ctx := testcontext.For(t)
+			ctx, cancel := context.WithTimeout(testcontext.For(t), 6*time.Second)
+			defer cancel()
 			var attempts atomic.Int32
 			tb := newRecordingTB()
 			tb.run(func() {
@@ -363,7 +366,8 @@ func TestRequire_FailureScenarios(t *testing.T) {
 	t.Run("Requiref includes message on timeout", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := testcontext.For(t)
+		ctx, cancel := context.WithTimeout(testcontext.For(t), time.Second)
+		defer cancel()
 		tb := newRecordingTB()
 		tb.run(func() {
 			await.Requiref(ctx, tb, func(t *await.T) {
@@ -482,7 +486,8 @@ func TestRequire_WaitsForInFlightAttemptOnTimeout(t *testing.T) {
 	t.Parallel()
 
 	var finished atomic.Bool
-	ctx := testcontext.For(t)
+	ctx, cancel := context.WithTimeout(testcontext.For(t), time.Second)
+	defer cancel()
 	tb := newRecordingTB()
 	tb.run(func() {
 		await.Require(ctx, tb, func(t *await.T) {
@@ -498,6 +503,7 @@ func TestRequire_WaitsForInFlightAttemptOnTimeout(t *testing.T) {
 // recordingTB is a minimal testing.TB implementation for testing failure scenarios.
 type recordingTB struct {
 	testing.TB    // embed for interface satisfaction
+	ctx           context.Context
 	mu            sync.Mutex
 	failed        atomic.Bool
 	errorMessages []string
@@ -507,7 +513,14 @@ type recordingTB struct {
 }
 
 func newRecordingTB() *recordingTB {
-	return &recordingTB{}
+	return &recordingTB{ctx: context.Background()}
+}
+
+func newRecordingTBWithTimeout(timeout time.Duration) *recordingTB {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	tb := &recordingTB{ctx: ctx}
+	tb.Cleanup(cancel)
+	return tb
 }
 
 func (r *recordingTB) Helper()      {}
@@ -519,7 +532,7 @@ func (r *recordingTB) Logf(format string, args ...any) {
 	r.logMessages = append(r.logMessages, fmt.Sprintf(format, args...))
 }
 func (r *recordingTB) Context() context.Context {
-	return context.Background()
+	return r.ctx
 }
 
 func (r *recordingTB) Cleanup(fn func()) {

--- a/common/testing/await/require_true.go
+++ b/common/testing/await/require_true.go
@@ -11,28 +11,30 @@ import (
 const requireTrueMisuseHint = "do not use test assertions inside the predicate - return false to retry or use await.Require for assertions"
 
 // RequireTrue runs `condition` repeatedly until it returns true, or until the
-// timeout expires. The timeout is capped at the test's deadline, if one is set.
-// The poll interval is the base for exponential backoff capped at 2s.
+// test context timeout expires. The timeout is capped at the test's deadline,
+// if one is set. The timeout argument is retained for source compatibility and
+// ignored; the poll interval is the base for exponential backoff capped at 2s.
 //
 // Use [RequireTrue] for simple local predicates only. Do not use assertions or
 // side effects in the predicate - use [Require] for these.
-func RequireTrue(tb testing.TB, condition func() bool, timeout, pollInterval time.Duration) {
+func RequireTrue(tb testing.TB, condition func() bool, _, pollInterval time.Duration) {
 	tb.Helper()
 	run(testcontext.For(tb), tb, func(t *T) {
 		if !condition() {
 			t.Fail()
 		}
-	}, legacyConfig(timeout, pollInterval, ""), "RequireTrue", requireTrueMisuseHint, false)
+	}, legacyConfig(pollInterval, ""), "RequireTrue", requireTrueMisuseHint, false)
 }
 
 // RequireTruef is like [RequireTrue] but accepts a format string that is included
 // in the failure message when the condition is not satisfied before the timeout.
-// Its poll interval is also used as the base for exponential backoff.
-func RequireTruef(tb testing.TB, condition func() bool, timeout, pollInterval time.Duration, msg string, args ...any) {
+// Its timeout argument is also ignored, and its poll interval is used as the
+// base for exponential backoff.
+func RequireTruef(tb testing.TB, condition func() bool, _, pollInterval time.Duration, msg string, args ...any) {
 	tb.Helper()
 	run(testcontext.For(tb), tb, func(t *T) {
 		if !condition() {
 			t.Fail()
 		}
-	}, legacyConfig(timeout, pollInterval, fmt.Sprintf(msg, args...)), "RequireTruef", requireTrueMisuseHint, false)
+	}, legacyConfig(pollInterval, fmt.Sprintf(msg, args...)), "RequireTruef", requireTrueMisuseHint, false)
 }

--- a/common/testing/await/require_true_test.go
+++ b/common/testing/await/require_true_test.go
@@ -58,7 +58,7 @@ func TestRequireTrue_FailureScenarios(t *testing.T) {
 	t.Run("reports timeout", func(t *testing.T) {
 		t.Parallel()
 
-		tb := newRecordingTB()
+		tb := newRecordingTBWithTimeout(time.Second)
 		tb.run(func() {
 			await.RequireTrue(tb, func() bool {
 				return false
@@ -71,7 +71,7 @@ func TestRequireTrue_FailureScenarios(t *testing.T) {
 	t.Run("RequireTruef includes message on timeout", func(t *testing.T) {
 		t.Parallel()
 
-		tb := newRecordingTB()
+		tb := newRecordingTBWithTimeout(time.Second)
 		tb.run(func() {
 			await.RequireTruef(tb, func() bool {
 				return false

--- a/common/testing/await/require_true_test.go
+++ b/common/testing/await/require_true_test.go
@@ -66,6 +66,7 @@ func TestRequireTrue_FailureScenarios(t *testing.T) {
 		})
 		require.True(t, tb.Failed())
 		require.Contains(t, tb.fatals(), "not satisfied after")
+		require.Empty(t, tb.errors())
 	})
 
 	t.Run("RequireTruef includes message on timeout", func(t *testing.T) {

--- a/common/testing/parallelsuite/suite_test.go
+++ b/common/testing/parallelsuite/suite_test.go
@@ -94,9 +94,8 @@ func (s *contextSuite) TestAwaitUsesSuiteContext() {
 
 	s.Await(func(s *contextSuite) {
 		s.Equal("decorated", s.Context().Value(key{}))
-		deadline, ok := s.Context().Deadline()
+		_, ok := s.Context().Deadline()
 		s.True(ok)
-		s.Less(time.Until(deadline), 200*time.Millisecond)
 	}, 100*time.Millisecond, time.Millisecond)
 }
 


### PR DESCRIPTION
## What changed?

Uses `testcontext.DefaultTimeout()` as Await's total timeout. Legacy timeout and poll interval arguments remain for source compatibility and are ignored. Parent-context and `go test` deadlines can still shorten the wait.

## Why?

Await and its owning test context should use one timeout policy, including `TEMPORAL_TEST_TIMEOUT` and the debug timeout multiplier.
