### PR TITLE
Test context caching (1/2): Make contexts safe to cache

### DIFF
--- a/common/testing/await/require_ctx.go
+++ b/common/testing/await/require_ctx.go
@@ -84,7 +84,7 @@ func run(
 
 	// Ensure enough context time for the await itself plus post-await reserve.
 	// This only works for [testcontext]s; other contexts will be left unchanged.
-	parentCtx = testcontext.EnsureRemaining(parentCtx, tb, cfg.totalTimeout+postAwaitTimeoutReserve)
+	testcontext.EnsureRemaining(parentCtx, tb, cfg.totalTimeout+postAwaitTimeoutReserve)
 
 	deadline := time.Now().Add(cfg.totalTimeout)
 	if parentDeadline, hasDeadline := parentCtx.Deadline(); hasDeadline {

--- a/common/testing/await/require_ctx_test.go
+++ b/common/testing/await/require_ctx_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -120,6 +121,24 @@ func TestRequire_SetsTimeoutContextDeadline(t *testing.T) {
 	require.True(t, shortDeadline.Before(longDeadline))
 	require.LessOrEqual(t, time.Until(shortDeadline), shortTimeout)
 	require.Greater(t, time.Until(shortDeadline), shortTimeout-200*time.Millisecond)
+}
+
+func TestRequire_ExtendsCachedTestContextPastActiveExpiration(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		ctx := testcontext.For(t)
+		completeAt := time.Now().Add(testcontext.DefaultTimeout() + time.Second)
+
+		await.Require(ctx, t, func(t *await.T) {
+			if time.Now().Before(completeAt) {
+				t.Error("not ready")
+			}
+		}, testcontext.DefaultTimeout()+5*time.Second, testcontext.DefaultTimeout()+time.Second)
+
+		require.Same(t, ctx, testcontext.For(t))
+		require.NoError(t, ctx.Err())
+	})
 }
 
 func TestRequire_PollIntervalStartsAfterAttemptFinishes(t *testing.T) {

--- a/common/testing/testcontext/context.go
+++ b/common/testing/testcontext/context.go
@@ -46,23 +46,10 @@ type config struct {
 	timeout time.Duration
 }
 
-// contextDecorator records a keyed transformation to replay on replacement contexts.
-type contextDecorator struct {
-	key      any
-	decorate func(context.Context) context.Context
-}
-
 // ownerKey marks a context as belonging to a test's context chain. Context
-// values are inherited, so any context derived from a test context - including
-// an outdated one - carries the mark too.
+// values are inherited, so any context derived from a test context carries the
+// mark too.
 type ownerKey struct{}
-
-// testContext wraps every context this package hands out, so [EnsureRemaining]
-// can tell one apart from a context the caller derived further (adding its own
-// deadline, cancellation, or values), which is not safe to replace.
-type testContext struct {
-	context.Context
-}
 
 // GoTestDeadline returns the deadline imposed by `go test -timeout`, if any.
 //
@@ -83,27 +70,6 @@ func GoTestDeadline(tb testing.TB) (deadline time.Time, ok bool) {
 	return d.Deadline()
 }
 
-// newTestContext creates a context for st that expires at deadline, capped by
-// the `go test -timeout` deadline.
-func newTestContext(tb testing.TB, st *contextState, deadline time.Time) (context.Context, context.CancelFunc) {
-	if goTestDeadline, ok := GoTestDeadline(tb); ok {
-		deadline = util.MinTime(deadline, goTestDeadline)
-	}
-
-	ctx, cancel := context.WithDeadline(tb.Context(), deadline)
-	ctx = context.WithValue(ctx, ownerKey{}, st)
-
-	// Annotate gRPC requests with the test name for OTEL tracing.
-	ctx = metadata.AppendToOutgoingContext(ctx, testNameMetadataKey, tb.Name())
-
-	// Apply context decorators, in order.
-	for _, decorator := range st.decorators {
-		ctx = decorator.decorate(ctx)
-	}
-
-	return &testContext{Context: ctx}, cancel
-}
-
 // DefaultTimeout returns the effective default timeout for test contexts.
 func DefaultTimeout() time.Duration {
 	timeout, _ := effectiveTimeout(0)
@@ -117,8 +83,10 @@ func DefaultTimeout() time.Duration {
 // return the current context, but an explicit different timeout fails instead
 // of being silently ignored.
 //
-// The result is not worth caching: [EnsureRemaining] replaces the context when
-// it extends the deadline, so a stored copy keeps the old, shorter one.
+// After decorators are attached, the result may be cached: [EnsureRemaining]
+// extends its active timeout without changing the context or its reported
+// deadline. Deadline reports the latest possible expiration. Done closes at
+// the current active expiration, initially the configured timeout.
 func For(tb testing.TB, opts ...Option) context.Context {
 	tb.Helper()
 
@@ -170,51 +138,40 @@ func AttachDecorator[K comparable](tb testing.TB, key K, decorator func(context.
 	st.mu.Lock()
 	defer st.mu.Unlock()
 
-	for _, existing := range st.decorators {
-		if existing.key == key {
-			return
-		}
+	if slices.Contains(st.decoratorKeys, any(key)) {
+		return
 	}
-	next := contextDecorator{
-		key:      key,
-		decorate: decorator,
-	}
-	st.current = &testContext{Context: next.decorate(st.current)}
-	st.decorators = append(st.decorators, next)
+	st.current = decorator(st.current)
+	st.decoratorKeys = append(st.decoratorKeys, key)
 }
 
 // EnsureRemaining extends the test context so at least minRemaining remains
-// from now, and returns the context to use.
+// from now.
 //
 // A context created with [WithTimeout] is never extended past that timeout;
 // one using the default or a TEMPORAL_TEST_TIMEOUT-configured timeout may
-// grow to a total lifetime of max(timeout, [maxTimeout]).
-//
-// Only the returned context - and later [For] calls - see the extension: a
-// context captured earlier keeps its original, shorter deadline, since a
-// context's effective deadline can only shrink as it is derived further, never
-// grow.
+// grow to a total lifetime of max(timeout, [maxTimeout]). A context that has
+// already expired is not revived.
 //
 // The context to extend is resolved from ctx, not tb, so a subtest's tb can
 // extend a context owned by its parent test - the dominant pattern in tests/,
 // e.g. await.Require(s.Context(), t, ...) inside a t.Run started from suite
 // method s.
 //
-// ctx comes back unchanged if it is not a test context at all (extension is an
-// optimization, so a foreign context is left alone rather than failing the
-// caller), or if the caller derived it further - e.g.
-// context.WithTimeout(env.Context(), ...) - because swapping it out would
-// silently discard that wrapping. The underlying test context is still
-// extended for later callers.
-func EnsureRemaining(ctx context.Context, tb testing.TB, minRemaining time.Duration) context.Context {
+// If ctx is not a test context at all, extension is an optimization, so a
+// foreign context is left alone rather than failing the caller. If the caller
+// derived it further - e.g. context.WithTimeout(env.Context(), ...) - its own
+// tighter deadline remains intact while the underlying test context is
+// extended.
+func EnsureRemaining(ctx context.Context, tb testing.TB, minRemaining time.Duration) {
 	tb.Helper()
 	if ctx == nil {
 		tb.Fatal("testcontext: nil context")
-		return nil
+		return
 	}
 	if minRemaining <= 0 {
 		tb.Fatalf("testcontext: min remaining must be positive: %v", minRemaining)
-		return ctx
+		return
 	}
 
 	st, _ := ctx.Value(ownerKey{}).(*contextState)
@@ -222,68 +179,48 @@ func EnsureRemaining(ctx context.Context, tb testing.TB, minRemaining time.Durat
 		// ctx isn't derived from any test context - e.g. one built directly
 		// from context.Background(), or tb.Context() itself - so there is
 		// nothing to extend.
-		return ctx
+		return
 	}
 
-	st.mu.Lock()
-	defer st.mu.Unlock()
-
-	testDeadline, ok := st.current.Deadline()
-	if !ok {
-		tb.Fatal("testcontext: current context has no deadline")
-		return ctx
-	}
-
-	// Cap the requested deadline at the context's ceiling.
-	requestedDeadline := util.MinTime(time.Now().Add(minRemaining), st.maxDeadline())
-
-	// Only a context this package handed out can be swapped for the extended
-	// one without dropping state the caller derived onto it.
-	_, bare := ctx.(*testContext)
-
-	// Extend the test context if the requested deadline is after the current deadline.
-	if requestedDeadline.After(testDeadline) {
-		st.push(newTestContext(st.owner, st, requestedDeadline))
-	}
-
-	if bare {
-		return st.current
-	}
-	return ctx
+	st.timeoutContext.extend(time.Now().Add(minRemaining))
 }
 
 // contextState is the mutable test context state shared by test helpers.
 type contextState struct {
-	// owner is the testing.TB this state was created for; immutable. Used to
-	// derive replacement contexts even when [EnsureRemaining] is reached
-	// through a different tb (e.g. a subtest given a parent's context).
-	owner     testing.TB
 	createdAt time.Time
 	// timeout is the timeout the context was created with; immutable.
-	timeout time.Duration
-	// explicitTimeout records whether timeout was pinned via [WithTimeout],
-	// making it a hard ceiling. TEMPORAL_TEST_TIMEOUT only raises the
-	// baseline and remains extendable, like the default. Immutable.
-	explicitTimeout bool
+	timeout        time.Duration
+	timeoutContext *timeoutContext
 
 	mu sync.Mutex
-	// current is the newest context; [EnsureRemaining] replaces it when the
-	// deadline is extended. Never nil, so late callers see a canceled context
-	// instead of a panic.
-	current context.Context
-	// cancels tracks every context created for this test so cleanup can release them all.
-	cancels    []context.CancelFunc
-	decorators []contextDecorator
+	// current is the context with every decorator attached. Never nil, so late
+	// callers see a canceled context instead of a panic.
+	current       context.Context
+	decoratorKeys []any
 }
 
 func newContextState(tb testing.TB, timeout time.Duration, explicitTimeout bool) *contextState {
-	st := &contextState{
-		owner:           tb,
-		createdAt:       time.Now(),
-		timeout:         timeout,
-		explicitTimeout: explicitTimeout,
+	createdAt := time.Now()
+	limit := timeout
+	if !explicitTimeout {
+		// A defaulted or TEMPORAL_TEST_TIMEOUT-configured timeout may grow,
+		// up to whichever of the two is larger; see [maxTimeout].
+		limit = max(limit, maxTimeout*debug.TimeoutMultiplier)
 	}
-	st.push(newTestContext(tb, st, st.createdAt.Add(timeout)))
+	ceiling := createdAt.Add(limit)
+	if goTestDeadline, ok := GoTestDeadline(tb); ok {
+		ceiling = util.MinTime(ceiling, goTestDeadline)
+	}
+
+	st := &contextState{
+		createdAt: createdAt,
+		timeout:   timeout,
+	}
+	st.timeoutContext = newTimeoutContext(tb.Context(), ceiling, createdAt.Add(timeout))
+	ctx := context.WithValue(st.timeoutContext, ownerKey{}, st)
+
+	// Annotate gRPC requests with the test name for OTEL tracing.
+	st.current = metadata.AppendToOutgoingContext(ctx, testNameMetadataKey, tb.Name())
 	return st
 }
 
@@ -320,43 +257,17 @@ func getOrCreateContextState(tb testing.TB, cfg config) *contextState {
 	return st
 }
 
-// maxDeadline is the furthest deadline [EnsureRemaining] may extend to.
-func (s *contextState) maxDeadline() time.Time {
-	limit := s.timeout
-	if !s.explicitTimeout {
-		// A defaulted or TEMPORAL_TEST_TIMEOUT-configured timeout may grow,
-		// up to whichever of the two is larger; see [maxTimeout].
-		limit = max(limit, maxTimeout*debug.TimeoutMultiplier)
-	}
-	return s.createdAt.Add(limit)
-}
-
-func (s *contextState) push(ctx context.Context, cancel context.CancelFunc) {
-	s.current = ctx
-	s.cancels = append(s.cancels, cancel)
-}
-
-// cleanup cancels every context created for the test and reports whether the
-// test's context deadline had already fired, and how long after createdAt that was.
+// cleanup cancels the test context and reports whether its active timeout had
+// already fired, and how long after createdAt that was.
 func (s *contextState) cleanup() (timedOut bool, timeout time.Duration) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	timedOut = s.current.Err() == context.DeadlineExceeded
-	timeout = s.timeout
-
-	if deadline, ok := s.current.Deadline(); ok {
-		timeout = deadline.Sub(s.createdAt)
-	}
-
-	for _, cancel := range slices.Backward(s.cancels) {
-		cancel()
-	}
+	s.timeoutContext.cancel()
+	err := s.timeoutContext.Err()
+	effectiveExpiration := s.timeoutContext.effectiveExpiration()
+	timedOut = err == context.DeadlineExceeded
+	timeout = effectiveExpiration.Sub(s.createdAt)
 
 	// Keep current: it is canceled now, but callers still racing with cleanup
-	// must get a context, not a panic. Clearing cancels makes cleanup idempotent.
-	s.cancels = nil
-	s.decorators = nil
+	// must get a context, not a panic.
 	return timedOut, timeout
 }
 

--- a/common/testing/testcontext/context_test.go
+++ b/common/testing/testcontext/context_test.go
@@ -25,7 +25,7 @@ func TestWithTimeout(t *testing.T) {
 			ctx := For(t)
 			deadline, ok := ctx.Deadline()
 			require.True(t, ok)
-			require.Equal(t, start.Add(DefaultTimeout()), deadline)
+			require.Equal(t, start.Add(maxTimeout), deadline)
 			require.Equal(t, 90*time.Second, DefaultTimeout())
 		})
 	})
@@ -72,25 +72,6 @@ func TestContextDecorators(t *testing.T) {
 
 		AttachDecorator(t, key{}, decorator)
 		ctx = For(t)
-		require.Equal(t, "decorated", ctx.Value(key{}))
-		require.Equal(t, int32(1), calls.Load(), "decorator should only be applied once")
-	})
-
-	t.Run("applied once for same key", func(t *testing.T) {
-		t.Parallel()
-
-		type key struct{}
-
-		var calls atomic.Int32
-		decorator := func(ctx context.Context) context.Context {
-			calls.Add(1)
-			return context.WithValue(ctx, key{}, "decorated")
-		}
-
-		AttachDecorator(t, key{}, decorator)
-		AttachDecorator(t, key{}, decorator)
-		ctx := For(t)
-
 		require.Equal(t, "decorated", ctx.Value(key{}))
 		require.Equal(t, int32(1), calls.Load(), "decorator should only be applied once")
 	})
@@ -158,21 +139,26 @@ func TestCleanup(t *testing.T) {
 			require.Equal(t, fmt.Sprintf("test exceeded timeout of %v", timeout), tb.error())
 		})
 	})
