### PR TITLE
Restore linting for legacy HSM packages

### DIFF
--- a/.github/.golangci.yml
+++ b/.github/.golangci.yml
@@ -171,7 +171,6 @@ linters:
       - ^api
       - ^proto
       - ^.git
-      - ^\.\./service/history/hsm/(callbacks|dummy|nexusoperations)/
     rules:
       - path-except: _test\.go|tests/.+\.go
         text: "time.Sleep"

--- a/service/history/hsm/callbacks/request_test.go
+++ b/service/history/hsm/callbacks/request_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/nexus-rpc/sdk-go/nexus"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/api/serviceerror"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
@@ -130,7 +129,9 @@ func TestRouteRequest_SourceHeaderUnknownCluster(t *testing.T) {
 func TestRouteSystemCallbackRequest_NilHeaders(t *testing.T) {
 	// When the request has nil headers, it should fall back to the local client.
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, commonnexus.PathCompletionCallbackNoIdentifier, r.URL.Path)
+		if r.URL.Path != commonnexus.PathCompletionCallbackNoIdentifier {
+			t.Errorf("unexpected request path: %q", r.URL.Path)
+		}
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer ts.Close()
@@ -239,7 +240,9 @@ func TestRouteSystemCallbackRequest_NamespaceNotFound(t *testing.T) {
 
 func TestRouteSystemCallbackRequest_Success(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, commonnexus.PathCompletionCallbackNoIdentifier, r.URL.Path)
+		if r.URL.Path != commonnexus.PathCompletionCallbackNoIdentifier {
+			t.Errorf("unexpected request path: %q", r.URL.Path)
+		}
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer ts.Close()
@@ -295,7 +298,9 @@ func TestRouteSystemCallbackRequest_Success(t *testing.T) {
 func TestRouteRequest_SystemCallback(t *testing.T) {
 	// Verify that routeRequest delegates to routeSystemCallbackRequest for system callback URLs.
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, commonnexus.PathCompletionCallbackNoIdentifier, r.URL.Path)
+		if r.URL.Path != commonnexus.PathCompletionCallbackNoIdentifier {
+			t.Errorf("unexpected request path: %q", r.URL.Path)
+		}
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer ts.Close()

--- a/service/history/hsm/callbacks/statemachine.go
+++ b/service/history/hsm/callbacks/statemachine.go
@@ -47,7 +47,7 @@ func NewWorkflowClosedTrigger() *persistencespb.CallbackInfo_Trigger {
 
 // NewCallback creates a new callback in the STANDBY state from given params.
 func NewCallback(
-	requestId string,
+	requestID string,
 	registrationTime *timestamppb.Timestamp,
 	trigger *persistencespb.CallbackInfo_Trigger,
 	cb *persistencespb.Callback,
@@ -58,7 +58,7 @@ func NewCallback(
 			Callback:         cb,
 			State:            enumsspb.CALLBACK_STATE_STANDBY,
 			RegistrationTime: registrationTime,
-			RequestId:        requestId,
+			RequestId:        requestID,
 		},
 	}
 }
@@ -71,9 +71,9 @@ func (c Callback) SetState(state enumsspb.CallbackState) {
 	c.CallbackInfo.State = state
 }
 
-func (c Callback) recordAttempt(ts time.Time) {
-	c.CallbackInfo.Attempt++
-	c.CallbackInfo.LastAttemptCompleteTime = timestamppb.New(ts)
+func (c *Callback) recordAttempt(ts time.Time) {
+	c.Attempt++
+	c.LastAttemptCompleteTime = timestamppb.New(ts)
 }
 
 func (c Callback) RegenerateTasks(*hsm.Node) ([]hsm.Task, error) {
@@ -95,8 +95,9 @@ func (c Callback) RegenerateTasks(*hsm.Node) ([]hsm.Task, error) {
 		default:
 			return nil, fmt.Errorf("unsupported callback variant %v", v)
 		}
+	default:
+		return nil, nil
 	}
-	return nil, nil
 }
 
 func (c Callback) output() (hsm.TransitionOutput, error) {
@@ -201,7 +202,7 @@ var TransitionRescheduled = hsm.NewTransition(
 	[]enumsspb.CallbackState{enumsspb.CALLBACK_STATE_BACKING_OFF},
 	enumsspb.CALLBACK_STATE_SCHEDULED,
 	func(cb Callback, event EventRescheduled) (hsm.TransitionOutput, error) {
-		cb.CallbackInfo.NextAttemptScheduleTime = nil
+		cb.NextAttemptScheduleTime = nil
 		return cb.output()
 	},
 )
@@ -221,8 +222,8 @@ var TransitionAttemptFailed = hsm.NewTransition(
 		// Use 0 for elapsed time as we don't limit the retry by time (for now).
 		nextDelay := event.RetryPolicy.ComputeNextDelay(0, int(cb.Attempt), event.Err)
 		nextAttemptScheduleTime := event.Time.Add(nextDelay)
-		cb.CallbackInfo.NextAttemptScheduleTime = timestamppb.New(nextAttemptScheduleTime)
-		cb.CallbackInfo.LastAttemptFailure = &failurepb.Failure{
+		cb.NextAttemptScheduleTime = timestamppb.New(nextAttemptScheduleTime)
+		cb.LastAttemptFailure = &failurepb.Failure{
 			Message: event.Err.Error(),
 			FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
 				ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
@@ -245,7 +246,7 @@ var TransitionFailed = hsm.NewTransition(
 	enumsspb.CALLBACK_STATE_FAILED,
 	func(cb Callback, event EventFailed) (hsm.TransitionOutput, error) {
 		cb.recordAttempt(event.Time)
-		cb.CallbackInfo.LastAttemptFailure = &failurepb.Failure{
+		cb.LastAttemptFailure = &failurepb.Failure{
 			Message: event.Err.Error(),
 			FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
 				ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
@@ -267,7 +268,7 @@ var TransitionSucceeded = hsm.NewTransition(
 	enumsspb.CALLBACK_STATE_SUCCEEDED,
 	func(cb Callback, event EventSucceeded) (hsm.TransitionOutput, error) {
 		cb.recordAttempt(event.Time)
-		cb.CallbackInfo.LastAttemptFailure = nil
+		cb.LastAttemptFailure = nil
 		return cb.output()
 	},
 )

--- a/service/history/hsm/callbacks/statemachine_test.go
+++ b/service/history/hsm/callbacks/statemachine_test.go
@@ -1,7 +1,7 @@
 package callbacks_test
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 	"time"
 
@@ -32,7 +32,7 @@ func TestValidTransitions(t *testing.T) {
 	// AttemptFailed
 	out, err := callbacks.TransitionAttemptFailed.Apply(callback, callbacks.EventAttemptFailed{
 		Time:        currentTime,
-		Err:         fmt.Errorf("test"),
+		Err:         errors.New("test"),
 		RetryPolicy: backoff.NewExponentialRetryPolicy(time.Second),
 	})
 	require.NoError(t, err)
@@ -92,7 +92,7 @@ func TestValidTransitions(t *testing.T) {
 	currentTime = currentTime.Add(time.Second)
 
 	// failed
-	out, err = callbacks.TransitionFailed.Apply(callback, callbacks.EventFailed{Time: currentTime, Err: fmt.Errorf("failed")})
+	out, err = callbacks.TransitionFailed.Apply(callback, callbacks.EventFailed{Time: currentTime, Err: errors.New("failed")})
 	require.NoError(t, err)
 
 	// Assert info object is updated only where needed

--- a/service/history/hsm/nexusoperations/completion.go
+++ b/service/history/hsm/nexusoperations/completion.go
@@ -151,7 +151,7 @@ func fabricateStartedEventIfMissing(
 				ScheduledEventId: eventID,
 				OperationToken:   operationToken,
 				// TODO(bergundy): Remove this fallback after the 1.27 release.
-				OperationId: operationToken,
+				OperationId: operationToken, //nolint:staticcheck // Retained for compatibility with older servers.
 				RequestId:   requestID,
 			},
 		}

--- a/service/history/hsm/nexusoperations/events.go
+++ b/service/history/hsm/nexusoperations/events.go
@@ -329,14 +329,14 @@ func findOperationNode(root *hsm.Node, event *historypb.HistoryEvent) (*hsm.Node
 
 	// Attributes is always a struct with a single field (e.g: HistoryEvent_NexusOperationScheduledEventAttributes)
 	if attrs.Kind() != reflect.Struct || attrs.NumField() != 1 {
-		panic("invalid event, expected Attributes field with a single field struct")
+		panic("invalid event, expected Attributes field with a single field struct") //nolint:forbidigo // The history event shape is an HSM invariant.
 	}
 
 	f := attrs.Field(0).Interface()
 
 	eventIDGetter, ok := f.(interface{ GetScheduledEventId() int64 })
 	if !ok {
-		panic("Event does not have a ScheduledEventId field")
+		panic("Event does not have a ScheduledEventId field") //nolint:forbidigo // The history event shape is an HSM invariant.
 	}
 	coll := MachineCollection(root)
 	nodeID := strconv.FormatInt(eventIDGetter.GetScheduledEventId(), 10)

--- a/service/history/hsm/nexusoperations/events_test.go
+++ b/service/history/hsm/nexusoperations/events_test.go
@@ -180,6 +180,8 @@ func TestTerminalStatesDeletion(t *testing.T) {
 				a.ScheduledEventId = eventID
 			case *historypb.NexusOperationTimedOutEventAttributes:
 				a.ScheduledEventId = eventID
+			default:
+				require.FailNowf(t, "unexpected attributes type", "%T", a)
 			}
 
 			event := &historypb.HistoryEvent{

--- a/service/history/hsm/nexusoperations/executors.go
+++ b/service/history/hsm/nexusoperations/executors.go
@@ -165,6 +165,7 @@ func buildCallbackFromTemplate(callbackTemplate string, ns *namespace.Namespace)
 	return builder.String(), nil
 }
 
+//nolint:revive // The legacy executor is kept intact while existing HSM operations remain loadable.
 func (e taskExecutor) executeInvocationTask(ctx context.Context, env hsm.Environment, ref hsm.Ref, task InvocationTask) error {
 	ns, err := e.NamespaceRegistry.GetNamespaceByID(namespace.ID(ref.WorkflowKey.NamespaceID))
 	if err != nil {
@@ -467,7 +468,7 @@ func (e taskExecutor) saveStartedResult(env hsm.Environment, node *hsm.Node, ope
 				ScheduledEventId: eventID,
 				OperationToken:   result.Pending.Token,
 				// TODO(bergundy): Remove this fallback after the 1.27 release.
-				OperationId: result.Pending.Token,
+				OperationId: result.Pending.Token, //nolint:staticcheck // Retained for compatibility with older servers.
 				RequestId:   operation.RequestId,
 			},
 		}
@@ -679,6 +680,7 @@ func (e taskExecutor) recordOperationTimeout(node *hsm.Node, timeoutType enumspb
 	})
 }
 
+//nolint:revive // The legacy executor is kept intact while existing HSM operations remain loadable.
 func (e taskExecutor) executeCancelationTask(ctx context.Context, env hsm.Environment, ref hsm.Ref, task CancelationTask) error {
 	ns, err := e.NamespaceRegistry.GetNamespaceByID(namespace.ID(ref.WorkflowKey.NamespaceID))
 	if err != nil {
@@ -861,6 +863,7 @@ func (e taskExecutor) loadArgsForCancelation(ctx context.Context, env hsm.Enviro
 	return
 }
 
+//nolint:revive // The legacy executor is kept intact while existing HSM operations remain loadable.
 func (e taskExecutor) saveCancelationResult(ctx context.Context, env hsm.Environment, ref hsm.Ref, callErr error, scheduledEventID int64) error {
 	return env.Access(ctx, ref, hsm.AccessWrite, func(n *hsm.Node) error {
 		return hsm.MachineTransition(n, func(c Cancelation) (hsm.TransitionOutput, error) {
@@ -957,7 +960,7 @@ func createNexusOperationFailure(operation Operation, scheduledEventID int64, ca
 				Operation:      operation.Operation,
 				OperationToken: operation.OperationToken,
 				// TODO(bergundy): This field is deprecated, remove it after the 1.27 release.
-				OperationId:      operation.OperationToken,
+				OperationId:      operation.OperationToken, //nolint:staticcheck // Retained for compatibility with older servers.
 				ScheduledEventId: scheduledEventID,
 			},
 		},

--- a/service/history/hsm/nexusoperations/executors_test.go
+++ b/service/history/hsm/nexusoperations/executors_test.go
@@ -153,7 +153,7 @@ func TestProcessInvocationTask(t *testing.T) {
 				protorequire.ProtoEqual(t, &historypb.NexusOperationStartedEventAttributes{
 					ScheduledEventId: 1,
 					OperationToken:   "op-token",
-					OperationId:      "op-token",
+					OperationId:      "op-token", //nolint:staticcheck // Verify compatibility with older servers.
 					RequestId:        op.RequestId,
 				}, events[0].GetNexusOperationStartedEventAttributes())
 				require.Len(t, events[0].Links, 1)
@@ -407,7 +407,7 @@ func TestProcessInvocationTask(t *testing.T) {
 			destinationDown:       true,
 			expectedMetricOutcome: "request-timeout",
 			onStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
-				time.Sleep(time.Millisecond * 100)
+				time.Sleep(time.Millisecond * 100) //nolint:forbidigo // Allow time.Sleep for timeout tests
 				return &nexus.HandlerStartOperationResultAsync{OperationToken: "op-token"}, nil
 			},
 			checkOutcome: func(t *testing.T, op nexusoperations.Operation, events []*historypb.HistoryEvent) {
@@ -1701,7 +1701,7 @@ func TestProcessInvocationTask_SystemEndpoint(t *testing.T) {
 				protorequire.ProtoEqual(t, &historypb.NexusOperationStartedEventAttributes{
 					ScheduledEventId: 1,
 					OperationToken:   "system-op-token",
-					OperationId:      "system-op-token",
+					OperationId:      "system-op-token", //nolint:staticcheck // Verify compatibility with older servers.
 					RequestId:        op.RequestId,
 				}, events[0].GetNexusOperationStartedEventAttributes())
 				require.Len(t, events[0].Links, 1)

--- a/service/history/hsm/nexusoperations/statemachine.go
+++ b/service/history/hsm/nexusoperations/statemachine.go
@@ -88,10 +88,10 @@ func (o Operation) SetState(state enumsspb.NexusOperationState) {
 	o.NexusOperationInfo.State = state
 }
 
-func (o Operation) recordAttempt(ts time.Time) {
-	o.NexusOperationInfo.Attempt++
-	o.NexusOperationInfo.LastAttemptCompleteTime = timestamppb.New(ts)
-	o.NexusOperationInfo.LastAttemptFailure = nil
+func (o *Operation) recordAttempt(ts time.Time) {
+	o.Attempt++
+	o.LastAttemptCompleteTime = timestamppb.New(ts)
+	o.LastAttemptFailure = nil
 }
 
 func (o Operation) cancelRequested(node *hsm.Node) (bool, error) {
@@ -534,10 +534,10 @@ func (c Cancelation) SetState(state enumspb.NexusOperationCancellationState) {
 	c.NexusOperationCancellationInfo.State = state
 }
 
-func (c Cancelation) recordAttempt(ts time.Time) {
-	c.NexusOperationCancellationInfo.Attempt++
-	c.NexusOperationCancellationInfo.LastAttemptCompleteTime = timestamppb.New(ts)
-	c.NexusOperationCancellationInfo.LastAttemptFailure = nil
+func (c *Cancelation) recordAttempt(ts time.Time) {
+	c.Attempt++
+	c.LastAttemptCompleteTime = timestamppb.New(ts)
+	c.LastAttemptFailure = nil
 }
 
 func (c Cancelation) RegenerateTasks(node *hsm.Node) ([]hsm.Task, error) {

--- a/service/history/hsm/nexusoperations/statemachine_test.go
+++ b/service/history/hsm/nexusoperations/statemachine_test.go
@@ -297,7 +297,8 @@ func TestRegenerateTasks(t *testing.T) {
 			}
 			node := newOperationNode(t, &hsmtest.NodeBackend{}, event)
 
-			if tc.state == enumsspb.NEXUS_OPERATION_STATE_BACKING_OFF {
+			switch tc.state {
+			case enumsspb.NEXUS_OPERATION_STATE_BACKING_OFF:
 				require.NoError(t, hsm.MachineTransition(node, func(op nexusoperations.Operation) (hsm.TransitionOutput, error) {
 					return nexusoperations.TransitionAttemptFailed.Apply(op, nexusoperations.EventAttemptFailed{
 						Time:        time.Now(),
@@ -306,7 +307,7 @@ func TestRegenerateTasks(t *testing.T) {
 						RetryPolicy: backoff.NewExponentialRetryPolicy(time.Second),
 					})
 				}))
-			} else if tc.state == enumsspb.NEXUS_OPERATION_STATE_STARTED {
+			case enumsspb.NEXUS_OPERATION_STATE_STARTED:
 				require.NoError(t, hsm.MachineTransition(node, func(op nexusoperations.Operation) (hsm.TransitionOutput, error) {
 					return nexusoperations.TransitionStarted.Apply(op, nexusoperations.EventStarted{
 						Time: time.Now(),
@@ -316,6 +317,9 @@ func TestRegenerateTasks(t *testing.T) {
 						},
 					})
 				}))
+			case enumsspb.NEXUS_OPERATION_STATE_SCHEDULED:
+			default:
+				require.FailNowf(t, "unexpected operation state", "%v", tc.state)
 			}
 
 			op, err := hsm.MachineData[nexusoperations.Operation](node)

--- a/service/history/hsm/nexusoperations/workflow/commands.go
+++ b/service/history/hsm/nexusoperations/workflow/commands.go
@@ -31,6 +31,7 @@ type commandHandler struct {
 	nexusProcessor   *chasm.NexusEndpointProcessor
 }
 
+//nolint:revive // The legacy handler is kept intact while existing HSM operations remain loadable.
 func (ch *commandHandler) HandleScheduleCommand(
 	ctx context.Context,
 	ms historyi.MutableState,
@@ -260,17 +261,16 @@ func (ch *commandHandler) HandleCancelCommand(
 	node, err := coll.Node(nodeID)
 	hasBufferedEvent := ms.HasAnyBufferedEvent(makeNexusOperationTerminalEventFilter(attrs.ScheduledEventId))
 	if err != nil {
-		if errors.Is(err, hsm.ErrStateMachineNotFound) {
-			if !hasBufferedEvent {
-				return chasmworkflow.FailWorkflowTaskError{
-					Cause:   enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_REQUEST_CANCEL_NEXUS_OPERATION_ATTRIBUTES,
-					Message: fmt.Sprintf("requested cancelation for a non-existing or already completed operation with scheduled event ID of %d", attrs.ScheduledEventId),
-				}
-			}
-			// Fallthrough and apply the event, there's special logic that will handle state machine not found below.
-		} else {
+		if !errors.Is(err, hsm.ErrStateMachineNotFound) {
 			return err
 		}
+		if !hasBufferedEvent {
+			return chasmworkflow.FailWorkflowTaskError{
+				Cause:   enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_REQUEST_CANCEL_NEXUS_OPERATION_ATTRIBUTES,
+				Message: fmt.Sprintf("requested cancelation for a non-existing or already completed operation with scheduled event ID of %d", attrs.ScheduledEventId),
+			}
+		}
+		// Fallthrough and apply the event, there's special logic that will handle state machine not found below.
 	}
 
 	if node != nil {

--- a/service/history/hsm/nexusoperations/workflow/commands_test.go
+++ b/service/history/hsm/nexusoperations/workflow/commands_test.go
@@ -975,6 +975,8 @@ func TestOperationNodeDeletionOnTerminalEvents(t *testing.T) {
 				a.ScheduledEventId = scheduledEvent.EventId
 			case *historypb.NexusOperationTimedOutEventAttributes:
 				a.ScheduledEventId = scheduledEvent.EventId
+			default:
+				require.FailNowf(t, "unexpected event attributes type", "%T", a)
 			}
 
 			applyTerminalEventAndAssertDeletion(t, tcx, scheduledEvent.EventId, tc.eventType, tc.eventAttr, tc.eventDef)


### PR DESCRIPTION
## What changed?

Removed the temporary golangci exclusion for the relocated legacy HSM packages.

## Why?

The exclusion was only needed while the package move itself is the lint diff.
