### PR TITLE
Emit force termination metric

### DIFF
--- a/chasm/metrics.go
+++ b/chasm/metrics.go
@@ -1,0 +1,12 @@
+package chasm
+
+import "go.temporal.io/server/common/metrics"
+
+const (
+	ExecutionForceTerminationReasonDeleteExecution              metrics.ReasonString = "delete_execution"
+	ExecutionForceTerminationReasonHistorySizeExceedsLimit      metrics.ReasonString = "history_size_limit"
+	ExecutionForceTerminationReasonHistoryCountExceedsLimit     metrics.ReasonString = "history_count_limit"
+	ExecutionForceTerminationReasonMutableStateSizeExceedsLimit metrics.ReasonString = "mutable_state_size_limit"
+	ExecutionForceTerminationReasonEventBatchSizeExceedsLimit   metrics.ReasonString = "event_batch_size_limit"
+	ExecutionForceTerminationReasonVersionConflict              metrics.ReasonString = "version_conflict"
+)

--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -3075,6 +3075,7 @@ func (n *Node) IsStale(
 
 func (n *Node) Terminate(
 	request TerminateComponentRequest,
+	forceTerminationReason metrics.ReasonString,
 ) error {
 	if n.parent != nil {
 		return softassert.UnexpectedInternalErr(
@@ -3104,6 +3105,24 @@ func (n *Node) Terminate(
 	}
 
 	n.terminated = true
+	namespaceName := ""
+	namespaceEntry := n.backend.GetNamespaceEntry()
+	if namespaceEntry != nil {
+		namespaceName = namespaceEntry.Name().String()
+	}
+
+	archetypeID := n.ArchetypeID()
+	archetypeName, ok := n.registry.ComponentFqnByID(archetypeID)
+	if !ok {
+		archetypeName = strconv.FormatUint(uint64(archetypeID), 10)
+	}
+
+	metrics.ExecutionForceTerminations.With(n.metricsHandler).Record(
+		1,
+		metrics.NamespaceTag(namespaceName),
+		metrics.ArchetypeTag(archetypeName),
+		metrics.ReasonTag(forceTerminationReason),
+	)
 	return nil
 }
 

--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -25,6 +25,8 @@ import (
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/metrics/metricstest"
+	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/testing/protoassert"
 	"go.temporal.io/server/common/testing/protorequire"
@@ -3626,6 +3628,11 @@ func (s *nodeSuite) TestCloseTransaction_ApplyMutation_PureTasks() {
 }
 
 func (s *nodeSuite) TestTerminate() {
+	metricsHandler := metricstest.NewCaptureHandler()
+	s.metricsHandler = metricsHandler
+	s.nodeBackend.HandleGetNamespaceEntry = func() *namespace.Namespace {
+		return namespace.NewNamespaceForTest(&persistencespb.NamespaceInfo{Name: "test-namespace"}, nil, false, nil, 0)
+	}
 	node := s.testComponentTree()
 
 	// First closeTransaction once to make the tree clean.
@@ -3635,10 +3642,22 @@ func (s *nodeSuite) TestTerminate() {
 	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING, s.nodeBackend.LastUpdateWorkflowState())
 	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, s.nodeBackend.LastUpdateWorkflowStatus())
 
+	capture := metricsHandler.StartCapture()
+	defer metricsHandler.StopCapture(capture)
+
 	// Then terminate the node and verify only that node will be in the mutation.
-	err = node.Terminate(TerminateComponentRequest{})
+	err = node.Terminate(
+		TerminateComponentRequest{Reason: "test-force-reason"},
+		ExecutionForceTerminationReasonMutableStateSizeExceedsLimit,
+	)
 	s.NoError(err)
 	s.True(node.terminated)
+	recordings := capture.Snapshot()[metrics.ExecutionForceTerminations.Name()]
+	s.Len(recordings, 1)
+	s.Equal(int64(1), recordings[0].Value)
+	s.Equal("test-namespace", recordings[0].Tags["namespace"])
+	s.Equal(testComponentFQN, recordings[0].Tags["archetype"])
+	s.Equal(string(ExecutionForceTerminationReasonMutableStateSizeExceedsLimit), recordings[0].Tags["reason"])
 
 	mutations, err := node.CloseTransaction()
 	s.NoError(err)

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1053,7 +1053,11 @@ var (
 	DuplicateReplicationEventsCounter             = NewCounterDef("duplicate_replication_events")
 	AcquireLockFailedCounter                      = NewCounterDef("acquire_lock_failed")
 	WorkflowContextCleared                        = NewCounterDef("workflow_context_cleared")
-	MutableStateSize                              = NewBytesHistogramDef(
+	ExecutionForceTerminations                    = NewCounterDef(
+		"execution_force_terminations",
+		WithDescription("The number of workflow or CHASM executions force terminated due to system conditions (not application specific reasons). Tagged by namespace, archetype, and reason."),
+	)
+	MutableStateSize = NewBytesHistogramDef(
 		"mutable_state_size",
 		WithDescription("The size of an individual Workflow Execution's state, emitted each time a workflow execution is retrieved or updated."),
 	)

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -478,6 +478,9 @@ type ReasonString string
 // ReasonTag is a generic tag can be used anywhere a reason is needed.
 // Make sure that the value is of limited cardinality.
 func ReasonTag(value ReasonString) Tag {
+	if len(value) == 0 {
+		value = unknownValue
+	}
 	return Tag{Key: reason, Value: string(value)}
 }
 

--- a/service/history/api/deleteworkflow/api.go
+++ b/service/history/api/deleteworkflow/api.go
@@ -5,6 +5,7 @@ import (
 
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/server/api/historyservice/v1"
+	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/locks"
 	"go.temporal.io/server/common/namespace"
@@ -64,7 +65,7 @@ func Invoke(
 				func(workflowLease api.WorkflowLease) (*api.UpdateWorkflowAction, error) {
 					mutableState := workflowLease.GetMutableState()
 
-					return api.UpdateWorkflowTerminate, workflow.TerminateWorkflow(
+					return api.UpdateWorkflowTerminate, workflow.ForceTerminateWorkflow(
 						mutableState,
 						"Delete workflow execution",
 						nil,
@@ -72,6 +73,8 @@ func Invoke(
 						true,
 						// TODO(bergundy): No links will be attached here for now, we may want to add support for this later though.
 						nil,
+						shardContext.GetMetricsHandler(),
+						chasm.ExecutionForceTerminationReasonDeleteExecution,
 					)
 				},
 				nil,

--- a/service/history/api/respondworkflowtaskcompleted/api.go
+++ b/service/history/api/respondworkflowtaskcompleted/api.go
@@ -688,13 +688,15 @@ func (handler *WorkflowTaskCompletedHandler) Invoke(
 				return nil, err
 			}
 
-			if err := workflow.TerminateWorkflow(
+			if err := workflow.ForceTerminateWorkflow(
 				ms,
 				common.FailureReasonTransactionSizeExceedsLimit,
 				payloads.EncodeString(updateErr.Error()),
 				consts.IdentityHistoryService,
 				false,
 				nil, // no links necessary.
+				handler.metricsHandler,
+				chasm.ExecutionForceTerminationReasonEventBatchSizeExceedsLimit,
 			); err != nil {
 				return nil, err
 			}

--- a/service/history/chasm_engine.go
+++ b/service/history/chasm_engine.go
@@ -627,7 +627,10 @@ func (e *ChasmEngine) deleteExecution(
 			}
 
 			chasmTree.SetDeleteAfterClose(true)
-			if err := chasmTree.Terminate(request.TerminateComponentRequest); err != nil {
+			if err := chasmTree.Terminate(
+				request.TerminateComponentRequest,
+				chasm.ExecutionForceTerminationReasonDeleteExecution,
+			); err != nil {
 				return err
 			}
 

--- a/service/history/interfaces/chasm_tree.go
+++ b/service/history/interfaces/chasm_tree.go
@@ -8,6 +8,7 @@ import (
 
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/service/history/tasks"
 )
 
@@ -25,7 +26,7 @@ type ChasmTree interface {
 	RefreshTasks() error
 	IsStateDirty() bool
 	IsDirty() bool
-	Terminate(chasm.TerminateComponentRequest) error
+	Terminate(chasm.TerminateComponentRequest, metrics.ReasonString) error
 	Archetype() (chasm.Archetype, error)
 	ArchetypeID() chasm.ArchetypeID
 	EachPureTask(

--- a/service/history/interfaces/chasm_tree_mock.go
+++ b/service/history/interfaces/chasm_tree_mock.go
@@ -16,6 +16,7 @@ import (
 
 	persistence "go.temporal.io/server/api/persistence/v1"
 	chasm "go.temporal.io/server/chasm"
+	metrics "go.temporal.io/server/common/metrics"
 	tasks "go.temporal.io/server/service/history/tasks"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -288,17 +289,17 @@ func (mr *MockChasmTreeMockRecorder) Snapshot(arg0 any) *gomock.Call {
 }
 
 // Terminate mocks base method.
-func (m *MockChasmTree) Terminate(arg0 chasm.TerminateComponentRequest) error {
+func (m *MockChasmTree) Terminate(arg0 chasm.TerminateComponentRequest, arg1 metrics.ReasonString) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Terminate", arg0)
+	ret := m.ctrl.Call(m, "Terminate", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Terminate indicates an expected call of Terminate.
-func (mr *MockChasmTreeMockRecorder) Terminate(arg0 any) *gomock.Call {
+func (mr *MockChasmTreeMockRecorder) Terminate(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Terminate", reflect.TypeOf((*MockChasmTree)(nil).Terminate), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Terminate", reflect.TypeOf((*MockChasmTree)(nil).Terminate), arg0, arg1)
 }
 
 // ValidateSideEffectTask mocks base method.

--- a/service/history/ndc/transaction_manager_existing_workflow.go
+++ b/service/history/ndc/transaction_manager_existing_workflow.go
@@ -10,6 +10,7 @@ import (
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	historyi "go.temporal.io/server/service/history/interfaces"
@@ -273,12 +274,16 @@ func (r *nDCTransactionMgrForExistingWorkflowImpl) updateAsCurrent(
 // (dispatchForExistingWorkflow only reaches the zombie path for a non-running target), so it stays
 // passive. Do NOT reuse this elsewhere or call it with a
 // nil current for a running target: it would report the target as suppressed without zombifying it.
-// Everywhere else, call targetWorkflow.SuppressBy(currentWorkflow) directly.
-func suppressTargetPolicy(targetWorkflow Workflow, currentWorkflow Workflow) (historyi.TransactionPolicy, error) {
+// Everywhere else, call targetWorkflow.SuppressBy(currentWorkflow, metricsHandler) directly.
+func suppressTargetPolicy(
+	targetWorkflow Workflow,
+	currentWorkflow Workflow,
+	metricsHandler metrics.Handler,
+) (historyi.TransactionPolicy, error) {
 	if currentWorkflow == nil {
 		return historyi.TransactionPolicyPassive, nil
 	}
-	return targetWorkflow.SuppressBy(currentWorkflow)
+	return targetWorkflow.SuppressBy(currentWorkflow, metricsHandler)
 }
 
 // suppressNewWorkflowPolicy suppresses the carried new run (continue-as-new/cron/retry successor) by
@@ -286,14 +291,18 @@ func suppressTargetPolicy(targetWorkflow Workflow, currentWorkflow Workflow) (hi
 // for the deleted-current-run (orphan) path, where currentWorkflow is nil because the current
 // execution record is gone.
 //
-// With a real current workflow it defers to newWorkflow.SuppressBy(currentWorkflow). With no current
-// to compare against, the new run cannot be the current run, so a still-running successor is forced
-// into the zombie state (a closed one is left as is) before the caller persists it bypass-current. On
-// the passive apply path the successor is always remote-active, so zombie (never terminate) is the
-// correct suppression, matching SuppressBy's remote-active branch.
-func suppressNewWorkflowPolicy(newWorkflow Workflow, currentWorkflow Workflow) (historyi.TransactionPolicy, error) {
+// With a real current workflow it defers to newWorkflow.SuppressBy(currentWorkflow, metricsHandler).
+// With no current to compare against, the new run cannot be the current run, so a still-running
+// successor is forced into the zombie state (a closed one is left as is) before the caller persists
+// it bypass-current. On the passive apply path the successor is always remote-active, so zombie
+// (never terminate) is the correct suppression, matching SuppressBy's remote-active branch.
+func suppressNewWorkflowPolicy(
+	newWorkflow Workflow,
+	currentWorkflow Workflow,
+	metricsHandler metrics.Handler,
+) (historyi.TransactionPolicy, error) {
 	if currentWorkflow != nil {
-		return newWorkflow.SuppressBy(currentWorkflow)
+		return newWorkflow.SuppressBy(currentWorkflow, metricsHandler)
 	}
 	newMutableState := newWorkflow.GetMutableState()
 	if newMutableState.IsWorkflowExecutionRunning() {
@@ -317,7 +326,8 @@ func (r *nDCTransactionMgrForExistingWorkflowImpl) updateAsZombie(
 	archetypeID chasm.ArchetypeID,
 ) error {
 
-	targetPolicy, err := suppressTargetPolicy(targetWorkflow, currentWorkflow)
+	metricsHandler := r.shardContext.GetMetricsHandler()
+	targetPolicy, err := suppressTargetPolicy(targetWorkflow, currentWorkflow, metricsHandler)
 	if err != nil {
 		return err
 	}
@@ -331,7 +341,7 @@ func (r *nDCTransactionMgrForExistingWorkflowImpl) updateAsZombie(
 	if newWorkflow != nil {
 		// currentWorkflow is nil on the deleted-current-run (orphan) path; suppressNewWorkflowPolicy
 		// handles that by parking the successor as a zombie instead of suppressing against a current.
-		newWorkflowPolicy, err := suppressNewWorkflowPolicy(newWorkflow, currentWorkflow)
+		newWorkflowPolicy, err := suppressNewWorkflowPolicy(newWorkflow, currentWorkflow, metricsHandler)
 		if err != nil {
 			return err
 		}
@@ -397,6 +407,7 @@ func (r *nDCTransactionMgrForExistingWorkflowImpl) suppressCurrentAndUpdateAsCur
 	if currentWorkflow.GetMutableState().IsWorkflowExecutionRunning() {
 		currentWorkflowPolicy, err = currentWorkflow.SuppressBy(
 			targetWorkflow,
+			r.shardContext.GetMetricsHandler(),
 		)
 		if err != nil {
 			return err
@@ -473,7 +484,8 @@ func (r *nDCTransactionMgrForExistingWorkflowImpl) conflictResolveAsZombie(
 	archetypeID chasm.ArchetypeID,
 ) error {
 
-	targetWorkflowPolicy, err := suppressTargetPolicy(targetWorkflow, currentWorkflow)
+	metricsHandler := r.shardContext.GetMetricsHandler()
+	targetWorkflowPolicy, err := suppressTargetPolicy(targetWorkflow, currentWorkflow, metricsHandler)
 	if err != nil {
 		return err
 	}
@@ -487,7 +499,7 @@ func (r *nDCTransactionMgrForExistingWorkflowImpl) conflictResolveAsZombie(
 	if newWorkflow != nil {
 		// currentWorkflow is nil on the deleted-current-run (orphan) path; suppressNewWorkflowPolicy
 		// handles that by parking the successor as a zombie instead of suppressing against a current.
-		newWorkflowPolicy, err = suppressNewWorkflowPolicy(newWorkflow, currentWorkflow)
+		newWorkflowPolicy, err = suppressNewWorkflowPolicy(newWorkflow, currentWorkflow, metricsHandler)
 		if err != nil {
 			return err
 		}

--- a/service/history/ndc/transaction_manager_existing_workflow_test.go
+++ b/service/history/ndc/transaction_manager_existing_workflow_test.go
@@ -11,6 +11,7 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/service/history/hsm"
@@ -49,6 +50,7 @@ func (s *transactionMgrForExistingWorkflowSuite) SetupTest() {
 	s.NoError(err)
 	s.mockShard.EXPECT().StateMachineRegistry().Return(reg).AnyTimes()
 	s.mockShard.EXPECT().GetThrottledLogger().Return(log.NewNoopLogger()).AnyTimes()
+	s.mockShard.EXPECT().GetMetricsHandler().Return(metrics.NoopMetricsHandler).AnyTimes()
 
 	mockTaskRefresher := workflow.NewMockTaskRefresher(s.controller)
 	mockTaskRefresher.EXPECT().Refresh(gomock.Any(), gomock.Any(), false).Return(nil).AnyTimes()
@@ -150,7 +152,7 @@ func (s *transactionMgrForExistingWorkflowSuite) TestDispatchForExistingWorkflow
 
 	targetWorkflow.EXPECT().HappensAfter(currentWorkflow).Return(true, nil)
 	currentMutableState.EXPECT().IsWorkflowExecutionRunning().Return(true).AnyTimes()
-	currentWorkflow.EXPECT().SuppressBy(targetWorkflow).Return(historyi.TransactionPolicyPassive, nil)
+	currentWorkflow.EXPECT().SuppressBy(targetWorkflow, gomock.Any()).Return(historyi.TransactionPolicyPassive, nil)
 	targetWorkflow.EXPECT().Revive(gomock.Any(), gomock.Any()).Return(nil)
 
 	targetContext.EXPECT().ConflictResolveWorkflowExecution(
@@ -226,7 +228,7 @@ func (s *transactionMgrForExistingWorkflowSuite) TestDispatchForExistingWorkflow
 
 	targetWorkflow.EXPECT().HappensAfter(currentWorkflow).Return(true, nil)
 	currentMutableState.EXPECT().IsWorkflowExecutionRunning().Return(false).AnyTimes()
-	currentWorkflow.EXPECT().SuppressBy(targetWorkflow).Return(historyi.TransactionPolicyPassive, nil).Times(0)
+	currentWorkflow.EXPECT().SuppressBy(targetWorkflow, gomock.Any()).Return(historyi.TransactionPolicyPassive, nil).Times(0)
 	targetWorkflow.EXPECT().Revive(gomock.Any(), gomock.Any()).Return(nil)
 
 	targetContext.EXPECT().ConflictResolveWorkflowExecution(
@@ -618,8 +620,8 @@ func (s *transactionMgrForExistingWorkflowSuite) TestDispatchForExistingWorkflow
 	s.mockTransactionMgr.EXPECT().CheckWorkflowExists(ctx, namespaceID, workflowID, newRunID, chasm.WorkflowArchetypeID).Return(false, nil)
 
 	targetWorkflow.EXPECT().HappensAfter(currentWorkflow).Return(false, nil)
-	targetWorkflow.EXPECT().SuppressBy(currentWorkflow).Return(historyi.TransactionPolicyPassive, nil)
-	newWorkflow.EXPECT().SuppressBy(currentWorkflow).Return(historyi.TransactionPolicyPassive, nil)
+	targetWorkflow.EXPECT().SuppressBy(currentWorkflow, gomock.Any()).Return(historyi.TransactionPolicyPassive, nil)
+	newWorkflow.EXPECT().SuppressBy(currentWorkflow, gomock.Any()).Return(historyi.TransactionPolicyPassive, nil)
 
 	targetContext.EXPECT().UpdateWorkflowExecutionWithNew(
 		gomock.Any(),
@@ -693,8 +695,8 @@ func (s *transactionMgrForExistingWorkflowSuite) TestDispatchForExistingWorkflow
 	s.mockTransactionMgr.EXPECT().CheckWorkflowExists(ctx, namespaceID, workflowID, newRunID, chasm.WorkflowArchetypeID).Return(true, nil)
 
 	targetWorkflow.EXPECT().HappensAfter(currentWorkflow).Return(false, nil)
-	targetWorkflow.EXPECT().SuppressBy(currentWorkflow).Return(historyi.TransactionPolicyPassive, nil)
-	newWorkflow.EXPECT().SuppressBy(currentWorkflow).Return(historyi.TransactionPolicyPassive, nil)
+	targetWorkflow.EXPECT().SuppressBy(currentWorkflow, gomock.Any()).Return(historyi.TransactionPolicyPassive, nil)
+	newWorkflow.EXPECT().SuppressBy(currentWorkflow, gomock.Any()).Return(historyi.TransactionPolicyPassive, nil)
 
 	targetContext.EXPECT().UpdateWorkflowExecutionWithNew(
 		gomock.Any(),
@@ -821,7 +823,7 @@ func (s *transactionMgrForExistingWorkflowSuite) TestDispatchForExistingWorkflow
 
 	targetWorkflow.EXPECT().HappensAfter(currentWorkflow).Return(true, nil)
 	currentMutableState.EXPECT().IsWorkflowExecutionRunning().Return(true).AnyTimes()
-	currentWorkflow.EXPECT().SuppressBy(targetWorkflow).Return(historyi.TransactionPolicyActive, nil)
+	currentWorkflow.EXPECT().SuppressBy(targetWorkflow, gomock.Any()).Return(historyi.TransactionPolicyActive, nil)
 	targetWorkflow.EXPECT().Revive(gomock.Any(), gomock.Any()).Return(nil)
 
 	targetContext.EXPECT().ConflictResolveWorkflowExecution(
@@ -899,8 +901,8 @@ func (s *transactionMgrForExistingWorkflowSuite) TestDispatchForExistingWorkflow
 	s.mockTransactionMgr.EXPECT().CheckWorkflowExists(ctx, namespaceID, workflowID, newRunID, chasm.WorkflowArchetypeID).Return(false, nil)
 
 	targetWorkflow.EXPECT().HappensAfter(currentWorkflow).Return(false, nil)
-	targetWorkflow.EXPECT().SuppressBy(currentWorkflow).Return(historyi.TransactionPolicyPassive, nil)
-	newWorkflow.EXPECT().SuppressBy(currentWorkflow).Return(historyi.TransactionPolicyPassive, nil)
+	targetWorkflow.EXPECT().SuppressBy(currentWorkflow, gomock.Any()).Return(historyi.TransactionPolicyPassive, nil)
+	newWorkflow.EXPECT().SuppressBy(currentWorkflow, gomock.Any()).Return(historyi.TransactionPolicyPassive, nil)
 
 	targetContext.EXPECT().ConflictResolveWorkflowExecution(
 		gomock.Any(),
@@ -977,8 +979,8 @@ func (s *transactionMgrForExistingWorkflowSuite) TestDispatchForExistingWorkflow
 	s.mockTransactionMgr.EXPECT().CheckWorkflowExists(ctx, namespaceID, workflowID, newRunID, chasm.WorkflowArchetypeID).Return(true, nil)
 
 	targetWorkflow.EXPECT().HappensAfter(currentWorkflow).Return(false, nil)
-	targetWorkflow.EXPECT().SuppressBy(currentWorkflow).Return(historyi.TransactionPolicyPassive, nil)
-	newWorkflow.EXPECT().SuppressBy(currentWorkflow).Return(historyi.TransactionPolicyPassive, nil)
+	targetWorkflow.EXPECT().SuppressBy(currentWorkflow, gomock.Any()).Return(historyi.TransactionPolicyPassive, nil)
+	newWorkflow.EXPECT().SuppressBy(currentWorkflow, gomock.Any()).Return(historyi.TransactionPolicyPassive, nil)
 
 	targetContext.EXPECT().ConflictResolveWorkflowExecution(
 		gomock.Any(),

--- a/service/history/ndc/transaction_manager_new_workflow.go
+++ b/service/history/ndc/transaction_manager_new_workflow.go
@@ -197,6 +197,7 @@ func (r *nDCTransactionMgrForNewWorkflowImpl) createAsZombie(
 
 	targetWorkflowPolicy, err := targetWorkflow.SuppressBy(
 		currentWorkflow,
+		r.shardContext.GetMetricsHandler(),
 	)
 	if err != nil {
 		return err
@@ -281,6 +282,7 @@ func (r *nDCTransactionMgrForNewWorkflowImpl) suppressCurrentAndCreateAsCurrent(
 
 	currentWorkflowPolicy, err := currentWorkflow.SuppressBy(
 		targetWorkflow,
+		r.shardContext.GetMetricsHandler(),
 	)
 	if err != nil {
 		return err

--- a/service/history/ndc/transaction_manager_new_workflow_test.go
+++ b/service/history/ndc/transaction_manager_new_workflow_test.go
@@ -11,6 +11,7 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/service/history/consts"
@@ -43,6 +44,7 @@ func (s *transactionMgrForNewWorkflowSuite) SetupTest() {
 	s.controller = gomock.NewController(s.T())
 	s.mockTransactionMgr = NewMockTransactionManager(s.controller)
 	s.mockShard = historyi.NewMockShardContext(s.controller)
+	s.mockShard.EXPECT().GetMetricsHandler().Return(metrics.NoopMetricsHandler).AnyTimes()
 
 	mockTaskRefresher := workflow.NewMockTaskRefresher(s.controller)
 	mockTaskRefresher.EXPECT().Refresh(gomock.Any(), gomock.Any(), false).Return(nil).AnyTimes()
@@ -258,7 +260,7 @@ func (s *transactionMgrForNewWorkflowSuite) TestDispatchForNewWorkflow_CreateAsZ
 	s.mockTransactionMgr.EXPECT().LoadWorkflow(ctx, namespaceID, workflowID, currentRunID, chasm.WorkflowArchetypeID).Return(currentWorkflow, nil)
 
 	targetWorkflow.EXPECT().HappensAfter(currentWorkflow).Return(false, nil)
-	targetWorkflow.EXPECT().SuppressBy(currentWorkflow).Return(historyi.TransactionPolicyPassive, nil)
+	targetWorkflow.EXPECT().SuppressBy(currentWorkflow, gomock.Any()).Return(historyi.TransactionPolicyPassive, nil)
 
 	targetContext.EXPECT().CreateWorkflowExecution(
 		gomock.Any(),
@@ -338,7 +340,7 @@ func (s *transactionMgrForNewWorkflowSuite) TestDispatchForNewWorkflow_CreateAsZ
 	s.mockTransactionMgr.EXPECT().LoadWorkflow(ctx, namespaceID, workflowID, currentRunID, chasm.WorkflowArchetypeID).Return(currentWorkflow, nil)
 
 	targetWorkflow.EXPECT().HappensAfter(currentWorkflow).Return(false, nil)
-	targetWorkflow.EXPECT().SuppressBy(currentWorkflow).Return(historyi.TransactionPolicyPassive, nil)
+	targetWorkflow.EXPECT().SuppressBy(currentWorkflow, gomock.Any()).Return(historyi.TransactionPolicyPassive, nil)
 
 	targetContext.EXPECT().CreateWorkflowExecution(
 		gomock.Any(),
@@ -409,7 +411,7 @@ func (s *transactionMgrForNewWorkflowSuite) TestDispatchForNewWorkflow_CreateAsZ
 	s.mockTransactionMgr.EXPECT().LoadWorkflow(ctx, namespaceID, workflowID, currentRunID, chasm.WorkflowArchetypeID).Return(currentWorkflow, nil)
 
 	targetWorkflow.EXPECT().HappensAfter(currentWorkflow).Return(false, nil)
-	targetWorkflow.EXPECT().SuppressBy(currentWorkflow).Return(historyi.TransactionPolicyPassive, nil)
+	targetWorkflow.EXPECT().SuppressBy(currentWorkflow, gomock.Any()).Return(historyi.TransactionPolicyPassive, nil)
 
 	targetContext.EXPECT().CreateWorkflowExecution(
 		gomock.Any(),
@@ -471,7 +473,7 @@ func (s *transactionMgrForNewWorkflowSuite) TestDispatchForNewWorkflow_SuppressC
 	targetWorkflow.EXPECT().HappensAfter(currentWorkflow).Return(true, nil)
 	currentMutableState.EXPECT().IsWorkflowExecutionRunning().Return(true).AnyTimes()
 	currentWorkflowPolicy := historyi.TransactionPolicyActive
-	currentWorkflow.EXPECT().SuppressBy(targetWorkflow).Return(currentWorkflowPolicy, nil)
+	currentWorkflow.EXPECT().SuppressBy(targetWorkflow, gomock.Any()).Return(currentWorkflowPolicy, nil)
 	targetWorkflow.EXPECT().Revive(gomock.Any(), gomock.Any()).Return(nil)
 
 	currentContext.EXPECT().UpdateWorkflowExecutionWithNew(

--- a/service/history/ndc/workflow.go
+++ b/service/history/ndc/workflow.go
@@ -13,6 +13,7 @@ import (
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/cluster"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/service/history/consts"
@@ -29,7 +30,7 @@ type (
 
 		HappensAfter(that Workflow) (bool, error)
 		Revive(ctx context.Context, taskRefresher workflow.TaskRefresher) error
-		SuppressBy(incomingWorkflow Workflow) (historyi.TransactionPolicy, error)
+		SuppressBy(incomingWorkflow Workflow, metricsHandler metrics.Handler) (historyi.TransactionPolicy, error)
 		FlushBufferedEvents() error
 	}
 
@@ -139,6 +140,7 @@ func (r *WorkflowImpl) Revive(ctx context.Context, taskRefresher workflow.TaskRe
 
 func (r *WorkflowImpl) SuppressBy(
 	incomingWorkflow Workflow,
+	metricsHandler metrics.Handler,
 ) (historyi.TransactionPolicy, error) {
 
 	// NOTE: READ BEFORE MODIFICATION
@@ -175,7 +177,7 @@ func (r *WorkflowImpl) SuppressBy(
 	currentCluster := r.clusterMetadata.GetCurrentClusterName()
 
 	if currentCluster == lastWriteCluster {
-		return historyi.TransactionPolicyActive, r.terminateMutableState(lastWriteVersion, incomingLastWriteVersion)
+		return historyi.TransactionPolicyActive, r.terminateMutableState(lastWriteVersion, incomingLastWriteVersion, metricsHandler)
 	}
 	_, err = r.mutableState.UpdateWorkflowStateStatus(
 		enumsspb.WORKFLOW_EXECUTION_STATE_ZOMBIE,
@@ -266,6 +268,7 @@ func (r *WorkflowImpl) failWorkflowTask() (*historypb.HistoryEvent, error) {
 func (r *WorkflowImpl) terminateMutableState(
 	lastWriteVersion int64,
 	incomingLastWriteVersion int64,
+	metricsHandler metrics.Handler,
 ) error {
 
 	if err := r.mutableState.UpdateCurrentVersion(lastWriteVersion, true); err != nil {
@@ -273,13 +276,23 @@ func (r *WorkflowImpl) terminateMutableState(
 	}
 
 	if !r.mutableState.IsWorkflow() {
-		return r.mutableState.ChasmTree().Terminate(chasm.TerminateComponentRequest{
-			Identity:  consts.IdentityHistoryService,
-			Reason:    common.FailureReasonWorkflowTerminationDueToVersionConflict,
-			Details:   payloads.EncodeString(fmt.Sprintf("terminated by version: %v", incomingLastWriteVersion)),
-			RequestID: primitives.NewUUID().String(),
-		})
+		return r.mutableState.ChasmTree().Terminate(
+			chasm.TerminateComponentRequest{
+				Identity:  consts.IdentityHistoryService,
+				Reason:    common.FailureReasonWorkflowTerminationDueToVersionConflict,
+				Details:   payloads.EncodeString(fmt.Sprintf("terminated by version: %v", incomingLastWriteVersion)),
+				RequestID: primitives.NewUUID().String(),
+			},
+			chasm.ExecutionForceTerminationReasonVersionConflict,
+		)
 	}
+
+	metrics.ExecutionForceTerminations.With(metricsHandler).Record(
+		1,
+		metrics.NamespaceTag(r.mutableState.GetNamespaceEntry().Name().String()),
+		metrics.ArchetypeTag(chasm.WorkflowArchetype),
+		metrics.ReasonTag(chasm.ExecutionForceTerminationReasonVersionConflict),
+	)
 
 	if _, err := r.failWorkflowTask(); err != nil {
 		return err

--- a/service/history/ndc/workflow_mock.go
+++ b/service/history/ndc/workflow_mock.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	metrics "go.temporal.io/server/common/metrics"
 	interfaces "go.temporal.io/server/service/history/interfaces"
 	workflow "go.temporal.io/server/service/history/workflow"
 	gomock "go.uber.org/mock/gomock"
@@ -144,16 +145,16 @@ func (mr *MockWorkflowMockRecorder) Revive(ctx, taskRefresher any) *gomock.Call 
 }
 
 // SuppressBy mocks base method.
-func (m *MockWorkflow) SuppressBy(incomingWorkflow Workflow) (interfaces.TransactionPolicy, error) {
+func (m *MockWorkflow) SuppressBy(incomingWorkflow Workflow, metricsHandler metrics.Handler) (interfaces.TransactionPolicy, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SuppressBy", incomingWorkflow)
+	ret := m.ctrl.Call(m, "SuppressBy", incomingWorkflow, metricsHandler)
 	ret0, _ := ret[0].(interfaces.TransactionPolicy)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SuppressBy indicates an expected call of SuppressBy.
-func (mr *MockWorkflowMockRecorder) SuppressBy(incomingWorkflow any) *gomock.Call {
+func (mr *MockWorkflowMockRecorder) SuppressBy(incomingWorkflow, metricsHandler any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SuppressBy", reflect.TypeOf((*MockWorkflow)(nil).SuppressBy), incomingWorkflow)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SuppressBy", reflect.TypeOf((*MockWorkflow)(nil).SuppressBy), incomingWorkflow, metricsHandler)
 }

--- a/service/history/ndc/workflow_test.go
+++ b/service/history/ndc/workflow_test.go
@@ -14,6 +14,8 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/cluster"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/service/history/consts"
 	historyi "go.temporal.io/server/service/history/interfaces"
 	wcache "go.temporal.io/server/service/history/workflow/cache"
@@ -195,7 +197,7 @@ func (s *workflowSuite) TestSuppressWorkflowBy_Error() {
 		RunId: incomingRunID,
 	}).AnyTimes()
 
-	_, err := nDCWorkflow.SuppressBy(incomingNDCWorkflow)
+	_, err := nDCWorkflow.SuppressBy(incomingNDCWorkflow, metrics.NoopMetricsHandler)
 	s.Error(err)
 }
 
@@ -246,6 +248,11 @@ func (s *workflowSuite) TestSuppressWorkflowBy_Terminate() {
 
 	s.mockMutableState.EXPECT().IsWorkflow().Return(true).AnyTimes()
 	s.mockMutableState.EXPECT().UpdateCurrentVersion(lastEventVersion, true).Return(nil).AnyTimes()
+	s.mockMutableState.EXPECT().GetNamespaceEntry().Return(namespace.NewLocalNamespaceForTest(
+		&persistencespb.NamespaceInfo{Name: "test-namespace"},
+		nil,
+		cluster.TestCurrentClusterName,
+	)).AnyTimes()
 	startedWorkflowTask := &historyi.WorkflowTaskInfo{
 		Version:          1234,
 		ScheduledEventID: 5678,
@@ -272,13 +279,13 @@ func (s *workflowSuite) TestSuppressWorkflowBy_Terminate() {
 	// if workflow is in zombie or finished state, keep as is
 	s.mockMutableState.EXPECT().IsWorkflowExecutionRunning().Return(false).Times(2)
 	s.mockMutableState.EXPECT().GetCloseVersion().Return(lastEventVersion, nil)
-	policy, err := nDCWorkflow.SuppressBy(incomingNDCWorkflow)
+	policy, err := nDCWorkflow.SuppressBy(incomingNDCWorkflow, metrics.NoopMetricsHandler)
 	s.NoError(err)
 	s.Equal(historyi.TransactionPolicyPassive, policy)
 
 	s.mockMutableState.EXPECT().IsWorkflowExecutionRunning().Return(true).Times(2)
 	s.mockMutableState.EXPECT().GetLastWriteVersion().Return(lastEventVersion, nil)
-	policy, err = nDCWorkflow.SuppressBy(incomingNDCWorkflow)
+	policy, err = nDCWorkflow.SuppressBy(incomingNDCWorkflow, metrics.NoopMetricsHandler)
 	s.NoError(err)
 	s.Equal(historyi.TransactionPolicyActive, policy)
 }
@@ -336,13 +343,13 @@ func (s *workflowSuite) TestSuppressWorkflowBy_Zombiefy() {
 	// if workflow is in zombie or finished state, keep as is
 	s.mockMutableState.EXPECT().IsWorkflowExecutionRunning().Return(false).Times(2)
 	s.mockMutableState.EXPECT().GetCloseVersion().Return(lastEventVersion, nil).AnyTimes()
-	policy, err := nDCWorkflow.SuppressBy(incomingNDCWorkflow)
+	policy, err := nDCWorkflow.SuppressBy(incomingNDCWorkflow, metrics.NoopMetricsHandler)
 	s.NoError(err)
 	s.Equal(historyi.TransactionPolicyPassive, policy)
 
 	s.mockMutableState.EXPECT().IsWorkflowExecutionRunning().Return(true).Times(2)
 	s.mockMutableState.EXPECT().GetLastWriteVersion().Return(lastEventVersion, nil).AnyTimes()
-	policy, err = nDCWorkflow.SuppressBy(incomingNDCWorkflow)
+	policy, err = nDCWorkflow.SuppressBy(incomingNDCWorkflow, metrics.NoopMetricsHandler)
 	s.NoError(err)
 	s.Equal(historyi.TransactionPolicyPassive, policy)
 	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_ZOMBIE, executionState.State)

--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -1292,7 +1292,12 @@ func (c *ContextImpl) enforceHistorySizeCheck(
 ) (bool, error) {
 	// Hard terminate workflow if still running and breached history size limit
 	if c.maxHistorySizeExceeded(shardContext) {
-		if err := c.forceTerminateWorkflow(ctx, shardContext, common.FailureReasonHistorySizeExceedsLimit); err != nil {
+		if err := c.forceTerminateWorkflow(
+			ctx,
+			shardContext,
+			common.FailureReasonHistorySizeExceedsLimit,
+			chasm.ExecutionForceTerminationReasonHistorySizeExceedsLimit,
+		); err != nil {
 			return false, err
 		}
 		// Return true to caller to indicate workflow state is overwritten to force terminate execution on update
@@ -1330,7 +1335,12 @@ func (c *ContextImpl) enforceHistoryCountCheck(
 ) (bool, error) {
 	// Hard terminate workflow if still running and breached history count limit
 	if c.maxHistoryCountExceeded(shardContext) {
-		if err := c.forceTerminateWorkflow(ctx, shardContext, common.FailureReasonHistoryCountExceedsLimit); err != nil {
+		if err := c.forceTerminateWorkflow(
+			ctx,
+			shardContext,
+			common.FailureReasonHistoryCountExceedsLimit,
+			chasm.ExecutionForceTerminationReasonHistoryCountExceedsLimit,
+		); err != nil {
 			return false, err
 		}
 		// Return true to caller to indicate workflow state is overwritten to force terminate execution on update
@@ -1366,7 +1376,12 @@ func (c *ContextImpl) maxHistoryCountExceeded(shardContext historyi.ShardContext
 // TODO: ideally this check should be after closing mutable state tx, but that would require a large refactor
 func (c *ContextImpl) enforceMutableStateSizeCheck(ctx context.Context, shardContext historyi.ShardContext) (bool, error) {
 	if c.maxMutableStateSizeExceeded(shardContext.ChasmRegistry()) {
-		if err := c.forceTerminateWorkflow(ctx, shardContext, common.FailureReasonMutableStateSizeExceedsLimit); err != nil {
+		if err := c.forceTerminateWorkflow(
+			ctx,
+			shardContext,
+			common.FailureReasonMutableStateSizeExceedsLimit,
+			chasm.ExecutionForceTerminationReasonMutableStateSizeExceedsLimit,
+		); err != nil {
 			return false, err
 		}
 		// Return true to caller to indicate workflow state is overwritten to force terminate execution on update
@@ -1407,6 +1422,7 @@ func (c *ContextImpl) forceTerminateWorkflow(
 	ctx context.Context,
 	shardContext historyi.ShardContext,
 	failureReason string,
+	metricReasonString metrics.ReasonString,
 ) error {
 	if !c.MutableState.IsWorkflowExecutionRunning() {
 		return nil
@@ -1427,21 +1443,26 @@ func (c *ContextImpl) forceTerminateWorkflow(
 	}
 
 	if !mutableState.IsWorkflow() {
-		return mutableState.ChasmTree().Terminate(chasm.TerminateComponentRequest{
-			Identity:  consts.IdentityHistoryService,
-			Reason:    failureReason,
-			Details:   nil,
-			RequestID: primitives.NewUUID().String(),
-		})
+		return mutableState.ChasmTree().Terminate(
+			chasm.TerminateComponentRequest{
+				Identity:  consts.IdentityHistoryService,
+				Reason:    failureReason,
+				Details:   nil,
+				RequestID: primitives.NewUUID().String(),
+			},
+			metricReasonString,
+		)
 	}
 
-	return TerminateWorkflow(
+	return ForceTerminateWorkflow(
 		mutableState,
 		failureReason,
 		nil,
 		consts.IdentityHistoryService,
 		false,
 		nil, // No links necessary.
+		shardContext.GetMetricsHandler(),
+		metricReasonString,
 	)
 }
 

--- a/service/history/workflow/noop_chasm_tree.go
+++ b/service/history/workflow/noop_chasm_tree.go
@@ -7,6 +7,7 @@ import (
 	"go.temporal.io/api/serviceerror"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/common/metrics"
 	historyi "go.temporal.io/server/service/history/interfaces"
 	"go.temporal.io/server/service/history/tasks"
 )
@@ -53,7 +54,7 @@ func (*noopChasmTree) IsDirty() bool {
 	return false
 }
 
-func (*noopChasmTree) Terminate(chasm.TerminateComponentRequest) error {
+func (*noopChasmTree) Terminate(chasm.TerminateComponentRequest, metrics.ReasonString) error {
 	return nil
 }
 

--- a/service/history/workflow/util.go
+++ b/service/history/workflow/util.go
@@ -11,9 +11,11 @@ import (
 	workflowpb "go.temporal.io/api/workflow/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/chasm"
 	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/effect"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/worker_versioning"
 	"go.temporal.io/server/components/callbacks"
@@ -122,6 +124,41 @@ func TerminateWorkflow(
 		links,
 	)
 	return err
+}
+
+func ForceTerminateWorkflow(
+	mutableState historyi.MutableState,
+	terminateReason string,
+	terminateDetails *commonpb.Payloads,
+	terminateIdentity string,
+	deleteAfterTerminate bool,
+	links []*commonpb.Link,
+	metricsHandler metrics.Handler,
+	forceTerminationReason metrics.ReasonString,
+) error {
+	if err := TerminateWorkflow(
+		mutableState,
+		terminateReason,
+		terminateDetails,
+		terminateIdentity,
+		deleteAfterTerminate,
+		links,
+	); err != nil {
+		return err
+	}
+
+	namespaceName := ""
+	if namespaceEntry := mutableState.GetNamespaceEntry(); namespaceEntry != nil {
+		namespaceName = namespaceEntry.Name().String()
+	}
+
+	metrics.ExecutionForceTerminations.With(metricsHandler).Record(
+		1,
+		metrics.NamespaceTag(namespaceName),
+		metrics.ArchetypeTag(chasm.WorkflowArchetype),
+		metrics.ReasonTag(forceTerminationReason),
+	)
+	return nil
 }
 
 // FindAutoResetPoint returns the auto reset point

--- a/service/history/workflow/util_test.go
+++ b/service/history/workflow/util_test.go
@@ -1,0 +1,57 @@
+package workflow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	historypb "go.temporal.io/api/history/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/metrics/metricstest"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/service/history/consts"
+	historyi "go.temporal.io/server/service/history/interfaces"
+	"go.uber.org/mock/gomock"
+)
+
+func TestForceTerminateWorkflowRecordsMetric(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mutableState := historyi.NewMockMutableState(ctrl)
+	mutableState.EXPECT().GetStartedWorkflowTask().Return(nil)
+	mutableState.EXPECT().AddWorkflowExecutionTerminatedEvent(
+		"force terminate",
+		nil,
+		consts.IdentityHistoryService,
+		false,
+		nil,
+	).Return(&historypb.HistoryEvent{}, nil)
+	mutableState.EXPECT().GetNamespaceEntry().Return(namespace.NewLocalNamespaceForTest(
+		&persistencespb.NamespaceInfo{Name: "test-namespace"},
+		nil,
+		"active",
+	))
+
+	metricsHandler := metricstest.NewCaptureHandler()
+	capture := metricsHandler.StartCapture()
+	defer metricsHandler.StopCapture(capture)
+
+	err := ForceTerminateWorkflow(
+		mutableState,
+		"force terminate",
+		nil,
+		consts.IdentityHistoryService,
+		false,
+		nil,
+		metricsHandler,
+		chasm.ExecutionForceTerminationReasonEventBatchSizeExceedsLimit,
+	)
+	require.NoError(t, err)
+
+	recordings := capture.Snapshot()[metrics.ExecutionForceTerminations.Name()]
+	require.Len(t, recordings, 1)
+	require.Equal(t, int64(1), recordings[0].Value)
+	require.Equal(t, "test-namespace", recordings[0].Tags["namespace"])
+	require.Equal(t, string(chasm.WorkflowArchetype), recordings[0].Tags["archetype"])
+	require.Equal(t, string(chasm.ExecutionForceTerminationReasonEventBatchSizeExceedsLimit), recordings[0].Tags["reason"])
+}


### PR DESCRIPTION
## What changed?
- Emit force termination metric tag with namespace, archetype and reason.
- This only includes executions terminated due to system/CHASM framework reason, not any application/workflow specific reasons. For example, terminating workflow due to certain workflow task failure reason are NOT considered as a system reason and does NOT have the metric emitted. 

## Why?
- Better observability into force terminations

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
- Metric change only.