+
+	t.Run("reports extended effective timeout", func(t *testing.T) {
+		t.Parallel()
+
+		synctest.Test(t, func(t *testing.T) {
+			timeout := DefaultTimeout() + 10*time.Second
+
+			tb := newRecordingTB()
+			tb.run(func() {
+				ctx := For(tb)
+				EnsureRemaining(ctx, tb, timeout)
+				<-ctx.Done()
+			})
+
+			require.Equal(t, fmt.Sprintf("test exceeded timeout of %v", timeout), tb.error())
+		})
+	})
 }
 
 func TestEnvTimeout(t *testing.T) {
-	t.Run("from env", func(t *testing.T) {
-		t.Setenv("TEMPORAL_TEST_TIMEOUT", "10s")
-
-		synctest.Test(t, func(t *testing.T) {
-			start := time.Now()
-			ctx := For(t)
-			deadline, ok := ctx.Deadline()
-			require.True(t, ok)
-			require.Equal(t, start.Add(10*time.Second), deadline)
-		})
-	})
-
 	t.Run("custom overrides env", func(t *testing.T) {
 		t.Setenv("TEMPORAL_TEST_TIMEOUT", "10s")
 
@@ -185,23 +171,32 @@ func TestEnvTimeout(t *testing.T) {
 		})
 	})
 
