### PR TITLE
feat: [Scheduler] add worker.schedulerV1VersionOverride

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -3605,6 +3605,12 @@ is non-fatal: the search continues past this threshold.`,
 The ceiling is reread on every tweakables evaluation but only ratchets tighter within a run (one execution between start and Continue-As-New): a looser or unset value never raises it, and it never lowers a version already recorded for the run. Lowering the ceiling therefore takes effect on the next run, when Continue-As-New rereads dynamic config. A run is one execution between start and Continue-As-New.
 Operational notes: (1) A ceiling below 12 holds the version below CHASM migration support, so it pauses all V1->V2 CHASM migrations for the namespace until the ceiling is lifted (deferred, not dropped). (2) A ceiling below 6 skips custom search-attribute updates on schedule edits. (3) This caps V1 scheduler histories only; schedules already migrated to CHASM V2 are not made rollback-safe by it.`,
 	)
+	SchedulerV1VersionOverride = NewNamespaceIntSetting(
+		"worker.schedulerV1VersionOverride",
+		-1,
+		`SchedulerV1VersionOverride selects a newer V1 scheduler workflow version without requiring a follow-up server release to change the default. Set it to an explicitly supported version greater than or equal to the current default; a negative value (the default) keeps the current default. Values below the current default or above the latest version supported by this binary are ignored.
+The override is reread during every scheduler tweakables evaluation through MutableSideEffect. It can advance the version in the current workflow run at the next evaluation, but cannot lower it or exceed that run's recorded SchedulerV1VersionCeiling.`,
+	)
 	WorkerDeleteNamespaceActivityLimits = NewGlobalTypedSetting(
 		"worker.deleteNamespaceActivityLimitsConfig",
 		sdkworker.Options{},

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -175,6 +175,8 @@ type Config struct {
 	EnableSchedules dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	// Ceiling on the V1 scheduler workflow's recorded version.
 	SchedulerV1VersionCeiling dynamicconfig.IntPropertyFnWithNamespaceFilter
+	// Override for the V1 scheduler workflow's recorded version.
+	SchedulerV1VersionOverride dynamicconfig.IntPropertyFnWithNamespaceFilter
 
 	// Enable CHASM tree infrastructure
 	EnableChasm dynamicconfig.BoolPropertyFnWithNamespaceFilter
@@ -385,6 +387,7 @@ func NewConfig(
 
 		EnableSchedules:                      dynamicconfig.FrontendEnableSchedules.Get(dc),
 		SchedulerV1VersionCeiling:            dynamicconfig.SchedulerV1VersionCeiling.Get(dc),
+		SchedulerV1VersionOverride:           dynamicconfig.SchedulerV1VersionOverride.Get(dc),
 		EnableChasm:                          dynamicconfig.EnableChasm.Get(dc),
 		EnableCHASMSchedulerCreation:         dynamicconfig.EnableCHASMSchedulerCreation.Get(dc),
 		CHASMSchedulerCreationRolloutPercent: dynamicconfig.CHASMSchedulerCreationRolloutPercent.Get(dc),

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -7068,7 +7068,8 @@ func (wh *WorkflowHandler) cleanScheduleMemo(memo *commonpb.Memo) *commonpb.Memo
 // This mutates request (but idempotent so safe for retries)
 func (wh *WorkflowHandler) addInitialScheduleMemo(request *workflowservice.CreateScheduleRequest, args *schedulespb.StartScheduleArgs) {
 	versionCeiling := wh.config.SchedulerV1VersionCeiling(request.Namespace)
-	info := scheduler.GetListInfoFromStartArgs(args, time.Now().UTC(), wh.scheduleSpecBuilder, versionCeiling)
+	versionOverride := wh.config.SchedulerV1VersionOverride(request.Namespace)
+	info := scheduler.GetListInfoFromStartArgs(args, time.Now().UTC(), wh.scheduleSpecBuilder, versionCeiling, versionOverride)
 	infoBytes, err := info.Marshal()
 	if err != nil {
 		wh.logger.Error("encoding initial schedule memo failed", tag.Error(err))

--- a/service/worker/scheduler/fx.go
+++ b/service/worker/scheduler/fx.go
@@ -56,6 +56,7 @@ type (
 		chasmMigrationRolloutPercent dynamicconfig.IntPropertyFnWithNamespaceFilter
 		migrateWithRunningWorkflows  dynamicconfig.BoolPropertyFnWithNamespaceFilter
 		schedulerV1VersionCeiling    dynamicconfig.IntPropertyFnWithNamespaceFilter
+		schedulerV1VersionOverride   dynamicconfig.IntPropertyFnWithNamespaceFilter
 		globalNSStartWorkflowRPS     dynamicconfig.TypedSubscribableWithNamespaceFilter[float64]
 		maxBlobSize                  dynamicconfig.IntPropertyFnWithNamespaceFilter
 		localActivitySleepLimit      dynamicconfig.DurationPropertyFnWithNamespaceFilter
@@ -95,6 +96,7 @@ func NewResult(
 			chasmMigrationRolloutPercent: dynamicconfig.CHASMSchedulerMigrationRolloutPercent.Get(dc),
 			migrateWithRunningWorkflows:  dynamicconfig.EnableCHASMSchedulerMigrationWithRunningWorkflows.Get(dc),
 			schedulerV1VersionCeiling:    dynamicconfig.SchedulerV1VersionCeiling.Get(dc),
+			schedulerV1VersionOverride:   dynamicconfig.SchedulerV1VersionOverride.Get(dc),
 			globalNSStartWorkflowRPS:     dynamicconfig.SchedulerNamespaceStartWorkflowRPS.Subscribe(dc),
 			maxBlobSize:                  dynamicconfig.BlobSizeLimitError.Get(dc),
 			localActivitySleepLimit:      dynamicconfig.SchedulerLocalActivitySleepLimit.Get(dc),
@@ -122,7 +124,10 @@ func (s *workerComponent) Register(registry sdkworker.Registry, ns *namespace.Na
 		versionCeiling := func() int {
 			return s.schedulerV1VersionCeiling(nsName)
 		}
-		return schedulerWorkflowWithSpecBuilder(ctx, args, s.specBuilder, enableMigration, migrateWithRunningWorkflows, versionCeiling)
+		versionOverride := func() int {
+			return s.schedulerV1VersionOverride(nsName)
+		}
+		return schedulerWorkflowWithSpecBuilderAndVersionOverride(ctx, args, s.specBuilder, enableMigration, migrateWithRunningWorkflows, versionCeiling, versionOverride)
 	}
 	registry.RegisterWorkflowWithOptions(wfFunc, workflow.RegisterOptions{Name: WorkflowType})
 

--- a/service/worker/scheduler/version_ceiling_test.go
+++ b/service/worker/scheduler/version_ceiling_test.go
@@ -16,202 +16,133 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
-func TestClampVersion(t *testing.T) {
-	for _, c := range []struct {
-		name    string
-		ceiling int
-		want    SchedulerWorkflowVersion
-	}{
-		{"negative is unset, no clamp", -1, TriggerImmediatelyTimestamp},
-		{"zero clamps to InitialVersion", 0, InitialVersion},
-		{"below current clamps down", 1, 1},
-		{"equal to current is a no-op", int(TriggerImmediatelyTimestamp), TriggerImmediatelyTimestamp},
-		{"above current is a no-op", int(TriggerImmediatelyTimestamp) + 1, TriggerImmediatelyTimestamp},
-	} {
-		require.Equalf(t, c.want, clampVersion(TriggerImmediatelyTimestamp, c.ceiling), "%s (ceiling=%d)", c.name, c.ceiling)
-	}
-}
-
-func TestVersionWithOverride(t *testing.T) {
-	for _, tc := range []struct {
-		name     string
-		ceiling  int
-		override int
-		want     SchedulerWorkflowVersion
-	}{
-		{name: "default version", ceiling: -1, override: -1, want: TriggerImmediatelyTimestamp},
-		{name: "override latest", ceiling: -1, override: int(LatestSchedulerWorkflowVersion), want: LatestSchedulerWorkflowVersion},
-		{name: "ceiling caps override", ceiling: int(TriggerImmediatelyTimestamp) - 1, override: int(LatestSchedulerWorkflowVersion), want: TriggerImmediatelyTimestamp - 1},
-		{name: "override below current ignored", ceiling: -1, override: int(TriggerImmediatelyTimestamp) - 1, want: TriggerImmediatelyTimestamp},
-		{name: "override above latest ignored", ceiling: -1, override: int(LatestSchedulerWorkflowVersion) + 1, want: TriggerImmediatelyTimestamp},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			version := versionWithOverride(TriggerImmediatelyTimestamp, tc.ceiling, tc.override)
-			require.Equal(t, tc.want, version)
-		})
-	}
-}
-
 func TestDetermineVersionTransitions(t *testing.T) {
 	for _, tc := range []struct {
-		name     string
-		ceiling  int
-		defaults []SchedulerWorkflowVersion
-		versions []SchedulerWorkflowVersion
+		name              string
+		defaultVersion    SchedulerWorkflowVersion
+		recordedVersion   SchedulerWorkflowVersion
+		recordedCeiling   int
+		configuredCeiling int
+		override          int
+		wantVersion       SchedulerWorkflowVersion
+		wantCeiling       int
 	}{
 		{
-			name:     "stays at ceiling",
-			ceiling:  oldPeerCeiling,
-			defaults: []SchedulerWorkflowVersion{oldPeerCeiling, oldPeerCeiling + 1, oldPeerCeiling + 2},
-			versions: []SchedulerWorkflowVersion{oldPeerCeiling, oldPeerCeiling, oldPeerCeiling},
+			name:              "no ceiling or override uses the default",
+			defaultVersion:    TriggerImmediatelyTimestamp,
+			recordedCeiling:   -1,
+			configuredCeiling: -1,
+			override:          -1,
+			wantVersion:       TriggerImmediatelyTimestamp,
+			wantCeiling:       -1,
 		},
 		{
-			name:     "current version below dynamic config ceiling",
-			ceiling:  oldPeerCeiling,
-			defaults: []SchedulerWorkflowVersion{oldPeerCeiling - 1, oldPeerCeiling, oldPeerCeiling + 1},
-			versions: []SchedulerWorkflowVersion{oldPeerCeiling - 1, oldPeerCeiling, oldPeerCeiling},
+			name:              "zero is a ceiling",
+			defaultVersion:    TriggerImmediatelyTimestamp,
+			recordedCeiling:   -1,
+			configuredCeiling: 0,
+			override:          -1,
+			wantVersion:       InitialVersion,
+			wantCeiling:       0,
 		},
 		{
-			name:     "advances without ceiling",
-			ceiling:  -1,
-			defaults: []SchedulerWorkflowVersion{TriggerImmediatelyTimestamp - 1, TriggerImmediatelyTimestamp, TriggerImmediatelyTimestamp + 1},
-			versions: []SchedulerWorkflowVersion{TriggerImmediatelyTimestamp - 1, TriggerImmediatelyTimestamp, TriggerImmediatelyTimestamp + 1},
+			name:              "configured ceiling caps the default",
+			defaultVersion:    oldPeerCeiling + 1,
+			recordedCeiling:   -1,
+			configuredCeiling: oldPeerCeiling,
+			override:          -1,
+			wantVersion:       oldPeerCeiling,
+			wantCeiling:       oldPeerCeiling,
+		},
+		{
+			name:              "default can advance up to the configured ceiling",
+			defaultVersion:    oldPeerCeiling,
+			recordedVersion:   oldPeerCeiling - 1,
+			recordedCeiling:   -1,
+			configuredCeiling: oldPeerCeiling,
+			override:          -1,
+			wantVersion:       oldPeerCeiling,
+			wantCeiling:       oldPeerCeiling,
+		},
+		{
+			name:              "recorded version is retained below a newly lowered ceiling",
+			defaultVersion:    oldPeerCeiling,
+			recordedVersion:   oldPeerCeiling + 1,
+			recordedCeiling:   -1,
+			configuredCeiling: oldPeerCeiling,
+			override:          -1,
+			wantVersion:       oldPeerCeiling + 1,
+			wantCeiling:       oldPeerCeiling,
+		},
+		{
+			name:              "recorded ceiling cannot increase",
+			defaultVersion:    MigrationHandoffFixes,
+			recordedVersion:   oldPeerCeiling,
+			recordedCeiling:   oldPeerCeiling,
+			configuredCeiling: int(MigrationHandoffFixes),
+			override:          int(MigrationHandoffFixes),
+			wantVersion:       oldPeerCeiling,
+			wantCeiling:       oldPeerCeiling,
+		},
+		{
+			name:              "unset config cannot increase the recorded ceiling",
+			defaultVersion:    MigrationHandoffFixes,
+			recordedVersion:   oldPeerCeiling,
+			recordedCeiling:   oldPeerCeiling,
+			configuredCeiling: -1,
+			override:          int(MigrationHandoffFixes),
+			wantVersion:       oldPeerCeiling,
+			wantCeiling:       oldPeerCeiling,
+		},
+		{
+			name:              "valid override advances the version",
+			defaultVersion:    TriggerImmediatelyTimestamp,
+			recordedCeiling:   -1,
+			configuredCeiling: -1,
+			override:          int(LatestSchedulerWorkflowVersion),
+			wantVersion:       LatestSchedulerWorkflowVersion,
+			wantCeiling:       -1,
+		},
+		{
+			name:              "ceiling caps an override",
+			defaultVersion:    TriggerImmediatelyTimestamp,
+			recordedCeiling:   -1,
+			configuredCeiling: oldPeerCeiling,
+			override:          int(LatestSchedulerWorkflowVersion),
+			wantVersion:       oldPeerCeiling,
+			wantCeiling:       oldPeerCeiling,
+		},
+		{
+			name:              "override below the default is ignored",
+			defaultVersion:    TriggerImmediatelyTimestamp,
+			recordedCeiling:   -1,
+			configuredCeiling: -1,
+			override:          oldPeerCeiling,
+			wantVersion:       TriggerImmediatelyTimestamp,
+			wantCeiling:       -1,
+		},
+		{
+			name:              "override above the latest supported version is ignored",
+			defaultVersion:    TriggerImmediatelyTimestamp,
+			recordedCeiling:   -1,
+			configuredCeiling: -1,
+			override:          int(LatestSchedulerWorkflowVersion) + 1,
+			wantVersion:       TriggerImmediatelyTimestamp,
+			wantCeiling:       -1,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			calls := 0
-			s := &scheduler{
-				logger: log.NewSdkLogger(log.NewNoopLogger()),
-				versionCeiling: func() int {
-					calls++
-					return tc.ceiling
-				},
-			}
-			for i, defaultVersion := range tc.defaults {
-				version, ceiling := s.determineVersion(defaultVersion)
-				require.Equal(t, tc.versions[i], version)
-				require.Equal(t, tc.ceiling, ceiling)
-
-				// MutableSideEffect stores this value for the next workflow task.
-				s.tweakables = CurrentTweakablePolicies
-				s.tweakables.Version = version
-				s.tweakables.VersionCeiling = ceiling
-				s.tweakables.VersionCeilingSet = true
-			}
-			require.Equal(t, len(tc.defaults), calls, "ceiling is re-read each iteration so it can ratchet tighter")
+			version, ceiling := determineVersionTransition(
+				tc.defaultVersion,
+				tc.recordedVersion,
+				tc.recordedCeiling,
+				tc.configuredCeiling,
+				tc.override,
+			)
+			require.Equal(t, tc.wantVersion, version)
+			require.Equal(t, tc.wantCeiling, ceiling)
 		})
 	}
-}
-
-// TestDetermineVersionTightenOnly drives multi-iteration runs where the configured ceiling and
-// override change between iterations, asserting the two run-scoped invariants: the effective
-// ceiling only ratchets tighter, and the version never decreases within a run (a lowered ceiling
-// is retained as a recorded floor and only downgrades on the next run).
-func TestDetermineVersionTightenOnly(t *testing.T) {
-	const v12 = TriggerImmediatelyTimestamp
-	const v13 = MigrationHandoffFixes
-	type step struct {
-		def      SchedulerWorkflowVersion
-		ceiling  int
-		override int
-		wantVer  SchedulerWorkflowVersion
-		wantCeil int
-	}
-	for _, tc := range []struct {
-		name  string
-		steps []step
-	}{
-		{
-			name: "tighten to 12 blocks a simultaneous override to 13",
-			steps: []step{
-				{def: v12, ceiling: -1, override: -1, wantVer: v12, wantCeil: -1},
-				{def: v12, ceiling: int(v12), override: int(v13), wantVer: v12, wantCeil: int(v12)},
-			},
-		},
-		{
-			name: "default advance to 13 is blocked by a tightened ceiling",
-			steps: []step{
-				{def: v12, ceiling: int(v12), override: -1, wantVer: v12, wantCeil: int(v12)},
-				{def: v13, ceiling: int(v12), override: -1, wantVer: v12, wantCeil: int(v12)},
-			},
-		},
-		{
-			name: "ceiling cannot loosen to 13 or unset within a run",
-			steps: []step{
-				{def: v12, ceiling: int(v12), override: -1, wantVer: v12, wantCeil: int(v12)},
-				{def: v13, ceiling: int(v13), override: int(v13), wantVer: v12, wantCeil: int(v12)},
-				{def: v13, ceiling: -1, override: int(v13), wantVer: v12, wantCeil: int(v12)},
-			},
-		},
-		{
-			name: "tightening below a recorded v13 keeps the version and records the tighter ceiling",
-			steps: []step{
-				{def: v12, ceiling: -1, override: int(v13), wantVer: v13, wantCeil: -1},
-				{def: v12, ceiling: int(v12), override: int(v13), wantVer: v13, wantCeil: int(v12)},
-			},
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			var ceiling, override int
-			s := &scheduler{
-				logger:          log.NewSdkLogger(log.NewNoopLogger()),
-				versionCeiling:  func() int { return ceiling },
-				versionOverride: func() int { return override },
-			}
-			for i, st := range tc.steps {
-				ceiling, override = st.ceiling, st.override
-				version, recordedCeiling := s.determineVersion(st.def)
-				require.Equalf(t, st.wantVer, version, "step %d version", i)
-				require.Equalf(t, st.wantCeil, recordedCeiling, "step %d recorded ceiling", i)
-				// A version above the effective ceiling is only ever the retained recorded floor.
-				if recordedCeiling >= 0 && version > SchedulerWorkflowVersion(recordedCeiling) {
-					require.GreaterOrEqualf(t, s.tweakables.Version, version,
-						"step %d: version above ceiling must be the retained recorded floor", i)
-				}
-				// MutableSideEffect stores this value for the next workflow task.
-				s.tweakables = CurrentTweakablePolicies
-				s.tweakables.Version = version
-				s.tweakables.VersionCeiling = recordedCeiling
-				s.tweakables.VersionCeilingSet = true
-			}
-		})
-	}
-}
-
-// TestDetermineVersionDowngradeOnNextRun verifies that after a run kept v13 as a floor while the
-// ceiling was tightened to 12, the following run (fresh tweakables after continue-as-new) reads
-// dynamic config and starts capped at 12.
-func TestDetermineVersionDowngradeOnNextRun(t *testing.T) {
-	ceiling := int(TriggerImmediatelyTimestamp)
-	s := &scheduler{
-		logger:         log.NewSdkLogger(log.NewNoopLogger()),
-		versionCeiling: func() int { return ceiling },
-	}
-	version, recordedCeiling := s.determineVersion(TriggerImmediatelyTimestamp)
-	require.Equal(t, SchedulerWorkflowVersion(TriggerImmediatelyTimestamp), version)
-	require.Equal(t, int(TriggerImmediatelyTimestamp), recordedCeiling)
-}
-
-// TestDetermineVersionLocksAtZeroCeiling verifies that zero is recorded as a real ceiling rather
-// than treated as an unset value.
-func TestDetermineVersionLocksAtZeroCeiling(t *testing.T) {
-	ceiling := 0
-	s := &scheduler{versionCeiling: func() int { return ceiling }}
-
-	// First evaluation clamps to InitialVersion (0) and records it.
-	version, recordedCeiling := s.determineVersion(TriggerImmediatelyTimestamp)
-	require.Equal(t, InitialVersion, version)
-	require.Equal(t, 0, recordedCeiling)
-	s.tweakables = CurrentTweakablePolicies
-	s.tweakables.Version = version
-	s.tweakables.VersionCeiling = recordedCeiling
-	s.tweakables.VersionCeilingSet = true
-
-	// The configured ceiling is lifted mid-run, but the recorded ceiling stays at InitialVersion.
-	ceiling = -1
-	version, recordedCeiling = s.determineVersion(TriggerImmediatelyTimestamp)
-	require.Equal(t, InitialVersion, version)
-	require.Equal(t, 0, recordedCeiling)
 }
 
 func TestDetermineVersionPreservesLegacyRecordedVersion(t *testing.T) {
@@ -241,51 +172,6 @@ func TestDetermineVersionPreservesLegacyRecordedVersion(t *testing.T) {
 			require.Zero(t, calls, "legacy histories must not read the current version ceiling")
 		})
 	}
-}
-
-func TestDetermineVersionAdvancesWithOverride(t *testing.T) {
-	override := -1
-	s := &scheduler{
-		logger:          log.NewSdkLogger(log.NewNoopLogger()),
-		versionCeiling:  func() int { return -1 },
-		versionOverride: func() int { return override },
-	}
-
-	version, ceiling := s.determineVersion(TriggerImmediatelyTimestamp)
-	require.Equal(t, SchedulerWorkflowVersion(TriggerImmediatelyTimestamp), version)
-	require.Equal(t, -1, ceiling)
-	s.tweakables = CurrentTweakablePolicies
-	s.tweakables.Version = version
-	s.tweakables.VersionCeiling = ceiling
-	s.tweakables.VersionCeilingSet = true
-
-	override = int(LatestSchedulerWorkflowVersion)
-	version, ceiling = s.determineVersion(TriggerImmediatelyTimestamp)
-	require.Equal(t, SchedulerWorkflowVersion(LatestSchedulerWorkflowVersion), version)
-	require.Equal(t, -1, ceiling)
-	s.tweakables.Version = version
-
-	override = -1
-	version, ceiling = s.determineVersion(TriggerImmediatelyTimestamp)
-	require.Equal(t, SchedulerWorkflowVersion(LatestSchedulerWorkflowVersion), version)
-	require.Equal(t, -1, ceiling)
-}
-
-func TestDetermineVersionOverrideRespectsRecordedCeiling(t *testing.T) {
-	s := &scheduler{
-		logger:          log.NewSdkLogger(log.NewNoopLogger()),
-		versionCeiling:  func() int { return oldPeerCeiling },
-		versionOverride: func() int { return int(LatestSchedulerWorkflowVersion) },
-		tweakables: TweakablePolicies{
-			Version:           oldPeerCeiling,
-			VersionCeiling:    oldPeerCeiling,
-			VersionCeilingSet: true,
-		},
-	}
-
-	version, ceiling := s.determineVersion(TriggerImmediatelyTimestamp)
-	require.Equal(t, SchedulerWorkflowVersion(oldPeerCeiling), version)
-	require.Equal(t, int(oldPeerCeiling), ceiling)
 }
 
 // TestVersionCeilingWithCHASMMigration verifies that a clamp below the CHASM gate keeps migration

--- a/service/worker/scheduler/version_ceiling_test.go
+++ b/service/worker/scheduler/version_ceiling_test.go
@@ -32,6 +32,26 @@ func TestClampVersion(t *testing.T) {
 	}
 }
 
