### PR TITLE
[Visibility Elasticsearch] Return empty page token when result size is less than page size

### DIFF
--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -908,7 +908,7 @@ func (s *VisibilityStore) GetListWorkflowExecutionsResponse(
 		lastHitSort = hit.Sort
 	}
 
-	if len(searchResult.Hits.Hits) > 0 { // this means the response might not the last page
+	if len(searchResult.Hits.Hits) == pageSize { // this means the response might not the last page
 		response.NextPageToken, err = s.serializePageToken(&visibilityPageToken{
 			SearchAfter: lastHitSort,
 		})

--- a/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
@@ -683,7 +683,7 @@ func (s *ESVisibilitySuite) TestGetListWorkflowExecutionsResponse() {
 	// test page size > number of results
 	resp, err = s.visibilityStore.GetListWorkflowExecutionsResponse(searchResult, testNamespace, 2, nil)
 	s.NoError(err)
-	s.Equal(serializedToken, resp.NextPageToken)
+	s.Empty(resp.NextPageToken)
 	s.Equal(1, len(resp.Executions))
 
 	// test for search after
@@ -704,7 +704,7 @@ func (s *ESVisibilitySuite) TestGetListWorkflowExecutionsResponse() {
 	// test page size > number of results
 	resp, err = s.visibilityStore.GetListWorkflowExecutionsResponse(searchResult, testNamespace, numOfHits+1, nil)
 	s.NoError(err)
-	s.Equal(serializedToken, resp.NextPageToken)
+	s.Empty(resp.NextPageToken)
 	s.Equal(numOfHits, len(resp.Executions))
 }
 


### PR DESCRIPTION
## What changed?
Return empty page token when result size is less than page size in Visibility with Elasticsearch.
This is a partial revert of https://github.com/temporalio/temporal/pull/10540.

## Why?
Since we disabled partial results in search queries, always returning page token is unnecessary.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