+	t.Run("environment timeout remains the active expiration", func(t *testing.T) {
+		t.Setenv("TEMPORAL_TEST_TIMEOUT", "10s")
+
+		synctest.Test(t, func(t *testing.T) {
+			tb := newRecordingTB()
+			tb.run(func() {
+				<-For(tb).Done()
+			})
+
+			require.Equal(t, "test exceeded timeout of 10s", tb.error())
+		})
+	})
+
 	t.Run("remains extendable, unlike an explicit WithTimeout", func(t *testing.T) {
 		t.Setenv("TEMPORAL_TEST_TIMEOUT", "10s")
 
 		synctest.Test(t, func(t *testing.T) {
-			start := time.Now()
 			ctx := For(t)
-			originalDeadline, ok := ctx.Deadline()
-			require.True(t, ok)
-			require.Equal(t, start.Add(10*time.Second), originalDeadline)
 
 			// TEMPORAL_TEST_TIMEOUT only raises the baseline; it must not pin
 			// a hard ceiling the way WithTimeout does.
-			refreshed := EnsureRemaining(ctx, t, time.Minute)
+			EnsureRemaining(ctx, t, time.Minute)
 
-			refreshedDeadline, ok := refreshed.Deadline()
-			require.True(t, ok)
-			require.Equal(t, start.Add(time.Minute), refreshedDeadline)
+			require.Same(t, ctx, For(t))
+			time.Sleep(11 * time.Second) //nolint:forbidigo // advance past the environment timeout
+			require.NoError(t, ctx.Err())
 		})
 	})
 }