+func TestVersionWithOverride(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		ceiling  int
+		override int
+		want     SchedulerWorkflowVersion
+	}{
+		{name: "default version", ceiling: -1, override: -1, want: TriggerImmediatelyTimestamp},
+		{name: "override latest", ceiling: -1, override: int(LatestSchedulerWorkflowVersion), want: LatestSchedulerWorkflowVersion},
+		{name: "ceiling caps override", ceiling: int(TriggerImmediatelyTimestamp) - 1, override: int(LatestSchedulerWorkflowVersion), want: TriggerImmediatelyTimestamp - 1},
+		{name: "override below current ignored", ceiling: -1, override: int(TriggerImmediatelyTimestamp) - 1, want: TriggerImmediatelyTimestamp},
+		{name: "override above latest ignored", ceiling: -1, override: int(LatestSchedulerWorkflowVersion) + 1, want: TriggerImmediatelyTimestamp},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			version := versionWithOverride(TriggerImmediatelyTimestamp, tc.ceiling, tc.override)
+			require.Equal(t, tc.want, version)
+		})
+	}
+}
+
 func TestDetermineVersionTransitions(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
@@ -79,6 +99,81 @@ func TestDetermineVersionTransitions(t *testing.T) {
 				s.tweakables.VersionCeilingSet = true
 			}
 			require.Equal(t, len(tc.defaults), calls, "ceiling is re-read each iteration so it can ratchet tighter")
+		})
+	}
+}
+
+// TestDetermineVersionTightenOnly drives multi-iteration runs where the configured ceiling and
+// override change between iterations, asserting the two run-scoped invariants: the effective
+// ceiling only ratchets tighter, and the version never decreases within a run (a lowered ceiling
+// is retained as a recorded floor and only downgrades on the next run).
+func TestDetermineVersionTightenOnly(t *testing.T) {
+	const v12 = TriggerImmediatelyTimestamp
+	const v13 = MigrationHandoffFixes
+	type step struct {
+		def      SchedulerWorkflowVersion
+		ceiling  int
+		override int
+		wantVer  SchedulerWorkflowVersion
+		wantCeil int
+	}
+	for _, tc := range []struct {
+		name  string
+		steps []step
+	}{
+		{
+			name: "tighten to 12 blocks a simultaneous override to 13",
+			steps: []step{
+				{def: v12, ceiling: -1, override: -1, wantVer: v12, wantCeil: -1},
+				{def: v12, ceiling: int(v12), override: int(v13), wantVer: v12, wantCeil: int(v12)},
+			},
+		},
+		{
+			name: "default advance to 13 is blocked by a tightened ceiling",
+			steps: []step{
+				{def: v12, ceiling: int(v12), override: -1, wantVer: v12, wantCeil: int(v12)},
+				{def: v13, ceiling: int(v12), override: -1, wantVer: v12, wantCeil: int(v12)},
+			},
+		},
+		{
+			name: "ceiling cannot loosen to 13 or unset within a run",
+			steps: []step{
+				{def: v12, ceiling: int(v12), override: -1, wantVer: v12, wantCeil: int(v12)},
+				{def: v13, ceiling: int(v13), override: int(v13), wantVer: v12, wantCeil: int(v12)},
+				{def: v13, ceiling: -1, override: int(v13), wantVer: v12, wantCeil: int(v12)},
+			},
+		},
+		{
+			name: "tightening below a recorded v13 keeps the version and records the tighter ceiling",
+			steps: []step{
+				{def: v12, ceiling: -1, override: int(v13), wantVer: v13, wantCeil: -1},
+				{def: v12, ceiling: int(v12), override: int(v13), wantVer: v13, wantCeil: int(v12)},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var ceiling, override int
+			s := &scheduler{
+				logger:          log.NewSdkLogger(log.NewNoopLogger()),
+				versionCeiling:  func() int { return ceiling },
+				versionOverride: func() int { return override },
+			}
+			for i, st := range tc.steps {
+				ceiling, override = st.ceiling, st.override
+				version, recordedCeiling := s.determineVersion(st.def)
+				require.Equalf(t, st.wantVer, version, "step %d version", i)
+				require.Equalf(t, st.wantCeil, recordedCeiling, "step %d recorded ceiling", i)
+				// A version above the effective ceiling is only ever the retained recorded floor.
+				if recordedCeiling >= 0 && version > SchedulerWorkflowVersion(recordedCeiling) {
+					require.GreaterOrEqualf(t, s.tweakables.Version, version,
+						"step %d: version above ceiling must be the retained recorded floor", i)
+				}
+				// MutableSideEffect stores this value for the next workflow task.
+				s.tweakables = CurrentTweakablePolicies
+				s.tweakables.Version = version
+				s.tweakables.VersionCeiling = recordedCeiling
+				s.tweakables.VersionCeilingSet = true
+			}
 		})
 	}
 }
