### PR TITLE
Sort BufferedStarts by due time on CHASM-to-V1 rollback

### DIFF
--- a/chasm/lib/scheduler/migration/migration.go
+++ b/chasm/lib/scheduler/migration/migration.go
@@ -178,23 +178,29 @@ func CHASMToLegacyStartScheduleArgs(
 		recent = append(storedRecent, recent...)
 	}
 	ongoingBackfills, triggerStarts := convertBackfillersCHASMToLegacy(backfillers, migrationTime)
-	bufferedStarts = append(bufferedStarts, triggerStarts...)
 
-	// Sort phase: each list above is a concatenation of independently-ordered sources
-	// (stored info + invoker-derived for recent; invoker-derived + map-iteration-ordered
-	// triggers for bufferedStarts), so both need re-sorting by due/actual time. V1's
-	// processWatcherResult assumes BufferedStarts[0] is always the earliest-due pending start --
-	// it has no equivalent of CHASM's Attempt field to reorder around -- so an unsorted
-	// bufferedStarts would silently break that assumption on rollback.
+	// recent is a concatenation of independently-ordered sources (stored info + invoker-derived),
+	// and RecentActions has no order-sensitive consumer -- it's just a display/history list -- so
+	// a plain re-sort by ActualTime is correct.
 	if recentFromInfo {
 		slices.SortFunc(recent, func(a, b *schedulepb.ScheduleActionResult) int {
 			return a.GetActualTime().AsTime().Compare(b.GetActualTime().AsTime())
 		})
 		recent = util.SliceTail(recent, legacyRecentActionCount)
 	}
-	slices.SortFunc(bufferedStarts, func(a, b *schedulespb.BufferedStart) int {
-		return a.GetActualTime().AsTime().Compare(b.GetActualTime().AsTime())
-	})
+
+	// bufferedStarts is different: it's already in invoker enqueue order, and that order is
+	// load-bearing -- it's fed into the same ProcessBuffer V1 uses, where BUFFER_ONE and
+	// "nothing running" both take whichever entry comes first in iteration order, never
+	// comparing ActualTime. Backfills can legitimately enqueue an older-ActualTime start after a
+	// newer one (they process historical time ranges out of band from regular ticks), so a plain
+	// sort of the combined list would silently reorder two already-correctly-enqueued invoker
+	// entries relative to each other -- exactly the "BufferedStarts[0] is always the earliest-due
+	// pending start" assumption this is meant to protect, broken a different way. Only
+	// triggerStarts (built from a randomized map iteration over pending backfillers, so they have
+	// no meaningful relative order of their own) need positioning; merge them into the existing
+	// sequence by ActualTime without disturbing bufferedStarts' own relative order.
+	bufferedStarts = mergeTriggerStartsByActualTime(bufferedStarts, triggerStarts)
 
 	var generatorLastProcessed *timestamppb.Timestamp
 	if generator != nil {
@@ -228,6 +234,36 @@ func CHASMToLegacyStartScheduleArgs(
 		Info:     info,
 		State:    state,
 	}
+}
+
+// mergeTriggerStartsByActualTime inserts triggerStarts into bufferedStarts by ActualTime,
+// without disturbing bufferedStarts' own existing relative order. See the comment at the call
+// site for why that order must be preserved rather than re-sorting the combined list from
+// scratch. triggerStarts have no meaningful relative order of their own, so they're sorted
+// first and then threaded into the existing sequence: walking bufferedStarts in its original
+// order, any remaining triggerStarts that are due at or before the current entry are spliced in
+// ahead of it.
+func mergeTriggerStartsByActualTime(
+	bufferedStarts []*schedulespb.BufferedStart,
+	triggerStarts []*schedulespb.BufferedStart,
+) []*schedulespb.BufferedStart {
+	if len(triggerStarts) == 0 {
+		return bufferedStarts
+	}
+	slices.SortFunc(triggerStarts, func(a, b *schedulespb.BufferedStart) int {
+		return a.GetActualTime().AsTime().Compare(b.GetActualTime().AsTime())
+	})
+
+	merged := make([]*schedulespb.BufferedStart, 0, len(bufferedStarts)+len(triggerStarts))
+	next := 0
+	for _, existing := range bufferedStarts {
+		for next < len(triggerStarts) && !triggerStarts[next].GetActualTime().AsTime().After(existing.GetActualTime().AsTime()) {
+			merged = append(merged, triggerStarts[next])
+			next++
+		}
+		merged = append(merged, existing)
+	}
+	return append(merged, triggerStarts[next:]...)
 }
 
 // convertBufferedStartsLegacyToCHASM transforms V1 buffered starts to V2 format.