@@ -215,15 +210,19 @@ func TestEnsureRemaining(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			start := time.Now()
 			ctx := For(t)
-			originalDeadline, ok := ctx.Deadline()
+			ceiling, ok := ctx.Deadline()
 			require.True(t, ok)
-			require.Equal(t, start.Add(DefaultTimeout()), originalDeadline)
+			require.Equal(t, start.Add(maxTimeout), ceiling)
 
-			refreshed := EnsureRemaining(ctx, t, DefaultTimeout()+10*time.Second)
+			EnsureRemaining(ctx, t, DefaultTimeout()+10*time.Second)
 
-			refreshedDeadline, ok := refreshed.Deadline()
+			deadline, ok := ctx.Deadline()
 			require.True(t, ok)
-			require.Equal(t, start.Add(DefaultTimeout()+10*time.Second), refreshedDeadline)
+			require.Equal(t, ceiling, deadline)
+			require.Same(t, ctx, For(t))
+
+			time.Sleep(DefaultTimeout() + time.Second) //nolint:forbidigo // advance past the original active expiration
+			require.NoError(t, ctx.Err())
 		})
 	})
 
@@ -232,16 +231,22 @@ func TestEnsureRemaining(t *testing.T) {
 
 		synctest.Test(t, func(t *testing.T) {
 			start := time.Now()
-			ctx := For(t)
-			originalDeadline, ok := ctx.Deadline()
-			require.True(t, ok)
-			require.Equal(t, start.Add(DefaultTimeout()), originalDeadline)
+			tb := newRecordingTB()
+			tb.run(func() {
+				ctx := For(tb)
+				ceiling, ok := ctx.Deadline()
+				require.True(t, ok)
+				require.Equal(t, start.Add(maxTimeout), ceiling)
 
-			refreshed := EnsureRemaining(ctx, t, 10*time.Minute)
+				EnsureRemaining(ctx, tb, 10*time.Minute)
 
-			refreshedDeadline, ok := refreshed.Deadline()
-			require.True(t, ok)
-			require.Equal(t, start.Add(maxTimeout), refreshedDeadline)
+				deadline, ok := ctx.Deadline()
+				require.True(t, ok)
+				require.Equal(t, ceiling, deadline)
+				<-ctx.Done()
+			})
+
+			require.Equal(t, fmt.Sprintf("test exceeded timeout of %v", maxTimeout), tb.error())
 		})
 	})
 
@@ -252,12 +257,12 @@ func TestEnsureRemaining(t *testing.T) {
 			start := time.Now()
 			ctx := For(t, WithTimeout(100*time.Millisecond))
 
-			refreshed := EnsureRemaining(ctx, t, 10*time.Minute)
+			EnsureRemaining(ctx, t, 10*time.Minute)
 
-			refreshedDeadline, ok := refreshed.Deadline()
+			deadline, ok := ctx.Deadline()
 			require.True(t, ok)
-			require.Equal(t, start.Add(100*time.Millisecond), refreshedDeadline)
-			require.Same(t, ctx, refreshed, "context should not have been replaced")
+			require.Equal(t, start.Add(100*time.Millisecond), deadline)
+			require.Same(t, ctx, For(t), "context should not have been replaced")
 		})
 	})
 