@@ -146,6 +241,51 @@ func TestDetermineVersionPreservesLegacyRecordedVersion(t *testing.T) {
 			require.Zero(t, calls, "legacy histories must not read the current version ceiling")
 		})
 	}
+}
+
+func TestDetermineVersionAdvancesWithOverride(t *testing.T) {
+	override := -1
+	s := &scheduler{
+		logger:          log.NewSdkLogger(log.NewNoopLogger()),
+		versionCeiling:  func() int { return -1 },
+		versionOverride: func() int { return override },
+	}
+
+	version, ceiling := s.determineVersion(TriggerImmediatelyTimestamp)
+	require.Equal(t, SchedulerWorkflowVersion(TriggerImmediatelyTimestamp), version)
+	require.Equal(t, -1, ceiling)
+	s.tweakables = CurrentTweakablePolicies
+	s.tweakables.Version = version
+	s.tweakables.VersionCeiling = ceiling
+	s.tweakables.VersionCeilingSet = true
+
+	override = int(LatestSchedulerWorkflowVersion)
+	version, ceiling = s.determineVersion(TriggerImmediatelyTimestamp)
+	require.Equal(t, SchedulerWorkflowVersion(LatestSchedulerWorkflowVersion), version)
+	require.Equal(t, -1, ceiling)
+	s.tweakables.Version = version
+
+	override = -1
+	version, ceiling = s.determineVersion(TriggerImmediatelyTimestamp)
+	require.Equal(t, SchedulerWorkflowVersion(LatestSchedulerWorkflowVersion), version)
+	require.Equal(t, -1, ceiling)
+}
+
+func TestDetermineVersionOverrideRespectsRecordedCeiling(t *testing.T) {
+	s := &scheduler{
+		logger:          log.NewSdkLogger(log.NewNoopLogger()),
+		versionCeiling:  func() int { return oldPeerCeiling },
+		versionOverride: func() int { return int(LatestSchedulerWorkflowVersion) },
+		tweakables: TweakablePolicies{
+			Version:           oldPeerCeiling,
+			VersionCeiling:    oldPeerCeiling,
+			VersionCeilingSet: true,
+		},
+	}
+
+	version, ceiling := s.determineVersion(TriggerImmediatelyTimestamp)
+	require.Equal(t, SchedulerWorkflowVersion(oldPeerCeiling), version)
+	require.Equal(t, int(oldPeerCeiling), ceiling)
 }
 
 // TestVersionCeilingWithCHASMMigration verifies that a clamp below the CHASM gate keeps migration

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -131,11 +131,8 @@ type (
 		// inside the "tweakables" MutableSideEffect.
 		enableCHASMMigration        func() bool
 		migrateWithRunningWorkflows func() bool
-		// versionCeiling and versionOverride are re-evaluated every iteration inside the
-		// "tweakables" MutableSideEffect, alongside the migration knobs above. The ceiling only
-		// ratchets tighter within a run (a looser or unset value never raises it); the override
-		// only advances the version. Neither can lower an already-recorded version mid-run --
-		// a lowered ceiling takes effect on the next run. See determineVersion.
+		// versionCeiling and versionOverride are re-evaluated in the "tweakables" MutableSideEffect.
+		// A run can only lower its ceiling and raise its version.
 		versionCeiling  func() int
 		versionOverride func() int
 
@@ -1815,23 +1812,13 @@ func (s *scheduler) hasMinVersion(version SchedulerWorkflowVersion) bool {
 	return s.tweakables.Version >= version
 }
 
-// determineVersion returns the scheduler workflow version to run for this iteration and the
-// ceiling to record alongside it. Two invariants hold within a single run (i.e. until the next
-// continue-as-new): the effective ceiling only ratchets tighter (a looser or unset configured
-// value never raises it), and the version never decreases. If a newly-lowered ceiling sits below
-// the version already recorded for this run, the recorded version is retained as a floor and the
-// downgrade takes effect on the next run, when continue-as-new re-reads dynamic config. See the
-// versionCeiling/versionOverride field comments.
+// determineVersion returns this iteration's version and the ceiling to record for the run.
 func (s *scheduler) determineVersion(defaultVersion SchedulerWorkflowVersion) (SchedulerWorkflowVersion, int) {
-	// A marker written before the VersionCeiling fields existed has already selected this run's
-	// version. Seed the ceiling from that recorded version; do not read dynamic config or apply a
-	// newly configured clamp retroactively to a run that predates the field.
+	// Preserve the version selected by histories that predate VersionCeiling.
 	if !s.tweakables.VersionCeilingSet && s.tweakables != (TweakablePolicies{}) {
 		return s.tweakables.Version, int(s.tweakables.Version)
 	}
 
-	// Ceiling recorded so far this run (-1 until first set). Combined tighten-only with the live
-	// configured value so the effective ceiling is monotonically non-increasing across iterations.
 	recordedCeiling := -1
 	if s.tweakables.VersionCeilingSet {
 		recordedCeiling = s.tweakables.VersionCeiling
@@ -1844,8 +1831,6 @@ func (s *scheduler) determineVersion(defaultVersion SchedulerWorkflowVersion) (S
 		s.logger.Warn("worker.schedulerV1VersionCeiling above the latest supported version; no effect in this binary",
 			"ceiling", configured, "latestSupportedVersion", LatestSchedulerWorkflowVersion)
 	}
-	ceiling := tightenCeiling(recordedCeiling, configured)
-
 	override := -1
 	if s.versionOverride != nil {
 		override = s.versionOverride()
@@ -1855,19 +1840,18 @@ func (s *scheduler) determineVersion(defaultVersion SchedulerWorkflowVersion) (S
 			"override", override, "latestSupportedVersion", LatestSchedulerWorkflowVersion)
 	}
 
-	// Never regress below the version already recorded for this run. Apply the advancing-only
-	// override and the effective ceiling, then re-floor at the recorded version so a lowered
-	// ceiling cannot downgrade a running workflow mid-run.
-	candidate := max(defaultVersion, s.tweakables.Version)
-	version := max(versionWithOverride(candidate, ceiling, override), s.tweakables.Version)
+	return determineVersionTransition(defaultVersion, s.tweakables.Version, recordedCeiling, configured, override)
+}
+
+// determineVersionTransition applies the run's recorded version and ceiling to the current config.
+// The version cannot decrease and the ceiling cannot increase until the next run.
+func determineVersionTransition(defaultVersion, recordedVersion SchedulerWorkflowVersion, recordedCeiling, configuredCeiling, override int) (SchedulerWorkflowVersion, int) {
+	ceiling := tightenCeiling(recordedCeiling, configuredCeiling)
+	version := max(versionWithOverride(max(defaultVersion, recordedVersion), ceiling, override), recordedVersion)
 	return version, ceiling
 }
 
-// tightenCeiling combines the ceiling recorded so far this run with a freshly configured value,
-// keeping whichever is tighter. A negative value means "no constraint": a negative configured
-// value never loosens an already-recorded ceiling, and a negative recorded ceiling adopts the
-// configured one. This makes the effective ceiling monotonically non-increasing within a run;
-// loosening only takes effect on the next run, when continue-as-new re-reads dynamic config.
+// tightenCeiling keeps the lower of the recorded and configured ceilings. A negative ceiling is unset.
 func tightenCeiling(recorded, configured int) int {
 	if configured < 0 {
 		return recorded

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -131,11 +131,13 @@ type (
 		// inside the "tweakables" MutableSideEffect.
 		enableCHASMMigration        func() bool
 		migrateWithRunningWorkflows func() bool
-		// versionCeiling is re-evaluated every iteration inside the "tweakables" MutableSideEffect,
-		// alongside the migration knobs above. The ceiling only ratchets tighter within a run (a
-		// looser or unset value never raises it) and never lowers an already-recorded version
-		// mid-run -- a lowered ceiling takes effect on the next run. See determineVersion.
-		versionCeiling func() int
+		// versionCeiling and versionOverride are re-evaluated every iteration inside the
+		// "tweakables" MutableSideEffect, alongside the migration knobs above. The ceiling only
+		// ratchets tighter within a run (a looser or unset value never raises it); the override
+		// only advances the version. Neither can lower an already-recorded version mid-run --
+		// a lowered ceiling takes effect on the next run. See determineVersion.
+		versionCeiling  func() int
+		versionOverride func() int
 
 		tweakables TweakablePolicies
 
@@ -258,6 +260,10 @@ func SchedulerWorkflow(ctx workflow.Context, args *schedulespb.StartScheduleArgs
 }
 
 func schedulerWorkflowWithSpecBuilder(ctx workflow.Context, args *schedulespb.StartScheduleArgs, specBuilder *SpecBuilder, enableCHASMMigration func() bool, migrateWithRunningWorkflows func() bool, versionCeiling func() int) error {
+	return schedulerWorkflowWithSpecBuilderAndVersionOverride(ctx, args, specBuilder, enableCHASMMigration, migrateWithRunningWorkflows, versionCeiling, func() int { return -1 })
+}
+
+func schedulerWorkflowWithSpecBuilderAndVersionOverride(ctx workflow.Context, args *schedulespb.StartScheduleArgs, specBuilder *SpecBuilder, enableCHASMMigration func() bool, migrateWithRunningWorkflows func() bool, versionCeiling func() int, versionOverride func() int) error {
 	scheduler := &scheduler{
 		StartScheduleArgs: args,
 		ctx:               ctx,
@@ -271,6 +277,7 @@ func schedulerWorkflowWithSpecBuilder(ctx workflow.Context, args *schedulespb.St
 		enableCHASMMigration:        enableCHASMMigration,
 		migrateWithRunningWorkflows: migrateWithRunningWorkflows,
 		versionCeiling:              versionCeiling,
+		versionOverride:             versionOverride,
 	}
 	return scheduler.run()
 }
@@ -1839,11 +1846,20 @@ func (s *scheduler) determineVersion(defaultVersion SchedulerWorkflowVersion) (S
 	}
 	ceiling := tightenCeiling(recordedCeiling, configured)
 
-	// Never regress below the version already recorded for this run. Apply the effective ceiling,
-	// then re-floor at the recorded version so a lowered ceiling cannot downgrade a running
-	// workflow mid-run.
+	override := -1
+	if s.versionOverride != nil {
+		override = s.versionOverride()
+	}
+	if override > int(LatestSchedulerWorkflowVersion) {
+		s.logger.Warn("worker.schedulerV1VersionOverride above the latest supported version; ignored",
+			"override", override, "latestSupportedVersion", LatestSchedulerWorkflowVersion)
+	}
+
+	// Never regress below the version already recorded for this run. Apply the advancing-only
+	// override and the effective ceiling, then re-floor at the recorded version so a lowered
+	// ceiling cannot downgrade a running workflow mid-run.
 	candidate := max(defaultVersion, s.tweakables.Version)
-	version := max(clampVersion(candidate, ceiling), s.tweakables.Version)
+	version := max(versionWithOverride(candidate, ceiling, override), s.tweakables.Version)
 	return version, ceiling
 }
 
@@ -1877,11 +1893,11 @@ func panicIfErr(err error) {
 	}
 }
 
-func GetListInfoFromStartArgs(args *schedulespb.StartScheduleArgs, now time.Time, specBuilder *SpecBuilder, versionCeiling int) *schedulepb.ScheduleListInfo {
+func GetListInfoFromStartArgs(args *schedulespb.StartScheduleArgs, now time.Time, specBuilder *SpecBuilder, versionCeiling, versionOverride int) *schedulepb.ScheduleListInfo {
 	// Create a scheduler outside of workflow context with just the fields we need to call
 	// getListInfo. Note that this does not take into account InitialPatch.
 	tweakables := CurrentTweakablePolicies
-	tweakables.Version = clampVersion(tweakables.Version, versionCeiling)
+	tweakables.Version = versionWithOverride(tweakables.Version, versionCeiling, versionOverride)
 	s := &scheduler{
 		StartScheduleArgs: args,
 		tweakables:        tweakables,
@@ -1891,6 +1907,13 @@ func GetListInfoFromStartArgs(args *schedulespb.StartScheduleArgs, now time.Time
 	s.compileSpec()
 	s.State.LastProcessedTime = timestamppb.New(now)
 	return s.getListInfo(false)
+}
+
+func versionWithOverride(defaultVersion SchedulerWorkflowVersion, ceiling, override int) SchedulerWorkflowVersion {
+	if override >= int(defaultVersion) && override <= int(LatestSchedulerWorkflowVersion) {
+		defaultVersion = SchedulerWorkflowVersion(override)
+	}
+	return clampVersion(defaultVersion, ceiling)
 }
 
 func isUserScheduleError(err error) bool {

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -401,6 +401,43 @@ func (s *workflowSuite) TestMigratedBufferedStartUsesLegacyIDsAtOldVersion() {
 	s.True(workflow.IsContinueAsNewError(s.env.GetWorkflowError()))
 }
 
+// TestMigratedBufferedStartLosesIdempotencyIDsUnderCeiling characterizes a known constraint of the
+// version ceiling: the v13 (MigrationHandoffFixes) preservation of a migrated start's
+// workflow/request IDs is undone if the recorded version is clamped below v13. This is the
+// failover path -- default is v13 but a rollback ceiling of v12 holds the run at v12 -- so a start
+// that was migrated from CHASM with preserved idempotency IDs is started with a freshly generated
+// request ID and the legacy generated workflow ID instead. Lowering the ceiling mid-flight can
+// therefore break migrated-start idempotency; documented rather than guarded (guarding would mean
+// refusing to clamp below the version that produced pending buffered starts).
+func (s *workflowSuite) TestMigratedBufferedStartLosesIdempotencyIDsUnderCeiling() {
+	previousTweakables := CurrentTweakablePolicies
+	defer func() { CurrentTweakablePolicies = previousTweakables }()
+	// Default is the newest version; only the ceiling holds the run down to v12.
+	CurrentTweakablePolicies.Version = MigrationHandoffFixes
+	CurrentTweakablePolicies.IterationsBeforeContinueAsNew = 1
+
+	s.expectStart(func(req *schedulespb.StartWorkflowRequest) (*schedulespb.StartWorkflowResponse, error) {
+		s.Equal("configured-workflow-id-2022-06-01T00:00:00Z", req.Request.WorkflowId)
+		s.NotEmpty(req.Request.RequestId)
+		s.NotEqual("migrated-request-id", req.Request.RequestId)
+		return nil, nil
+	})
+
+	wf := func(ctx workflow.Context, args *schedulespb.StartScheduleArgs) error {
+		return schedulerWorkflowWithSpecBuilderAndVersionOverride(
+			ctx, args, newSpecBuilderForTest(0, 0),
+			func() bool { return false },                           // enableCHASMMigration
+			func() bool { return false },                           // migrateWithRunningWorkflows
+			func() int { return int(TriggerImmediatelyTimestamp) }, // versionCeiling: rollback clamp below v13
+			func() int { return -1 },                               // versionOverride
+		)
+	}
+	s.env.SetStartTime(baseStartTime)
+	s.env.ExecuteWorkflow(wf, s.migratedStartScheduleArgs())
+	s.True(s.env.IsWorkflowCompleted())
+	s.True(workflow.IsContinueAsNewError(s.env.GetWorkflowError()))
+}
+
 func (s *workflowSuite) TestNativeBufferedStartFallsBackAtNewVersion() {
 	// Complement to TestMigratedBufferedStart*: a schedule that never went through
 	// CHASM has BufferedStart.WorkflowId/RequestId empty (the common case -- see


### PR DESCRIPTION
> **Stack 2/3** (base `sched-version-ceiling` / #11831): #11831 → **#11832** → #11833. Reviewable slices of the change formerly in #11652.

## What changed?

Adds `worker.schedulerV1VersionOverride`, a namespace integer dynamic-config setting whose default `-1` leaves the scheduler workflow version unchanged. A supported override can advance a namespace to a newer V1 scheduler version without a server release.

The override is re-read in each `tweakables` `MutableSideEffect` evaluation. It is ignored when below the default version or above the latest version supported by this binary. The current ceiling from #11831 caps it on that evaluation.

The same override is threaded through initial schedule memo/list-info construction so it agrees with the version recorded by the workflow. The PR includes dynamic-config, frontend-config, and scheduler-worker wiring.

## Why?

This is the forward counterpart to the rollback ceiling: operators can stage a version rollout for one namespace through dynamic config, while retaining a ceiling for failover or rollback compatibility. Lifting that ceiling lets the workflow use the override on its next evaluation.

## Coverage and compatibility

`determineVersionTransition` is a pure function covering the recorded version, current ceiling, and override. Its table-driven test covers:

- unset and zero ceilings;
- capping the default or a valid override;
- retaining a previously recorded version after a new lower ceiling;
- advancing when the ceiling is raised or removed; and
- rejecting below-default or above-supported overrides.

The remaining legacy-history test verifies that a pre-`VersionCeilingSet` marker still bypasses current dynamic config. Replay coverage across ceiling and override configurations is in #11833.