### PR TITLE
Validate cron schedule in SignalWithStart request validator

### DIFF
--- a/chasm/lib/workflow/validator.go
+++ b/chasm/lib/workflow/validator.go
@@ -8,6 +8,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/enums"
 	commonlinks "go.temporal.io/server/common/links"
 	"go.temporal.io/server/common/primitives/timestamp"
@@ -187,6 +188,10 @@ func (v *RequestValidator) ValidateSignalWithStartRequest(request *workflowservi
 	}
 
 	if err := v.ValidateRetryPolicy(request.GetNamespace(), request.RetryPolicy); err != nil {
+		return err
+	}
+
+	if err := backoff.ValidateSchedule(request.GetCronSchedule()); err != nil {
 		return err
 	}
 

--- a/chasm/lib/workflow/validator_test.go
+++ b/chasm/lib/workflow/validator_test.go
@@ -150,6 +150,20 @@ func TestValidateSignalWithStartRequest(t *testing.T) {
 		require.ErrorContains(t, err, "WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE cannot be used together with WorkflowIdConflictPolicy WORKFLOW_ID_CONFLICT_POLICY_TERMINATE_EXISTING")
 	})
 
+	t.Run("ValidCronSchedule", func(t *testing.T) {
+		req := validSWSRequest()
+		req.CronSchedule = "0 * * * *"
+		err := v.ValidateSignalWithStartRequest(req)
+		require.NoError(t, err)
+	})
+
+	t.Run("InvalidCronSchedule", func(t *testing.T) {
+		req := validSWSRequest()
+		req.CronSchedule = "not-a-cron-schedule"
+		err := v.ValidateSignalWithStartRequest(req)
+		require.ErrorContains(t, err, "invalid CronSchedule")
+	})
+
 	t.Run("CronAndStartDelaySetTogether", func(t *testing.T) {
 		req := validSWSRequest()
 		req.CronSchedule = "0 * * * *"

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -2368,10 +2368,6 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(ctx context.Context,
 		return nil, errRequestNotSet
 	}
 
-	if err := backoff.ValidateSchedule(request.GetCronSchedule()); err != nil {
-		return nil, err
-	}
-
 	// The validator will modify the request proto if there are any search attributes to validate.
 	// To avoid modifying the caller's object, which may be reused on retry, we clone the request here if needed.
 	if len(request.GetSearchAttributes().GetIndexedFields()) > 0 {


### PR DESCRIPTION
## What changed?
Move backoff.ValidateSchedule from the frontend handler to
the shared RequestValidator.ValidateSignalWithStartRequest.
Update unit test.

## Why?
Fixes #11822

This allows System Nexus/CHASM to also validate the cron strings.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)