@@ -270,70 +275,16 @@ func TestEnsureRemaining(t *testing.T) {
 
 			// The caller wrapped the test context with its own, tighter
 			// deadline (e.g. context.WithTimeout(env.Context(), ...)).
-			// Swapping it for the extended test context would silently
-			// discard that wrapping, so it must come back unchanged.
+			// Replacing it would silently discard that wrapping, so extension
+			// must leave the derived context intact.
 			derived, cancel := context.WithTimeout(ctx, time.Second)
 			defer cancel()
 
-			refreshed := EnsureRemaining(derived, t, DefaultTimeout()+10*time.Second)
+			EnsureRemaining(derived, t, DefaultTimeout()+10*time.Second)
 
-			require.Same(t, derived, refreshed, "the caller's own wrapping must not be discarded")
-			refreshedDeadline, ok := refreshed.Deadline()
+			deadline, ok := derived.Deadline()
 			require.True(t, ok)
-			require.Equal(t, start.Add(time.Second), refreshedDeadline, "the caller's tighter deadline still governs")
-
-			// The underlying test context is still extended for later callers.
-			extendedDeadline, ok := For(t).Deadline()
-			require.True(t, ok)
-			require.Equal(t, start.Add(DefaultTimeout()+10*time.Second), extendedDeadline)
-		})
-	})
-
-	t.Run("replays decorators", func(t *testing.T) {
-		t.Parallel()
-
-		type key struct{}
-
-		AttachDecorator(t, key{}, func(ctx context.Context) context.Context {
-			return context.WithValue(ctx, key{}, "decorated")
-		})
-		ctx := For(t)
-		require.Equal(t, "decorated", ctx.Value(key{}))
-
-		refreshed := EnsureRemaining(ctx, t, DefaultTimeout()+10*time.Second)
-
-		require.NotSame(t, ctx, refreshed, "context should have been replaced")
-		require.Equal(t, "decorated", refreshed.Value(key{}))
-	})
-
-	t.Run("preserves test name metadata", func(t *testing.T) {
-		t.Parallel()
-
-		ctx := For(t)
-		refreshed := EnsureRemaining(ctx, t, DefaultTimeout()+10*time.Second)
-
-		require.NotSame(t, ctx, refreshed, "context should have been replaced")
-		md, ok := metadata.FromOutgoingContext(refreshed)
-		require.True(t, ok)
-		require.Equal(t, []string{t.Name()}, md.Get(testNameMetadataKey))
-	})
-
-	t.Run("recognizes older context after repeated extensions", func(t *testing.T) {
-		t.Parallel()
-
-		synctest.Test(t, func(t *testing.T) {
-			original := For(t)
-
-			firstRefresh := EnsureRemaining(original, t, DefaultTimeout()+10*time.Second)
-			firstDeadline, ok := firstRefresh.Deadline()
-			require.True(t, ok)
-			require.Equal(t, time.Now().Add(DefaultTimeout()+10*time.Second), firstDeadline)
-
-			// The original context is outdated by now, but still recognized.
-			refreshed := EnsureRemaining(original, t, DefaultTimeout()+20*time.Second)
-			refreshedDeadline, ok := refreshed.Deadline()
-			require.True(t, ok)
-			require.Equal(t, time.Now().Add(DefaultTimeout()+20*time.Second), refreshedDeadline)
+			require.Equal(t, start.Add(time.Second), deadline, "the caller's tighter deadline still governs")
 		})
 	})
 
@@ -347,17 +298,19 @@ func TestEnsureRemaining(t *testing.T) {
 
 				withDeadline, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 				defer cancel()
+				originalDeadline, ok := withDeadline.Deadline()
+				require.True(t, ok)
 
 				// Neither context is derived from a test context - e.g. a
 				// standalone RPC context built from context.Background().
 				// Extending is an optimization, so it isn't in a position to
 				// fail the call; leave the caller's own deadline and
 				// cancellation intact.
-				require.Same(t, withDeadline, EnsureRemaining(withDeadline, tb, 10*time.Millisecond))
-				// context.Background() isn't a pointer, so require.Same can't
-				// compare it; require.Equal is identity-equivalent here since
-				// it's a zero-sized singleton value.
-				require.Equal(t, context.Background(), EnsureRemaining(context.Background(), tb, 10*time.Millisecond))
+				EnsureRemaining(withDeadline, tb, 10*time.Millisecond)
+				deadline, ok := withDeadline.Deadline()
+				require.True(t, ok)
+				require.Equal(t, originalDeadline, deadline)
+				EnsureRemaining(context.Background(), tb, 10*time.Millisecond)
 			})
 
 			require.Empty(t, tb.fatal())
