### PR TITLE
Fix FirstWorkflowTaskBackoff Accumulation upon ContinueAsNew

### DIFF
--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -2975,9 +2975,13 @@ func (ms *MutableStateImpl) ContinueAsNewMinBackoff(backoffDuration *durationpb.
 	// lifetime of previous execution
 	// todo@time-skipping: time skipping is naturally supported for continue as new backoff, and need to
 	// make sure the backoff is correctly applied in the time skipping case
-	lifetime := ms.timeSource.Now().Sub(ms.executionState.StartTime.AsTime().UTC())
+	now := ms.timeSource.Now()
+	lifetime := max(time.Duration(0), now.Sub(ms.executionState.StartTime.AsTime().UTC()))
 	if ms.executionInfo.ExecutionTime != nil {
-		lifetime = ms.timeSource.Now().Sub(ms.executionInfo.ExecutionTime.AsTime().UTC())
+		executionLifetime := now.Sub(ms.executionInfo.ExecutionTime.AsTime().UTC())
+		if executionLifetime >= 0 {
+			lifetime = executionLifetime
+		}
 	}
 
 	interval := lifetime

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -2215,6 +2215,36 @@ func (s *mutableStateSuite) TestContinueAsNewMinBackoff() {
 	s.True(minBackoff == backoff)
 }
 
+func (s *mutableStateSuite) TestContinueAsNewMinBackoffExecutionCompletesBeforeExecutionTime() {
+	s.mockConfig.WorkflowIdReuseMinimalInterval = func(namespace string) time.Duration {
+		return time.Second
+	}
+
+	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	s.mutableState.timeSource = clock.NewEventTimeSource().Update(now)
+
+	// Guard against clock skew or malformed state making StartTime later than now.
+	// The lifetime should be clamped at zero, so the full minimal interval is still applied.
+	s.mutableState.executionState.StartTime = timestamppb.New(now.Add(time.Second))
+	s.mutableState.executionInfo.ExecutionTime = nil
+
+	minBackoff := s.mutableState.ContinueAsNewMinBackoff(nil).AsDuration()
+	s.Equal(time.Second, minBackoff)
+
+	// Simulate a delayed-start run that actually executed and closed before its ExecutionTime.
+	// In that case lifetime should fall back to close - StartTime, not become negative.
+	s.mutableState.executionState.StartTime = timestamppb.New(now.Add(-100 * time.Millisecond))
+	s.mutableState.executionInfo.ExecutionTime = timestamppb.New(now.Add(time.Second))
+
+	minBackoff = s.mutableState.ContinueAsNewMinBackoff(nil).AsDuration()
+	s.Equal(900*time.Millisecond, minBackoff)
+
+	// Existing backoff already satisfies the minimal interval when combined with the fallback lifetime.
+	backoff := time.Second
+	minBackoff = s.mutableState.ContinueAsNewMinBackoff(durationpb.New(backoff)).AsDuration()
+	s.Equal(backoff, minBackoff)
+}
+
 func (s *mutableStateSuite) TestEventReapplied() {
 	runID := uuid.NewString()
 	eventID := int64(1)

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -2220,7 +2220,7 @@ func (s *mutableStateSuite) TestContinueAsNewMinBackoffExecutionCompletesBeforeE
 		return time.Second
 	}
 
-	now := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	now := time.Now()
 	s.mutableState.timeSource = clock.NewEventTimeSource().Update(now)
 
 	// Guard against clock skew or malformed state making StartTime later than now.

--- a/tests/continue_as_new_test.go
+++ b/tests/continue_as_new_test.go
@@ -620,7 +620,7 @@ func (s *ContinueAsNewTestSuite) TestContinueAsNewMinBackoffDoesNotAccumulate() 
 	const continueAsNewCount = 3
 	var firstWorkflowTaskBackoffs []time.Duration
 	runIDs := []string{we.RunId}
-	for i := 0; i < continueAsNewCount+1; i++ {
+	for i := range continueAsNewCount + 1 {
 		// Each task is polled after the run has been made executable. For continued runs,
 		// the admitted update below schedules a workflow task before ExecutionTime.
 		task, err := env.FrontendClient().PollWorkflowTaskQueue(s.Context(), &workflowservice.PollWorkflowTaskQueueRequest{

--- a/tests/continue_as_new_test.go
+++ b/tests/continue_as_new_test.go
@@ -13,6 +13,7 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
+	protocolpb "go.temporal.io/api/protocol/v1"
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
@@ -586,6 +587,138 @@ func (s *ContinueAsNewTestSuite) TestContinueAsNewWithDelayStart() {
 	startedTime := finalEvents[0].GetEventTime().AsTime()
 	scheduledTime := finalEvents[1].GetEventTime().AsTime()
 	s.GreaterOrEqual(scheduledTime.Sub(startedTime), delayStart)
+}
+
+func (s *ContinueAsNewTestSuite) TestContinueAsNewMinBackoffDoesNotAccumulate() {
+	env := testcore.NewEnv(s.T())
+
+	const minimalInterval = 10 * time.Second
+	env.OverrideDynamicConfig(dynamicconfig.WorkflowIdReuseMinimalInterval, minimalInterval)
+
+	id := "functional-continue-as-new-min-backoff-does-not-accumulate-test"
+	wt := "functional-continue-as-new-min-backoff-does-not-accumulate-test-type"
+	tl := "functional-continue-as-new-min-backoff-does-not-accumulate-test-taskqueue"
+	identity := "worker1"
+
+	workflowType := &commonpb.WorkflowType{Name: wt}
+	taskQueue := &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL}
+
+	request := &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:           uuid.NewString(),
+		Namespace:           env.Namespace().String(),
+		WorkflowId:          id,
+		WorkflowType:        workflowType,
+		TaskQueue:           taskQueue,
+		WorkflowRunTimeout:  durationpb.New(100 * time.Second),
+		WorkflowTaskTimeout: durationpb.New(10 * time.Second),
+		Identity:            identity,
+	}
+
+	we, err := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
+	s.NoError(err)
+
+	const continueAsNewCount = 3
+	var firstWorkflowTaskBackoffs []time.Duration
+	runIDs := []string{we.RunId}
+	for i := 0; i < continueAsNewCount+1; i++ {
+		// Each task is polled after the run has been made executable. For continued runs,
+		// the admitted update below schedules a workflow task before ExecutionTime.
+		task, err := env.FrontendClient().PollWorkflowTaskQueue(s.Context(), &workflowservice.PollWorkflowTaskQueueRequest{
+			Namespace: env.Namespace().String(),
+			TaskQueue: taskQueue,
+			Identity:  identity,
+		})
+		s.NoError(err)
+		s.NotEmpty(task.GetTaskToken())
+
+		startAttrs := task.History.Events[0].GetWorkflowExecutionStartedEventAttributes()
+		firstWorkflowTaskBackoff := startAttrs.GetFirstWorkflowTaskBackoff().AsDuration()
+		firstWorkflowTaskBackoffs = append(firstWorkflowTaskBackoffs, firstWorkflowTaskBackoff)
+
+		var messages []*protocolpb.Message
+		var commands []*commandpb.Command
+		if i > 0 {
+			s.NotEmpty(task.Messages, "expected update message in task")
+			updateTV := env.Tv().
+				WithWorkflowID(id).
+				WithRunID(runIDs[i]).
+				WithUpdateIDNumber(i).
+				WithMessageIDNumber(i)
+			messages = env.UpdateAcceptCompleteMessages(updateTV, task.Messages[0])
+			commands = env.UpdateAcceptCompleteCommands(updateTV)
+		}
+		if i < continueAsNewCount {
+			// Continue as new without an explicit backoff. The server applies the default
+			// WorkflowIdReuseMinimalInterval because the previous run closes quickly.
+			commands = append(commands, &commandpb.Command{
+				CommandType: enumspb.COMMAND_TYPE_CONTINUE_AS_NEW_WORKFLOW_EXECUTION,
+				Attributes: &commandpb.Command_ContinueAsNewWorkflowExecutionCommandAttributes{
+					ContinueAsNewWorkflowExecutionCommandAttributes: &commandpb.ContinueAsNewWorkflowExecutionCommandAttributes{
+						WorkflowType:        workflowType,
+						TaskQueue:           taskQueue,
+						WorkflowRunTimeout:  durationpb.New(100 * time.Second),
+						WorkflowTaskTimeout: durationpb.New(10 * time.Second),
+					},
+				},
+			})
+		} else {
+			commands = append(commands, &commandpb.Command{
+				CommandType: enumspb.COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION,
+				Attributes: &commandpb.Command_CompleteWorkflowExecutionCommandAttributes{
+					CompleteWorkflowExecutionCommandAttributes: &commandpb.CompleteWorkflowExecutionCommandAttributes{
+						Result: payloads.EncodeString("Done"),
+					},
+				},
+			})
+		}
+
+		_, err = env.FrontendClient().RespondWorkflowTaskCompleted(s.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
+			Namespace: env.Namespace().String(),
+			TaskToken: task.GetTaskToken(),
+			Identity:  identity,
+			Commands:  commands,
+			Messages:  messages,
+		})
+		s.NoError(err)
+
+		events := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{
+			WorkflowId: id,
+			RunId:      runIDs[len(runIDs)-1],
+		})
+		lastEvent := events[len(events)-1]
+		if i < continueAsNewCount {
+			s.Equal(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW, lastEvent.GetEventType())
+			newRunID := lastEvent.GetWorkflowExecutionContinuedAsNewEventAttributes().GetNewExecutionRunId()
+			runIDs = append(runIDs, newRunID)
+			// Admit a noop update on the delayed continued run. This schedules the next
+			// workflow task immediately, so the run can close before its ExecutionTime.
+			updateTV := env.Tv().
+				WithWorkflowID(id).
+				WithRunID(newRunID).
+				WithUpdateIDNumber(i + 1).
+				WithMessageIDNumber(i + 1)
+			go func(updateTV *testvars.TestVars) {
+				_, updateErr := env.FrontendClient().UpdateWorkflowExecution(
+					testcore.NewContext(),
+					updateWorkflowRequest(env, updateTV, nil),
+				)
+				if updateErr != nil {
+					s.T().Errorf("Update failed: %v", updateErr)
+				}
+			}(updateTV)
+			waitUpdateAdmitted(env, updateTV)
+		} else {
+			s.Equal(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED, lastEvent.GetEventType())
+		}
+	}
+
+	// The first run has no inherited backoff. Every continued run should stay capped at
+	// the default minimal interval instead of accumulating across the tight loop.
+	s.Len(firstWorkflowTaskBackoffs, continueAsNewCount+1)
+	s.Zero(firstWorkflowTaskBackoffs[0])
+	for i, firstWorkflowTaskBackoff := range firstWorkflowTaskBackoffs[1:] {
+		s.LessOrEqual(firstWorkflowTaskBackoff, minimalInterval, "firstWorkflowTaskBackoff accumulated at run %d: %v", i+1, firstWorkflowTaskBackoff)
+	}
 }
 
 type (


### PR DESCRIPTION
## What changed?
- Fix FirstWorkflowTaskBackoff Accumulation upon ContinueAsNew

## Why?
- Today if workflow continueAsNew before executionTime, the calculated lifetime will be negative and causing backoff to keep accumulating via continueAsNew.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)