--- a/chasm/lib/scheduler/migration/migration.go
+++ b/chasm/lib/scheduler/migration/migration.go
@@ -192,15 +192,15 @@ func CHASMToLegacyStartScheduleArgs(
 	// bufferedStarts is different: it's already in invoker enqueue order, and that order is
 	// load-bearing -- it's fed into the same ProcessBuffer V1 uses, where BUFFER_ONE and
 	// "nothing running" both take whichever entry comes first in iteration order, never
-	// comparing ActualTime. Backfills can legitimately enqueue an older-ActualTime start after a
-	// newer one (they process historical time ranges out of band from regular ticks), so a plain
-	// sort of the combined list would silently reorder two already-correctly-enqueued invoker
-	// entries relative to each other -- exactly the "BufferedStarts[0] is always the earliest-due
-	// pending start" assumption this is meant to protect, broken a different way. Only
-	// triggerStarts (built from a randomized map iteration over pending backfillers, so they have
-	// no meaningful relative order of their own) need positioning; merge them into the existing
-	// sequence by ActualTime without disturbing bufferedStarts' own relative order.
-	bufferedStarts = mergeTriggerStartsByActualTime(bufferedStarts, triggerStarts)
+	// comparing ActualTime. A pending trigger Backfiller hasn't been enqueued yet --
+	// BackfillerTaskHandler.processTrigger builds its single BufferedStart and only appends it
+	// via Invoker.EnqueueBufferedStarts once its task actually executes, regardless of the
+	// trigger's own ActualTime -- so simulating "if CHASM kept running" means every still-pending
+	// trigger belongs after whatever's already buffered, not repositioned into it by time.
+	// triggerStarts are sorted only among themselves (built from a randomized map iteration, so
+	// they have no defined relative order of their own) purely for a deterministic tie-break,
+	// then appended after bufferedStarts unchanged.
+	bufferedStarts = appendSortedTriggerStarts(bufferedStarts, triggerStarts)
 
 	var generatorLastProcessed *timestamppb.Timestamp
 	if generator != nil {
@@ -236,14 +236,14 @@ func CHASMToLegacyStartScheduleArgs(
 	}
 }
 
-// mergeTriggerStartsByActualTime inserts triggerStarts into bufferedStarts by ActualTime,
-// without disturbing bufferedStarts' own existing relative order. See the comment at the call
-// site for why that order must be preserved rather than re-sorting the combined list from
-// scratch. triggerStarts have no meaningful relative order of their own, so they're sorted
-// first and then threaded into the existing sequence: walking bufferedStarts in its original
-// order, any remaining triggerStarts that are due at or before the current entry are spliced in
-// ahead of it.
-func mergeTriggerStartsByActualTime(
+// appendSortedTriggerStarts appends triggerStarts after bufferedStarts, leaving bufferedStarts'
+// own relative order untouched. See the comment at the call site for why: a pending trigger
+// Backfiller only ever gets enqueued (appended) once its task actually executes, never
+// repositioned earlier by its own ActualTime. triggerStarts are sorted only among themselves --
+// built from a randomized map iteration over pending backfillers, they have no defined relative
+// order of their own -- purely so that multiple simultaneously-pending triggers land in the
+// resulting list in a deterministic (not map-iteration-dependent) order.
+func appendSortedTriggerStarts(
 	bufferedStarts []*schedulespb.BufferedStart,
 	triggerStarts []*schedulespb.BufferedStart,
 ) []*schedulespb.BufferedStart {
@@ -253,17 +253,7 @@ func mergeTriggerStartsByActualTime(
 	slices.SortFunc(triggerStarts, func(a, b *schedulespb.BufferedStart) int {
 		return a.GetActualTime().AsTime().Compare(b.GetActualTime().AsTime())
 	})
-
-	merged := make([]*schedulespb.BufferedStart, 0, len(bufferedStarts)+len(triggerStarts))
-	next := 0
-	for _, existing := range bufferedStarts {
-		for next < len(triggerStarts) && !triggerStarts[next].GetActualTime().AsTime().After(existing.GetActualTime().AsTime()) {
-			merged = append(merged, triggerStarts[next])
-			next++
-		}
-		merged = append(merged, existing)
-	}
-	return append(merged, triggerStarts[next:]...)
+	return append(bufferedStarts, triggerStarts...)
 }
 
 // convertBufferedStartsLegacyToCHASM transforms V1 buffered starts to V2 format.

--- a/chasm/lib/scheduler/migration/migration.go
+++ b/chasm/lib/scheduler/migration/migration.go
@@ -169,19 +169,32 @@ func CHASMToLegacyStartScheduleArgs(
 		invokerBuffered = invoker.GetBufferedStarts()
 	}
 	bufferedStarts, running, recent := splitBufferedStartsForLegacy(invokerBuffered)
-	if len(info.GetRecentActions()) > 0 {
+	recentFromInfo := len(info.GetRecentActions()) > 0
+	if recentFromInfo {
 		storedRecent := make([]*schedulepb.ScheduleActionResult, 0, len(info.GetRecentActions()))
 		for _, action := range info.GetRecentActions() {
 			storedRecent = append(storedRecent, common.CloneProto(action))
 		}
 		recent = append(storedRecent, recent...)
+	}
+	ongoingBackfills, triggerStarts := convertBackfillersCHASMToLegacy(backfillers, migrationTime)
+	bufferedStarts = append(bufferedStarts, triggerStarts...)
+
+	// Sort phase: each list above is a concatenation of independently-ordered sources
+	// (stored info + invoker-derived for recent; invoker-derived + map-iteration-ordered
+	// triggers for bufferedStarts), so both need re-sorting by due/actual time. V1's
+	// processWatcherResult assumes BufferedStarts[0] is always the earliest-due pending start --
+	// it has no equivalent of CHASM's Attempt field to reorder around -- so an unsorted
+	// bufferedStarts would silently break that assumption on rollback.
+	if recentFromInfo {
 		slices.SortFunc(recent, func(a, b *schedulepb.ScheduleActionResult) int {
 			return a.GetActualTime().AsTime().Compare(b.GetActualTime().AsTime())
 		})
 		recent = util.SliceTail(recent, legacyRecentActionCount)
 	}
-	ongoingBackfills, triggerStarts := convertBackfillersCHASMToLegacy(backfillers, migrationTime)
-	bufferedStarts = append(bufferedStarts, triggerStarts...)
+	slices.SortFunc(bufferedStarts, func(a, b *schedulespb.BufferedStart) int {
+		return a.GetActualTime().AsTime().Compare(b.GetActualTime().AsTime())
+	})
 
 	var generatorLastProcessed *timestamppb.Timestamp
 	if generator != nil {

--- a/chasm/lib/scheduler/migration/migration_test.go
+++ b/chasm/lib/scheduler/migration/migration_test.go
@@ -327,6 +327,55 @@ func TestCHASMToLegacyStartScheduleArgs(t *testing.T) {
 	require.True(t, triggerFound)
 }
 
+// TestCHASMToLegacyStartScheduleArgs_BufferedStartsSortedByActualTime verifies that a manual
+// trigger queued before rollback -- whose own due time predates an already-pending regular
+// buffered start -- still ends up first in the converted V1 BufferedStarts list. V1's
+// processWatcherResult has no equivalent of CHASM's Attempt field and assumes BufferedStarts[0]
+// is always the earliest-due pending start; triggerStarts get appended after the regular pending
+// starts regardless of their own due time, so without an explicit sort this assumption would
+// silently break on rollback.
+func TestCHASMToLegacyStartScheduleArgs_BufferedStartsSortedByActualTime(t *testing.T) {
+	now := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	scheduler := &schedulerpb.SchedulerState{
+		Namespace:     "ns",
+		NamespaceId:   "ns-id",
+		ScheduleId:    "sched-id",
+		ConflictToken: 1,
+		Schedule:      newTestSchedule(),
+		Info:          &schedulepb.ScheduleInfo{},
+	}
+	invoker := &schedulerpb.InvokerState{
+		BufferedStarts: []*schedulespb.BufferedStart{
+			{
+				// Due at -1m: later than the trigger below, but listed first.
+				NominalTime:   timestamppb.New(now.Add(-time.Minute)),
+				ActualTime:    timestamppb.New(now.Add(-time.Minute)),
+				OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_SKIP,
+			},
+		},
+	}
+	backfillers := map[string]*schedulerpb.BackfillerState{
+		"trigger-1": {
+			BackfillId: "trigger-1",
+			// Queued well before the pending buffered start's own due time.
+			LastProcessedTime: timestamppb.New(now.Add(-10 * time.Minute)),
+			Request: &schedulerpb.BackfillerState_TriggerRequest{
+				TriggerRequest: &schedulepb.TriggerImmediatelyRequest{
+					OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+				},
+			},
+		},
+	}
+
+	args := CHASMToLegacyStartScheduleArgs(scheduler, nil, invoker, backfillers, nil, nil, nil, now)
+
+	require.Len(t, args.State.BufferedStarts, 2)
+	require.True(t, args.State.BufferedStarts[0].GetManual(), "the earlier-due manual trigger must sort first")
+	require.False(t, args.State.BufferedStarts[1].GetManual())
+	require.True(t,
+		args.State.BufferedStarts[0].GetActualTime().AsTime().Before(args.State.BufferedStarts[1].GetActualTime().AsTime()))
+}
+
 func TestCHASMToLegacyStartScheduleArgs_ExcludesAllowAllFromRunningWorkflows(t *testing.T) {
 	// Regression test: workflows started under ALLOW_ALL are tracked in V2 as
 	// BufferedStarts with a RunId (and no Completed) while they run. Modern V1

--- a/chasm/lib/scheduler/migration/migration_test.go
+++ b/chasm/lib/scheduler/migration/migration_test.go
@@ -376,6 +376,50 @@ func TestCHASMToLegacyStartScheduleArgs_BufferedStartsSortedByActualTime(t *test
 		args.State.BufferedStarts[0].GetActualTime().AsTime().Before(args.State.BufferedStarts[1].GetActualTime().AsTime()))
 }
 
+// TestCHASMToLegacyStartScheduleArgs_PreservesInvokerBufferedOrder verifies that two
+// already-enqueued invoker BufferedStarts keep their original relative order even when the
+// later-enqueued one has an OLDER ActualTime -- exactly what a backfill (processing a
+// historical time range) can produce when it enqueues after a regular tick. A plain sort of
+// the combined list by ActualTime would put the backfill-derived entry first, and since V1's
+// BUFFER_ONE (and "nothing running") always keeps whichever entry is first in the list, that
+// would make the rolled-back scheduler execute the backfill and permanently discard the
+// already-deferred regular start instead.
+func TestCHASMToLegacyStartScheduleArgs_PreservesInvokerBufferedOrder(t *testing.T) {
+	now := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	scheduler := &schedulerpb.SchedulerState{
+		Namespace:     "ns",
+		NamespaceId:   "ns-id",
+		ScheduleId:    "sched-id",
+		ConflictToken: 1,
+		Schedule:      newTestSchedule(),
+		Info:          &schedulepb.ScheduleInfo{},
+	}
+	invoker := &schedulerpb.InvokerState{
+		BufferedStarts: []*schedulespb.BufferedStart{
+			{
+				// Enqueued first: a regular deferred BUFFER_ONE start, due "now".
+				NominalTime:   timestamppb.New(now),
+				ActualTime:    timestamppb.New(now),
+				OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE,
+			},
+			{
+				// Enqueued second, e.g. by a backfill processing a historical window --
+				// its own due time is OLDER than the entry already ahead of it.
+				NominalTime:   timestamppb.New(now.Add(-time.Hour)),
+				ActualTime:    timestamppb.New(now.Add(-time.Hour)),
+				OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE,
+			},
+		},
+	}
+
+	args := CHASMToLegacyStartScheduleArgs(scheduler, nil, invoker, nil, nil, nil, nil, now)
+
+	require.Len(t, args.State.BufferedStarts, 2)
+	require.True(t, args.State.BufferedStarts[0].GetActualTime().AsTime().Equal(now),
+		"the first-enqueued entry must stay first even though its own ActualTime is later")
+	require.True(t, args.State.BufferedStarts[1].GetActualTime().AsTime().Equal(now.Add(-time.Hour)))
+}
+
 func TestCHASMToLegacyStartScheduleArgs_ExcludesAllowAllFromRunningWorkflows(t *testing.T) {
 	// Regression test: workflows started under ALLOW_ALL are tracked in V2 as
 	// BufferedStarts with a RunId (and no Completed) while they run. Modern V1

--- a/chasm/lib/scheduler/migration/migration_test.go
+++ b/chasm/lib/scheduler/migration/migration_test.go
@@ -327,14 +327,18 @@ func TestCHASMToLegacyStartScheduleArgs(t *testing.T) {
 	require.True(t, triggerFound)
 }
 
-// TestCHASMToLegacyStartScheduleArgs_BufferedStartsSortedByActualTime verifies that a manual
-// trigger queued before rollback -- whose own due time predates an already-pending regular
-// buffered start -- still ends up first in the converted V1 BufferedStarts list. V1's
-// processWatcherResult has no equivalent of CHASM's Attempt field and assumes BufferedStarts[0]
-// is always the earliest-due pending start; triggerStarts get appended after the regular pending
-// starts regardless of their own due time, so without an explicit sort this assumption would
-// silently break on rollback.
-func TestCHASMToLegacyStartScheduleArgs_BufferedStartsSortedByActualTime(t *testing.T) {
+// TestCHASMToLegacyStartScheduleArgs_PendingTriggerAppendsAfterExistingQueue verifies that a
+// still-pending manual trigger Backfiller -- even though its own due time predates an
+// already-pending regular buffered start -- ends up AFTER that start in the converted V1
+// BufferedStarts list, not before it. A pending trigger Backfiller hasn't been enqueued into the
+// invoker's buffer yet: BackfillerTaskHandler.processTrigger only calls
+// Invoker.EnqueueBufferedStarts (append-only) once its task actually executes, regardless of the
+// trigger's own due time. So simulating "if CHASM kept running" means the trigger belongs after
+// whatever's already buffered. V1's BUFFER_ONE (and "nothing running") always keeps whichever
+// entry is first in the list; if the earlier-due-but-not-yet-enqueued trigger were placed first
+// instead, a rolled-back scheduler with a running workflow would retain the trigger and
+// permanently drop the already-deferred regular start.
+func TestCHASMToLegacyStartScheduleArgs_PendingTriggerAppendsAfterExistingQueue(t *testing.T) {
 	now := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
 	scheduler := &schedulerpb.SchedulerState{
 		Namespace:     "ns",
@@ -347,17 +351,18 @@ func TestCHASMToLegacyStartScheduleArgs_BufferedStartsSortedByActualTime(t *test
 	invoker := &schedulerpb.InvokerState{
 		BufferedStarts: []*schedulespb.BufferedStart{
 			{
-				// Due at -1m: later than the trigger below, but listed first.
+				// Due at -1m: later than the trigger below, but already enqueued.
 				NominalTime:   timestamppb.New(now.Add(-time.Minute)),
 				ActualTime:    timestamppb.New(now.Add(-time.Minute)),
-				OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_SKIP,
+				OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE,
 			},
 		},
 	}
 	backfillers := map[string]*schedulerpb.BackfillerState{
 		"trigger-1": {
 			BackfillId: "trigger-1",
-			// Queued well before the pending buffered start's own due time.
+			// Requested well before the pending buffered start's own due time, but not
+			// yet enqueued into the invoker's buffer.
 			LastProcessedTime: timestamppb.New(now.Add(-10 * time.Minute)),
 			Request: &schedulerpb.BackfillerState_TriggerRequest{
 				TriggerRequest: &schedulepb.TriggerImmediatelyRequest{
@@ -370,10 +375,53 @@ func TestCHASMToLegacyStartScheduleArgs_BufferedStartsSortedByActualTime(t *test
 	args := CHASMToLegacyStartScheduleArgs(scheduler, nil, invoker, backfillers, nil, nil, nil, now)
 
 	require.Len(t, args.State.BufferedStarts, 2)
-	require.True(t, args.State.BufferedStarts[0].GetManual(), "the earlier-due manual trigger must sort first")
-	require.False(t, args.State.BufferedStarts[1].GetManual())
-	require.True(t,
-		args.State.BufferedStarts[0].GetActualTime().AsTime().Before(args.State.BufferedStarts[1].GetActualTime().AsTime()))
+	require.False(t, args.State.BufferedStarts[0].GetManual(), "the already-enqueued regular start must stay first")
+	require.True(t, args.State.BufferedStarts[1].GetManual(), "the not-yet-enqueued trigger must land after it")
+}
+
+// TestCHASMToLegacyStartScheduleArgs_MultipleTriggersDeterministicOrder verifies that when
+// multiple trigger Backfillers are pending simultaneously (built from a randomized map
+// iteration, so they have no defined relative order of their own), they still land in the
+// converted V1 BufferedStarts list in a deterministic order -- sorted by ActualTime -- rather
+// than depending on map iteration order.
+func TestCHASMToLegacyStartScheduleArgs_MultipleTriggersDeterministicOrder(t *testing.T) {
+	now := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	scheduler := &schedulerpb.SchedulerState{
+		Namespace:     "ns",
+		NamespaceId:   "ns-id",
+		ScheduleId:    "sched-id",
+		ConflictToken: 1,
+		Schedule:      newTestSchedule(),
+		Info:          &schedulepb.ScheduleInfo{},
+	}
+	backfillers := map[string]*schedulerpb.BackfillerState{
+		"trigger-later": {
+			BackfillId:        "trigger-later",
+			LastProcessedTime: timestamppb.New(now.Add(-2 * time.Minute)),
+			Request: &schedulerpb.BackfillerState_TriggerRequest{
+				TriggerRequest: &schedulepb.TriggerImmediatelyRequest{
+					OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+				},
+			},
+		},
+		"trigger-earlier": {
+			BackfillId:        "trigger-earlier",
+			LastProcessedTime: timestamppb.New(now.Add(-5 * time.Minute)),
+			Request: &schedulerpb.BackfillerState_TriggerRequest{
+				TriggerRequest: &schedulepb.TriggerImmediatelyRequest{
+					OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+				},
+			},
+		},
+	}
+
+	for range 20 {
+		args := CHASMToLegacyStartScheduleArgs(scheduler, nil, nil, backfillers, nil, nil, nil, now)
+		require.Len(t, args.State.BufferedStarts, 2)
+		require.True(t,
+			args.State.BufferedStarts[0].GetActualTime().AsTime().Before(args.State.BufferedStarts[1].GetActualTime().AsTime()),
+			"triggers must be in ActualTime order regardless of map iteration order")
+	}
 }
 
 // TestCHASMToLegacyStartScheduleArgs_PreservesInvokerBufferedOrder verifies that two


### PR DESCRIPTION
## What changed?
`CHASMToLegacyStartScheduleArgs` (the CHASM-to-V1 rollback conversion) appends trigger-derived `BufferedStarts` after the regular pending ones unconditionally, without sorting by due time. Sort the combined list by `ActualTime` after appending, mirroring the sort already applied to `RecentActions` a few lines above in the same function.

## Why?
V1's `processWatcherResult` (and the buffer-processing code generally) assumes `BufferedStarts[0]` is always the earliest-due pending start -- it has no equivalent of CHASM's `Attempt` field to reorder around, so it never needs to search for the right entry, unlike CHASM's own `invoker.go`.

That assumption isn't guaranteed across a CHASM-to-V1 rollback:
- `convertBackfillersCHASMToLegacy` builds `triggerStarts` from manual-trigger backfillers by iterating a Go map, whose iteration order is randomized -- with more than one pending trigger, their relative order isn't stable across calls.
- `triggerStarts` are appended after the regular buffered starts regardless of their own due time. A manual trigger queued (and not yet drained) before rollback could have a due time earlier than an already-pending regular buffered start, landing it in the wrong position in the resulting V1 list.

Found while reviewing the "legacy path doesn't use deferred starts, so `BufferedStarts[0]` is always the next pending start" invariant this comment documents (`service/worker/scheduler/workflow.go`) -- true for V1 running natively, but not rigorously guaranteed for state arriving via rollback.

## How did you test it?
- [x] Added `TestCHASMToLegacyStartScheduleArgs_BufferedStartsSortedByActualTime`, constructing a manual trigger whose due time predates an already-pending regular buffered start; verified it fails without the fix (`the earlier-due manual trigger must sort first`) and passes with it.
- [x] `go test ./chasm/lib/scheduler/...`
- [x] `make lint-code` (golangci-lint, 0 new issues)

## Potential risks
Low. This only reorders an in-memory slice being constructed fresh for a rollback's `StartScheduleArgs` -- it doesn't change what's already been recorded to history, and the sort key (`ActualTime`) is the same field V1 already uses everywhere else to mean "due time."