@@ -370,8 +323,8 @@ func TestEnsureRemaining(t *testing.T) {
 		For(t)
 
 		// t.Context() is the test context's parent, so it carries no owner
-		// marker and has no deadline to extend: it comes back unchanged.
-		require.Same(t, t.Context(), EnsureRemaining(t.Context(), t, DefaultTimeout()))
+		// marker and has no deadline to extend.
+		EnsureRemaining(t.Context(), t, DefaultTimeout())
 	})
 
 	t.Run("extends a context belonging to a different tb", func(t *testing.T) {
@@ -383,24 +336,21 @@ func TestEnsureRemaining(t *testing.T) {
 		// tb, so this must extend the owning (here, parent) state rather
 		// than failing or silently no-op'ing.
 		synctest.Test(t, func(t *testing.T) {
-			start := time.Now()
 			other := For(t)
 
 			tb := newRecordingTB()
-			var refreshed context.Context
 			tb.run(func() {
 				For(tb) // tb has its own, unrelated state too
 
-				refreshed = EnsureRemaining(other, tb, DefaultTimeout()+10*time.Second)
+				EnsureRemaining(other, tb, DefaultTimeout()+10*time.Second)
 			})
 
 			require.Empty(t, tb.fatal())
-			refreshedDeadline, ok := refreshed.Deadline()
-			require.True(t, ok)
-			require.Equal(t, start.Add(DefaultTimeout()+10*time.Second), refreshedDeadline)
+			time.Sleep(DefaultTimeout() + time.Second) //nolint:forbidigo // advance past the original active expiration
+			require.NoError(t, other.Err())
 
 			// The extension is visible to the owning test too.
-			require.Same(t, refreshed, For(t))
+			require.Same(t, other, For(t))
 		})
 	})
 
@@ -424,26 +374,23 @@ func TestEnsureRemaining(t *testing.T) {
 		t.Parallel()
 
 		synctest.Test(t, func(t *testing.T) {
-			start := time.Now()
 			ctx := For(t)
 
 			var wg sync.WaitGroup
-			refreshed := make([]context.Context, 8)
-			for i := range refreshed {
+			for range 8 {
 				wg.Go(func() {
-					refreshed[i] = EnsureRemaining(ctx, t, DefaultTimeout()+10*time.Second)
+					EnsureRemaining(ctx, t, DefaultTimeout()+10*time.Second)
 				})
 			}
 			wg.Wait()
 
-			// All callers observe the extended deadline, no matter who extended it.
-			for _, got := range refreshed {
-				deadline, ok := got.Deadline()
-				require.True(t, ok)
-				require.Equal(t, start.Add(DefaultTimeout()+10*time.Second), deadline)
-			}
+			// All callers extend the same cached context.
+			require.Same(t, ctx, For(t))
+			time.Sleep(DefaultTimeout() + time.Second) //nolint:forbidigo // advance past the original active expiration
+			require.NoError(t, ctx.Err())
 		})
 	})
+
 }
 
 // recordingTB records failures instead of failing a real test.

--- a/common/testing/testcontext/timeout_context.go
+++ b/common/testing/testcontext/timeout_context.go
@@ -1,0 +1,126 @@
+package testcontext
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// timeoutContext separates two clocks so its identity stays stable: ceiling is
+// the fixed hard limit reported by Deadline, while activeExpiration controls
+// when Done closes and only moves forward through extend.
+type timeoutContext struct {
+	context.Context
+	ceiling time.Time
+	done    chan struct{}
+
+	mu                 sync.Mutex
+	activeExpiration   time.Time
+	timer              *time.Timer
+	stopParentCallback func() bool
+	err                error
+}
+
+func newTimeoutContext(parent context.Context, ceiling, activeExpiration time.Time) *timeoutContext {
+	if parentDeadline, ok := parent.Deadline(); ok && parentDeadline.Before(ceiling) {
+		ceiling = parentDeadline
+	}
+	if ceiling.Before(activeExpiration) {
+		activeExpiration = ceiling
+	}
+	ctx := &timeoutContext{
+		Context:          context.WithoutCancel(parent),
+		ceiling:          ceiling,
+		done:             make(chan struct{}),
+		activeExpiration: activeExpiration,
+	}
+
+	// Either callback may run immediately, and finishLocked needs both handles
+	// initialized. Hold the lock until both are installed.
+	ctx.mu.Lock()
+	ctx.timer = time.AfterFunc(time.Until(activeExpiration), ctx.expire)
+	ctx.stopParentCallback = context.AfterFunc(parent, func() {
+		ctx.finish(parent.Err())
+	})
+	ctx.mu.Unlock()
+	return ctx
+}
+
+// Deadline reports the ceiling, not the active expiration: the context's
+// identity is stable across [timeoutContext.extend], so the reported deadline
+// must not shrink or grow with it. Done may therefore close well before the
+// reported deadline. Watch Done; do not compute a budget from Deadline.
+func (c *timeoutContext) Deadline() (time.Time, bool) {
+	return c.ceiling, true
+}
+
+func (c *timeoutContext) Done() <-chan struct{} {
+	return c.done
+}
+
+func (c *timeoutContext) Err() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.err
+}
+
+func (c *timeoutContext) extend(expiration time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.err != nil {
+		return
+	}
+	if c.ceiling.Before(expiration) {
+		expiration = c.ceiling
+	}
+	if !expiration.After(c.activeExpiration) {
+		return
+	}
+
+	c.activeExpiration = expiration
+	c.timer.Reset(time.Until(expiration))
+}
+
+func (c *timeoutContext) effectiveExpiration() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.activeExpiration
+}
+
+func (c *timeoutContext) cancel() {
+	c.finish(context.Canceled)
+}
+
+func (c *timeoutContext) finish(err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.finishLocked(err)
+}
+
+func (c *timeoutContext) expire() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.err != nil {
+		return
+	}
+	// Reset may race a callback that already started. Re-check the active
+	// expiration so that stale callbacks cannot cancel an extended context.
+	if remaining := time.Until(c.activeExpiration); remaining > 0 {
+		c.timer.Reset(remaining)
+		return
+	}
+	c.finishLocked(context.DeadlineExceeded)
+}
+
+func (c *timeoutContext) finishLocked(err error) {
+	if c.err != nil {
+		return
+	}
+	c.err = err
+	close(c.done)
+	c.timer.Stop()
+	c.stopParentCallback()
+}

--- a/common/testing/testcontext/timeout_context_test.go
+++ b/common/testing/testcontext/timeout_context_test.go
@@ -1,0 +1,210 @@
+package testcontext
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimeoutContextReportsCeilingAndExpiresAtActiveExpiration(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		start := time.Now()
+		ctx := newTimeoutContext(t.Context(), start.Add(time.Minute), start.Add(10*time.Second))
+
+		deadline, ok := ctx.Deadline()
+		require.True(t, ok)
+		require.Equal(t, start.Add(time.Minute), deadline)
+
+		time.Sleep(10 * time.Second) //nolint:forbidigo // advance the synctest clock to the active deadline
+		<-ctx.Done()
+		require.ErrorIs(t, ctx.Err(), context.DeadlineExceeded)
+	})
+}
+
+func TestTimeoutContextInheritsParentDeadline(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		start := time.Now()
+		parent, cancel := context.WithDeadline(t.Context(), start.Add(time.Second))
+		defer cancel()
+		ctx := newTimeoutContext(parent, start.Add(time.Minute), start.Add(10*time.Second))
+
+		deadline, ok := ctx.Deadline()
+		require.True(t, ok)
+		require.Equal(t, start.Add(time.Second), deadline)
+
+		time.Sleep(time.Second) //nolint:forbidigo // advance to the parent deadline
+		<-ctx.Done()
+		require.ErrorIs(t, ctx.Err(), context.DeadlineExceeded)
+	})
+}
+
+func TestTimeoutContextStartsCanceledWithCanceledParent(t *testing.T) {
+	t.Parallel()
+
+	parent, cancelParent := context.WithCancel(t.Context())
+	cancelParent()
+	start := time.Now()
+	ctx := newTimeoutContext(parent, start.Add(time.Minute), start.Add(10*time.Second))
+
+	<-ctx.Done()
+	require.ErrorIs(t, ctx.Err(), context.Canceled)
+}
+
+func TestTimeoutContextExtensionKeepsIdentityAlivePastOldDeadline(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		start := time.Now()
+		ctx := newTimeoutContext(t.Context(), start.Add(time.Minute), start.Add(10*time.Second))
+
+		ctx.extend(start.Add(20 * time.Second))
+		time.Sleep(11 * time.Second) //nolint:forbidigo // advance past the original active deadline
+		require.NoError(t, ctx.Err())
+
+		time.Sleep(9 * time.Second) //nolint:forbidigo // advance to the extended active deadline
+		<-ctx.Done()
+		require.ErrorIs(t, ctx.Err(), context.DeadlineExceeded)
+	})
+}
+
+func TestTimeoutContextExtensionsAreMonotonic(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		start := time.Now()
+		ctx := newTimeoutContext(t.Context(), start.Add(time.Minute), start.Add(10*time.Second))
+
+		var wg sync.WaitGroup
+		for _, extension := range []time.Duration{15 * time.Second, 30 * time.Second, 20 * time.Second, 25 * time.Second} {
+			wg.Go(func() {
+				ctx.extend(start.Add(extension))
+			})
+		}
+		wg.Wait()
+
+		require.Equal(t, start.Add(30*time.Second), ctx.effectiveExpiration())
+		time.Sleep(29 * time.Second) //nolint:forbidigo // advance close to the furthest extension
+		require.NoError(t, ctx.Err())
+		time.Sleep(time.Second) //nolint:forbidigo // advance to the furthest extension
+		<-ctx.Done()
+		require.ErrorIs(t, ctx.Err(), context.DeadlineExceeded)
+	})
+}
+
+func TestTimeoutContextCancellationIsTerminal(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		cancel func(context.CancelFunc, *timeoutContext)
+	}{
+		{
+			name: "parent",
+			cancel: func(cancelParent context.CancelFunc, _ *timeoutContext) {
+				cancelParent()
+			},
+		},
+		{
+			name: "cleanup",
+			cancel: func(_ context.CancelFunc, ctx *timeoutContext) {
+				ctx.cancel()
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			synctest.Test(t, func(t *testing.T) {
+				start := time.Now()
+				parent, cancelParent := context.WithCancel(t.Context())
+				ctx := newTimeoutContext(parent, start.Add(time.Minute), start.Add(10*time.Second))
+
+				tc.cancel(cancelParent, ctx)
+				<-ctx.Done()
+				require.ErrorIs(t, ctx.Err(), context.Canceled)
+				ctx.extend(start.Add(20 * time.Second))
+				require.ErrorIs(t, ctx.Err(), context.Canceled)
+			})
+		})
+	}
+}
+
+func TestTimeoutContextDerivedDeadlineRemainsTighter(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		start := time.Now()
+		ctx := newTimeoutContext(t.Context(), start.Add(time.Minute), start.Add(10*time.Second))
+		derived, cancel := context.WithTimeout(ctx, 20*time.Second)
+		defer cancel()
+
+		ctx.extend(start.Add(30 * time.Second))
+		deadline, ok := derived.Deadline()
+		require.True(t, ok)
+		require.Equal(t, start.Add(20*time.Second), deadline)
+
+		time.Sleep(20 * time.Second) //nolint:forbidigo // advance past the original active expiration to the derived deadline
+		<-derived.Done()
+		require.ErrorIs(t, derived.Err(), context.DeadlineExceeded)
+		require.NoError(t, ctx.Err())
+	})
+}
+
+func TestTimeoutContextCauseRemainsDeadlineExceededAfterParentCancellation(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		start := time.Now()
+		parent, cancelParent := context.WithCancel(t.Context())
+		ctx := newTimeoutContext(parent, start.Add(time.Minute), start.Add(time.Second))
+
+		time.Sleep(time.Second) //nolint:forbidigo // advance to the active expiration
+		<-ctx.Done()
+		require.ErrorIs(t, context.Cause(ctx), context.DeadlineExceeded)
+
+		cancelParent()
+		require.ErrorIs(t, context.Cause(ctx), context.DeadlineExceeded)
+	})
+}
+
+func TestTimeoutContextExpirationIsTerminal(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		start := time.Now()
+		ctx := newTimeoutContext(t.Context(), start.Add(time.Minute), start.Add(time.Second))
+
+		time.Sleep(time.Second) //nolint:forbidigo // advance to the active expiration
+		<-ctx.Done()
+		require.ErrorIs(t, ctx.Err(), context.DeadlineExceeded)
+
+		ctx.extend(start.Add(2 * time.Second))
+		require.ErrorIs(t, ctx.Err(), context.DeadlineExceeded)
+	})
+}
+
+func TestTimeoutContextIgnoresStaleExpirationAfterExtension(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		start := time.Now()
+		ctx := newTimeoutContext(t.Context(), start.Add(time.Minute), start.Add(time.Second))
+
+		ctx.extend(start.Add(2 * time.Second))
+		ctx.expire() // simulate the original timer callback racing after extension
+
+		time.Sleep(time.Second) //nolint:forbidigo // advance past the original active expiration
+		require.NoError(t, ctx.Err())
+		time.Sleep(time.Second) //nolint:forbidigo // advance to the extended active expiration
+		<-ctx.Done()
+		require.ErrorIs(t, ctx.Err(), context.DeadlineExceeded)
+	})
+}

--- a/tests/activity_driver_test.go
+++ b/tests/activity_driver_test.go
@@ -3,16 +3,13 @@ package tests
 // Self-tests for the activity drivers.
 
 import (
-	"context"
 	"testing"
-	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/server/chasm/lib/activity/model"
 	"go.temporal.io/server/common/testing/await"
-	"go.temporal.io/server/common/testing/testcontext"
 )
 
 // TestDriversRecognizeTimeoutObservedBeforeWait reproduces a race in awaitTimeout: a retryable timeout
@@ -51,43 +48,4 @@ func (s *activityParityTestSuite) TestDriversRecognizeTimeoutObservedBeforeWait(
 		waitUntilTimeoutVisible(t, a.timeoutInfo)
 		a.awaitTimeout(t, model.StartToCloseElapses, time.Now().Add(waitForDriver))
 	})
-}
-
-// contextualDriver is the slice of a driver's API this test exercises.
-type contextualDriver interface{ testContext() context.Context }
-
-// TestDriverContextReflectsExtension proves the drivers fetch their context fresh on every call
-// instead of caching the one observed at construction, so a timeout extension made after the driver
-// starts is visible to later RPCs. env is nil: testContext() never touches it.
-//
-// Runs inside a synctest bubble so it doesn't need to wait out real minutes of test-context timeout,
-// and so `go test -timeout` (a real-clock deadline, meaningless in a fake-clock bubble) can't cap the
-// context and mask the very extension this test is checking for.
-func TestDriverContextReflectsExtension(t *testing.T) {
-	t.Parallel()
-
-	for name, newDriver := range map[string]func(*testing.T) contextualDriver{
-		"SAA": func(t *testing.T) contextualDriver { return newSAADriver(t, nil, activityConfig{}) },
-		"WFA": func(t *testing.T) contextualDriver { return newWFADriver(t, nil, activityConfig{}) },
-	} {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
-			synctest.Test(t, func(t *testing.T) {
-				d := newDriver(t)
-				before, ok := d.testContext().Deadline()
-				require.True(t, ok)
-
-				extended := testcontext.EnsureRemaining(testcontext.For(t), t, testcontext.DefaultTimeout()+time.Minute)
-				extendedDeadline, ok := extended.Deadline()
-				require.True(t, ok)
-				require.True(t, extendedDeadline.After(before), "test setup: EnsureRemaining should have extended the deadline")
-
-				after, ok := d.testContext().Deadline()
-				require.True(t, ok)
-				require.Equal(t, extendedDeadline, after,
-					"driver must observe the extended deadline, not the one captured at construction")
-			})
-		})
-	}
 }


### PR DESCRIPTION
## What changed?

Introduces a stable test context whose managed timer can be extended without replacing the context. `EnsureRemaining` resets that timer while `Deadline` continues to report the extension ceiling.

## Before and after

```text
Before

helper -> For(t) -> ctx A
EnsureRemaining  -> replaces ctx A with ctx B
helper -> For(t) -> ctx B
cached ctx A     -> expires at the old deadline

After

helper -> For(t) --------> stable ctx A (cached)
EnsureRemaining ---------> resets managed timer
managed timer -----------> cancels ctx A later
```

## Why?

Callers can safely cache a test context without retaining an older context that expires before a later extension.
