### PR TITLE
Refactor Nexus dispatch result classification

### DIFF
--- a/common/nexus/dispatch_outcome.go
+++ b/common/nexus/dispatch_outcome.go
@@ -199,6 +199,7 @@ func ClassifyCancelOperationDispatch(resp *matchingservice.DispatchNexusTaskResp
 // a Temporal failurepb.Failure.
 func deprecatedHandlerErrorToFailure(handlerErr *nexuspb.HandlerError) *failurepb.Failure {
 	failure := &failurepb.Failure{
+		Message: handlerErr.GetFailure().GetMessage(),
 		FailureInfo: &failurepb.Failure_NexusHandlerFailureInfo{
 			NexusHandlerFailureInfo: &failurepb.NexusHandlerFailureInfo{
 				Type:          handlerErr.GetErrorType(),

--- a/common/nexus/dispatch_outcome.go
+++ b/common/nexus/dispatch_outcome.go
@@ -291,6 +291,8 @@ func (r DispatchResult) metricOutcome() string {
 		return "handler_error:" + boundHandlerErrorType(hErrType)
 	case DispatchOutcomeRequestTimeout:
 		return "handler_timeout"
+	case DispatchOutcomeUnrecognized:
+		return "handler_error:EMPTY_OUTCOME"
 	default:
 		return "handler_error:EMPTY_OUTCOME"
 	}

--- a/common/nexus/dispatch_outcome.go
+++ b/common/nexus/dispatch_outcome.go
@@ -77,9 +77,9 @@ func (o DispatchOutcome) Succeeded() bool {
 type DispatchResult struct {
 	Outcome DispatchOutcome
 
-	// SyncPayload is the operation's result. Set for DispatchOutcomeSyncSuccess, where it may still
+	// OperationResult is the operation's result. Set for DispatchOutcomeSyncSuccess, where it may still
 	// be nil: an operation is allowed to succeed with no value.
-	SyncPayload *commonpb.Payload
+	OperationResult *commonpb.Payload
 
 	// OperationToken is set for DispatchOutcomeAsyncSuccess.
 	OperationToken string
@@ -143,9 +143,9 @@ func classifyStartOperationResponse(resp *nexuspb.StartOperationResponse) Dispat
 	switch t := resp.GetVariant().(type) {
 	case *nexuspb.StartOperationResponse_SyncSuccess:
 		return DispatchResult{
-			Outcome:     DispatchOutcomeSyncSuccess,
-			SyncPayload: t.SyncSuccess.GetPayload(),
-			Links:       t.SyncSuccess.GetLinks(),
+			Outcome:         DispatchOutcomeSyncSuccess,
+			OperationResult: t.SyncSuccess.GetPayload(),
+			Links:           t.SyncSuccess.GetLinks(),
 		}
 
 	case *nexuspb.StartOperationResponse_AsyncSuccess:
@@ -199,7 +199,6 @@ func ClassifyCancelOperationDispatch(resp *matchingservice.DispatchNexusTaskResp
 // a Temporal failurepb.Failure.
 func deprecatedHandlerErrorToFailure(handlerErr *nexuspb.HandlerError) *failurepb.Failure {
 	failure := &failurepb.Failure{
-		Message: handlerErr.GetFailure().GetMessage(),
 		FailureInfo: &failurepb.Failure_NexusHandlerFailureInfo{
 			NexusHandlerFailureInfo: &failurepb.NexusHandlerFailureInfo{
 				Type:          handlerErr.GetErrorType(),

--- a/common/nexus/dispatch_outcome.go
+++ b/common/nexus/dispatch_outcome.go
@@ -292,7 +292,7 @@ func (r DispatchResult) metricOutcome() string {
 	case DispatchOutcomeRequestTimeout:
 		return "handler_timeout"
 	case DispatchOutcomeUnrecognized:
-		return "handler_error:EMPTY_OUTCOME"
+		fallthrough
 	default:
 		return "handler_error:EMPTY_OUTCOME"
 	}

--- a/common/nexus/dispatch_outcome.go
+++ b/common/nexus/dispatch_outcome.go
@@ -1,0 +1,323 @@
+package nexus
+
+import (
+	"github.com/nexus-rpc/sdk-go/nexus"
+	commonpb "go.temporal.io/api/common/v1"
+	failurepb "go.temporal.io/api/failure/v1"
+	nexuspb "go.temporal.io/api/nexus/v1"
+	"go.temporal.io/server/api/matchingservice/v1"
+	"go.temporal.io/server/common/metrics"
+)
+
+// DispatchOutcome names the arm of matching's DispatchNexusTaskResponse that came back from a
+// DispatchNexusTask call. The nested oneofs and the deprecated variants collapse into one flat set of
+// cases. (Including those from a worker sending the deprecated failure responses, those will get
+// silently converted into the newer forms.)
+//
+// The zero value is the empty string and is not a valid outcome, so a switch over a DispatchOutcome
+// needs a default clause. For metric tags use DispatchResult.OutcomeTag, not the string value.
+type DispatchOutcome string
+
+const (
+	// DispatchOutcomeUnrecognized is a response this build cannot interpret: no outcome set, an
+	// outcome variant added after this build, or a worker answer that carries nothing usable.
+	DispatchOutcomeUnrecognized DispatchOutcome = "unrecognized-outcome"
+
+	// DispatchOutcomeSyncSuccess means the worker ran the operation to completion inline.
+	DispatchOutcomeSyncSuccess DispatchOutcome = "sync-success"
+
+	// DispatchOutcomeAsyncSuccess means the worker started the operation; the result arrives later,
+	// out of band.
+	DispatchOutcomeAsyncSuccess DispatchOutcome = "async-success"
+
+	// DispatchOutcomeCancelAccepted means the worker accepted the cancellation request.
+	DispatchOutcomeCancelAccepted DispatchOutcome = "cancel-accepted"
+
+	// DispatchOutcomeOperationFailure means the worker ran the operation and it resolved as failed
+	// or canceled. The task was delivered and answered; just the operation itself did not succeed.
+	//
+	// e.g. the Nexus handler fails with:
+	//     nexus.NewOperationFailedError("insufficient funds")
+	//     nexus.NewOperationCanceledError("already canceled upstream")
+	DispatchOutcomeOperationFailure DispatchOutcome = "operation-failure"
+
+	// DispatchOutcomeHandlerFailure means the worker answered with a Nexus handler error, whose retry
+	// behavior says whether another attempt is worthwhile. The handler can return one itself, or the
+	// worker can fail the task before the handler runs.
+	//
+	// e.g.
+	//     nexus.NewHandlerErrorf(nexus.HandlerErrorTypeNotFound, "no such workflow")
+	//     nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "cannot deserialize input")
+	DispatchOutcomeHandlerFailure DispatchOutcome = "nexus-handler-failure"
+
+	// DispatchOutcomeWorkerFailure means the worker failed the task with a failure carrying no Nexus
+	// handler failure info. RespondNexusTaskFailed rejects such a response, so matching cannot produce
+	// this outcome today. It exists so that a malformed response is classified rather than read as a
+	// handler error with no type.
+	DispatchOutcomeWorkerFailure DispatchOutcome = "worker-failure"
+
+	// DispatchOutcomeRequestTimeout means matching gave up before the task was answered: no worker
+	// was polling the task queue, or a worker took the task and never responded.
+	DispatchOutcomeRequestTimeout DispatchOutcome = "request-timeout"
+)
+
+// Succeeded reports whether the worker accepted the request. An asynchronous start counts: the worker
+// took responsibility for the operation, even though it has not finished it.
+func (o DispatchOutcome) Succeeded() bool {
+	switch o {
+	case DispatchOutcomeSyncSuccess, DispatchOutcomeAsyncSuccess, DispatchOutcomeCancelAccepted:
+		return true
+	default:
+		return false
+	}
+}
+
+// DispatchResult is the classified form of a DispatchNexusTaskResponse: the outcome, plus whatever
+// that arm of the response carried, hoisted out of the nested oneofs.
+type DispatchResult struct {
+	Outcome DispatchOutcome
+
+	// SyncPayload is the operation's result. Set for DispatchOutcomeSyncSuccess, where it may still
+	// be nil: an operation is allowed to succeed with no value.
+	SyncPayload *commonpb.Payload
+
+	// OperationToken is set for DispatchOutcomeAsyncSuccess.
+	OperationToken string
+
+	// Links are the handler links the worker attached to a successful start. Set for
+	// DispatchOutcomeSyncSuccess and DispatchOutcomeAsyncSuccess.
+	Links []*nexuspb.Link
+
+	// Failure is the Temporal failure the worker reported. Set for DispatchOutcomeHandlerFailure,
+	// DispatchOutcomeWorkerFailure and DispatchOutcomeOperationFailure.
+	//
+	// IMPORTANT: For the current response formats this aliases the proto inside the response rather
+	// than copying it, so callers that convert it in place mutate the response too.
+	Failure *failurepb.Failure
+
+	// usedDeprecatedFormat records that the worker answered in a format predating Temporal failure
+	// responses. Outcome and Failure are normalized either way; only the metric tag differs.
+	usedDeprecatedFormat bool
+}
+
+// baseClassifyDispatchNexusTaskResponse converts a DispatchNexusTaskResponse into a DispatchResult.
+//
+// onResponseFn classifies a Response outcome. The DispatchNexusTaskResponse proto is shared by every
+// kind of Nexus task, so only the caller knows how to interpret a succesful response.
+func baseClassifyDispatchNexusTaskResponse(
+	resp *matchingservice.DispatchNexusTaskResponse,
+	onResponseFn func(*nexuspb.StartOperationResponse) DispatchResult,
+) DispatchResult {
+	switch t := resp.GetOutcome().(type) {
+	case *matchingservice.DispatchNexusTaskResponse_Failure:
+		// A handler error is a Nexus-level refusal whose retry behavior is meaningful; anything else
+		// is an arbitrary failure the worker chose to report.
+		outcome := DispatchOutcomeWorkerFailure
+		if t.Failure.GetNexusHandlerFailureInfo() != nil {
+			outcome = DispatchOutcomeHandlerFailure
+		}
+		return DispatchResult{Outcome: outcome, Failure: t.Failure}
+
+	case *matchingservice.DispatchNexusTaskResponse_HandlerError: //nolint:staticcheck // Deprecated, still sent by older workers.
+		return DispatchResult{
+			Outcome: DispatchOutcomeHandlerFailure,
+			//nolint:staticcheck // Deprecated field on a deprecated variant.
+			Failure:              deprecatedHandlerErrorToFailure(t.HandlerError),
+			usedDeprecatedFormat: true,
+		}
+
+	case *matchingservice.DispatchNexusTaskResponse_RequestTimeout:
+		return DispatchResult{Outcome: DispatchOutcomeRequestTimeout}
+
+	case *matchingservice.DispatchNexusTaskResponse_Response:
+		// Only the caller knows how to interpret a successful response, so defer to onResponseFn.
+		return onResponseFn(t.Response.GetStartOperation())
+
+	default:
+		return DispatchResult{Outcome: DispatchOutcomeUnrecognized}
+	}
+}
+
+// classifyStartOperationResponse classifies the response a worker gave to a StartOperation request.
+func classifyStartOperationResponse(resp *nexuspb.StartOperationResponse) DispatchResult {
+	switch t := resp.GetVariant().(type) {
+	case *nexuspb.StartOperationResponse_SyncSuccess:
+		return DispatchResult{
+			Outcome:     DispatchOutcomeSyncSuccess,
+			SyncPayload: t.SyncSuccess.GetPayload(),
+			Links:       t.SyncSuccess.GetLinks(),
+		}
+
+	case *nexuspb.StartOperationResponse_AsyncSuccess:
+		token := t.AsyncSuccess.GetOperationToken()
+		if token == "" {
+			// Workers predating the operation-token rename only set the operation ID.
+			//nolint:staticcheck // Deprecated, still sent by older workers.
+			token = t.AsyncSuccess.GetOperationId()
+		}
+		return DispatchResult{
+			Outcome:        DispatchOutcomeAsyncSuccess,
+			OperationToken: token,
+			Links:          t.AsyncSuccess.GetLinks(),
+		}
+
+	case *nexuspb.StartOperationResponse_Failure:
+		return DispatchResult{
+			Outcome: DispatchOutcomeOperationFailure,
+			Failure: t.Failure,
+		}
+
+	case *nexuspb.StartOperationResponse_OperationError: //nolint:staticcheck // Deprecated, still sent by older workers.
+		return DispatchResult{
+			Outcome: DispatchOutcomeOperationFailure,
+			//nolint:staticcheck // Deprecated field on a deprecated variant.
+			Failure:              deprecatedOperationErrorToFailure(t.OperationError),
+			usedDeprecatedFormat: true,
+		}
+
+	default:
+		return DispatchResult{Outcome: DispatchOutcomeUnrecognized}
+	}
+}
+
+// ClassifyStartOperationDispatch classifies matching's response to a dispatched StartOperation task.
+func ClassifyStartOperationDispatch(resp *matchingservice.DispatchNexusTaskResponse) DispatchResult {
+	return baseClassifyDispatchNexusTaskResponse(resp, classifyStartOperationResponse)
+}
+
+// ClassifyCancelOperationDispatch classifies matching's response to a dispatched CancelOperation task.
+func ClassifyCancelOperationDispatch(resp *matchingservice.DispatchNexusTaskResponse) DispatchResult {
+	return baseClassifyDispatchNexusTaskResponse(
+		resp,
+		func(*nexuspb.StartOperationResponse) DispatchResult {
+			// A cancel response carries no fields, so any response means the worker accepted.
+			return DispatchResult{Outcome: DispatchOutcomeCancelAccepted}
+		})
+}
+
+// deprecatedHandlerErrorToFailure converts the deprecated nexuspb.HandlerError into the new format,
+// a Temporal failurepb.Failure.
+func deprecatedHandlerErrorToFailure(handlerErr *nexuspb.HandlerError) *failurepb.Failure {
+	failure := &failurepb.Failure{
+		FailureInfo: &failurepb.Failure_NexusHandlerFailureInfo{
+			NexusHandlerFailureInfo: &failurepb.NexusHandlerFailureInfo{
+				Type:          handlerErr.GetErrorType(),
+				RetryBehavior: handlerErr.GetRetryBehavior(),
+			},
+		},
+	}
+	if handlerErr.GetFailure() != nil {
+		failure.Cause = convertNexusFailureToTemporalFailure(handlerErr.GetFailure())
+	}
+	return failure
+}
+
+// deprecatedOperationErrorToFailure converts the deprecated nexuspb.UnsuccessfulOperationError into
+// the new format, a Temporal failurepb.Failure proto.
+//
+// The deprecated variant reports the operation state in a field of its own and sends the handler's
+// failure bare. The current format has no state field: the failure that wraps the handler's failure is
+// what reports the state, canceled or failed. So the wrapper is rebuilt here from the state field.
+// Workers converting in the other direction drop the wrapper and keep its cause.
+func deprecatedOperationErrorToFailure(opErr *nexuspb.UnsuccessfulOperationError) *failurepb.Failure {
+	cause := convertNexusFailureToTemporalFailure(opErr.GetFailure())
+	// The deprecated variant carries no message of its own, so the wrapper repeats the cause's.
+	failure := &failurepb.Failure{Message: cause.GetMessage(), Cause: cause}
+
+	if nexus.OperationState(opErr.GetOperationState()) == nexus.OperationStateCanceled {
+		failure.FailureInfo = &failurepb.Failure_CanceledFailureInfo{
+			CanceledFailureInfo: &failurepb.CanceledFailureInfo{},
+		}
+	} else {
+		failure.FailureInfo = &failurepb.Failure_ApplicationFailureInfo{
+			ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
+				Type:         "OperationError",
+				NonRetryable: true,
+			},
+		}
+	}
+	return failure
+}
+
+// convertNexusFailureToTemporalFailure converts the deprecated nexuspb.Failure into the new format,
+// a Temporal failurepb.Failure.
+func convertNexusFailureToTemporalFailure(nexusFailure *nexuspb.Failure) *failurepb.Failure {
+	//nolint:staticcheck // Deprecated function still in use for backward compatibility.
+	converted, err := NexusFailureToTemporalFailure(ProtoFailureToNexusFailure(nexusFailure))
+	// A failure that cannot be re-encoded falls back to its message. We know the operation failed,
+	// we just don't recognize the format of the data in its cause/details.
+	if err != nil {
+		return &failurepb.Failure{
+			Message: nexusFailure.GetMessage(),
+			FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+				ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
+					Type:         "NexusFailure",
+					NonRetryable: false,
+				},
+			},
+		}
+	}
+	return converted
+}
+
+// OutcomeTag returns the metrics outcome tag for a dispatch.
+//
+// A handler failure reports its error type as the tag's suffix. A type outside the Nexus spec, or a
+// failure with no type at all, reports "handler_error:UNKNOWN" so that a worker cannot mint new time
+// series.
+func (r DispatchResult) OutcomeTag() metrics.Tag {
+	return metrics.OutcomeTag(r.metricOutcome())
+}
+
+func (r DispatchResult) metricOutcome() string {
+	// NOTE: Some of these are confusing (e.g. "success" for CancelAccepted), but
+	// changing these would break existing dashboards.
+	switch r.Outcome {
+	case DispatchOutcomeSyncSuccess:
+		return "sync_success"
+	case DispatchOutcomeAsyncSuccess:
+		return "async_success"
+	case DispatchOutcomeCancelAccepted:
+		return "success"
+	case DispatchOutcomeOperationFailure:
+		if r.usedDeprecatedFormat {
+			return "operation_error"
+		}
+		return "failure"
+	case DispatchOutcomeHandlerFailure,
+		DispatchOutcomeWorkerFailure:
+		// A worker failure has no handler error type to report and will map to UNKNOWN.
+		hErrType := r.Failure.GetNexusHandlerFailureInfo().GetType()
+		return "handler_error:" + boundHandlerErrorType(hErrType)
+	case DispatchOutcomeRequestTimeout:
+		return "handler_timeout"
+	default:
+		return "handler_error:EMPTY_OUTCOME"
+	}
+}
+
+// handlerErrorTypes are the handler error types that may appear verbatim in a metric tag.
+// Keep in sync with the HandlerErrorType consts in nexus-rpc/sdk-go/nexus/errors.go.
+var handlerErrorTypes = map[string]struct{}{
+	string(nexus.HandlerErrorTypeBadRequest):        {},
+	string(nexus.HandlerErrorTypeUnauthenticated):   {},
+	string(nexus.HandlerErrorTypeUnauthorized):      {},
+	string(nexus.HandlerErrorTypeNotFound):          {},
+	string(nexus.HandlerErrorTypeRequestTimeout):    {},
+	string(nexus.HandlerErrorTypeConflict):          {},
+	string(nexus.HandlerErrorTypeResourceExhausted): {},
+	string(nexus.HandlerErrorTypeInternal):          {},
+	string(nexus.HandlerErrorTypeNotImplemented):    {},
+	string(nexus.HandlerErrorTypeUnavailable):       {},
+	string(nexus.HandlerErrorTypeUpstreamTimeout):   {},
+}
+
+// boundHandlerErrorType bounds the metric cardinality a worker can introduce through a handler error
+// type. Types in the Nexus spec pass through; anything else, including the empty string, collapses to
+// UNKNOWN.
+func boundHandlerErrorType(errType string) string {
+	if _, ok := handlerErrorTypes[errType]; ok {
+		return errType
+	}
+	return "UNKNOWN"
+}

--- a/common/nexus/dispatch_outcome_test.go
+++ b/common/nexus/dispatch_outcome_test.go
@@ -1,0 +1,523 @@
+package nexus
+
+import (
+	"testing"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	failurepb "go.temporal.io/api/failure/v1"
+	nexuspb "go.temporal.io/api/nexus/v1"
+	"go.temporal.io/server/api/matchingservice/v1"
+)
+
+// Response fixtures, shared with dispatch_response_test.go.
+
+func startResponse(sor *nexuspb.StartOperationResponse) *matchingservice.DispatchNexusTaskResponse {
+	return &matchingservice.DispatchNexusTaskResponse{
+		Outcome: &matchingservice.DispatchNexusTaskResponse_Response{
+			Response: &nexuspb.Response{
+				Variant: &nexuspb.Response_StartOperation{StartOperation: sor},
+			},
+		},
+	}
+}
+
+func syncSuccessResponse(sync *nexuspb.StartOperationResponse_Sync) *matchingservice.DispatchNexusTaskResponse {
+	return startResponse(&nexuspb.StartOperationResponse{
+		Variant: &nexuspb.StartOperationResponse_SyncSuccess{SyncSuccess: sync},
+	})
+}
+
+func operationFailureResponse(f *failurepb.Failure) *matchingservice.DispatchNexusTaskResponse {
+	return startResponse(&nexuspb.StartOperationResponse{
+		Variant: &nexuspb.StartOperationResponse_Failure{Failure: f},
+	})
+}
+
+func cancelResponse() *matchingservice.DispatchNexusTaskResponse {
+	return &matchingservice.DispatchNexusTaskResponse{
+		Outcome: &matchingservice.DispatchNexusTaskResponse_Response{
+			Response: &nexuspb.Response{
+				Variant: &nexuspb.Response_CancelOperation{
+					CancelOperation: &nexuspb.CancelOperationResponse{},
+				},
+			},
+		},
+	}
+}
+
+// taskFailureResponse is the arm a worker reaches through RespondNexusTaskFailed.
+func taskFailureResponse(f *failurepb.Failure) *matchingservice.DispatchNexusTaskResponse {
+	return &matchingservice.DispatchNexusTaskResponse{
+		Outcome: &matchingservice.DispatchNexusTaskResponse_Failure{Failure: f},
+	}
+}
+
+func requestTimeoutResponse() *matchingservice.DispatchNexusTaskResponse {
+	return &matchingservice.DispatchNexusTaskResponse{
+		Outcome: &matchingservice.DispatchNexusTaskResponse_RequestTimeout{
+			RequestTimeout: &matchingservice.DispatchNexusTaskResponse_Timeout{},
+		},
+	}
+}
+
+func handlerFailureResponse(errType string, retry enumspb.NexusHandlerErrorRetryBehavior) *matchingservice.DispatchNexusTaskResponse {
+	return taskFailureResponse(&failurepb.Failure{
+		Message: "handler said no",
+		FailureInfo: &failurepb.Failure_NexusHandlerFailureInfo{
+			NexusHandlerFailureInfo: &failurepb.NexusHandlerFailureInfo{
+				Type:          errType,
+				RetryBehavior: retry,
+			},
+		},
+	})
+}
+
+func applicationFailure(msg, errType string) *failurepb.Failure {
+	return &failurepb.Failure{
+		Message: msg,
+		FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+			ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{Type: errType},
+		},
+	}
+}
+
+func canceledFailure(msg string) *failurepb.Failure {
+	return &failurepb.Failure{
+		Message: msg,
+		FailureInfo: &failurepb.Failure_CanceledFailureInfo{
+			CanceledFailureInfo: &failurepb.CanceledFailureInfo{},
+		},
+	}
+}
+
+func deprecatedHandlerErrorResponse(he *nexuspb.HandlerError) *matchingservice.DispatchNexusTaskResponse {
+	return &matchingservice.DispatchNexusTaskResponse{
+		//nolint:staticcheck // Exercising the deprecated variant on purpose.
+		Outcome: &matchingservice.DispatchNexusTaskResponse_HandlerError{HandlerError: he},
+	}
+}
+
+func deprecatedOperationErrorResponse(opErr *nexuspb.UnsuccessfulOperationError) *matchingservice.DispatchNexusTaskResponse {
+	return startResponse(&nexuspb.StartOperationResponse{
+		//nolint:staticcheck // Exercising the deprecated variant on purpose.
+		Variant: &nexuspb.StartOperationResponse_OperationError{OperationError: opErr},
+	})
+}
+
+func TestClassifyStartOperationDispatch_SyncSuccess(t *testing.T) {
+	payload := &commonpb.Payload{Data: []byte("v")}
+	links := []*nexuspb.Link{{Url: "http://a.test/l", Type: "t"}}
+	r := ClassifyStartOperationDispatch(syncSuccessResponse(
+		&nexuspb.StartOperationResponse_Sync{Payload: payload, Links: links}))
+
+	require.Equal(t, DispatchOutcomeSyncSuccess, r.Outcome)
+	require.True(t, r.Outcome.Succeeded())
+	require.Same(t, payload, r.SyncPayload)
+	require.Equal(t, links, r.Links)
+}
+
+// An operation is allowed to succeed with no value.
+func TestClassifyStartOperationDispatch_SyncSuccess_NoPayload(t *testing.T) {
+	r := ClassifyStartOperationDispatch(syncSuccessResponse(&nexuspb.StartOperationResponse_Sync{}))
+
+	require.Equal(t, DispatchOutcomeSyncSuccess, r.Outcome)
+	require.True(t, r.Outcome.Succeeded())
+	require.Nil(t, r.SyncPayload)
+	require.Empty(t, r.Links)
+}
+
+func TestClassifyStartOperationDispatch_AsyncSuccess(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		async     *nexuspb.StartOperationResponse_Async
+		wantToken string
+	}{
+		{
+			name: "operation token wins over the deprecated id",
+			//nolint:staticcheck // Exercising the deprecated field on purpose.
+			async:     &nexuspb.StartOperationResponse_Async{OperationToken: "tok", OperationId: "id"},
+			wantToken: "tok",
+		},
+		{
+			name: "falls back to the deprecated id",
+			//nolint:staticcheck // Exercising the deprecated field on purpose.
+			async:     &nexuspb.StartOperationResponse_Async{OperationId: "id"},
+			wantToken: "id",
+		},
+		{
+			name:      "neither set",
+			async:     &nexuspb.StartOperationResponse_Async{},
+			wantToken: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := ClassifyStartOperationDispatch(startResponse(&nexuspb.StartOperationResponse{
+				Variant: &nexuspb.StartOperationResponse_AsyncSuccess{AsyncSuccess: tc.async},
+			}))
+			require.Equal(t, DispatchOutcomeAsyncSuccess, r.Outcome)
+			require.True(t, r.Outcome.Succeeded())
+			require.Equal(t, tc.wantToken, r.OperationToken)
+		})
+	}
+}
+
+func TestClassifyStartOperationDispatch_OperationFailure(t *testing.T) {
+	failure := &failurepb.Failure{Message: "op failed"}
+	r := ClassifyStartOperationDispatch(operationFailureResponse(failure))
+
+	require.Equal(t, DispatchOutcomeOperationFailure, r.Outcome)
+	require.False(t, r.Outcome.Succeeded())
+	require.Same(t, failure, r.Failure)
+}
+
+// A worker predating Temporal failure responses answers with the deprecated operation error. The
+// classifier re-encodes it so that callers see the same outcome and failure as the current variant,
+// with the state the deprecated variant reports separately rebuilt as the wrapping failure.
+func TestClassifyStartOperationDispatch_DeprecatedOperationError(t *testing.T) {
+	r := ClassifyStartOperationDispatch(deprecatedOperationErrorResponse(
+		&nexuspb.UnsuccessfulOperationError{
+			OperationState: string(nexus.OperationStateCanceled),
+			Failure:        &nexuspb.Failure{Message: "canceled"},
+		}))
+
+	require.Equal(t, DispatchOutcomeOperationFailure, r.Outcome)
+	require.False(t, r.Outcome.Succeeded())
+	require.Equal(t, "canceled", r.Failure.GetMessage())
+	require.NotNil(t, r.Failure.GetCanceledFailureInfo(),
+		"the deprecated state field must become a canceled failure")
+	// The worker's own failure is kept underneath the state the response reported.
+	require.Equal(t, "canceled", r.Failure.GetCause().GetMessage())
+}
+
+// A failed state becomes the non-retryable application failure the current format wraps a failed
+// operation in.
+func TestClassifyStartOperationDispatch_DeprecatedOperationErrorFailedState(t *testing.T) {
+	r := ClassifyStartOperationDispatch(deprecatedOperationErrorResponse(
+		&nexuspb.UnsuccessfulOperationError{
+			OperationState: string(nexus.OperationStateFailed),
+			Failure:        &nexuspb.Failure{Message: "op failed"},
+		}))
+
+	require.Equal(t, DispatchOutcomeOperationFailure, r.Outcome)
+	require.Equal(t, "op failed", r.Failure.GetMessage())
+	require.Nil(t, r.Failure.GetCanceledFailureInfo())
+	info := r.Failure.GetApplicationFailureInfo()
+	require.NotNil(t, info)
+	require.Equal(t, "OperationError", info.GetType())
+	require.True(t, info.GetNonRetryable())
+	require.Equal(t, "op failed", r.Failure.GetCause().GetMessage())
+}
+
+// The state field is the only thing that decides whether the operation failed or was canceled. A
+// worker that failed the operation with a canceled error underneath must not be reported as canceled:
+// the caller would record a cancellation the worker never claimed.
+func TestClassifyStartOperationDispatch_DeprecatedOperationErrorFailedStateWithCanceledCause(t *testing.T) {
+	nf, err := TemporalFailureToNexusFailure(canceledFailure("canceled underneath"))
+	require.NoError(t, err)
+
+	r := ClassifyStartOperationDispatch(deprecatedOperationErrorResponse(
+		&nexuspb.UnsuccessfulOperationError{
+			OperationState: string(nexus.OperationStateFailed),
+			Failure:        NexusFailureToProtoFailure(nf),
+		}))
+
+	require.Equal(t, DispatchOutcomeOperationFailure, r.Outcome)
+	require.Nil(t, r.Failure.GetCanceledFailureInfo(), "a failed operation must not report as canceled")
+	require.Equal(t, "OperationError", r.Failure.GetApplicationFailureInfo().GetType())
+	require.NotNil(t, r.Failure.GetCause().GetCanceledFailureInfo(),
+		"the worker's canceled failure is kept as the cause")
+}
+
+// A worker can send a failure the server cannot re-encode. The dispatch is still classified by what
+// happened to the operation -- calling the whole response unrecognized would turn a settled operation
+// into a retryable internal error -- so the failure degrades to its message.
+func TestClassifyStartOperationDispatch_DeprecatedOperationErrorMalformedFailure(t *testing.T) {
+	r := ClassifyStartOperationDispatch(deprecatedOperationErrorResponse(
+		&nexuspb.UnsuccessfulOperationError{
+			OperationState: string(nexus.OperationStateFailed),
+			Failure: &nexuspb.Failure{
+				Message:  "boom",
+				Metadata: map[string]string{"type": failureTypeString},
+				Details:  []byte("not-json"),
+			},
+		}))
+
+	require.Equal(t, DispatchOutcomeOperationFailure, r.Outcome)
+	require.Equal(t, "boom", r.Failure.GetMessage())
+	require.Equal(t, "NexusFailure", r.Failure.GetCause().GetApplicationFailureInfo().GetType())
+}
+
+// A handler failure and a plain worker failure arrive in the same response arm and have to be told
+// apart by whether the failure carries Nexus handler failure info.
+func TestClassifyStartOperationDispatch_HandlerFailureVsWorkerFailure(t *testing.T) {
+	t.Run("handler failure", func(t *testing.T) {
+		resp := handlerFailureResponse(string(nexus.HandlerErrorTypeBadRequest), enumspb.NEXUS_HANDLER_ERROR_RETRY_BEHAVIOR_UNSPECIFIED)
+		r := ClassifyStartOperationDispatch(resp)
+		require.Equal(t, DispatchOutcomeHandlerFailure, r.Outcome)
+		require.False(t, r.Outcome.Succeeded())
+		require.NotNil(t, r.Failure)
+	})
+
+	t.Run("worker failure", func(t *testing.T) {
+		r := ClassifyStartOperationDispatch(
+			taskFailureResponse(applicationFailure("worker exploded", "SomeError")))
+		require.Equal(t, DispatchOutcomeWorkerFailure, r.Outcome)
+		require.False(t, r.Outcome.Succeeded())
+		require.NotNil(t, r.Failure)
+	})
+}
+
+// A worker predating Temporal failure responses answers with the deprecated handler error. The
+// classifier re-encodes it as the Nexus handler failure the current variant carries, keeping the type
+// and retry behavior callers act on and nesting the worker's failure as the cause.
+func TestClassifyStartOperationDispatch_DeprecatedHandlerError(t *testing.T) {
+	r := ClassifyStartOperationDispatch(deprecatedHandlerErrorResponse(&nexuspb.HandlerError{
+		ErrorType:     string(nexus.HandlerErrorTypeResourceExhausted),
+		RetryBehavior: enumspb.NEXUS_HANDLER_ERROR_RETRY_BEHAVIOR_RETRYABLE,
+		Failure:       &nexuspb.Failure{Message: "slow down"},
+	}))
+
+	require.Equal(t, DispatchOutcomeHandlerFailure, r.Outcome)
+	require.False(t, r.Outcome.Succeeded())
+	info := r.Failure.GetNexusHandlerFailureInfo()
+	require.NotNil(t, info)
+	require.Equal(t, string(nexus.HandlerErrorTypeResourceExhausted), info.GetType())
+	require.Equal(t, enumspb.NEXUS_HANDLER_ERROR_RETRY_BEHAVIOR_RETRYABLE, info.GetRetryBehavior())
+	require.Equal(t, "slow down", r.Failure.GetCause().GetMessage())
+}
+
+// A handler error with no failure of its own still classifies, and fabricates no empty cause.
+func TestClassifyStartOperationDispatch_DeprecatedHandlerErrorWithoutFailure(t *testing.T) {
+	r := ClassifyStartOperationDispatch(deprecatedHandlerErrorResponse(&nexuspb.HandlerError{
+		ErrorType: string(nexus.HandlerErrorTypeNotFound),
+	}))
+
+	require.Equal(t, DispatchOutcomeHandlerFailure, r.Outcome)
+	require.Equal(t, string(nexus.HandlerErrorTypeNotFound),
+		r.Failure.GetNexusHandlerFailureInfo().GetType())
+	require.Nil(t, r.Failure.GetCause())
+}
+
+func TestClassifyStartOperationDispatch_RequestTimeout(t *testing.T) {
+	r := ClassifyStartOperationDispatch(requestTimeoutResponse())
+
+	require.Equal(t, DispatchOutcomeRequestTimeout, r.Outcome)
+	require.False(t, r.Outcome.Succeeded())
+}
+
+func TestClassifyStartOperationDispatch_Unrecognized(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		resp *matchingservice.DispatchNexusTaskResponse
+	}{
+		{name: "nil response", resp: nil},
+		{name: "no outcome", resp: &matchingservice.DispatchNexusTaskResponse{}},
+		{name: "no start variant", resp: startResponse(&nexuspb.StartOperationResponse{})},
+		{name: "nil start operation", resp: startResponse(nil)},
+		{name: "a cancel answer to a start request", resp: cancelResponse()},
+		{
+			name: "an empty response envelope",
+			resp: &matchingservice.DispatchNexusTaskResponse{
+				Outcome: &matchingservice.DispatchNexusTaskResponse_Response{
+					Response: &nexuspb.Response{},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := ClassifyStartOperationDispatch(tc.resp)
+			require.Equal(t, DispatchOutcomeUnrecognized, r.Outcome)
+			require.False(t, r.Outcome.Succeeded())
+		})
+	}
+}
+
+// A cancel dispatch shares every failure arm with a start dispatch, and differs only in that any
+// response at all means the cancel was accepted.
+func TestClassifyCancelOperationDispatch(t *testing.T) {
+	t.Run("any response is accepted", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			resp *matchingservice.DispatchNexusTaskResponse
+		}{
+			{name: "cancel variant", resp: cancelResponse()},
+			{
+				name: "empty envelope",
+				resp: &matchingservice.DispatchNexusTaskResponse{
+					Outcome: &matchingservice.DispatchNexusTaskResponse_Response{
+						Response: &nexuspb.Response{},
+					},
+				},
+			},
+			{
+				// The outcome arm is what marks the task as answered, not the message inside it.
+				name: "nil envelope",
+				resp: &matchingservice.DispatchNexusTaskResponse{
+					Outcome: &matchingservice.DispatchNexusTaskResponse_Response{},
+				},
+			},
+			{
+				name: "a start answer to a cancel request is still accepted",
+				resp: syncSuccessResponse(&nexuspb.StartOperationResponse_Sync{}),
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				r := ClassifyCancelOperationDispatch(tc.resp)
+				require.Equal(t, DispatchOutcomeCancelAccepted, r.Outcome)
+				require.True(t, r.Outcome.Succeeded())
+			})
+		}
+	})
+
+	t.Run("failure arms match the start path", func(t *testing.T) {
+		resp := handlerFailureResponse(string(nexus.HandlerErrorTypeNotFound), enumspb.NEXUS_HANDLER_ERROR_RETRY_BEHAVIOR_UNSPECIFIED)
+		r := ClassifyCancelOperationDispatch(resp)
+		require.Equal(t, DispatchOutcomeHandlerFailure, r.Outcome)
+	})
+
+	t.Run("deprecated handler error", func(t *testing.T) {
+		r := ClassifyCancelOperationDispatch(deprecatedHandlerErrorResponse(&nexuspb.HandlerError{
+			ErrorType: string(nexus.HandlerErrorTypeNotImplemented),
+		}))
+		require.Equal(t, DispatchOutcomeHandlerFailure, r.Outcome)
+		require.Equal(t, string(nexus.HandlerErrorTypeNotImplemented),
+			r.Failure.GetNexusHandlerFailureInfo().GetType())
+	})
+
+	t.Run("request timeout", func(t *testing.T) {
+		r := ClassifyCancelOperationDispatch(requestTimeoutResponse())
+		require.Equal(t, DispatchOutcomeRequestTimeout, r.Outcome)
+	})
+
+	t.Run("unrecognized", func(t *testing.T) {
+		r := ClassifyCancelOperationDispatch(&matchingservice.DispatchNexusTaskResponse{})
+		require.Equal(t, DispatchOutcomeUnrecognized, r.Outcome)
+	})
+}
+
+// The classifier aliases the response's failure proto rather than copying it, which callers that
+// convert failures in place rely on.
+func TestClassifyStartOperationDispatch_FailureAliasesTheResponse(t *testing.T) {
+	failure := applicationFailure("worker exploded", "SomeError")
+	r := ClassifyStartOperationDispatch(taskFailureResponse(failure))
+	require.Same(t, failure, r.Failure)
+}
+
+// With an integer enum, iota made duplicate values impossible. With string values a copy-paste can
+// silently alias two outcomes into one, so assert they stay distinct and non-empty -- the empty string
+// is the zero value and must not name a real outcome.
+func TestDispatchOutcomeValuesAreDistinct(t *testing.T) {
+	seen := map[DispatchOutcome]struct{}{}
+	for _, o := range []DispatchOutcome{
+		DispatchOutcomeUnrecognized, DispatchOutcomeSyncSuccess, DispatchOutcomeAsyncSuccess,
+		DispatchOutcomeCancelAccepted, DispatchOutcomeOperationFailure,
+		DispatchOutcomeHandlerFailure, DispatchOutcomeWorkerFailure,
+		DispatchOutcomeRequestTimeout,
+	} {
+		require.NotEmpty(t, o)
+		require.NotContains(t, seen, o, "outcome values must be distinct")
+		seen[o] = struct{}{}
+	}
+}
+
+// The outcome tag values are what existing dashboards query, so they are pinned here rather than only
+// asserted end-to-end through a handler.
+func TestDispatchResultOutcomeTag(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		result DispatchResult
+		want   string
+	}{
+		{
+			name:   "sync success",
+			result: DispatchResult{Outcome: DispatchOutcomeSyncSuccess},
+			want:   "sync_success",
+		},
+		{
+			name:   "async success",
+			result: DispatchResult{Outcome: DispatchOutcomeAsyncSuccess},
+			want:   "async_success",
+		},
+		{
+			name:   "cancel accepted",
+			result: DispatchResult{Outcome: DispatchOutcomeCancelAccepted},
+			want:   "success",
+		},
+		{
+			name:   "operation failure",
+			result: DispatchResult{Outcome: DispatchOutcomeOperationFailure},
+			want:   "failure",
+		},
+		{
+			// Old-format operation errors have always had their own tag value, so normalizing the
+			// outcome must not merge them into "failure".
+			name: "deprecated operation error",
+			result: ClassifyStartOperationDispatch(deprecatedOperationErrorResponse(
+				&nexuspb.UnsuccessfulOperationError{
+					OperationState: string(nexus.OperationStateFailed),
+					Failure:        &nexuspb.Failure{Message: "op failed"},
+				})),
+			want: "operation_error",
+		},
+		{
+			name:   "request timeout",
+			result: DispatchResult{Outcome: DispatchOutcomeRequestTimeout},
+			want:   "handler_timeout",
+		},
+		{
+			name:   "unrecognized",
+			result: DispatchResult{Outcome: DispatchOutcomeUnrecognized},
+			want:   "handler_error:EMPTY_OUTCOME",
+		},
+		{
+			// The zero value is not a named outcome; it must still land somewhere sensible.
+			name:   "zero value",
+			result: DispatchResult{},
+			want:   "handler_error:EMPTY_OUTCOME",
+		},
+		{
+			name: "handler failure reports its type",
+			result: ClassifyStartOperationDispatch(handlerFailureResponse(
+				string(nexus.HandlerErrorTypeBadRequest),
+				enumspb.NEXUS_HANDLER_ERROR_RETRY_BEHAVIOR_UNSPECIFIED,
+			)),
+			want: "handler_error:BAD_REQUEST",
+		},
+		{
+			name: "deprecated handler error reports its type",
+			result: ClassifyStartOperationDispatch(deprecatedHandlerErrorResponse(
+				&nexuspb.HandlerError{ErrorType: string(nexus.HandlerErrorTypeNotFound)})),
+			want: "handler_error:NOT_FOUND",
+		},
+		{
+			// Not a handler error, so there is no type to report and the suffix bounds to UNKNOWN.
+			name: "worker failure",
+			result: ClassifyStartOperationDispatch(
+				taskFailureResponse(applicationFailure("worker exploded", "SomeError"))),
+			want: "handler_error:UNKNOWN",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tag := tc.result.OutcomeTag()
+			require.Equal(t, "outcome", tag.Key)
+			require.Equal(t, tc.want, tag.Value)
+		})
+	}
+}
+
+func TestBoundHandlerErrorType(t *testing.T) {
+	for _, spec := range []string{
+		"BAD_REQUEST", "UNAUTHENTICATED", "UNAUTHORIZED", "NOT_FOUND", "REQUEST_TIMEOUT",
+		"CONFLICT", "RESOURCE_EXHAUSTED", "INTERNAL", "NOT_IMPLEMENTED", "UNAVAILABLE",
+		"UPSTREAM_TIMEOUT",
+	} {
+		require.Equal(t, spec, boundHandlerErrorType(spec), "spec types pass through verbatim")
+	}
+	// A worker picks this string, so it must not be able to mint new time series.
+	require.Equal(t, "UNKNOWN", boundHandlerErrorType("whatever-the-worker-said"))
+	require.Equal(t, "UNKNOWN", boundHandlerErrorType(""))
+	require.Equal(t, "UNKNOWN", boundHandlerErrorType("bad_request"), "matching is case sensitive")
+}

--- a/common/nexus/dispatch_outcome_test.go
+++ b/common/nexus/dispatch_outcome_test.go
@@ -133,18 +133,18 @@ func TestClassifyOperationDispatch(t *testing.T) {
 			Name:     "sync success",
 			Response: syncSuccessResponse(&nexuspb.StartOperationResponse_Sync{Payload: payload, Links: links}),
 			Want: DispatchResult{
-				Outcome:     DispatchOutcomeSyncSuccess,
-				SyncPayload: payload,
-				Links:       links,
+				Outcome:         DispatchOutcomeSyncSuccess,
+				OperationResult: payload,
+				Links:           links,
 			},
 		},
 		{
 			Name:     "sync success (no payload, links)",
 			Response: syncSuccessResponse(&nexuspb.StartOperationResponse_Sync{}),
 			Want: DispatchResult{
-				Outcome:     DispatchOutcomeSyncSuccess,
-				SyncPayload: nil,
-				Links:       nil,
+				Outcome:         DispatchOutcomeSyncSuccess,
+				OperationResult: nil,
+				Links:           nil,
 			},
 		},
 
@@ -332,7 +332,6 @@ func TestClassifyOperationDispatch(t *testing.T) {
 			Want: DispatchResult{
 				Outcome: DispatchOutcomeHandlerFailure,
 				Failure: &failurepb.Failure{
-					Message: "slow down",
 					FailureInfo: &failurepb.Failure_NexusHandlerFailureInfo{
 						NexusHandlerFailureInfo: &failurepb.NexusHandlerFailureInfo{
 							Type:          "RESOURCE_EXHAUSTED",
@@ -405,6 +404,43 @@ func TestClassifyOperationDispatch(t *testing.T) {
 				Outcome: DispatchOutcomeUnrecognized,
 			},
 		},
+		{
+			Name:     "unrecognized (no start variant)",
+			Response: startResponse(&nexuspb.StartOperationResponse{}),
+			Want: DispatchResult{
+				Outcome: DispatchOutcomeUnrecognized,
+			},
+		},
+		{
+			Name:     "unrecognized (nil start operation)",
+			Response: startResponse(nil),
+			Want: DispatchResult{
+				Outcome: DispatchOutcomeUnrecognized,
+			},
+		},
+		{
+			Name: "unrecognized (empty response envelope)",
+			Response: &matchingservice.DispatchNexusTaskResponse{
+				Outcome: &matchingservice.DispatchNexusTaskResponse_Response{
+					Response: &nexuspb.Response{},
+				},
+			},
+			Want: DispatchResult{
+				Outcome: DispatchOutcomeUnrecognized,
+			},
+		},
+		{
+			// The only fixture that reaches the start classifier with a nil Response inside a set
+			// outcome arm. On the cancel side it is also the case proving the outcome arm is what
+			// marks the task answered, not the message inside it.
+			Name: "unrecognized (nil response envelope)",
+			Response: &matchingservice.DispatchNexusTaskResponse{
+				Outcome: &matchingservice.DispatchNexusTaskResponse_Response{},
+			},
+			Want: DispatchResult{
+				Outcome: DispatchOutcomeUnrecognized,
+			},
+		},
 
 		// DispatchOutcomeRequestTimeout
 		{
@@ -417,21 +453,21 @@ func TestClassifyOperationDispatch(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			assertClassificationsMatch := func(want, got DispatchResult) {
+			assertClassificationsMatch := func(t *testing.T, want, got DispatchResult) {
 				require.Equal(t, want.Outcome, got.Outcome)
 				require.Equal(t, want.OperationToken, got.OperationToken)
 				require.Equal(t, want.usedDeprecatedFormat, got.usedDeprecatedFormat)
 
 				// TIP: To get a better error message, use require.Equal(...) for the
 				// specific testcase that is producing the wrong proto result.
-				protorequire.DeepEqual(t, want.SyncPayload, got.SyncPayload)
+				protorequire.DeepEqual(t, want.OperationResult, got.OperationResult)
 				protorequire.DeepEqual(t, want.Failure, got.Failure)
 				protorequire.DeepEqual(t, want.Links, got.Links)
 			}
 
 			t.Run("ClassifyStartOperationDispatch", func(t *testing.T) {
 				got := ClassifyStartOperationDispatch(tc.Response)
-				assertClassificationsMatch(tc.Want, got)
+				assertClassificationsMatch(t, tc.Want, got)
 			})
 
 			t.Run("ClassifyCancelOperationDispatch", func(t *testing.T) {
@@ -444,30 +480,23 @@ func TestClassifyOperationDispatch(t *testing.T) {
 					want := DispatchResult{
 						Outcome: DispatchOutcomeCancelAccepted,
 					}
-					assertClassificationsMatch(want, got)
+					assertClassificationsMatch(t, want, got)
 				} else {
-					assertClassificationsMatch(tc.Want, got)
+					assertClassificationsMatch(t, tc.Want, got)
 				}
 			})
 		})
 	}
 }
 
-// With an integer enum, iota made duplicate values impossible. With string values a copy-paste can
-// silently alias two outcomes into one, so assert they stay distinct and non-empty -- the empty string
-// is the zero value and must not name a real outcome.
-func TestDispatchOutcomeValuesAreDistinct(t *testing.T) {
-	seen := map[DispatchOutcome]struct{}{}
-	for _, o := range []DispatchOutcome{
-		DispatchOutcomeUnrecognized, DispatchOutcomeSyncSuccess, DispatchOutcomeAsyncSuccess,
-		DispatchOutcomeCancelAccepted, DispatchOutcomeOperationFailure,
-		DispatchOutcomeHandlerFailure, DispatchOutcomeWorkerFailure,
-		DispatchOutcomeRequestTimeout,
-	} {
-		require.NotEmpty(t, o)
-		require.NotContains(t, seen, o, "outcome values must be distinct")
-		seen[o] = struct{}{}
-	}
+// The classifier aliases the response's failure proto rather than copying it, which callers that
+// convert failures in place rely on. DispatchResult.Failure documents this as part of its contract,
+// and service/frontend's TemporalFailureToNexusFailureInPlace call depends on it. The table above
+// compares protos by value, so only an identity assertion catches a change to cloning.
+func TestClassifyStartOperationDispatch_FailureAliasesTheResponse(t *testing.T) {
+	failure := applicationFailure("worker exploded", "SomeError")
+	r := ClassifyStartOperationDispatch(taskFailureResponse(failure))
+	require.Same(t, failure, r.Failure)
 }
 
 // The outcome tag values are what existing dashboards query, so they are pinned here rather than only

--- a/common/nexus/dispatch_outcome_test.go
+++ b/common/nexus/dispatch_outcome_test.go
@@ -10,6 +10,7 @@ import (
 	failurepb "go.temporal.io/api/failure/v1"
 	nexuspb "go.temporal.io/api/nexus/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
+	"go.temporal.io/server/common/testing/protorequire"
 )
 
 // Response fixtures, shared with dispatch_response_test.go.
@@ -27,6 +28,12 @@ func startResponse(sor *nexuspb.StartOperationResponse) *matchingservice.Dispatc
 func syncSuccessResponse(sync *nexuspb.StartOperationResponse_Sync) *matchingservice.DispatchNexusTaskResponse {
 	return startResponse(&nexuspb.StartOperationResponse{
 		Variant: &nexuspb.StartOperationResponse_SyncSuccess{SyncSuccess: sync},
+	})
+}
+
+func asyncSuccessResponse(async *nexuspb.StartOperationResponse_Async) *matchingservice.DispatchNexusTaskResponse {
+	return startResponse(&nexuspb.StartOperationResponse{
+		Variant: &nexuspb.StartOperationResponse_AsyncSuccess{AsyncSuccess: async},
 	})
 }
 
@@ -107,303 +114,343 @@ func deprecatedOperationErrorResponse(opErr *nexuspb.UnsuccessfulOperationError)
 	})
 }
 
-func TestClassifyStartOperationDispatch_SyncSuccess(t *testing.T) {
-	payload := &commonpb.Payload{Data: []byte("v")}
-	links := []*nexuspb.Link{{Url: "http://a.test/l", Type: "t"}}
-	r := ClassifyStartOperationDispatch(syncSuccessResponse(
-		&nexuspb.StartOperationResponse_Sync{Payload: payload, Links: links}))
-
-	require.Equal(t, DispatchOutcomeSyncSuccess, r.Outcome)
-	require.True(t, r.Outcome.Succeeded())
-	require.Same(t, payload, r.SyncPayload)
-	require.Equal(t, links, r.Links)
-}
-
-// An operation is allowed to succeed with no value.
-func TestClassifyStartOperationDispatch_SyncSuccess_NoPayload(t *testing.T) {
-	r := ClassifyStartOperationDispatch(syncSuccessResponse(&nexuspb.StartOperationResponse_Sync{}))
-
-	require.Equal(t, DispatchOutcomeSyncSuccess, r.Outcome)
-	require.True(t, r.Outcome.Succeeded())
-	require.Nil(t, r.SyncPayload)
-	require.Empty(t, r.Links)
-}
-
-func TestClassifyStartOperationDispatch_AsyncSuccess(t *testing.T) {
-	for _, tc := range []struct {
-		name      string
-		async     *nexuspb.StartOperationResponse_Async
-		wantToken string
-	}{
-		{
-			name: "operation token wins over the deprecated id",
-			//nolint:staticcheck // Exercising the deprecated field on purpose.
-			async:     &nexuspb.StartOperationResponse_Async{OperationToken: "tok", OperationId: "id"},
-			wantToken: "tok",
-		},
-		{
-			name: "falls back to the deprecated id",
-			//nolint:staticcheck // Exercising the deprecated field on purpose.
-			async:     &nexuspb.StartOperationResponse_Async{OperationId: "id"},
-			wantToken: "id",
-		},
-		{
-			name:      "neither set",
-			async:     &nexuspb.StartOperationResponse_Async{},
-			wantToken: "",
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			r := ClassifyStartOperationDispatch(startResponse(&nexuspb.StartOperationResponse{
-				Variant: &nexuspb.StartOperationResponse_AsyncSuccess{AsyncSuccess: tc.async},
-			}))
-			require.Equal(t, DispatchOutcomeAsyncSuccess, r.Outcome)
-			require.True(t, r.Outcome.Succeeded())
-			require.Equal(t, tc.wantToken, r.OperationToken)
-		})
-	}
-}
-
-func TestClassifyStartOperationDispatch_OperationFailure(t *testing.T) {
+// Tests for *BOTH* ClassifyStartOperationDispatch and ClassifyCancelOperationDispatch.
+func TestClassifyOperationDispatch(t *testing.T) {
 	failure := &failurepb.Failure{Message: "op failed"}
-	r := ClassifyStartOperationDispatch(operationFailureResponse(failure))
+	links := []*nexuspb.Link{{Url: "http://a.test/l", Type: "t"}}
+	payload := &commonpb.Payload{Data: []byte("xxx")}
 
-	require.Equal(t, DispatchOutcomeOperationFailure, r.Outcome)
-	require.False(t, r.Outcome.Succeeded())
-	require.Same(t, failure, r.Failure)
-}
-
-// A worker predating Temporal failure responses answers with the deprecated operation error. The
-// classifier re-encodes it so that callers see the same outcome and failure as the current variant,
-// with the state the deprecated variant reports separately rebuilt as the wrapping failure.
-func TestClassifyStartOperationDispatch_DeprecatedOperationError(t *testing.T) {
-	r := ClassifyStartOperationDispatch(deprecatedOperationErrorResponse(
-		&nexuspb.UnsuccessfulOperationError{
-			OperationState: string(nexus.OperationStateCanceled),
-			Failure:        &nexuspb.Failure{Message: "canceled"},
-		}))
-
-	require.Equal(t, DispatchOutcomeOperationFailure, r.Outcome)
-	require.False(t, r.Outcome.Succeeded())
-	require.Equal(t, "canceled", r.Failure.GetMessage())
-	require.NotNil(t, r.Failure.GetCanceledFailureInfo(),
-		"the deprecated state field must become a canceled failure")
-	// The worker's own failure is kept underneath the state the response reported.
-	require.Equal(t, "canceled", r.Failure.GetCause().GetMessage())
-}
-
-// A failed state becomes the non-retryable application failure the current format wraps a failed
-// operation in.
-func TestClassifyStartOperationDispatch_DeprecatedOperationErrorFailedState(t *testing.T) {
-	r := ClassifyStartOperationDispatch(deprecatedOperationErrorResponse(
-		&nexuspb.UnsuccessfulOperationError{
-			OperationState: string(nexus.OperationStateFailed),
-			Failure:        &nexuspb.Failure{Message: "op failed"},
-		}))
-
-	require.Equal(t, DispatchOutcomeOperationFailure, r.Outcome)
-	require.Equal(t, "op failed", r.Failure.GetMessage())
-	require.Nil(t, r.Failure.GetCanceledFailureInfo())
-	info := r.Failure.GetApplicationFailureInfo()
-	require.NotNil(t, info)
-	require.Equal(t, "OperationError", info.GetType())
-	require.True(t, info.GetNonRetryable())
-	require.Equal(t, "op failed", r.Failure.GetCause().GetMessage())
-}
-
-// The state field is the only thing that decides whether the operation failed or was canceled. A
-// worker that failed the operation with a canceled error underneath must not be reported as canceled:
-// the caller would record a cancellation the worker never claimed.
-func TestClassifyStartOperationDispatch_DeprecatedOperationErrorFailedStateWithCanceledCause(t *testing.T) {
-	nf, err := TemporalFailureToNexusFailure(canceledFailure("canceled underneath"))
+	nexusCanceledFailure, err := TemporalFailureToNexusFailure(canceledFailure("canceled within Nexus"))
 	require.NoError(t, err)
 
-	r := ClassifyStartOperationDispatch(deprecatedOperationErrorResponse(
-		&nexuspb.UnsuccessfulOperationError{
-			OperationState: string(nexus.OperationStateFailed),
-			Failure:        NexusFailureToProtoFailure(nf),
-		}))
-
-	require.Equal(t, DispatchOutcomeOperationFailure, r.Outcome)
-	require.Nil(t, r.Failure.GetCanceledFailureInfo(), "a failed operation must not report as canceled")
-	require.Equal(t, "OperationError", r.Failure.GetApplicationFailureInfo().GetType())
-	require.NotNil(t, r.Failure.GetCause().GetCanceledFailureInfo(),
-		"the worker's canceled failure is kept as the cause")
-}
-
-// A worker can send a failure the server cannot re-encode. The dispatch is still classified by what
-// happened to the operation -- calling the whole response unrecognized would turn a settled operation
-// into a retryable internal error -- so the failure degrades to its message.
-func TestClassifyStartOperationDispatch_DeprecatedOperationErrorMalformedFailure(t *testing.T) {
-	r := ClassifyStartOperationDispatch(deprecatedOperationErrorResponse(
-		&nexuspb.UnsuccessfulOperationError{
-			OperationState: string(nexus.OperationStateFailed),
-			Failure: &nexuspb.Failure{
-				Message:  "boom",
-				Metadata: map[string]string{"type": failureTypeString},
-				Details:  []byte("not-json"),
-			},
-		}))
-
-	require.Equal(t, DispatchOutcomeOperationFailure, r.Outcome)
-	require.Equal(t, "boom", r.Failure.GetMessage())
-	require.Equal(t, "NexusFailure", r.Failure.GetCause().GetApplicationFailureInfo().GetType())
-}
-
-// A handler failure and a plain worker failure arrive in the same response arm and have to be told
-// apart by whether the failure carries Nexus handler failure info.
-func TestClassifyStartOperationDispatch_HandlerFailureVsWorkerFailure(t *testing.T) {
-	t.Run("handler failure", func(t *testing.T) {
-		resp := handlerFailureResponse(string(nexus.HandlerErrorTypeBadRequest), enumspb.NEXUS_HANDLER_ERROR_RETRY_BEHAVIOR_UNSPECIFIED)
-		r := ClassifyStartOperationDispatch(resp)
-		require.Equal(t, DispatchOutcomeHandlerFailure, r.Outcome)
-		require.False(t, r.Outcome.Succeeded())
-		require.NotNil(t, r.Failure)
-	})
-
-	t.Run("worker failure", func(t *testing.T) {
-		r := ClassifyStartOperationDispatch(
-			taskFailureResponse(applicationFailure("worker exploded", "SomeError")))
-		require.Equal(t, DispatchOutcomeWorkerFailure, r.Outcome)
-		require.False(t, r.Outcome.Succeeded())
-		require.NotNil(t, r.Failure)
-	})
-}
-
-// A worker predating Temporal failure responses answers with the deprecated handler error. The
-// classifier re-encodes it as the Nexus handler failure the current variant carries, keeping the type
-// and retry behavior callers act on and nesting the worker's failure as the cause.
-func TestClassifyStartOperationDispatch_DeprecatedHandlerError(t *testing.T) {
-	r := ClassifyStartOperationDispatch(deprecatedHandlerErrorResponse(&nexuspb.HandlerError{
-		ErrorType:     string(nexus.HandlerErrorTypeResourceExhausted),
-		RetryBehavior: enumspb.NEXUS_HANDLER_ERROR_RETRY_BEHAVIOR_RETRYABLE,
-		Failure:       &nexuspb.Failure{Message: "slow down"},
-	}))
-
-	require.Equal(t, DispatchOutcomeHandlerFailure, r.Outcome)
-	require.False(t, r.Outcome.Succeeded())
-	info := r.Failure.GetNexusHandlerFailureInfo()
-	require.NotNil(t, info)
-	require.Equal(t, string(nexus.HandlerErrorTypeResourceExhausted), info.GetType())
-	require.Equal(t, enumspb.NEXUS_HANDLER_ERROR_RETRY_BEHAVIOR_RETRYABLE, info.GetRetryBehavior())
-	require.Equal(t, "slow down", r.Failure.GetCause().GetMessage())
-}
-
-// A handler error with no failure of its own still classifies, and fabricates no empty cause.
-func TestClassifyStartOperationDispatch_DeprecatedHandlerErrorWithoutFailure(t *testing.T) {
-	r := ClassifyStartOperationDispatch(deprecatedHandlerErrorResponse(&nexuspb.HandlerError{
-		ErrorType: string(nexus.HandlerErrorTypeNotFound),
-	}))
-
-	require.Equal(t, DispatchOutcomeHandlerFailure, r.Outcome)
-	require.Equal(t, string(nexus.HandlerErrorTypeNotFound),
-		r.Failure.GetNexusHandlerFailureInfo().GetType())
-	require.Nil(t, r.Failure.GetCause())
-}
-
-func TestClassifyStartOperationDispatch_RequestTimeout(t *testing.T) {
-	r := ClassifyStartOperationDispatch(requestTimeoutResponse())
-
-	require.Equal(t, DispatchOutcomeRequestTimeout, r.Outcome)
-	require.False(t, r.Outcome.Succeeded())
-}
-
-func TestClassifyStartOperationDispatch_Unrecognized(t *testing.T) {
-	for _, tc := range []struct {
-		name string
-		resp *matchingservice.DispatchNexusTaskResponse
+	cases := []struct {
+		Name     string
+		Response *matchingservice.DispatchNexusTaskResponse
+		Want     DispatchResult
 	}{
-		{name: "nil response", resp: nil},
-		{name: "no outcome", resp: &matchingservice.DispatchNexusTaskResponse{}},
-		{name: "no start variant", resp: startResponse(&nexuspb.StartOperationResponse{})},
-		{name: "nil start operation", resp: startResponse(nil)},
-		{name: "a cancel answer to a start request", resp: cancelResponse()},
+		// DispatchOutcomeSyncSuccess
 		{
-			name: "an empty response envelope",
-			resp: &matchingservice.DispatchNexusTaskResponse{
-				Outcome: &matchingservice.DispatchNexusTaskResponse_Response{
-					Response: &nexuspb.Response{},
-				},
+			Name:     "sync success",
+			Response: syncSuccessResponse(&nexuspb.StartOperationResponse_Sync{Payload: payload, Links: links}),
+			Want: DispatchResult{
+				Outcome:     DispatchOutcomeSyncSuccess,
+				SyncPayload: payload,
+				Links:       links,
 			},
 		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			r := ClassifyStartOperationDispatch(tc.resp)
-			require.Equal(t, DispatchOutcomeUnrecognized, r.Outcome)
-			require.False(t, r.Outcome.Succeeded())
-		})
-	}
-}
+		{
+			Name:     "sync success (no payload, links)",
+			Response: syncSuccessResponse(&nexuspb.StartOperationResponse_Sync{}),
+			Want: DispatchResult{
+				Outcome:     DispatchOutcomeSyncSuccess,
+				SyncPayload: nil,
+				Links:       nil,
+			},
+		},
 
-// A cancel dispatch shares every failure arm with a start dispatch, and differs only in that any
-// response at all means the cancel was accepted.
-func TestClassifyCancelOperationDispatch(t *testing.T) {
-	t.Run("any response is accepted", func(t *testing.T) {
-		for _, tc := range []struct {
-			name string
-			resp *matchingservice.DispatchNexusTaskResponse
-		}{
-			{name: "cancel variant", resp: cancelResponse()},
-			{
-				name: "empty envelope",
-				resp: &matchingservice.DispatchNexusTaskResponse{
-					Outcome: &matchingservice.DispatchNexusTaskResponse_Response{
-						Response: &nexuspb.Response{},
+		// DispatchOutcomeAsyncSuccess
+		{
+			Name: "async (pick op token over token id)",
+			//nolint:staticcheck // Exercising the deprecated field on purpose.
+			Response: asyncSuccessResponse(&nexuspb.StartOperationResponse_Async{OperationToken: "op-token", OperationId: "old-and-busted"}),
+			Want: DispatchResult{
+				Outcome:        DispatchOutcomeAsyncSuccess,
+				OperationToken: "op-token",
+			},
+		},
+		{
+			Name: "async (falls back to deprecated ID)",
+			//nolint:staticcheck // Exercising the deprecated field on purpose.
+			Response: asyncSuccessResponse(&nexuspb.StartOperationResponse_Async{OperationId: "operation-id"}),
+			Want: DispatchResult{
+				Outcome:        DispatchOutcomeAsyncSuccess,
+				OperationToken: "operation-id",
+			},
+		},
+		{
+			Name:     "async (no token set)",
+			Response: asyncSuccessResponse(&nexuspb.StartOperationResponse_Async{}),
+			Want: DispatchResult{
+				Outcome:        DispatchOutcomeAsyncSuccess,
+				OperationToken: "",
+			},
+		},
+
+		// DispatchOutcomeOperationFailure
+		{
+			Name:     "failure",
+			Response: operationFailureResponse(failure),
+			Want: DispatchResult{
+				Outcome: DispatchOutcomeOperationFailure,
+				Failure: failure,
+			},
+		},
+
+		// DispatchOutcomeOperationFailure (using deprecated proto)
+		{
+			// The deprecated error response does some extra work in the conversion,
+			// setting the ApplicationFailureInfo to Canceled based on the OperationState.
+			Name: "failure (deprecated proto, canceled)",
+			Response: deprecatedOperationErrorResponse(
+				&nexuspb.UnsuccessfulOperationError{
+					OperationState: string(nexus.OperationStateCanceled),
+					Failure:        &nexuspb.Failure{Message: "operation canceled"},
+				}),
+			Want: DispatchResult{
+				Outcome: DispatchOutcomeOperationFailure,
+				Failure: &failurepb.Failure{
+					Message: "operation canceled",
+					Cause: &failurepb.Failure{
+						Message: "operation canceled",
+					},
+					FailureInfo: &failurepb.Failure_CanceledFailureInfo{
+						CanceledFailureInfo: &failurepb.CanceledFailureInfo{},
+					},
+				},
+				usedDeprecatedFormat: true,
+			},
+		},
+		{
+			// The OperationStateFailed becomes an unretryable "OperationError".
+			Name: "failure (deprecated proto, failed)",
+			Response: deprecatedOperationErrorResponse(
+				&nexuspb.UnsuccessfulOperationError{
+					OperationState: string(nexus.OperationStateFailed),
+					Failure:        &nexuspb.Failure{Message: "operation failed"},
+				}),
+			Want: DispatchResult{
+				Outcome: DispatchOutcomeOperationFailure,
+				Failure: &failurepb.Failure{
+					Message: "operation failed",
+					Cause: &failurepb.Failure{
+						Message: "operation failed",
+					},
+					FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+						ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
+							Type:         "OperationError",
+							NonRetryable: true,
+						},
+					},
+				},
+				usedDeprecatedFormat: true,
+			},
+		},
+		{
+			// The operation state is failed, but the cause is due to a cancellation.
+			// Set both ApplicationFailureInfos, for both levels of the failurepb.Failure.
+			Name: "failure (deprecated proto, failed surfaces canceled info)",
+			Response: deprecatedOperationErrorResponse(
+				&nexuspb.UnsuccessfulOperationError{
+					OperationState: string(nexus.OperationStateFailed),
+					Failure:        NexusFailureToProtoFailure(nexusCanceledFailure),
+				}),
+			Want: DispatchResult{
+				Outcome: DispatchOutcomeOperationFailure,
+				Failure: &failurepb.Failure{
+					Message: "canceled within Nexus",
+					Cause: &failurepb.Failure{
+						Message: "canceled within Nexus",
+						FailureInfo: &failurepb.Failure_CanceledFailureInfo{
+							CanceledFailureInfo: &failurepb.CanceledFailureInfo{},
+						},
+					},
+					FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+						ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
+							Type:         "OperationError",
+							NonRetryable: true,
+						},
+					},
+				},
+				usedDeprecatedFormat: true,
+			},
+		},
+		{
+			// A worker can send a failure the server cannot re-encode. The dispatch is still classified by what
+			// happened to the operation -- calling the whole response unrecognized would turn a settled operation
+			// into a retryable internal error -- so the failure degrades to its message.
+			Name: "failure (deprecated proto, unrecognized)",
+			Response: deprecatedOperationErrorResponse(
+				&nexuspb.UnsuccessfulOperationError{
+					OperationState: string(nexus.OperationStateFailed),
+					Failure: &nexuspb.Failure{
+						Message:  "unrecognized error message",
+						Metadata: map[string]string{"type": failureTypeString},
+						Details:  []byte("clearly not a JSON blob!"),
+					},
+				}),
+			Want: DispatchResult{
+				Outcome: DispatchOutcomeOperationFailure,
+				Failure: &failurepb.Failure{
+					Message: "unrecognized error message",
+					Cause: &failurepb.Failure{
+						Message: "unrecognized error message",
+						FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+							ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
+								Type: "NexusFailure",
+							},
+						},
+					},
+					FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+						ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
+							Type:         "OperationError",
+							NonRetryable: true,
+						},
+					},
+				},
+				usedDeprecatedFormat: true,
+			},
+		},
+
+		// DispatchOutcomeHandlerFailure
+		{
+			Name:     "handler failure",
+			Response: handlerFailureResponse(string(nexus.HandlerErrorTypeBadRequest), enumspb.NEXUS_HANDLER_ERROR_RETRY_BEHAVIOR_UNSPECIFIED),
+			Want: DispatchResult{
+				Outcome: DispatchOutcomeHandlerFailure,
+				Failure: &failurepb.Failure{
+					Message: "handler said no",
+					FailureInfo: &failurepb.Failure_NexusHandlerFailureInfo{
+						NexusHandlerFailureInfo: &failurepb.NexusHandlerFailureInfo{
+							Type: "BAD_REQUEST",
+						},
 					},
 				},
 			},
-			{
-				// The outcome arm is what marks the task as answered, not the message inside it.
-				name: "nil envelope",
-				resp: &matchingservice.DispatchNexusTaskResponse{
-					Outcome: &matchingservice.DispatchNexusTaskResponse_Response{},
+		},
+
+		// DispatchOutcomeHandlerFailure (using deprecated protos)
+		{
+			// A worker predating Temporal failure responses answers with the deprecated handler error. The
+			// classifier re-encodes it as the Nexus handler failure the current variant carries, keeping the type
+			// and retry behavior callers act on and nesting the worker's failure as the cause.
+			Name: "handler failure (deprecated proto, custom retry behavior)",
+			Response: deprecatedHandlerErrorResponse(&nexuspb.HandlerError{
+				ErrorType:     string(nexus.HandlerErrorTypeResourceExhausted),
+				RetryBehavior: enumspb.NEXUS_HANDLER_ERROR_RETRY_BEHAVIOR_RETRYABLE,
+				Failure:       &nexuspb.Failure{Message: "slow down"},
+			}),
+			Want: DispatchResult{
+				Outcome: DispatchOutcomeHandlerFailure,
+				Failure: &failurepb.Failure{
+					Message: "slow down",
+					FailureInfo: &failurepb.Failure_NexusHandlerFailureInfo{
+						NexusHandlerFailureInfo: &failurepb.NexusHandlerFailureInfo{
+							Type:          "RESOURCE_EXHAUSTED",
+							RetryBehavior: enumspb.NEXUS_HANDLER_ERROR_RETRY_BEHAVIOR_RETRYABLE,
+						},
+					},
+					Cause: &failurepb.Failure{
+						Message: "slow down",
+					},
+				},
+				usedDeprecatedFormat: true,
+			},
+		},
+		{
+			// A handler error with no failure of its own still classifies correctly.
+			Name: "handler failure (deprecated proto, no message)",
+			Response: deprecatedHandlerErrorResponse(&nexuspb.HandlerError{
+				ErrorType: string(nexus.HandlerErrorTypeNotFound),
+			}),
+			Want: DispatchResult{
+				Outcome: DispatchOutcomeHandlerFailure,
+				Failure: &failurepb.Failure{
+					Message: "",
+					FailureInfo: &failurepb.Failure_NexusHandlerFailureInfo{
+						NexusHandlerFailureInfo: &failurepb.NexusHandlerFailureInfo{
+							Type: "NOT_FOUND",
+						},
+					},
+				},
+				usedDeprecatedFormat: true,
+			},
+		},
+
+		// DispatchOutcomeWorkerFailure
+		{
+			Name:     "worker error",
+			Response: taskFailureResponse(applicationFailure("worker exploded", "ErrTypeStr")),
+			Want: DispatchResult{
+				Outcome: DispatchOutcomeWorkerFailure,
+				Failure: &failurepb.Failure{
+					Message: "worker exploded",
+					FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+						ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
+							Type: "ErrTypeStr",
+						},
+					},
 				},
 			},
-			{
-				name: "a start answer to a cancel request is still accepted",
-				resp: syncSuccessResponse(&nexuspb.StartOperationResponse_Sync{}),
+		},
+
+		// DispatchOutcomeUnrecognized
+		{
+			Name:     "unrecognized (no outcome)",
+			Response: &matchingservice.DispatchNexusTaskResponse{},
+			Want: DispatchResult{
+				Outcome: DispatchOutcomeUnrecognized,
 			},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				r := ClassifyCancelOperationDispatch(tc.resp)
-				require.Equal(t, DispatchOutcomeCancelAccepted, r.Outcome)
-				require.True(t, r.Outcome.Succeeded())
+		},
+		{
+			Name:     "unrecognized (nil)",
+			Response: nil,
+			Want: DispatchResult{
+				Outcome: DispatchOutcomeUnrecognized,
+			},
+		},
+		{
+			Name:     "unrecognized (cancel answer to start request)",
+			Response: cancelResponse(),
+			Want: DispatchResult{
+				Outcome: DispatchOutcomeUnrecognized,
+			},
+		},
+
+		// DispatchOutcomeRequestTimeout
+		{
+			Name:     "request-timeout",
+			Response: requestTimeoutResponse(),
+			Want: DispatchResult{
+				Outcome: DispatchOutcomeRequestTimeout,
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			assertClassificationsMatch := func(want, got DispatchResult) {
+				require.Equal(t, want.Outcome, got.Outcome)
+				require.Equal(t, want.OperationToken, got.OperationToken)
+				require.Equal(t, want.usedDeprecatedFormat, got.usedDeprecatedFormat)
+
+				// TIP: To get a better error message, use require.Equal(...) for the
+				// specific testcase that is producing the wrong proto result.
+				protorequire.DeepEqual(t, want.SyncPayload, got.SyncPayload)
+				protorequire.DeepEqual(t, want.Failure, got.Failure)
+				protorequire.DeepEqual(t, want.Links, got.Links)
+			}
+
+			t.Run("ClassifyStartOperationDispatch", func(t *testing.T) {
+				got := ClassifyStartOperationDispatch(tc.Response)
+				assertClassificationsMatch(tc.Want, got)
 			})
-		}
-	})
 
-	t.Run("failure arms match the start path", func(t *testing.T) {
-		resp := handlerFailureResponse(string(nexus.HandlerErrorTypeNotFound), enumspb.NEXUS_HANDLER_ERROR_RETRY_BEHAVIOR_UNSPECIFIED)
-		r := ClassifyCancelOperationDispatch(resp)
-		require.Equal(t, DispatchOutcomeHandlerFailure, r.Outcome)
-	})
-
-	t.Run("deprecated handler error", func(t *testing.T) {
-		r := ClassifyCancelOperationDispatch(deprecatedHandlerErrorResponse(&nexuspb.HandlerError{
-			ErrorType: string(nexus.HandlerErrorTypeNotImplemented),
-		}))
-		require.Equal(t, DispatchOutcomeHandlerFailure, r.Outcome)
-		require.Equal(t, string(nexus.HandlerErrorTypeNotImplemented),
-			r.Failure.GetNexusHandlerFailureInfo().GetType())
-	})
-
-	t.Run("request timeout", func(t *testing.T) {
-		r := ClassifyCancelOperationDispatch(requestTimeoutResponse())
-		require.Equal(t, DispatchOutcomeRequestTimeout, r.Outcome)
-	})
-
-	t.Run("unrecognized", func(t *testing.T) {
-		r := ClassifyCancelOperationDispatch(&matchingservice.DispatchNexusTaskResponse{})
-		require.Equal(t, DispatchOutcomeUnrecognized, r.Outcome)
-	})
-}
-
-// The classifier aliases the response's failure proto rather than copying it, which callers that
-// convert failures in place rely on.
-func TestClassifyStartOperationDispatch_FailureAliasesTheResponse(t *testing.T) {
-	failure := applicationFailure("worker exploded", "SomeError")
-	r := ClassifyStartOperationDispatch(taskFailureResponse(failure))
-	require.Same(t, failure, r.Failure)
+			t.Run("ClassifyCancelOperationDispatch", func(t *testing.T) {
+				// Testing the Cancel- variant is simple. Any response that sets the
+				// successful Outcome variant is considered success.
+				//
+				// Any other type of response uses the same error handling as before.
+				got := ClassifyCancelOperationDispatch(tc.Response)
+				if _, ok := tc.Response.GetOutcome().(*matchingservice.DispatchNexusTaskResponse_Response); ok {
+					want := DispatchResult{
+						Outcome: DispatchOutcomeCancelAccepted,
+					}
+					assertClassificationsMatch(want, got)
+				} else {
+					assertClassificationsMatch(tc.Want, got)
+				}
+			})
+		})
+	}
 }
 
 // With an integer enum, iota made duplicate values impossible. With string values a copy-paste can

--- a/common/nexus/dispatch_response.go
+++ b/common/nexus/dispatch_response.go
@@ -2,7 +2,6 @@ package nexus
 
 import (
 	"github.com/nexus-rpc/sdk-go/nexus"
-	nexuspb "go.temporal.io/api/nexus/v1"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/server/api/matchingservice/v1"
 )
@@ -11,35 +10,43 @@ import (
 // Returns nil if the response indicates success.
 //
 // For failure cases (worker explicitly returned an error), the Temporal SDK's failure
-// converter is used to produce standard Go errors (ApplicationError, CanceledError).
+// converter is used to produce standard Go errors (temporal.ApplicationError, temporal.CanceledError).
 // For transport-level issues (timeout, internal), a nexus.HandlerError is returned
 // so the caller can check Retryable().
 func MatchingDispatchResponseToError(resp *matchingservice.DispatchNexusTaskResponse) error {
-	switch t := resp.GetOutcome().(type) {
-	case *matchingservice.DispatchNexusTaskResponse_Failure:
-		// Worker received the task and explicitly failed it (via RespondNexusTaskFailed).
-		return temporal.GetDefaultFailureConverter().FailureToError(t.Failure)
-	case *matchingservice.DispatchNexusTaskResponse_RequestTimeout:
-		return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeUpstreamTimeout, "upstream timeout")
-	case *matchingservice.DispatchNexusTaskResponse_Response:
-		return StartOperationResponseToError(t.Response.GetStartOperation())
-	default:
-		return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "empty or unknown dispatch outcome")
-	}
+	return DispatchResultToError(ClassifyStartOperationDispatch(resp))
 }
 
-// StartOperationResponseToError converts a StartOperationResponse proto into a Go error.
-// Returns nil for success variants (SyncSuccess, AsyncSuccess).
-func StartOperationResponseToError(resp *nexuspb.StartOperationResponse) error {
-	switch t := resp.GetVariant().(type) {
-	case *nexuspb.StartOperationResponse_SyncSuccess:
+// DispatchResultToError converts a classified dispatch into a Go error for server-internal
+// consumption. Returns nil for the success outcomes.
+//
+// The errors this produces are SDK-shaped: a failure the worker reported becomes a
+// *temporal.ApplicationError or *temporal.CanceledError, and a Nexus handler error becomes a
+// *nexus.HandlerError.
+//
+// Wire-facing paths convert through nexusrpc instead. The Nexus HTTP handler re-serializes a returned
+// error with nexusrpc's failure converter, which flattens an SDK-shaped cause to just its message and
+// drops the failure type and details.
+func DispatchResultToError(result DispatchResult) error {
+	if result.Outcome.Succeeded() {
 		return nil
-	case *nexuspb.StartOperationResponse_AsyncSuccess:
-		return nil
-	case *nexuspb.StartOperationResponse_Failure:
-		// Operation processed but failed — the worker returned an explicit failure.
-		return temporal.GetDefaultFailureConverter().FailureToError(t.Failure)
+	}
+
+	switch result.Outcome {
+	case DispatchOutcomeHandlerFailure,
+		DispatchOutcomeWorkerFailure,
+		DispatchOutcomeOperationFailure:
+		// The worker either failed the task (via RespondNexusTaskFailed) or answered with a failed
+		// operation. Either way the failure reports what the worker said.
+		return temporal.GetDefaultFailureConverter().FailureToError(result.Failure)
+
+	case DispatchOutcomeRequestTimeout:
+		return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeUpstreamTimeout, "upstream timeout")
+
 	default:
-		return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "empty or unknown start operation response variant")
+		return nexus.NewHandlerErrorf(
+			nexus.HandlerErrorTypeInternal,
+			"unsupported or unrecognized dispatch outcome: %s", result.Outcome,
+		)
 	}
 }

--- a/common/nexus/dispatch_response_test.go
+++ b/common/nexus/dispatch_response_test.go
@@ -1,160 +1,220 @@
 package nexus
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/nexus-rpc/sdk-go/nexus"
 	"github.com/stretchr/testify/require"
-	failurepb "go.temporal.io/api/failure/v1"
+	enumspb "go.temporal.io/api/enums/v1"
 	nexuspb "go.temporal.io/api/nexus/v1"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/server/api/matchingservice/v1"
 )
 
-func TestMatchingDispatchResponseToError_SyncSuccess(t *testing.T) {
-	resp := &matchingservice.DispatchNexusTaskResponse{
-		Outcome: &matchingservice.DispatchNexusTaskResponse_Response{
-			Response: &nexuspb.Response{
-				Variant: &nexuspb.Response_StartOperation{
-					StartOperation: &nexuspb.StartOperationResponse{
-						Variant: &nexuspb.StartOperationResponse_SyncSuccess{
-							SyncSuccess: &nexuspb.StartOperationResponse_Sync{},
-						},
-					},
-				},
-			},
+// DispatchResultToError serves server-internal callers, which branch on *nexus.HandlerError -- a
+// delivery problem whose Retryable() says whether to re-deliver the task -- versus any other error,
+// which is the worker's own answer and therefore permanent. These tests pin that split for every
+// outcome, and pin that a worker answering in a deprecated format lands on the same error as one
+// answering in the current format.
+//
+// Response fixtures live in dispatch_outcome_test.go.
+
+// An async start counts as success: the worker took responsibility for the operation even though it
+// has not finished it.
+func TestDispatchResultToError_SuccessOutcomes(t *testing.T) {
+	require.NoError(t, MatchingDispatchResponseToError(
+		syncSuccessResponse(&nexuspb.StartOperationResponse_Sync{})))
+	require.NoError(t, MatchingDispatchResponseToError(startResponse(&nexuspb.StartOperationResponse{
+		Variant: &nexuspb.StartOperationResponse_AsyncSuccess{
+			AsyncSuccess: &nexuspb.StartOperationResponse_Async{OperationToken: "tok"},
 		},
-	}
-	err := MatchingDispatchResponseToError(resp)
-	require.NoError(t, err)
+	})))
+	require.NoError(t, DispatchResultToError(ClassifyCancelOperationDispatch(cancelResponse())))
 }
 
-func TestMatchingDispatchResponseToError_AsyncSuccess(t *testing.T) {
-	resp := &matchingservice.DispatchNexusTaskResponse{
-		Outcome: &matchingservice.DispatchNexusTaskResponse_Response{
-			Response: &nexuspb.Response{
-				Variant: &nexuspb.Response_StartOperation{
-					StartOperation: &nexuspb.StartOperationResponse{
-						Variant: &nexuspb.StartOperationResponse_AsyncSuccess{
-							AsyncSuccess: &nexuspb.StartOperationResponse_Async{
-								OperationId: "test-op-id",
-							},
-						},
-					},
-				},
-			},
+// A task that never reached a handler, or an answer this build cannot interpret, is a delivery problem
+// rather than an answer, so it has to surface as a handler error.
+func TestDispatchResultToError_DeliveryProblems(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		resp     *matchingservice.DispatchNexusTaskResponse
+		wantType nexus.HandlerErrorType
+	}{
+		{
+			name:     "request timeout",
+			resp:     requestTimeoutResponse(),
+			wantType: nexus.HandlerErrorTypeUpstreamTimeout,
 		},
+		{
+			name:     "no outcome",
+			resp:     &matchingservice.DispatchNexusTaskResponse{},
+			wantType: nexus.HandlerErrorTypeInternal,
+		},
+		{
+			name:     "no start operation variant",
+			resp:     startResponse(&nexuspb.StartOperationResponse{}),
+			wantType: nexus.HandlerErrorTypeInternal,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var handlerErr *nexus.HandlerError
+			require.ErrorAs(t, MatchingDispatchResponseToError(tc.resp), &handlerErr)
+			require.Equal(t, tc.wantType, handlerErr.Type)
+		})
 	}
-	err := MatchingDispatchResponseToError(resp)
-	require.NoError(t, err)
 }
 
-func TestMatchingDispatchResponseToError_RequestTimeout(t *testing.T) {
-	resp := &matchingservice.DispatchNexusTaskResponse{
-		Outcome: &matchingservice.DispatchNexusTaskResponse_RequestTimeout{
-			RequestTimeout: &matchingservice.DispatchNexusTaskResponse_Timeout{},
+// A failure the worker reported becomes an SDK-shaped error and never a handler error, so callers
+// treat it as the worker's answer instead of re-delivering the task.
+func TestDispatchResultToError_WorkerReportedFailures(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		resp        *matchingservice.DispatchNexusTaskResponse
+		wantMessage string
+		wantType    string
+	}{
+		{
+			name:        "failed task",
+			resp:        taskFailureResponse(applicationFailure("bad request from worker", "SomeError")),
+			wantMessage: "bad request from worker",
+			wantType:    "SomeError",
 		},
+		{
+			name:        "failed operation",
+			resp:        operationFailureResponse(applicationFailure("activity failed", "SomeError")),
+			wantMessage: "activity failed",
+			wantType:    "SomeError",
+		},
+		{
+			// The classifier rebuilds the wrapper the current variant sends, so a failed operation
+			// reports the same failure type either way.
+			name: "deprecated operation error",
+			resp: deprecatedOperationErrorResponse(&nexuspb.UnsuccessfulOperationError{
+				OperationState: string(nexus.OperationStateFailed),
+				Failure:        &nexuspb.Failure{Message: "operation failed"},
+			}),
+			wantMessage: "operation failed",
+			wantType:    "OperationError",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := MatchingDispatchResponseToError(tc.resp)
+			var appErr *temporal.ApplicationError
+			require.ErrorAs(t, err, &appErr)
+			require.Equal(t, tc.wantMessage, appErr.Message())
+			require.Equal(t, tc.wantType, appErr.Type())
+			var handlerErr *nexus.HandlerError
+			require.NotErrorAs(t, err, &handlerErr)
+		})
 	}
-	err := MatchingDispatchResponseToError(resp)
-	require.Error(t, err)
+}
+
+// A canceled operation has to reach the caller as a canceled error however the worker encoded it,
+// since callers branch on the error type rather than on the response format.
+func TestDispatchResultToError_CanceledOutcomes(t *testing.T) {
+	t.Run("a canceled failure", func(t *testing.T) {
+		var canceledErr *temporal.CanceledError
+		require.ErrorAs(t, MatchingDispatchResponseToError(
+			operationFailureResponse(canceledFailure("canceled"))), &canceledErr)
+	})
+
+	t.Run("a canceled failure in the deprecated variant", func(t *testing.T) {
+		nf, err := TemporalFailureToNexusFailure(canceledFailure("operation canceled"))
+		require.NoError(t, err)
+
+		var canceledErr *temporal.CanceledError
+		require.ErrorAs(t, MatchingDispatchResponseToError(deprecatedOperationErrorResponse(
+			&nexuspb.UnsuccessfulOperationError{
+				OperationState: string(nexus.OperationStateCanceled),
+				Failure:        NexusFailureToProtoFailure(nf),
+			})), &canceledErr)
+	})
+
+	// A handler outside Temporal sends a failure with no Temporal failure info, so the deprecated state
+	// field is the only signal that the operation was canceled. The worker's own failure still has to
+	// survive as the cause, or the caller loses why the operation was canceled.
+	t.Run("the deprecated state field alone", func(t *testing.T) {
+		err := MatchingDispatchResponseToError(deprecatedOperationErrorResponse(
+			&nexuspb.UnsuccessfulOperationError{
+				OperationState: string(nexus.OperationStateCanceled),
+				Failure:        &nexuspb.Failure{Message: "operation canceled"},
+			}))
+
+		var canceledErr *temporal.CanceledError
+		require.ErrorAs(t, err, &canceledErr)
+		var appErr *temporal.ApplicationError
+		require.ErrorAs(t, errors.Unwrap(canceledErr), &appErr)
+		require.Equal(t, "operation canceled", appErr.Message())
+	})
+}
+
+// Callers decide whether re-delivering the task is worthwhile from Retryable(), so both response
+// formats have to preserve the worker's error type and retry behavior.
+func TestDispatchResultToError_HandlerFailureRetryBehavior(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		errType       nexus.HandlerErrorType
+		retryBehavior enumspb.NexusHandlerErrorRetryBehavior
+		wantRetryable bool
+	}{
+		{
+			name:          "non-retryable by type",
+			errType:       nexus.HandlerErrorTypeBadRequest,
+			retryBehavior: enumspb.NEXUS_HANDLER_ERROR_RETRY_BEHAVIOR_UNSPECIFIED,
+			wantRetryable: false,
+		},
+		{
+			name:          "retryable by type",
+			errType:       nexus.HandlerErrorTypeUnavailable,
+			retryBehavior: enumspb.NEXUS_HANDLER_ERROR_RETRY_BEHAVIOR_UNSPECIFIED,
+			wantRetryable: true,
+		},
+		{
+			name:          "explicit override wins over the type default",
+			errType:       nexus.HandlerErrorTypeBadRequest,
+			retryBehavior: enumspb.NEXUS_HANDLER_ERROR_RETRY_BEHAVIOR_RETRYABLE,
+			wantRetryable: true,
+		},
+	} {
+		for _, format := range []struct {
+			name string
+			resp *matchingservice.DispatchNexusTaskResponse
+		}{
+			{
+				name: "current",
+				resp: handlerFailureResponse(string(tc.errType), tc.retryBehavior),
+			},
+			{
+				name: "deprecated",
+				resp: deprecatedHandlerErrorResponse(&nexuspb.HandlerError{
+					ErrorType:     string(tc.errType),
+					RetryBehavior: tc.retryBehavior,
+					Failure:       &nexuspb.Failure{Message: "worker said no"},
+				}),
+			},
+		} {
+			t.Run(format.name+"/"+tc.name, func(t *testing.T) {
+				var handlerErr *nexus.HandlerError
+				require.ErrorAs(t, MatchingDispatchResponseToError(format.resp), &handlerErr)
+				require.Equal(t, tc.errType, handlerErr.Type)
+				require.Equal(t, tc.wantRetryable, handlerErr.Retryable())
+			})
+		}
+	}
+}
+
+// The deprecated variant carries the worker's failure in the Nexus encoding. It has to come back as
+// the handler error's cause in the same SDK shape the current variant produces.
+func TestDispatchResultToError_DeprecatedHandlerErrorCause(t *testing.T) {
+	err := MatchingDispatchResponseToError(deprecatedHandlerErrorResponse(&nexuspb.HandlerError{
+		ErrorType: string(nexus.HandlerErrorTypeInternal),
+		Failure:   &nexuspb.Failure{Message: "worker said no"},
+	}))
 
 	var handlerErr *nexus.HandlerError
 	require.ErrorAs(t, err, &handlerErr)
-	require.Equal(t, nexus.HandlerErrorTypeUpstreamTimeout, handlerErr.Type)
-}
-
-func TestMatchingDispatchResponseToError_WorkerFailure(t *testing.T) {
-	resp := &matchingservice.DispatchNexusTaskResponse{
-		Outcome: &matchingservice.DispatchNexusTaskResponse_Failure{
-			Failure: &failurepb.Failure{
-				Message: "bad request from worker",
-				FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
-					ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
-						Type: "SomeError",
-					},
-				},
-			},
-		},
-	}
-	err := MatchingDispatchResponseToError(resp)
-	require.Error(t, err)
-
 	var appErr *temporal.ApplicationError
-	require.ErrorAs(t, err, &appErr)
-	require.Equal(t, "SomeError", appErr.Type())
-}
-
-func TestMatchingDispatchResponseToError_OperationFailure_ApplicationError(t *testing.T) {
-	resp := &matchingservice.DispatchNexusTaskResponse{
-		Outcome: &matchingservice.DispatchNexusTaskResponse_Response{
-			Response: &nexuspb.Response{
-				Variant: &nexuspb.Response_StartOperation{
-					StartOperation: &nexuspb.StartOperationResponse{
-						Variant: &nexuspb.StartOperationResponse_Failure{
-							Failure: &failurepb.Failure{
-								Message: "activity failed",
-								FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
-									ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
-										Type: "SomeError",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	err := MatchingDispatchResponseToError(resp)
-	require.Error(t, err)
-
-	var appErr *temporal.ApplicationError
-	require.ErrorAs(t, err, &appErr)
-	require.Equal(t, "SomeError", appErr.Type())
-}
-
-func TestMatchingDispatchResponseToError_OperationFailure_CanceledError(t *testing.T) {
-	resp := &matchingservice.DispatchNexusTaskResponse{
-		Outcome: &matchingservice.DispatchNexusTaskResponse_Response{
-			Response: &nexuspb.Response{
-				Variant: &nexuspb.Response_StartOperation{
-					StartOperation: &nexuspb.StartOperationResponse{
-						Variant: &nexuspb.StartOperationResponse_Failure{
-							Failure: &failurepb.Failure{
-								Message: "canceled",
-								FailureInfo: &failurepb.Failure_CanceledFailureInfo{
-									CanceledFailureInfo: &failurepb.CanceledFailureInfo{},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	err := MatchingDispatchResponseToError(resp)
-	require.Error(t, err)
-
-	var cancelErr *temporal.CanceledError
-	require.ErrorAs(t, err, &cancelErr)
-}
-
-func TestMatchingDispatchResponseToError_EmptyOutcome(t *testing.T) {
-	resp := &matchingservice.DispatchNexusTaskResponse{}
-	err := MatchingDispatchResponseToError(resp)
-	require.Error(t, err)
-
-	var handlerErr *nexus.HandlerError
-	require.ErrorAs(t, err, &handlerErr)
-	require.Equal(t, nexus.HandlerErrorTypeInternal, handlerErr.Type)
-}
-
-func TestStartOperationResponseToError_EmptyVariant(t *testing.T) {
-	resp := &nexuspb.StartOperationResponse{}
-	err := StartOperationResponseToError(resp)
-	require.Error(t, err)
-
-	var handlerErr *nexus.HandlerError
-	require.ErrorAs(t, err, &handlerErr)
-	require.Equal(t, nexus.HandlerErrorTypeInternal, handlerErr.Type)
+	require.ErrorAs(t, handlerErr.Cause, &appErr)
+	require.Equal(t, "worker said no", appErr.Message())
 }

--- a/service/frontend/nexus_dispatch_result.go
+++ b/service/frontend/nexus_dispatch_result.go
@@ -9,13 +9,13 @@ import (
 	"go.temporal.io/server/common/nexus/nexusrpc"
 )
 
-// startOperationOutcome converts matching's response to a StartOperation dispatch into the result the
+// handleStartOperationResponse converts matching's response to a StartOperation dispatch into the result the
 // Nexus SDK expects, recording the metrics outcome tag and the failure-source response header along
 // the way.
 //
 // Links are returned to the caller instead of being attached here: nexus.AddHandlerLinks requires the
 // SDK's handler context.
-func (c *operationContext) startOperationOutcome(
+func (c *operationContext) handleStartOperationResponse(
 	resp *matchingservice.DispatchNexusTaskResponse,
 	operation string,
 ) (nexus.HandlerStartOperationResult[any], []nexus.Link, error) {
@@ -25,7 +25,7 @@ func (c *operationContext) startOperationOutcome(
 	switch result.Outcome {
 	case commonnexus.DispatchOutcomeSyncSuccess:
 		return &nexus.HandlerStartOperationResultSync[any]{
-			Value: result.SyncPayload,
+			Value: result.OperationResult,
 		}, parseLinks(result.Links, c.logger), nil
 
 	case commonnexus.DispatchOutcomeAsyncSuccess:
@@ -47,14 +47,14 @@ func (c *operationContext) startOperationOutcome(
 		return nil, nil, c.operationError(state, cause, operation)
 
 	default:
-		return nil, nil, c.dispatchFailureToNexusError(result, operation)
+		return nil, nil, c.failedDispatchToNexusError(result, operation)
 	}
 }
 
-// cancelOperationOutcome converts matching's response to a CancelOperation dispatch into the error the
+// handleCancelOperationResponse converts matching's response to a CancelOperation dispatch into the error the
 // Nexus SDK expects, recording the metrics outcome tag and the failure-source response header along
 // the way. A nil error means the cancel was accepted.
-func (c *operationContext) cancelOperationOutcome(
+func (c *operationContext) handleCancelOperationResponse(
 	resp *matchingservice.DispatchNexusTaskResponse,
 	operation string,
 ) error {
@@ -64,13 +64,13 @@ func (c *operationContext) cancelOperationOutcome(
 	if result.Outcome == commonnexus.DispatchOutcomeCancelAccepted {
 		return nil
 	}
-	return c.dispatchFailureToNexusError(result, operation)
+	return c.failedDispatchToNexusError(result, operation)
 }
 
-// dispatchFailureToNexusError converts the outcomes that mean the task was never handled, or was
+// failedDispatchToNexusError converts the outcomes that mean the task was never handled, or was
 // refused outright, into the error to report to the caller. These arms are identical for every kind of
 // dispatched request, so both handler methods share them.
-func (c *operationContext) dispatchFailureToNexusError(
+func (c *operationContext) failedDispatchToNexusError(
 	result commonnexus.DispatchResult,
 	operation string,
 ) error {

--- a/service/frontend/nexus_dispatch_result.go
+++ b/service/frontend/nexus_dispatch_result.go
@@ -2,9 +2,7 @@ package frontend
 
 import (
 	"github.com/nexus-rpc/sdk-go/nexus"
-	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
-	nexuspb "go.temporal.io/api/nexus/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
 	"go.temporal.io/server/common/log/tag"
 	commonnexus "go.temporal.io/server/common/nexus"
@@ -21,67 +19,36 @@ func (c *operationContext) startOperationOutcome(
 	resp *matchingservice.DispatchNexusTaskResponse,
 	operation string,
 ) (nexus.HandlerStartOperationResult[any], []nexus.Link, error) {
-	c.recordDispatchOutcome(commonnexus.ClassifyStartOperationDispatch(resp))
+	result := commonnexus.ClassifyStartOperationDispatch(resp)
+	c.recordDispatchOutcome(result)
 
-	switch t := resp.GetOutcome().(type) {
-	case *matchingservice.DispatchNexusTaskResponse_Failure:
-		// A failure conversion error below is the worker's fault: it implies a malformed completion
-		// was sent from the worker.
-		he, internalErr := c.convertWorkerFailure(t.Failure, operation)
+	switch result.Outcome {
+	case commonnexus.DispatchOutcomeSyncSuccess:
+		return &nexus.HandlerStartOperationResultSync[any]{
+			Value: result.SyncPayload,
+		}, parseLinks(result.Links, c.logger), nil
+
+	case commonnexus.DispatchOutcomeAsyncSuccess:
+		return &nexus.HandlerStartOperationResultAsync{
+			OperationToken: result.OperationToken,
+		}, parseLinks(result.Links, c.logger), nil
+
+	case commonnexus.DispatchOutcomeOperationFailure:
+		// The worker ran the operation and it came back failed or canceled. That is a legitimate
+		// answer, reported to the caller as a Nexus operation error rather than a handler error.
+		cause, internalErr := c.convertWorkerFailure(result.Failure, operation)
 		if internalErr != nil {
 			return nil, nil, internalErr
 		}
-		return nil, nil, he
-
-	case *matchingservice.DispatchNexusTaskResponse_HandlerError: //nolint:staticcheck // Deprecated, still sent by older workers.
-		// Deprecated case. Replaced with DispatchNexusTaskResponse_Failure
-		return nil, nil, convertOutcomeToNexusHandlerError(t)
-
-	case *matchingservice.DispatchNexusTaskResponse_RequestTimeout:
-		return nil, nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeUpstreamTimeout, "upstream timeout")
-
-	case *matchingservice.DispatchNexusTaskResponse_Response:
-		switch t := t.Response.GetStartOperation().GetVariant().(type) {
-		case *nexuspb.StartOperationResponse_SyncSuccess:
-			return &nexus.HandlerStartOperationResultSync[any]{
-				Value: t.SyncSuccess.GetPayload(),
-			}, parseLinks(t.SyncSuccess.GetLinks(), c.logger), nil
-
-		case *nexuspb.StartOperationResponse_AsyncSuccess:
-			token := t.AsyncSuccess.GetOperationToken()
-			if token == "" {
-				// Workers predating the operation-token rename only set the operation ID.
-				//nolint:staticcheck // Deprecated, still sent by older workers.
-				token = t.AsyncSuccess.GetOperationId()
-			}
-			return &nexus.HandlerStartOperationResultAsync{
-				OperationToken: token,
-			}, parseLinks(t.AsyncSuccess.GetLinks(), c.logger), nil
-
-		case *nexuspb.StartOperationResponse_OperationError: //nolint:staticcheck // Deprecated, still sent by older workers.
-			cause := &nexus.FailureError{
-				//nolint:staticcheck // Deprecated function still in use for backward compatibility.
-				Failure: commonnexus.ProtoFailureToNexusFailure(t.OperationError.GetFailure()),
-			}
-			//nolint:staticcheck // Deprecated field on a deprecated variant.
-			state := nexus.OperationState(t.OperationError.GetOperationState())
-			return nil, nil, c.operationError(state, cause, operation)
-
-		case *nexuspb.StartOperationResponse_Failure:
-			// A failure conversion error below is the worker's fault: it implies a malformed completion
-			// was sent from the worker.
-			cause, internalErr := c.convertWorkerFailure(t.Failure, operation)
-			if internalErr != nil {
-				return nil, nil, internalErr
-			}
-			state := nexus.OperationStateFailed
-			if t.Failure.GetCanceledFailureInfo() != nil {
-				state = nexus.OperationStateCanceled
-			}
-			return nil, nil, c.operationError(state, cause, operation)
+		state := nexus.OperationStateFailed
+		if result.Failure.GetCanceledFailureInfo() != nil {
+			state = nexus.OperationStateCanceled
 		}
+		return nil, nil, c.operationError(state, cause, operation)
+
+	default:
+		return nil, nil, c.dispatchFailureToNexusError(result, operation)
 	}
-	return nil, nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "empty outcome")
 }
 
 // cancelOperationOutcome converts matching's response to a CancelOperation dispatch into the error the
@@ -91,30 +58,39 @@ func (c *operationContext) cancelOperationOutcome(
 	resp *matchingservice.DispatchNexusTaskResponse,
 	operation string,
 ) error {
-	c.recordDispatchOutcome(commonnexus.ClassifyCancelOperationDispatch(resp))
+	result := commonnexus.ClassifyCancelOperationDispatch(resp)
+	c.recordDispatchOutcome(result)
 
-	switch t := resp.GetOutcome().(type) {
-	case *matchingservice.DispatchNexusTaskResponse_Failure:
-		// A failure conversion error below is the worker's fault: it implies a malformed completion
-		// was sent from the worker.
-		he, internalErr := c.convertWorkerFailure(t.Failure, operation)
+	if result.Outcome == commonnexus.DispatchOutcomeCancelAccepted {
+		return nil
+	}
+	return c.dispatchFailureToNexusError(result, operation)
+}
+
+// dispatchFailureToNexusError converts the outcomes that mean the task was never handled, or was
+// refused outright, into the error to report to the caller. These arms are identical for every kind of
+// dispatched request, so both handler methods share them.
+func (c *operationContext) dispatchFailureToNexusError(
+	result commonnexus.DispatchResult,
+	operation string,
+) error {
+	switch result.Outcome {
+	case commonnexus.DispatchOutcomeHandlerFailure, commonnexus.DispatchOutcomeWorkerFailure:
+		// A handler error round-trips as a handler error. Anything else the worker used to fail the
+		// task converts to an opaque failure error, which the SDK reports to the caller as internal.
+		// Neither is wrapped, so both errors are reported to the caller unchanged.
+		cause, internalErr := c.convertWorkerFailure(result.Failure, operation)
 		if internalErr != nil {
 			return internalErr
 		}
-		return he
+		return cause
 
-	case *matchingservice.DispatchNexusTaskResponse_HandlerError: //nolint:staticcheck // Deprecated, still sent by older workers.
-		// Deprecated case. Replaced with DispatchNexusTaskResponse_Failure
-		return convertOutcomeToNexusHandlerError(t)
-
-	case *matchingservice.DispatchNexusTaskResponse_RequestTimeout:
+	case commonnexus.DispatchOutcomeRequestTimeout:
 		return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeUpstreamTimeout, "upstream timeout")
 
-	case *matchingservice.DispatchNexusTaskResponse_Response:
-		// A cancel response carries no fields, so any response means the worker accepted.
-		return nil
+	default:
+		return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "empty outcome")
 	}
-	return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "empty outcome")
 }
 
 // convertWorkerFailure converts a Temporal failure a worker reported into its Nexus-shaped
@@ -170,26 +146,5 @@ func (c *operationContext) recordDispatchOutcome(result commonnexus.DispatchResu
 	c.metricsHandler = c.metricsHandler.WithTags(result.OutcomeTag())
 	if !result.Outcome.Succeeded() {
 		c.setFailureSource(commonnexus.FailureSourceWorker)
-	}
-}
-
-// convertOutcomeToNexusHandlerError converts the deprecated handler error outcome into the Nexus
-// handler error to report to the caller.
-func convertOutcomeToNexusHandlerError(resp *matchingservice.DispatchNexusTaskResponse_HandlerError) *nexus.HandlerError { //nolint:staticcheck // Deprecated, still sent by older workers.
-	var retryBehavior nexus.HandlerErrorRetryBehavior
-	// nolint:exhaustive // unspecified is the default
-	switch resp.HandlerError.RetryBehavior {
-	case enumspb.NEXUS_HANDLER_ERROR_RETRY_BEHAVIOR_RETRYABLE:
-		retryBehavior = nexus.HandlerErrorRetryBehaviorRetryable
-	case enumspb.NEXUS_HANDLER_ERROR_RETRY_BEHAVIOR_NON_RETRYABLE:
-		retryBehavior = nexus.HandlerErrorRetryBehaviorNonRetryable
-	}
-	// nolint:staticcheck // Deprecated function still in use for backward compatibility.
-	cause := commonnexus.ProtoFailureToNexusFailure(resp.HandlerError.GetFailure())
-	return &nexus.HandlerError{
-		// nolint:staticcheck // Deprecated function still in use for backward compatibility.
-		Type:          nexus.HandlerErrorType(resp.HandlerError.GetErrorType()),
-		RetryBehavior: retryBehavior,
-		Cause:         &nexus.FailureError{Failure: cause},
 	}
 }

--- a/service/frontend/nexus_dispatch_result.go
+++ b/service/frontend/nexus_dispatch_result.go
@@ -7,7 +7,6 @@ import (
 	nexuspb "go.temporal.io/api/nexus/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
 	"go.temporal.io/server/common/log/tag"
-	"go.temporal.io/server/common/metrics"
 	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/nexus/nexusrpc"
 )
@@ -22,13 +21,12 @@ func (c *operationContext) startOperationOutcome(
 	resp *matchingservice.DispatchNexusTaskResponse,
 	operation string,
 ) (nexus.HandlerStartOperationResult[any], []nexus.Link, error) {
+	c.recordDispatchOutcome(commonnexus.ClassifyStartOperationDispatch(resp))
+
 	switch t := resp.GetOutcome().(type) {
 	case *matchingservice.DispatchNexusTaskResponse_Failure:
-		// Set the failure source to "worker" if we've reached this case.
-		// Failure conversions errors below are the user's fault, as it implies that malformed completions were sent from
-		// the worker.
-		c.setFailureSource(commonnexus.FailureSourceWorker)
-		c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("handler_error:" + t.Failure.GetNexusHandlerFailureInfo().GetType()))
+		// A failure conversion error below is the worker's fault: it implies a malformed completion
+		// was sent from the worker.
 		he, internalErr := c.convertWorkerFailure(t.Failure, operation)
 		if internalErr != nil {
 			return nil, nil, internalErr
@@ -37,26 +35,19 @@ func (c *operationContext) startOperationOutcome(
 
 	case *matchingservice.DispatchNexusTaskResponse_HandlerError: //nolint:staticcheck // Deprecated, still sent by older workers.
 		// Deprecated case. Replaced with DispatchNexusTaskResponse_Failure
-		//nolint:staticcheck // Deprecated field on a deprecated variant.
-		c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("handler_error:" + t.HandlerError.GetErrorType()))
-		c.setFailureSource(commonnexus.FailureSourceWorker)
 		return nil, nil, convertOutcomeToNexusHandlerError(t)
 
 	case *matchingservice.DispatchNexusTaskResponse_RequestTimeout:
-		c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("handler_timeout"))
-		c.setFailureSource(commonnexus.FailureSourceWorker)
 		return nil, nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeUpstreamTimeout, "upstream timeout")
 
 	case *matchingservice.DispatchNexusTaskResponse_Response:
 		switch t := t.Response.GetStartOperation().GetVariant().(type) {
 		case *nexuspb.StartOperationResponse_SyncSuccess:
-			c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("sync_success"))
 			return &nexus.HandlerStartOperationResultSync[any]{
 				Value: t.SyncSuccess.GetPayload(),
 			}, parseLinks(t.SyncSuccess.GetLinks(), c.logger), nil
 
 		case *nexuspb.StartOperationResponse_AsyncSuccess:
-			c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("async_success"))
 			token := t.AsyncSuccess.GetOperationToken()
 			if token == "" {
 				// Workers predating the operation-token rename only set the operation ID.
@@ -68,8 +59,6 @@ func (c *operationContext) startOperationOutcome(
 			}, parseLinks(t.AsyncSuccess.GetLinks(), c.logger), nil
 
 		case *nexuspb.StartOperationResponse_OperationError: //nolint:staticcheck // Deprecated, still sent by older workers.
-			c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("operation_error"))
-			c.setFailureSource(commonnexus.FailureSourceWorker)
 			cause := &nexus.FailureError{
 				//nolint:staticcheck // Deprecated function still in use for backward compatibility.
 				Failure: commonnexus.ProtoFailureToNexusFailure(t.OperationError.GetFailure()),
@@ -79,11 +68,8 @@ func (c *operationContext) startOperationOutcome(
 			return nil, nil, c.operationError(state, cause, operation)
 
 		case *nexuspb.StartOperationResponse_Failure:
-			// Set the failure source to "worker" if we've reached this case.
-			// Failure conversions errors below are the user's fault, as it implies that malformed completions were sent from
-			// the worker.
-			c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("failure"))
-			c.setFailureSource(commonnexus.FailureSourceWorker)
+			// A failure conversion error below is the worker's fault: it implies a malformed completion
+			// was sent from the worker.
 			cause, internalErr := c.convertWorkerFailure(t.Failure, operation)
 			if internalErr != nil {
 				return nil, nil, internalErr
@@ -95,10 +81,6 @@ func (c *operationContext) startOperationOutcome(
 			return nil, nil, c.operationError(state, cause, operation)
 		}
 	}
-	// This is the worker's fault.
-	c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("handler_error:EMPTY_OUTCOME"))
-	c.setFailureSource(commonnexus.FailureSourceWorker)
-
 	return nil, nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "empty outcome")
 }
 
@@ -109,13 +91,12 @@ func (c *operationContext) cancelOperationOutcome(
 	resp *matchingservice.DispatchNexusTaskResponse,
 	operation string,
 ) error {
+	c.recordDispatchOutcome(commonnexus.ClassifyCancelOperationDispatch(resp))
+
 	switch t := resp.GetOutcome().(type) {
 	case *matchingservice.DispatchNexusTaskResponse_Failure:
-		c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("handler_error:" + t.Failure.GetNexusHandlerFailureInfo().GetType()))
-		// Set the failure source to "worker" if we've reached this case.
-		// Failure conversions errors below are the user's fault, as it implies that malformed completions were sent from
-		// the worker.
-		c.setFailureSource(commonnexus.FailureSourceWorker)
+		// A failure conversion error below is the worker's fault: it implies a malformed completion
+		// was sent from the worker.
 		he, internalErr := c.convertWorkerFailure(t.Failure, operation)
 		if internalErr != nil {
 			return internalErr
@@ -124,25 +105,15 @@ func (c *operationContext) cancelOperationOutcome(
 
 	case *matchingservice.DispatchNexusTaskResponse_HandlerError: //nolint:staticcheck // Deprecated, still sent by older workers.
 		// Deprecated case. Replaced with DispatchNexusTaskResponse_Failure
-		//nolint:staticcheck // Deprecated field on a deprecated variant.
-		c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("handler_error:" + t.HandlerError.GetErrorType()))
-		c.setFailureSource(commonnexus.FailureSourceWorker)
 		return convertOutcomeToNexusHandlerError(t)
 
 	case *matchingservice.DispatchNexusTaskResponse_RequestTimeout:
-		c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("handler_timeout"))
-		c.setFailureSource(commonnexus.FailureSourceWorker)
 		return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeUpstreamTimeout, "upstream timeout")
 
 	case *matchingservice.DispatchNexusTaskResponse_Response:
 		// A cancel response carries no fields, so any response means the worker accepted.
-		c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("success"))
 		return nil
 	}
-	// This is the worker's fault.
-	c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("handler_error:EMPTY_OUTCOME"))
-	c.setFailureSource(commonnexus.FailureSourceWorker)
-
 	return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "empty outcome")
 }
 
@@ -191,6 +162,15 @@ func (c *operationContext) operationError(
 		return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error")
 	}
 	return opErr
+}
+
+// recordDispatchOutcome tags the request's metrics with the dispatch outcome and, when the dispatch
+// did not succeed, attributes the failure to the worker in the response header.
+func (c *operationContext) recordDispatchOutcome(result commonnexus.DispatchResult) {
+	c.metricsHandler = c.metricsHandler.WithTags(result.OutcomeTag())
+	if !result.Outcome.Succeeded() {
+		c.setFailureSource(commonnexus.FailureSourceWorker)
+	}
 }
 
 // convertOutcomeToNexusHandlerError converts the deprecated handler error outcome into the Nexus

--- a/service/frontend/nexus_dispatch_result.go
+++ b/service/frontend/nexus_dispatch_result.go
@@ -1,0 +1,215 @@
+package frontend
+
+import (
+	"github.com/nexus-rpc/sdk-go/nexus"
+	enumspb "go.temporal.io/api/enums/v1"
+	failurepb "go.temporal.io/api/failure/v1"
+	nexuspb "go.temporal.io/api/nexus/v1"
+	"go.temporal.io/server/api/matchingservice/v1"
+	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
+	commonnexus "go.temporal.io/server/common/nexus"
+	"go.temporal.io/server/common/nexus/nexusrpc"
+)
+
+// startOperationOutcome converts matching's response to a StartOperation dispatch into the result the
+// Nexus SDK expects, recording the metrics outcome tag and the failure-source response header along
+// the way.
+//
+// Links are returned to the caller instead of being attached here: nexus.AddHandlerLinks requires the
+// SDK's handler context.
+func (c *operationContext) startOperationOutcome(
+	resp *matchingservice.DispatchNexusTaskResponse,
+	operation string,
+) (nexus.HandlerStartOperationResult[any], []nexus.Link, error) {
+	switch t := resp.GetOutcome().(type) {
+	case *matchingservice.DispatchNexusTaskResponse_Failure:
+		// Set the failure source to "worker" if we've reached this case.
+		// Failure conversions errors below are the user's fault, as it implies that malformed completions were sent from
+		// the worker.
+		c.setFailureSource(commonnexus.FailureSourceWorker)
+		c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("handler_error:" + t.Failure.GetNexusHandlerFailureInfo().GetType()))
+		he, internalErr := c.convertWorkerFailure(t.Failure, operation)
+		if internalErr != nil {
+			return nil, nil, internalErr
+		}
+		return nil, nil, he
+
+	case *matchingservice.DispatchNexusTaskResponse_HandlerError: //nolint:staticcheck // Deprecated, still sent by older workers.
+		// Deprecated case. Replaced with DispatchNexusTaskResponse_Failure
+		//nolint:staticcheck // Deprecated field on a deprecated variant.
+		c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("handler_error:" + t.HandlerError.GetErrorType()))
+		c.setFailureSource(commonnexus.FailureSourceWorker)
+		return nil, nil, convertOutcomeToNexusHandlerError(t)
+
+	case *matchingservice.DispatchNexusTaskResponse_RequestTimeout:
+		c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("handler_timeout"))
+		c.setFailureSource(commonnexus.FailureSourceWorker)
+		return nil, nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeUpstreamTimeout, "upstream timeout")
+
+	case *matchingservice.DispatchNexusTaskResponse_Response:
+		switch t := t.Response.GetStartOperation().GetVariant().(type) {
+		case *nexuspb.StartOperationResponse_SyncSuccess:
+			c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("sync_success"))
+			return &nexus.HandlerStartOperationResultSync[any]{
+				Value: t.SyncSuccess.GetPayload(),
+			}, parseLinks(t.SyncSuccess.GetLinks(), c.logger), nil
+
+		case *nexuspb.StartOperationResponse_AsyncSuccess:
+			c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("async_success"))
+			token := t.AsyncSuccess.GetOperationToken()
+			if token == "" {
+				// Workers predating the operation-token rename only set the operation ID.
+				//nolint:staticcheck // Deprecated, still sent by older workers.
+				token = t.AsyncSuccess.GetOperationId()
+			}
+			return &nexus.HandlerStartOperationResultAsync{
+				OperationToken: token,
+			}, parseLinks(t.AsyncSuccess.GetLinks(), c.logger), nil
+
+		case *nexuspb.StartOperationResponse_OperationError: //nolint:staticcheck // Deprecated, still sent by older workers.
+			c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("operation_error"))
+			c.setFailureSource(commonnexus.FailureSourceWorker)
+			cause := &nexus.FailureError{
+				//nolint:staticcheck // Deprecated function still in use for backward compatibility.
+				Failure: commonnexus.ProtoFailureToNexusFailure(t.OperationError.GetFailure()),
+			}
+			//nolint:staticcheck // Deprecated field on a deprecated variant.
+			state := nexus.OperationState(t.OperationError.GetOperationState())
+			return nil, nil, c.operationError(state, cause, operation)
+
+		case *nexuspb.StartOperationResponse_Failure:
+			// Set the failure source to "worker" if we've reached this case.
+			// Failure conversions errors below are the user's fault, as it implies that malformed completions were sent from
+			// the worker.
+			c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("failure"))
+			c.setFailureSource(commonnexus.FailureSourceWorker)
+			cause, internalErr := c.convertWorkerFailure(t.Failure, operation)
+			if internalErr != nil {
+				return nil, nil, internalErr
+			}
+			state := nexus.OperationStateFailed
+			if t.Failure.GetCanceledFailureInfo() != nil {
+				state = nexus.OperationStateCanceled
+			}
+			return nil, nil, c.operationError(state, cause, operation)
+		}
+	}
+	// This is the worker's fault.
+	c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("handler_error:EMPTY_OUTCOME"))
+	c.setFailureSource(commonnexus.FailureSourceWorker)
+
+	return nil, nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "empty outcome")
+}
+
+// cancelOperationOutcome converts matching's response to a CancelOperation dispatch into the error the
+// Nexus SDK expects, recording the metrics outcome tag and the failure-source response header along
+// the way. A nil error means the cancel was accepted.
+func (c *operationContext) cancelOperationOutcome(
+	resp *matchingservice.DispatchNexusTaskResponse,
+	operation string,
+) error {
+	switch t := resp.GetOutcome().(type) {
+	case *matchingservice.DispatchNexusTaskResponse_Failure:
+		c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("handler_error:" + t.Failure.GetNexusHandlerFailureInfo().GetType()))
+		// Set the failure source to "worker" if we've reached this case.
+		// Failure conversions errors below are the user's fault, as it implies that malformed completions were sent from
+		// the worker.
+		c.setFailureSource(commonnexus.FailureSourceWorker)
+		he, internalErr := c.convertWorkerFailure(t.Failure, operation)
+		if internalErr != nil {
+			return internalErr
+		}
+		return he
+
+	case *matchingservice.DispatchNexusTaskResponse_HandlerError: //nolint:staticcheck // Deprecated, still sent by older workers.
+		// Deprecated case. Replaced with DispatchNexusTaskResponse_Failure
+		//nolint:staticcheck // Deprecated field on a deprecated variant.
+		c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("handler_error:" + t.HandlerError.GetErrorType()))
+		c.setFailureSource(commonnexus.FailureSourceWorker)
+		return convertOutcomeToNexusHandlerError(t)
+
+	case *matchingservice.DispatchNexusTaskResponse_RequestTimeout:
+		c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("handler_timeout"))
+		c.setFailureSource(commonnexus.FailureSourceWorker)
+		return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeUpstreamTimeout, "upstream timeout")
+
+	case *matchingservice.DispatchNexusTaskResponse_Response:
+		// A cancel response carries no fields, so any response means the worker accepted.
+		c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("success"))
+		return nil
+	}
+	// This is the worker's fault.
+	c.metricsHandler = c.metricsHandler.WithTags(metrics.OutcomeTag("handler_error:EMPTY_OUTCOME"))
+	c.setFailureSource(commonnexus.FailureSourceWorker)
+
+	return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "empty outcome")
+}
+
+// convertWorkerFailure converts a Temporal failure a worker reported into its Nexus-shaped
+// equivalent, preserving the cause chain in the form the wire needs.
+//
+// Exactly one of the returned errors is non-nil. cause is the worker's own failure, which the caller
+// may return directly or use as the cause of an OperationError. internalErr means the worker sent a
+// failure the server could not parse; the caller must return it as-is, since the operation's outcome
+// is unknown at that point.
+func (c *operationContext) convertWorkerFailure(
+	failure *failurepb.Failure,
+	operation string,
+) (cause error, internalErr error) {
+	// Converting in place is safe here: the failure belongs to a response this request owns.
+	nf, err := commonnexus.TemporalFailureToNexusFailureInPlace(failure)
+	if err != nil {
+		c.logger.Error("error converting Temporal failure to Nexus failure",
+			tag.Error(err), tag.Operation(operation), tag.WorkflowNamespace(c.namespaceName))
+		return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error")
+	}
+	cause, err = nexusrpc.DefaultFailureConverter().FailureToError(nf)
+	if err != nil {
+		c.logger.Error("error converting Nexus failure to Nexus error",
+			tag.Error(err), tag.Operation(operation), tag.WorkflowNamespace(c.namespaceName))
+		return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error")
+	}
+	return cause, nil
+}
+
+// operationError builds the envelope that tells a Nexus caller the operation itself failed, marked so
+// that a Temporal caller unwraps to the real cause instead of recording the synthetic envelope.
+func (c *operationContext) operationError(
+	state nexus.OperationState,
+	cause error,
+	operation string,
+) error {
+	opErr := &nexus.OperationError{
+		State:   state,
+		Message: "operation error",
+		Cause:   cause,
+	}
+	if err := nexusrpc.MarkAsWrapperError(nexusrpc.DefaultFailureConverter(), opErr); err != nil {
+		c.logger.Error("error converting OperationError to Nexus failure",
+			tag.Error(err), tag.Operation(operation), tag.WorkflowNamespace(c.namespaceName))
+		return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error")
+	}
+	return opErr
+}
+
+// convertOutcomeToNexusHandlerError converts the deprecated handler error outcome into the Nexus
+// handler error to report to the caller.
+func convertOutcomeToNexusHandlerError(resp *matchingservice.DispatchNexusTaskResponse_HandlerError) *nexus.HandlerError { //nolint:staticcheck // Deprecated, still sent by older workers.
+	var retryBehavior nexus.HandlerErrorRetryBehavior
+	// nolint:exhaustive // unspecified is the default
+	switch resp.HandlerError.RetryBehavior {
+	case enumspb.NEXUS_HANDLER_ERROR_RETRY_BEHAVIOR_RETRYABLE:
+		retryBehavior = nexus.HandlerErrorRetryBehaviorRetryable
+	case enumspb.NEXUS_HANDLER_ERROR_RETRY_BEHAVIOR_NON_RETRYABLE:
+		retryBehavior = nexus.HandlerErrorRetryBehaviorNonRetryable
+	}
+	// nolint:staticcheck // Deprecated function still in use for backward compatibility.
+	cause := commonnexus.ProtoFailureToNexusFailure(resp.HandlerError.GetFailure())
+	return &nexus.HandlerError{
+		// nolint:staticcheck // Deprecated function still in use for backward compatibility.
+		Type:          nexus.HandlerErrorType(resp.HandlerError.GetErrorType()),
+		RetryBehavior: retryBehavior,
+		Cause:         &nexus.FailureError{Failure: cause},
+	}
+}

--- a/service/frontend/nexus_dispatch_result_test.go
+++ b/service/frontend/nexus_dispatch_result_test.go
@@ -254,8 +254,8 @@ func TestStartOperationOutcome_WorkerFailure_NotAHandlerError(t *testing.T) {
 	require.Equal(t, "worker exploded", failureErr.Failure.Message)
 	var handlerErr *nexus.HandlerError
 	require.NotErrorAs(t, err, &handlerErr, "not reported as a handler error today")
-	// There is no handler error type to report, so the tag's suffix is empty.
-	require.Equal(t, "handler_error:", outcomeTagOf(t, oc))
+	// There is no handler error type to report, so the tag bounds to UNKNOWN.
+	require.Equal(t, "handler_error:UNKNOWN", outcomeTagOf(t, oc))
 	require.Equal(t, commonnexus.FailureSourceWorker, failureSourceOf(oc))
 }
 
@@ -598,28 +598,28 @@ func TestStartOperationOutcome_HandlerFailureDetailsAreWellFormed(t *testing.T) 
 	require.Equal(t, "BAD_REQUEST", details["type"])
 }
 
-// The handler error type in the outcome tag is whatever string the worker chose, so today every
-// distinct value a worker sends becomes its own time series.
-func TestStartOperationOutcome_HandlerErrorTypeTagUsesTheWorkersType(t *testing.T) {
+// The handler error type in the outcome tag is a string the worker chose, so it must not be able to
+// mint new time series.
+func TestStartOperationOutcome_HandlerErrorTypeTagIsBounded(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
 		errType string
 		wantTag string
 	}{
 		{
-			name:    "a spec type",
+			name:    "a spec type passes through",
 			errType: string(nexus.HandlerErrorTypeUnavailable),
 			wantTag: "handler_error:UNAVAILABLE",
 		},
 		{
-			name:    "an arbitrary worker string",
+			name:    "an arbitrary worker string is collapsed",
 			errType: "MY_CUSTOM_ERROR_a1b2c3",
-			wantTag: "handler_error:MY_CUSTOM_ERROR_a1b2c3",
+			wantTag: "handler_error:UNKNOWN",
 		},
 		{
-			name:    "an empty type",
+			name:    "an empty type is collapsed",
 			errType: "",
-			wantTag: "handler_error:",
+			wantTag: "handler_error:UNKNOWN",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -638,6 +638,7 @@ func TestStartOperationOutcome_HandlerErrorTypeTagUsesTheWorkersType(t *testing.
 			_, _, err := oc.startOperationOutcome(resp, "op")
 			require.Error(t, err)
 			require.Equal(t, tc.wantTag, outcomeTagOf(t, oc))
+			// The error itself still carries the worker's real type; only the metric is bounded.
 			var handlerErr *nexus.HandlerError
 			require.ErrorAs(t, err, &handlerErr)
 			require.Equal(t, nexus.HandlerErrorType(tc.errType), handlerErr.Type)
@@ -645,8 +646,8 @@ func TestStartOperationOutcome_HandlerErrorTypeTagUsesTheWorkersType(t *testing.
 	}
 }
 
-// The deprecated handler error variant reports the worker's type the same way.
-func TestCancelOperationOutcome_DeprecatedHandlerErrorTypeTagUsesTheWorkersType(t *testing.T) {
+// The deprecated handler error variant is bounded the same way.
+func TestCancelOperationOutcome_DeprecatedHandlerErrorTypeTagIsBounded(t *testing.T) {
 	oc := testOperationContext()
 	resp := &matchingservice.DispatchNexusTaskResponse{
 		//nolint:staticcheck // Exercising the deprecated variant on purpose.
@@ -656,5 +657,5 @@ func TestCancelOperationOutcome_DeprecatedHandlerErrorTypeTagUsesTheWorkersType(
 	}
 
 	require.Error(t, oc.cancelOperationOutcome(resp, "op"))
-	require.Equal(t, "handler_error:something-a-worker-made-up", outcomeTagOf(t, oc))
+	require.Equal(t, "handler_error:UNKNOWN", outcomeTagOf(t, oc))
 }

--- a/service/frontend/nexus_dispatch_result_test.go
+++ b/service/frontend/nexus_dispatch_result_test.go
@@ -1,0 +1,660 @@
+package frontend
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	failurepb "go.temporal.io/api/failure/v1"
+	nexuspb "go.temporal.io/api/nexus/v1"
+	"go.temporal.io/server/api/matchingservice/v1"
+	"go.temporal.io/server/common/metrics/metricstest"
+	commonnexus "go.temporal.io/server/common/nexus"
+)
+
+// These tests pin down how the frontend turns matching's DispatchNexusTaskResponse into the result the
+// Nexus SDK serializes back to the caller. Every arm of the response oneof is wire-visible: the error
+// type decides the HTTP status, and the outcome tag and failure-source header are consumed by
+// dashboards and by interceptRequest's error-reporting cleanup. They are asserted here so that moving
+// this logic out of the handler methods cannot silently change any of it.
+
+// outcomeTagOf reads the outcome tag accumulated on the context's metrics handler.
+func outcomeTagOf(t *testing.T, oc *operationContext) string {
+	t.Helper()
+	mh, ok := oc.metricsHandler.(*metricstest.CaptureHandler)
+	require.True(t, ok, "expected a capture handler")
+	capture := mh.StartCapture()
+	oc.metricsHandler.Counter("test").Record(1)
+	mh.StopCapture(capture)
+	snap := capture.Snapshot()
+	require.Len(t, snap["test"], 1)
+	return snap["test"][0].Tags["outcome"]
+}
+
+func failureSourceOf(oc *operationContext) string {
+	return oc.responseHeaders[commonnexus.FailureSourceHeaderName]
+}
+
+func testOperationContext() *operationContext {
+	return newOperationContext(contextOptions{
+		namespaceState:          enumspb.NAMESPACE_STATE_REGISTERED,
+		quota:                   1,
+		namespaceRateLimitAllow: true,
+		rateLimitAllow:          true,
+	})
+}
+
+// startOperationResponse wraps a StartOperationResponse in the matching response envelope. The oneof
+// variant interface is unexported, so callers pass a fully built StartOperationResponse.
+func startOperationResponse(sor *nexuspb.StartOperationResponse) *matchingservice.DispatchNexusTaskResponse {
+	return &matchingservice.DispatchNexusTaskResponse{
+		Outcome: &matchingservice.DispatchNexusTaskResponse_Response{
+			Response: &nexuspb.Response{
+				Variant: &nexuspb.Response_StartOperation{StartOperation: sor},
+			},
+		},
+	}
+}
+
+func TestStartOperationOutcome_SyncSuccess(t *testing.T) {
+	oc := testOperationContext()
+	payload := &commonpb.Payload{Data: []byte("hello")}
+	resp := startOperationResponse(&nexuspb.StartOperationResponse{
+		Variant: &nexuspb.StartOperationResponse_SyncSuccess{
+			SyncSuccess: &nexuspb.StartOperationResponse_Sync{
+				Payload: payload,
+				Links: []*nexuspb.Link{
+					{Url: "http://links.test/valid", Type: "some.Type"},
+					{Url: "http://not\na/url", Type: "bad"}, // dropped, non-fatal
+				},
+			},
+		},
+	})
+
+	result, links, err := oc.startOperationOutcome(resp, "op")
+	require.NoError(t, err)
+	sync, ok := result.(*nexus.HandlerStartOperationResultSync[any])
+	require.True(t, ok, "expected a sync result, got %T", result)
+	require.Same(t, payload, sync.Value)
+	require.Len(t, links, 1)
+	require.Equal(t, "http://links.test/valid", links[0].URL.String())
+	require.Equal(t, "some.Type", links[0].Type)
+	require.Equal(t, "sync_success", outcomeTagOf(t, oc))
+	require.Empty(t, failureSourceOf(oc), "success must not be attributed to the worker")
+}
+
+func TestStartOperationOutcome_SyncSuccess_NoPayloadNoLinks(t *testing.T) {
+	oc := testOperationContext()
+	resp := startOperationResponse(&nexuspb.StartOperationResponse{
+		Variant: &nexuspb.StartOperationResponse_SyncSuccess{
+			SyncSuccess: &nexuspb.StartOperationResponse_Sync{},
+		},
+	})
+
+	result, links, err := oc.startOperationOutcome(resp, "op")
+	require.NoError(t, err)
+	sync, ok := result.(*nexus.HandlerStartOperationResultSync[any])
+	require.True(t, ok)
+	require.Nil(t, sync.Value)
+	require.Empty(t, links)
+	require.Equal(t, "sync_success", outcomeTagOf(t, oc))
+}
+
+func TestStartOperationOutcome_AsyncSuccess_PrefersOperationToken(t *testing.T) {
+	oc := testOperationContext()
+	resp := startOperationResponse(&nexuspb.StartOperationResponse{
+		Variant: &nexuspb.StartOperationResponse_AsyncSuccess{
+			AsyncSuccess: &nexuspb.StartOperationResponse_Async{
+				OperationToken: "token",
+				//nolint:staticcheck // Exercising the deprecated field on purpose.
+				OperationId: "id",
+				Links:       []*nexuspb.Link{{Url: "http://links.test/a", Type: "t"}},
+			},
+		},
+	})
+
+	result, links, err := oc.startOperationOutcome(resp, "op")
+	require.NoError(t, err)
+	async, ok := result.(*nexus.HandlerStartOperationResultAsync)
+	require.True(t, ok, "expected an async result, got %T", result)
+	require.Equal(t, "token", async.OperationToken)
+	require.Len(t, links, 1)
+	require.Equal(t, "async_success", outcomeTagOf(t, oc))
+	require.Empty(t, failureSourceOf(oc))
+}
+
+// Workers older than the operation-token rename only set the deprecated operation ID.
+func TestStartOperationOutcome_AsyncSuccess_FallsBackToOperationID(t *testing.T) {
+	oc := testOperationContext()
+	resp := startOperationResponse(&nexuspb.StartOperationResponse{
+		Variant: &nexuspb.StartOperationResponse_AsyncSuccess{
+			//nolint:staticcheck // Exercising the deprecated field on purpose.
+			AsyncSuccess: &nexuspb.StartOperationResponse_Async{OperationId: "id-only"},
+		},
+	})
+
+	result, _, err := oc.startOperationOutcome(resp, "op")
+	require.NoError(t, err)
+	async, ok := result.(*nexus.HandlerStartOperationResultAsync)
+	require.True(t, ok)
+	require.Equal(t, "id-only", async.OperationToken)
+}
+
+func TestStartOperationOutcome_HandlerFailure(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		retryBehavior enumspb.NexusHandlerErrorRetryBehavior
+		wantRetryable bool
+	}{
+		{
+			name:          "explicitly retryable",
+			retryBehavior: enumspb.NEXUS_HANDLER_ERROR_RETRY_BEHAVIOR_RETRYABLE,
+			wantRetryable: true,
+		},
+		{
+			// BAD_REQUEST is non-retryable by default in the Nexus spec.
+			name:          "unspecified defers to the error type",
+			retryBehavior: enumspb.NEXUS_HANDLER_ERROR_RETRY_BEHAVIOR_UNSPECIFIED,
+			wantRetryable: false,
+		},
+		{
+			name:          "explicitly non-retryable",
+			retryBehavior: enumspb.NEXUS_HANDLER_ERROR_RETRY_BEHAVIOR_NON_RETRYABLE,
+			wantRetryable: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			oc := testOperationContext()
+			resp := &matchingservice.DispatchNexusTaskResponse{
+				Outcome: &matchingservice.DispatchNexusTaskResponse_Failure{
+					Failure: &failurepb.Failure{
+						Message: "handler said no",
+						FailureInfo: &failurepb.Failure_NexusHandlerFailureInfo{
+							NexusHandlerFailureInfo: &failurepb.NexusHandlerFailureInfo{
+								Type:          string(nexus.HandlerErrorTypeBadRequest),
+								RetryBehavior: tc.retryBehavior,
+							},
+						},
+					},
+				},
+			}
+
+			result, links, err := oc.startOperationOutcome(resp, "op")
+			require.Nil(t, result)
+			require.Nil(t, links)
+			var handlerErr *nexus.HandlerError
+			require.ErrorAs(t, err, &handlerErr)
+			require.Equal(t, nexus.HandlerErrorTypeBadRequest, handlerErr.Type)
+			require.Equal(t, "handler said no", handlerErr.Message)
+			require.Equal(t, tc.wantRetryable, handlerErr.Retryable())
+			require.NoError(t, handlerErr.Cause, "no cause on the wire means no cause on the error")
+			require.Equal(t, "handler_error:BAD_REQUEST", outcomeTagOf(t, oc))
+			require.Equal(t, commonnexus.FailureSourceWorker, failureSourceOf(oc))
+		})
+	}
+}
+
+// The cause chain must stay Nexus-shaped all the way down: the HTTP layer re-serializes this error
+// with the same failure converter, and an SDK-shaped cause would be flattened to just its message.
+func TestStartOperationOutcome_HandlerFailure_CauseChainStaysNexusShaped(t *testing.T) {
+	oc := testOperationContext()
+	resp := &matchingservice.DispatchNexusTaskResponse{
+		Outcome: &matchingservice.DispatchNexusTaskResponse_Failure{
+			Failure: &failurepb.Failure{
+				Message: "handler said no",
+				FailureInfo: &failurepb.Failure_NexusHandlerFailureInfo{
+					NexusHandlerFailureInfo: &failurepb.NexusHandlerFailureInfo{
+						Type: string(nexus.HandlerErrorTypeInternal),
+					},
+				},
+				Cause: &failurepb.Failure{
+					Message: "the real problem",
+					FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+						ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{Type: "RootCause"},
+					},
+				},
+			},
+		},
+	}
+
+	_, _, err := oc.startOperationOutcome(resp, "op")
+	var handlerErr *nexus.HandlerError
+	require.ErrorAs(t, err, &handlerErr)
+	cause, ok := handlerErr.Cause.(*nexus.FailureError)
+	require.True(t, ok, "expected a Nexus FailureError cause, got %T", handlerErr.Cause)
+	require.Equal(t, "the real problem", cause.Failure.Message)
+	// The application failure info survives as structured details, not as a flattened string.
+	require.Equal(t, "temporal.api.failure.v1.Failure", cause.Failure.Metadata["type"])
+	require.Contains(t, string(cause.Failure.Details), "RootCause")
+}
+
+// A worker that fails the task with something other than a handler error (a plain
+// RespondNexusTaskFailed) produces an opaque FailureError, which the SDK reports to the caller as an
+// internal error. Documented here because it is current behavior, not because it is desirable.
+func TestStartOperationOutcome_WorkerFailure_NotAHandlerError(t *testing.T) {
+	oc := testOperationContext()
+	resp := &matchingservice.DispatchNexusTaskResponse{
+		Outcome: &matchingservice.DispatchNexusTaskResponse_Failure{
+			Failure: &failurepb.Failure{
+				Message: "worker exploded",
+				FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+					ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{Type: "SomeError"},
+				},
+			},
+		},
+	}
+
+	_, _, err := oc.startOperationOutcome(resp, "op")
+	require.Error(t, err)
+	var failureErr *nexus.FailureError
+	require.ErrorAs(t, err, &failureErr)
+	require.Equal(t, "worker exploded", failureErr.Failure.Message)
+	var handlerErr *nexus.HandlerError
+	require.NotErrorAs(t, err, &handlerErr, "not reported as a handler error today")
+	// There is no handler error type to report, so the tag's suffix is empty.
+	require.Equal(t, "handler_error:", outcomeTagOf(t, oc))
+	require.Equal(t, commonnexus.FailureSourceWorker, failureSourceOf(oc))
+}
+
+func TestStartOperationOutcome_DeprecatedHandlerError(t *testing.T) {
+	oc := testOperationContext()
+	resp := &matchingservice.DispatchNexusTaskResponse{
+		//nolint:staticcheck // Exercising the deprecated variant on purpose.
+		Outcome: &matchingservice.DispatchNexusTaskResponse_HandlerError{
+			HandlerError: &nexuspb.HandlerError{
+				ErrorType:     string(nexus.HandlerErrorTypeResourceExhausted),
+				RetryBehavior: enumspb.NEXUS_HANDLER_ERROR_RETRY_BEHAVIOR_RETRYABLE,
+				Failure:       &nexuspb.Failure{Message: "slow down"},
+			},
+		},
+	}
+
+	result, links, err := oc.startOperationOutcome(resp, "op")
+	require.Nil(t, result)
+	require.Nil(t, links)
+	var handlerErr *nexus.HandlerError
+	require.ErrorAs(t, err, &handlerErr)
+	require.Equal(t, nexus.HandlerErrorTypeResourceExhausted, handlerErr.Type)
+	require.True(t, handlerErr.Retryable())
+	deprecatedCause, ok := handlerErr.Cause.(*nexus.FailureError)
+	require.True(t, ok, "expected a Nexus FailureError cause, got %T", handlerErr.Cause)
+	require.Equal(t, "slow down", deprecatedCause.Failure.Message)
+	require.Equal(t, "handler_error:RESOURCE_EXHAUSTED", outcomeTagOf(t, oc))
+	require.Equal(t, commonnexus.FailureSourceWorker, failureSourceOf(oc))
+}
+
+func TestStartOperationOutcome_RequestTimeout(t *testing.T) {
+	oc := testOperationContext()
+	resp := &matchingservice.DispatchNexusTaskResponse{
+		Outcome: &matchingservice.DispatchNexusTaskResponse_RequestTimeout{
+			RequestTimeout: &matchingservice.DispatchNexusTaskResponse_Timeout{},
+		},
+	}
+
+	result, links, err := oc.startOperationOutcome(resp, "op")
+	require.Nil(t, result)
+	require.Nil(t, links)
+	var handlerErr *nexus.HandlerError
+	require.ErrorAs(t, err, &handlerErr)
+	require.Equal(t, nexus.HandlerErrorTypeUpstreamTimeout, handlerErr.Type)
+	require.Equal(t, "upstream timeout", handlerErr.Message)
+	require.Equal(t, "handler_timeout", outcomeTagOf(t, oc))
+	require.Equal(t, commonnexus.FailureSourceWorker, failureSourceOf(oc))
+}
+
+func TestStartOperationOutcome_OperationFailure(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		info      *failurepb.Failure
+		wantState nexus.OperationState
+	}{
+		{
+			name: "application failure is a failed operation",
+			info: &failurepb.Failure{
+				Message: "activity failed",
+				FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+					ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{Type: "SomeError"},
+				},
+			},
+			wantState: nexus.OperationStateFailed,
+		},
+		{
+			name: "canceled failure is a canceled operation",
+			info: &failurepb.Failure{
+				Message: "canceled",
+				FailureInfo: &failurepb.Failure_CanceledFailureInfo{
+					CanceledFailureInfo: &failurepb.CanceledFailureInfo{},
+				},
+			},
+			wantState: nexus.OperationStateCanceled,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			oc := testOperationContext()
+			resp := startOperationResponse(&nexuspb.StartOperationResponse{
+				Variant: &nexuspb.StartOperationResponse_Failure{Failure: tc.info},
+			})
+
+			result, links, err := oc.startOperationOutcome(resp, "op")
+			require.Nil(t, result)
+			require.Nil(t, links)
+			var opErr *nexus.OperationError
+			require.ErrorAs(t, err, &opErr)
+			require.Equal(t, tc.wantState, opErr.State)
+			require.Equal(t, "operation error", opErr.Message)
+			require.IsType(t, &nexus.FailureError{}, opErr.Cause) //nolint:testifylint // Asserting the concrete wire shape, not error identity.
+			// The envelope must be marked so a Temporal caller unwraps to the real cause instead of
+			// recording the synthetic "operation error" wrapper.
+			require.NotNil(t, opErr.OriginalFailure)
+			require.Equal(t, "true", opErr.OriginalFailure.Metadata["unwrap-error"])
+			require.NotNil(t, opErr.OriginalFailure.Cause)
+			require.Equal(t, "failure", outcomeTagOf(t, oc))
+			require.Equal(t, commonnexus.FailureSourceWorker, failureSourceOf(oc))
+		})
+	}
+}
+
+func TestStartOperationOutcome_DeprecatedOperationError(t *testing.T) {
+	oc := testOperationContext()
+	resp := startOperationResponse(&nexuspb.StartOperationResponse{
+		//nolint:staticcheck // Exercising the deprecated variant on purpose.
+		Variant: &nexuspb.StartOperationResponse_OperationError{
+			OperationError: &nexuspb.UnsuccessfulOperationError{
+				OperationState: string(nexus.OperationStateCanceled),
+				Failure:        &nexuspb.Failure{Message: "worker canceled it"},
+			},
+		},
+	})
+
+	result, links, err := oc.startOperationOutcome(resp, "op")
+	require.Nil(t, result)
+	require.Nil(t, links)
+	var opErr *nexus.OperationError
+	require.ErrorAs(t, err, &opErr)
+	require.Equal(t, nexus.OperationStateCanceled, opErr.State)
+	require.Equal(t, "operation error", opErr.Message)
+	cause, ok := opErr.Cause.(*nexus.FailureError)
+	require.True(t, ok, "expected a FailureError cause, got %T", opErr.Cause)
+	require.Equal(t, "worker canceled it", cause.Failure.Message)
+	require.NotNil(t, opErr.OriginalFailure)
+	require.Equal(t, "true", opErr.OriginalFailure.Metadata["unwrap-error"])
+	require.Equal(t, "operation_error", outcomeTagOf(t, oc))
+	require.Equal(t, commonnexus.FailureSourceWorker, failureSourceOf(oc))
+}
+
+// The deprecated operation error carries the worker's failure in the Nexus encoding, and reports the
+// operation state in a field of its own. Today both are passed through untouched: the state becomes the
+// operation error's state, and the worker's failure becomes its cause verbatim.
+func TestStartOperationOutcome_DeprecatedOperationErrorPassesTheWorkerFailureThrough(t *testing.T) {
+	oc := testOperationContext()
+	resp := startOperationResponse(&nexuspb.StartOperationResponse{
+		//nolint:staticcheck // Exercising the deprecated variant on purpose.
+		Variant: &nexuspb.StartOperationResponse_OperationError{
+			OperationError: &nexuspb.UnsuccessfulOperationError{
+				OperationState: string(nexus.OperationStateFailed),
+				Failure: &nexuspb.Failure{
+					Message:  "deliberate test failure",
+					Metadata: map[string]string{"k": "v"},
+					Details:  []byte(`"details"`),
+				},
+			},
+		},
+	})
+
+	_, _, err := oc.startOperationOutcome(resp, "op")
+	var opErr *nexus.OperationError
+	require.ErrorAs(t, err, &opErr)
+	require.Equal(t, nexus.OperationStateFailed, opErr.State)
+	cause, ok := opErr.Cause.(*nexus.FailureError)
+	require.True(t, ok, "expected a FailureError cause, got %T", opErr.Cause)
+	require.Equal(t, "deliberate test failure", cause.Failure.Message)
+	// The worker's failure reaches the caller exactly as the worker encoded it.
+	require.Equal(t, map[string]string{"k": "v"}, cause.Failure.Metadata)
+	require.JSONEq(t, `"details"`, string(cause.Failure.Details))
+	require.Equal(t, "operation_error", outcomeTagOf(t, oc))
+}
+
+// Anything the frontend cannot interpret is blamed on the worker and reported as an internal error.
+func TestStartOperationOutcome_UnrecognizedOutcomes(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		resp *matchingservice.DispatchNexusTaskResponse
+	}{
+		{
+			name: "no outcome set",
+			resp: &matchingservice.DispatchNexusTaskResponse{},
+		},
+		{
+			name: "nil response",
+			resp: nil,
+		},
+		{
+			name: "response with no start operation variant",
+			resp: startOperationResponse(&nexuspb.StartOperationResponse{}),
+		},
+		{
+			name: "response carrying a cancel outcome instead of a start outcome",
+			resp: &matchingservice.DispatchNexusTaskResponse{
+				Outcome: &matchingservice.DispatchNexusTaskResponse_Response{
+					Response: &nexuspb.Response{
+						Variant: &nexuspb.Response_CancelOperation{
+							CancelOperation: &nexuspb.CancelOperationResponse{},
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			oc := testOperationContext()
+			result, links, err := oc.startOperationOutcome(tc.resp, "op")
+			require.Nil(t, result)
+			require.Nil(t, links)
+			var handlerErr *nexus.HandlerError
+			require.ErrorAs(t, err, &handlerErr)
+			require.Equal(t, nexus.HandlerErrorTypeInternal, handlerErr.Type)
+			require.Equal(t, "empty outcome", handlerErr.Message)
+			require.Equal(t, "handler_error:EMPTY_OUTCOME", outcomeTagOf(t, oc))
+			require.Equal(t, commonnexus.FailureSourceWorker, failureSourceOf(oc))
+		})
+	}
+}
+
+// CancelOperation accepts any Response outcome without inspecting its variant.
+func TestCancelOperationOutcome_Success(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		resp *matchingservice.DispatchNexusTaskResponse
+	}{
+		{
+			name: "cancel response",
+			resp: &matchingservice.DispatchNexusTaskResponse{
+				Outcome: &matchingservice.DispatchNexusTaskResponse_Response{
+					Response: &nexuspb.Response{
+						Variant: &nexuspb.Response_CancelOperation{
+							CancelOperation: &nexuspb.CancelOperationResponse{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "response with no variant is still accepted",
+			resp: &matchingservice.DispatchNexusTaskResponse{
+				Outcome: &matchingservice.DispatchNexusTaskResponse_Response{
+					Response: &nexuspb.Response{},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			oc := testOperationContext()
+			require.NoError(t, oc.cancelOperationOutcome(tc.resp, "op"))
+			require.Equal(t, "success", outcomeTagOf(t, oc))
+			require.Empty(t, failureSourceOf(oc))
+		})
+	}
+}
+
+func TestCancelOperationOutcome_HandlerFailure(t *testing.T) {
+	oc := testOperationContext()
+	resp := &matchingservice.DispatchNexusTaskResponse{
+		Outcome: &matchingservice.DispatchNexusTaskResponse_Failure{
+			Failure: &failurepb.Failure{
+				Message: "cannot cancel",
+				FailureInfo: &failurepb.Failure_NexusHandlerFailureInfo{
+					NexusHandlerFailureInfo: &failurepb.NexusHandlerFailureInfo{
+						Type: string(nexus.HandlerErrorTypeNotFound),
+					},
+				},
+			},
+		},
+	}
+
+	err := oc.cancelOperationOutcome(resp, "op")
+	var handlerErr *nexus.HandlerError
+	require.ErrorAs(t, err, &handlerErr)
+	require.Equal(t, nexus.HandlerErrorTypeNotFound, handlerErr.Type)
+	require.Equal(t, "cannot cancel", handlerErr.Message)
+	require.Equal(t, "handler_error:NOT_FOUND", outcomeTagOf(t, oc))
+	require.Equal(t, commonnexus.FailureSourceWorker, failureSourceOf(oc))
+}
+
+func TestCancelOperationOutcome_DeprecatedHandlerError(t *testing.T) {
+	oc := testOperationContext()
+	resp := &matchingservice.DispatchNexusTaskResponse{
+		//nolint:staticcheck // Exercising the deprecated variant on purpose.
+		Outcome: &matchingservice.DispatchNexusTaskResponse_HandlerError{
+			HandlerError: &nexuspb.HandlerError{
+				ErrorType: string(nexus.HandlerErrorTypeNotImplemented),
+				Failure:   &nexuspb.Failure{Message: "nope"},
+			},
+		},
+	}
+
+	err := oc.cancelOperationOutcome(resp, "op")
+	var handlerErr *nexus.HandlerError
+	require.ErrorAs(t, err, &handlerErr)
+	require.Equal(t, nexus.HandlerErrorTypeNotImplemented, handlerErr.Type)
+	require.Equal(t, "handler_error:NOT_IMPLEMENTED", outcomeTagOf(t, oc))
+	require.Equal(t, commonnexus.FailureSourceWorker, failureSourceOf(oc))
+}
+
+func TestCancelOperationOutcome_RequestTimeout(t *testing.T) {
+	oc := testOperationContext()
+	resp := &matchingservice.DispatchNexusTaskResponse{
+		Outcome: &matchingservice.DispatchNexusTaskResponse_RequestTimeout{
+			RequestTimeout: &matchingservice.DispatchNexusTaskResponse_Timeout{},
+		},
+	}
+
+	err := oc.cancelOperationOutcome(resp, "op")
+	var handlerErr *nexus.HandlerError
+	require.ErrorAs(t, err, &handlerErr)
+	require.Equal(t, nexus.HandlerErrorTypeUpstreamTimeout, handlerErr.Type)
+	require.Equal(t, "upstream timeout", handlerErr.Message)
+	require.Equal(t, "handler_timeout", outcomeTagOf(t, oc))
+	require.Equal(t, commonnexus.FailureSourceWorker, failureSourceOf(oc))
+}
+
+func TestCancelOperationOutcome_UnrecognizedOutcome(t *testing.T) {
+	oc := testOperationContext()
+	err := oc.cancelOperationOutcome(&matchingservice.DispatchNexusTaskResponse{}, "op")
+	var handlerErr *nexus.HandlerError
+	require.ErrorAs(t, err, &handlerErr)
+	require.Equal(t, nexus.HandlerErrorTypeInternal, handlerErr.Type)
+	require.Equal(t, "empty outcome", handlerErr.Message)
+	require.Equal(t, "handler_error:EMPTY_OUTCOME", outcomeTagOf(t, oc))
+	require.Equal(t, commonnexus.FailureSourceWorker, failureSourceOf(oc))
+}
+
+// The details blob of a converted handler failure has to stay parseable by the Nexus failure
+// converter on the other side of the wire.
+func TestStartOperationOutcome_HandlerFailureDetailsAreWellFormed(t *testing.T) {
+	oc := testOperationContext()
+	resp := &matchingservice.DispatchNexusTaskResponse{
+		Outcome: &matchingservice.DispatchNexusTaskResponse_Failure{
+			Failure: &failurepb.Failure{
+				Message: "bad input",
+				FailureInfo: &failurepb.Failure_NexusHandlerFailureInfo{
+					NexusHandlerFailureInfo: &failurepb.NexusHandlerFailureInfo{
+						Type: string(nexus.HandlerErrorTypeBadRequest),
+					},
+				},
+			},
+		},
+	}
+
+	_, _, err := oc.startOperationOutcome(resp, "op")
+	var handlerErr *nexus.HandlerError
+	require.ErrorAs(t, err, &handlerErr)
+	require.NotNil(t, handlerErr.OriginalFailure)
+	require.Equal(t, "nexus.HandlerError", handlerErr.OriginalFailure.Metadata["type"])
+	var details map[string]any
+	require.NoError(t, json.Unmarshal(handlerErr.OriginalFailure.Details, &details))
+	require.Equal(t, "BAD_REQUEST", details["type"])
+}
+
+// The handler error type in the outcome tag is whatever string the worker chose, so today every
+// distinct value a worker sends becomes its own time series.
+func TestStartOperationOutcome_HandlerErrorTypeTagUsesTheWorkersType(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		errType string
+		wantTag string
+	}{
+		{
+			name:    "a spec type",
+			errType: string(nexus.HandlerErrorTypeUnavailable),
+			wantTag: "handler_error:UNAVAILABLE",
+		},
+		{
+			name:    "an arbitrary worker string",
+			errType: "MY_CUSTOM_ERROR_a1b2c3",
+			wantTag: "handler_error:MY_CUSTOM_ERROR_a1b2c3",
+		},
+		{
+			name:    "an empty type",
+			errType: "",
+			wantTag: "handler_error:",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			oc := testOperationContext()
+			resp := &matchingservice.DispatchNexusTaskResponse{
+				Outcome: &matchingservice.DispatchNexusTaskResponse_Failure{
+					Failure: &failurepb.Failure{
+						Message: "nope",
+						FailureInfo: &failurepb.Failure_NexusHandlerFailureInfo{
+							NexusHandlerFailureInfo: &failurepb.NexusHandlerFailureInfo{Type: tc.errType},
+						},
+					},
+				},
+			}
+
+			_, _, err := oc.startOperationOutcome(resp, "op")
+			require.Error(t, err)
+			require.Equal(t, tc.wantTag, outcomeTagOf(t, oc))
+			var handlerErr *nexus.HandlerError
+			require.ErrorAs(t, err, &handlerErr)
+			require.Equal(t, nexus.HandlerErrorType(tc.errType), handlerErr.Type)
+		})
+	}
+}
+
+// The deprecated handler error variant reports the worker's type the same way.
+func TestCancelOperationOutcome_DeprecatedHandlerErrorTypeTagUsesTheWorkersType(t *testing.T) {
+	oc := testOperationContext()
+	resp := &matchingservice.DispatchNexusTaskResponse{
+		//nolint:staticcheck // Exercising the deprecated variant on purpose.
+		Outcome: &matchingservice.DispatchNexusTaskResponse_HandlerError{
+			HandlerError: &nexuspb.HandlerError{ErrorType: "something-a-worker-made-up"},
+		},
+	}
+
+	require.Error(t, oc.cancelOperationOutcome(resp, "op"))
+	require.Equal(t, "handler_error:something-a-worker-made-up", outcomeTagOf(t, oc))
+}

--- a/service/frontend/nexus_dispatch_result_test.go
+++ b/service/frontend/nexus_dispatch_result_test.go
@@ -18,8 +18,8 @@ import (
 // These tests pin down how the frontend turns matching's DispatchNexusTaskResponse into the result the
 // Nexus SDK serializes back to the caller. Every arm of the response oneof is wire-visible: the error
 // type decides the HTTP status, and the outcome tag and failure-source header are consumed by
-// dashboards and by interceptRequest's error-reporting cleanup. They are asserted here so that moving
-// this logic out of the handler methods cannot silently change any of it.
+// dashboards and by interceptRequest's error-reporting cleanup. They are asserted here so the shared
+// classifier introduced alongside them cannot silently change any of it.
 
 // outcomeTagOf reads the outcome tag accumulated on the context's metrics handler.
 func outcomeTagOf(t *testing.T, oc *operationContext) string {
@@ -386,9 +386,10 @@ func TestStartOperationOutcome_DeprecatedOperationError(t *testing.T) {
 }
 
 // The deprecated operation error carries the worker's failure in the Nexus encoding, and reports the
-// operation state in a field of its own. Today both are passed through untouched: the state becomes the
-// operation error's state, and the worker's failure becomes its cause verbatim.
-func TestStartOperationOutcome_DeprecatedOperationErrorPassesTheWorkerFailureThrough(t *testing.T) {
+// operation state in a field of its own. The classifier re-encodes both, so the caller receives what a
+// current-format worker would have sent: the state as the wrapping failure, and the worker's metadata
+// and details underneath it as the details of a NexusFailure application failure.
+func TestStartOperationOutcome_DeprecatedOperationErrorReEncodesWorkerFailure(t *testing.T) {
 	oc := testOperationContext()
 	resp := startOperationResponse(&nexuspb.StartOperationResponse{
 		//nolint:staticcheck // Exercising the deprecated variant on purpose.
@@ -411,9 +412,18 @@ func TestStartOperationOutcome_DeprecatedOperationErrorPassesTheWorkerFailureThr
 	cause, ok := opErr.Cause.(*nexus.FailureError)
 	require.True(t, ok, "expected a FailureError cause, got %T", opErr.Cause)
 	require.Equal(t, "deliberate test failure", cause.Failure.Message)
-	// The worker's failure reaches the caller exactly as the worker encoded it.
-	require.Equal(t, map[string]string{"k": "v"}, cause.Failure.Metadata)
-	require.JSONEq(t, `"details"`, string(cause.Failure.Details))
+
+	// Decoding the wire failure the way a Temporal caller does recovers the wrapper the current format
+	// sends for a failed operation, with the worker's failure whole underneath it.
+	tFailure, convErr := commonnexus.NexusFailureToTemporalFailure(cause.Failure)
+	require.NoError(t, convErr)
+	require.Equal(t, "OperationError", tFailure.GetApplicationFailureInfo().GetType())
+	details := tFailure.GetCause().GetApplicationFailureInfo().GetDetails().GetPayloads()
+	require.Len(t, details, 1)
+	var workerFailure nexus.Failure
+	require.NoError(t, json.Unmarshal(details[0].GetData(), &workerFailure))
+	require.Equal(t, map[string]string{"k": "v"}, workerFailure.Metadata)
+	require.JSONEq(t, `"details"`, string(workerFailure.Details))
 	require.Equal(t, "operation_error", outcomeTagOf(t, oc))
 }
 

--- a/service/frontend/nexus_dispatch_result_test.go
+++ b/service/frontend/nexus_dispatch_result_test.go
@@ -59,7 +59,7 @@ func startOperationResponse(sor *nexuspb.StartOperationResponse) *matchingservic
 	}
 }
 
-func TestStartOperationOutcome_SyncSuccess(t *testing.T) {
+func TestHandleStartOperationResponse_SyncSuccess(t *testing.T) {
 	oc := testOperationContext()
 	payload := &commonpb.Payload{Data: []byte("hello")}
 	resp := startOperationResponse(&nexuspb.StartOperationResponse{
@@ -74,7 +74,7 @@ func TestStartOperationOutcome_SyncSuccess(t *testing.T) {
 		},
 	})
 
-	result, links, err := oc.startOperationOutcome(resp, "op")
+	result, links, err := oc.handleStartOperationResponse(resp, "op")
 	require.NoError(t, err)
 	sync, ok := result.(*nexus.HandlerStartOperationResultSync[any])
 	require.True(t, ok, "expected a sync result, got %T", result)
@@ -86,7 +86,7 @@ func TestStartOperationOutcome_SyncSuccess(t *testing.T) {
 	require.Empty(t, failureSourceOf(oc), "success must not be attributed to the worker")
 }
 
-func TestStartOperationOutcome_SyncSuccess_NoPayloadNoLinks(t *testing.T) {
+func TestHandleStartOperationResponse_SyncSuccess_NoPayloadNoLinks(t *testing.T) {
 	oc := testOperationContext()
 	resp := startOperationResponse(&nexuspb.StartOperationResponse{
 		Variant: &nexuspb.StartOperationResponse_SyncSuccess{
@@ -94,7 +94,7 @@ func TestStartOperationOutcome_SyncSuccess_NoPayloadNoLinks(t *testing.T) {
 		},
 	})
 
-	result, links, err := oc.startOperationOutcome(resp, "op")
+	result, links, err := oc.handleStartOperationResponse(resp, "op")
 	require.NoError(t, err)
 	sync, ok := result.(*nexus.HandlerStartOperationResultSync[any])
 	require.True(t, ok)
@@ -103,7 +103,7 @@ func TestStartOperationOutcome_SyncSuccess_NoPayloadNoLinks(t *testing.T) {
 	require.Equal(t, "sync_success", outcomeTagOf(t, oc))
 }
 
-func TestStartOperationOutcome_AsyncSuccess_PrefersOperationToken(t *testing.T) {
+func TestHandleStartOperationResponse_AsyncSuccess_PrefersOperationToken(t *testing.T) {
 	oc := testOperationContext()
 	resp := startOperationResponse(&nexuspb.StartOperationResponse{
 		Variant: &nexuspb.StartOperationResponse_AsyncSuccess{
@@ -116,7 +116,7 @@ func TestStartOperationOutcome_AsyncSuccess_PrefersOperationToken(t *testing.T) 
 		},
 	})
 
-	result, links, err := oc.startOperationOutcome(resp, "op")
+	result, links, err := oc.handleStartOperationResponse(resp, "op")
 	require.NoError(t, err)
 	async, ok := result.(*nexus.HandlerStartOperationResultAsync)
 	require.True(t, ok, "expected an async result, got %T", result)
@@ -127,7 +127,7 @@ func TestStartOperationOutcome_AsyncSuccess_PrefersOperationToken(t *testing.T) 
 }
 
 // Workers older than the operation-token rename only set the deprecated operation ID.
-func TestStartOperationOutcome_AsyncSuccess_FallsBackToOperationID(t *testing.T) {
+func TestHandleStartOperationResponse_AsyncSuccess_FallsBackToOperationID(t *testing.T) {
 	oc := testOperationContext()
 	resp := startOperationResponse(&nexuspb.StartOperationResponse{
 		Variant: &nexuspb.StartOperationResponse_AsyncSuccess{
@@ -136,14 +136,14 @@ func TestStartOperationOutcome_AsyncSuccess_FallsBackToOperationID(t *testing.T)
 		},
 	})
 
-	result, _, err := oc.startOperationOutcome(resp, "op")
+	result, _, err := oc.handleStartOperationResponse(resp, "op")
 	require.NoError(t, err)
 	async, ok := result.(*nexus.HandlerStartOperationResultAsync)
 	require.True(t, ok)
 	require.Equal(t, "id-only", async.OperationToken)
 }
 
-func TestStartOperationOutcome_HandlerFailure(t *testing.T) {
+func TestHandleStartOperationResponse_HandlerFailure(t *testing.T) {
 	for _, tc := range []struct {
 		name          string
 		retryBehavior enumspb.NexusHandlerErrorRetryBehavior
@@ -182,7 +182,7 @@ func TestStartOperationOutcome_HandlerFailure(t *testing.T) {
 				},
 			}
 
-			result, links, err := oc.startOperationOutcome(resp, "op")
+			result, links, err := oc.handleStartOperationResponse(resp, "op")
 			require.Nil(t, result)
 			require.Nil(t, links)
 			var handlerErr *nexus.HandlerError
@@ -199,7 +199,7 @@ func TestStartOperationOutcome_HandlerFailure(t *testing.T) {
 
 // The cause chain must stay Nexus-shaped all the way down: the HTTP layer re-serializes this error
 // with the same failure converter, and an SDK-shaped cause would be flattened to just its message.
-func TestStartOperationOutcome_HandlerFailure_CauseChainStaysNexusShaped(t *testing.T) {
+func TestHandleStartOperationResponse_HandlerFailure_CauseChainStaysNexusShaped(t *testing.T) {
 	oc := testOperationContext()
 	resp := &matchingservice.DispatchNexusTaskResponse{
 		Outcome: &matchingservice.DispatchNexusTaskResponse_Failure{
@@ -220,7 +220,7 @@ func TestStartOperationOutcome_HandlerFailure_CauseChainStaysNexusShaped(t *test
 		},
 	}
 
-	_, _, err := oc.startOperationOutcome(resp, "op")
+	_, _, err := oc.handleStartOperationResponse(resp, "op")
 	var handlerErr *nexus.HandlerError
 	require.ErrorAs(t, err, &handlerErr)
 	cause, ok := handlerErr.Cause.(*nexus.FailureError)
@@ -234,7 +234,7 @@ func TestStartOperationOutcome_HandlerFailure_CauseChainStaysNexusShaped(t *test
 // A worker that fails the task with something other than a handler error (a plain
 // RespondNexusTaskFailed) produces an opaque FailureError, which the SDK reports to the caller as an
 // internal error. Documented here because it is current behavior, not because it is desirable.
-func TestStartOperationOutcome_WorkerFailure_NotAHandlerError(t *testing.T) {
+func TestHandleStartOperationResponse_WorkerFailure_NotAHandlerError(t *testing.T) {
 	oc := testOperationContext()
 	resp := &matchingservice.DispatchNexusTaskResponse{
 		Outcome: &matchingservice.DispatchNexusTaskResponse_Failure{
@@ -247,7 +247,7 @@ func TestStartOperationOutcome_WorkerFailure_NotAHandlerError(t *testing.T) {
 		},
 	}
 
-	_, _, err := oc.startOperationOutcome(resp, "op")
+	_, _, err := oc.handleStartOperationResponse(resp, "op")
 	require.Error(t, err)
 	var failureErr *nexus.FailureError
 	require.ErrorAs(t, err, &failureErr)
@@ -259,7 +259,7 @@ func TestStartOperationOutcome_WorkerFailure_NotAHandlerError(t *testing.T) {
 	require.Equal(t, commonnexus.FailureSourceWorker, failureSourceOf(oc))
 }
 
-func TestStartOperationOutcome_DeprecatedHandlerError(t *testing.T) {
+func TestHandleStartOperationResponse_DeprecatedHandlerError(t *testing.T) {
 	oc := testOperationContext()
 	resp := &matchingservice.DispatchNexusTaskResponse{
 		//nolint:staticcheck // Exercising the deprecated variant on purpose.
@@ -272,7 +272,7 @@ func TestStartOperationOutcome_DeprecatedHandlerError(t *testing.T) {
 		},
 	}
 
-	result, links, err := oc.startOperationOutcome(resp, "op")
+	result, links, err := oc.handleStartOperationResponse(resp, "op")
 	require.Nil(t, result)
 	require.Nil(t, links)
 	var handlerErr *nexus.HandlerError
@@ -286,7 +286,7 @@ func TestStartOperationOutcome_DeprecatedHandlerError(t *testing.T) {
 	require.Equal(t, commonnexus.FailureSourceWorker, failureSourceOf(oc))
 }
 
-func TestStartOperationOutcome_RequestTimeout(t *testing.T) {
+func TestHandleStartOperationResponse_RequestTimeout(t *testing.T) {
 	oc := testOperationContext()
 	resp := &matchingservice.DispatchNexusTaskResponse{
 		Outcome: &matchingservice.DispatchNexusTaskResponse_RequestTimeout{
@@ -294,7 +294,7 @@ func TestStartOperationOutcome_RequestTimeout(t *testing.T) {
 		},
 	}
 
-	result, links, err := oc.startOperationOutcome(resp, "op")
+	result, links, err := oc.handleStartOperationResponse(resp, "op")
 	require.Nil(t, result)
 	require.Nil(t, links)
 	var handlerErr *nexus.HandlerError
@@ -305,7 +305,7 @@ func TestStartOperationOutcome_RequestTimeout(t *testing.T) {
 	require.Equal(t, commonnexus.FailureSourceWorker, failureSourceOf(oc))
 }
 
-func TestStartOperationOutcome_OperationFailure(t *testing.T) {
+func TestHandleStartOperationResponse_OperationFailure(t *testing.T) {
 	for _, tc := range []struct {
 		name      string
 		info      *failurepb.Failure
@@ -338,7 +338,7 @@ func TestStartOperationOutcome_OperationFailure(t *testing.T) {
 				Variant: &nexuspb.StartOperationResponse_Failure{Failure: tc.info},
 			})
 
-			result, links, err := oc.startOperationOutcome(resp, "op")
+			result, links, err := oc.handleStartOperationResponse(resp, "op")
 			require.Nil(t, result)
 			require.Nil(t, links)
 			var opErr *nexus.OperationError
@@ -357,7 +357,85 @@ func TestStartOperationOutcome_OperationFailure(t *testing.T) {
 	}
 }
 
-func TestStartOperationOutcome_DeprecatedOperationError(t *testing.T) {
+// unconvertibleFailure is a Temporal failure the server cannot put on the wire: protojson rejects the
+// invalid UTF-8 in Type, so TemporalFailureToNexusFailureInPlace fails while serializing it. Used to
+// reach the conversion-error arms below without stubbing the failure converter.
+func unconvertibleFailure() *failurepb.Failure {
+	return &failurepb.Failure{
+		Message: "worker sent something unserializable",
+		FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+			ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{Type: string([]byte{0xff})},
+		},
+	}
+}
+
+// A failure the server cannot convert means the operation's real outcome is unknown, so it must not be
+// reported as a legitimate operation error with a missing cause.
+func TestHandleStartOperationResponse_OperationFailure_UnconvertibleFailureIsInternal(t *testing.T) {
+	oc := testOperationContext()
+	resp := startOperationResponse(&nexuspb.StartOperationResponse{
+		Variant: &nexuspb.StartOperationResponse_Failure{Failure: unconvertibleFailure()},
+	})
+
+	result, links, err := oc.handleStartOperationResponse(resp, "op")
+	require.Nil(t, result)
+	require.Nil(t, links)
+	var handlerErr *nexus.HandlerError
+	require.ErrorAs(t, err, &handlerErr)
+	require.Equal(t, nexus.HandlerErrorTypeInternal, handlerErr.Type)
+	var opErr *nexus.OperationError
+	require.NotErrorAs(t, err, &opErr, "an unreadable failure is not a legitimate operation error")
+	// The outcome was still classified as an operation failure, so the tag and header stand.
+	require.Equal(t, "failure", outcomeTagOf(t, oc))
+	require.Equal(t, commonnexus.FailureSourceWorker, failureSourceOf(oc))
+}
+
+// The cause is converted before the handler error wrapping it, so an unconvertible cause fails the
+// whole conversion. The caller gets the internal error rather than a handler error with no cause.
+func TestHandleStartOperationResponse_HandlerFailure_UnconvertibleCauseIsInternal(t *testing.T) {
+	oc := testOperationContext()
+	resp := &matchingservice.DispatchNexusTaskResponse{
+		Outcome: &matchingservice.DispatchNexusTaskResponse_Failure{
+			Failure: &failurepb.Failure{
+				Message: "handler said no",
+				FailureInfo: &failurepb.Failure_NexusHandlerFailureInfo{
+					NexusHandlerFailureInfo: &failurepb.NexusHandlerFailureInfo{
+						Type: string(nexus.HandlerErrorTypeBadRequest),
+					},
+				},
+				Cause: unconvertibleFailure(),
+			},
+		},
+	}
+
+	result, links, err := oc.handleStartOperationResponse(resp, "op")
+	require.Nil(t, result)
+	require.Nil(t, links)
+	var handlerErr *nexus.HandlerError
+	require.ErrorAs(t, err, &handlerErr)
+	require.Equal(t, nexus.HandlerErrorTypeInternal, handlerErr.Type,
+		"the worker's own BAD_REQUEST must not survive a failed conversion")
+	require.Equal(t, "handler_error:BAD_REQUEST", outcomeTagOf(t, oc))
+	require.Equal(t, commonnexus.FailureSourceWorker, failureSourceOf(oc))
+}
+
+// The conversion arm is shared with the start path, but cancel returns a bare error, where a dropped
+// internal error would surface as a nil error, i.e. an accepted cancel.
+func TestHandleCancelOperationResponse_UnconvertibleFailureIsInternal(t *testing.T) {
+	oc := testOperationContext()
+	resp := &matchingservice.DispatchNexusTaskResponse{
+		Outcome: &matchingservice.DispatchNexusTaskResponse_Failure{
+			Failure: unconvertibleFailure(),
+		},
+	}
+
+	err := oc.handleCancelOperationResponse(resp, "op")
+	var handlerErr *nexus.HandlerError
+	require.ErrorAs(t, err, &handlerErr)
+	require.Equal(t, nexus.HandlerErrorTypeInternal, handlerErr.Type)
+}
+
+func TestHandleStartOperationResponse_DeprecatedOperationError(t *testing.T) {
 	oc := testOperationContext()
 	resp := startOperationResponse(&nexuspb.StartOperationResponse{
 		//nolint:staticcheck // Exercising the deprecated variant on purpose.
@@ -369,7 +447,7 @@ func TestStartOperationOutcome_DeprecatedOperationError(t *testing.T) {
 		},
 	})
 
-	result, links, err := oc.startOperationOutcome(resp, "op")
+	result, links, err := oc.handleStartOperationResponse(resp, "op")
 	require.Nil(t, result)
 	require.Nil(t, links)
 	var opErr *nexus.OperationError
@@ -389,7 +467,7 @@ func TestStartOperationOutcome_DeprecatedOperationError(t *testing.T) {
 // operation state in a field of its own. The classifier re-encodes both, so the caller receives what a
 // current-format worker would have sent: the state as the wrapping failure, and the worker's metadata
 // and details underneath it as the details of a NexusFailure application failure.
-func TestStartOperationOutcome_DeprecatedOperationErrorReEncodesWorkerFailure(t *testing.T) {
+func TestHandleStartOperationResponse_DeprecatedOperationErrorReEncodesWorkerFailure(t *testing.T) {
 	oc := testOperationContext()
 	resp := startOperationResponse(&nexuspb.StartOperationResponse{
 		//nolint:staticcheck // Exercising the deprecated variant on purpose.
@@ -405,7 +483,7 @@ func TestStartOperationOutcome_DeprecatedOperationErrorReEncodesWorkerFailure(t 
 		},
 	})
 
-	_, _, err := oc.startOperationOutcome(resp, "op")
+	_, _, err := oc.handleStartOperationResponse(resp, "op")
 	var opErr *nexus.OperationError
 	require.ErrorAs(t, err, &opErr)
 	require.Equal(t, nexus.OperationStateFailed, opErr.State)
@@ -428,7 +506,7 @@ func TestStartOperationOutcome_DeprecatedOperationErrorReEncodesWorkerFailure(t 
 }
 
 // Anything the frontend cannot interpret is blamed on the worker and reported as an internal error.
-func TestStartOperationOutcome_UnrecognizedOutcomes(t *testing.T) {
+func TestHandleStartOperationResponse_UnrecognizedOutcomes(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		resp *matchingservice.DispatchNexusTaskResponse
@@ -460,7 +538,7 @@ func TestStartOperationOutcome_UnrecognizedOutcomes(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			oc := testOperationContext()
-			result, links, err := oc.startOperationOutcome(tc.resp, "op")
+			result, links, err := oc.handleStartOperationResponse(tc.resp, "op")
 			require.Nil(t, result)
 			require.Nil(t, links)
 			var handlerErr *nexus.HandlerError
@@ -474,7 +552,7 @@ func TestStartOperationOutcome_UnrecognizedOutcomes(t *testing.T) {
 }
 
 // CancelOperation accepts any Response outcome without inspecting its variant.
-func TestCancelOperationOutcome_Success(t *testing.T) {
+func TestHandleCancelOperationResponse_Success(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		resp *matchingservice.DispatchNexusTaskResponse
@@ -502,14 +580,14 @@ func TestCancelOperationOutcome_Success(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			oc := testOperationContext()
-			require.NoError(t, oc.cancelOperationOutcome(tc.resp, "op"))
+			require.NoError(t, oc.handleCancelOperationResponse(tc.resp, "op"))
 			require.Equal(t, "success", outcomeTagOf(t, oc))
 			require.Empty(t, failureSourceOf(oc))
 		})
 	}
 }
 
-func TestCancelOperationOutcome_HandlerFailure(t *testing.T) {
+func TestHandleCancelOperationResponse_HandlerFailure(t *testing.T) {
 	oc := testOperationContext()
 	resp := &matchingservice.DispatchNexusTaskResponse{
 		Outcome: &matchingservice.DispatchNexusTaskResponse_Failure{
@@ -524,7 +602,7 @@ func TestCancelOperationOutcome_HandlerFailure(t *testing.T) {
 		},
 	}
 
-	err := oc.cancelOperationOutcome(resp, "op")
+	err := oc.handleCancelOperationResponse(resp, "op")
 	var handlerErr *nexus.HandlerError
 	require.ErrorAs(t, err, &handlerErr)
 	require.Equal(t, nexus.HandlerErrorTypeNotFound, handlerErr.Type)
@@ -533,7 +611,7 @@ func TestCancelOperationOutcome_HandlerFailure(t *testing.T) {
 	require.Equal(t, commonnexus.FailureSourceWorker, failureSourceOf(oc))
 }
 
-func TestCancelOperationOutcome_DeprecatedHandlerError(t *testing.T) {
+func TestHandleCancelOperationResponse_DeprecatedHandlerError(t *testing.T) {
 	oc := testOperationContext()
 	resp := &matchingservice.DispatchNexusTaskResponse{
 		//nolint:staticcheck // Exercising the deprecated variant on purpose.
@@ -545,7 +623,7 @@ func TestCancelOperationOutcome_DeprecatedHandlerError(t *testing.T) {
 		},
 	}
 
-	err := oc.cancelOperationOutcome(resp, "op")
+	err := oc.handleCancelOperationResponse(resp, "op")
 	var handlerErr *nexus.HandlerError
 	require.ErrorAs(t, err, &handlerErr)
 	require.Equal(t, nexus.HandlerErrorTypeNotImplemented, handlerErr.Type)
@@ -553,7 +631,7 @@ func TestCancelOperationOutcome_DeprecatedHandlerError(t *testing.T) {
 	require.Equal(t, commonnexus.FailureSourceWorker, failureSourceOf(oc))
 }
 
-func TestCancelOperationOutcome_RequestTimeout(t *testing.T) {
+func TestHandleCancelOperationResponse_RequestTimeout(t *testing.T) {
 	oc := testOperationContext()
 	resp := &matchingservice.DispatchNexusTaskResponse{
 		Outcome: &matchingservice.DispatchNexusTaskResponse_RequestTimeout{
@@ -561,7 +639,7 @@ func TestCancelOperationOutcome_RequestTimeout(t *testing.T) {
 		},
 	}
 
-	err := oc.cancelOperationOutcome(resp, "op")
+	err := oc.handleCancelOperationResponse(resp, "op")
 	var handlerErr *nexus.HandlerError
 	require.ErrorAs(t, err, &handlerErr)
 	require.Equal(t, nexus.HandlerErrorTypeUpstreamTimeout, handlerErr.Type)
@@ -570,9 +648,9 @@ func TestCancelOperationOutcome_RequestTimeout(t *testing.T) {
 	require.Equal(t, commonnexus.FailureSourceWorker, failureSourceOf(oc))
 }
 
-func TestCancelOperationOutcome_UnrecognizedOutcome(t *testing.T) {
+func TestHandleCancelOperationResponse_UnrecognizedOutcome(t *testing.T) {
 	oc := testOperationContext()
-	err := oc.cancelOperationOutcome(&matchingservice.DispatchNexusTaskResponse{}, "op")
+	err := oc.handleCancelOperationResponse(&matchingservice.DispatchNexusTaskResponse{}, "op")
 	var handlerErr *nexus.HandlerError
 	require.ErrorAs(t, err, &handlerErr)
 	require.Equal(t, nexus.HandlerErrorTypeInternal, handlerErr.Type)
@@ -583,7 +661,7 @@ func TestCancelOperationOutcome_UnrecognizedOutcome(t *testing.T) {
 
 // The details blob of a converted handler failure has to stay parseable by the Nexus failure
 // converter on the other side of the wire.
-func TestStartOperationOutcome_HandlerFailureDetailsAreWellFormed(t *testing.T) {
+func TestHandleStartOperationResponse_HandlerFailureDetailsAreWellFormed(t *testing.T) {
 	oc := testOperationContext()
 	resp := &matchingservice.DispatchNexusTaskResponse{
 		Outcome: &matchingservice.DispatchNexusTaskResponse_Failure{
@@ -598,7 +676,7 @@ func TestStartOperationOutcome_HandlerFailureDetailsAreWellFormed(t *testing.T) 
 		},
 	}
 
-	_, _, err := oc.startOperationOutcome(resp, "op")
+	_, _, err := oc.handleStartOperationResponse(resp, "op")
 	var handlerErr *nexus.HandlerError
 	require.ErrorAs(t, err, &handlerErr)
 	require.NotNil(t, handlerErr.OriginalFailure)
@@ -610,7 +688,7 @@ func TestStartOperationOutcome_HandlerFailureDetailsAreWellFormed(t *testing.T) 
 
 // The handler error type in the outcome tag is a string the worker chose, so it must not be able to
 // mint new time series.
-func TestStartOperationOutcome_HandlerErrorTypeTagIsBounded(t *testing.T) {
+func TestHandleStartOperationResponse_HandlerErrorTypeTagIsBounded(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
 		errType string
@@ -645,7 +723,7 @@ func TestStartOperationOutcome_HandlerErrorTypeTagIsBounded(t *testing.T) {
 				},
 			}
 
-			_, _, err := oc.startOperationOutcome(resp, "op")
+			_, _, err := oc.handleStartOperationResponse(resp, "op")
 			require.Error(t, err)
 			require.Equal(t, tc.wantTag, outcomeTagOf(t, oc))
 			// The error itself still carries the worker's real type; only the metric is bounded.
@@ -657,7 +735,7 @@ func TestStartOperationOutcome_HandlerErrorTypeTagIsBounded(t *testing.T) {
 }
 
 // The deprecated handler error variant is bounded the same way.
-func TestCancelOperationOutcome_DeprecatedHandlerErrorTypeTagIsBounded(t *testing.T) {
+func TestHandleCancelOperationResponse_DeprecatedHandlerErrorTypeTagIsBounded(t *testing.T) {
 	oc := testOperationContext()
 	resp := &matchingservice.DispatchNexusTaskResponse{
 		//nolint:staticcheck // Exercising the deprecated variant on purpose.
@@ -666,6 +744,6 @@ func TestCancelOperationOutcome_DeprecatedHandlerErrorTypeTagIsBounded(t *testin
 		},
 	}
 
-	require.Error(t, oc.cancelOperationOutcome(resp, "op"))
+	require.Error(t, oc.handleCancelOperationResponse(resp, "op"))
 	require.Equal(t, "handler_error:UNKNOWN", outcomeTagOf(t, oc))
 }

--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -484,114 +484,12 @@ func (h *nexusHandler) StartOperation(
 		return nil, commonnexus.ConvertGRPCError(err, false)
 	}
 	// Convert to standard Nexus SDK response.
-	switch t := response.GetOutcome().(type) {
-	case *matchingservice.DispatchNexusTaskResponse_Failure:
-		// Set the failure source to "worker" if we've reached this case.
-		// Failure conversions errors below are the user's fault, as it implies that malformed completions were sent from
-		// the worker.
-		oc.setFailureSource(commonnexus.FailureSourceWorker)
-		oc.metricsHandler = oc.metricsHandler.WithTags(metrics.OutcomeTag("handler_error:" + t.Failure.GetNexusHandlerFailureInfo().GetType()))
-		nf, err := commonnexus.TemporalFailureToNexusFailureInPlace(t.Failure)
-		if err != nil {
-			oc.logger.Error("error converting Temporal failure to Nexus failure", tag.Error(err), tag.Operation(operation), tag.WorkflowNamespace(oc.namespaceName))
-			return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error")
-		}
-		he, err := nexusrpc.DefaultFailureConverter().FailureToError(nf)
-		if err != nil {
-			oc.logger.Error("error converting Nexus failure to Nexus HandlerError", tag.Error(err), tag.Operation(operation), tag.WorkflowNamespace(oc.namespaceName))
-			return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error")
-		}
-		return nil, he
-
-	case *matchingservice.DispatchNexusTaskResponse_HandlerError:
-		// Deprecated case. Replaced with DispatchNexusTaskResponse_Failure
-		oc.metricsHandler = oc.metricsHandler.WithTags(metrics.OutcomeTag("handler_error:" + t.HandlerError.GetErrorType()))
-		oc.setFailureSource(commonnexus.FailureSourceWorker)
-		err := convertOutcomeToNexusHandlerError(t)
+	result, handlerLinks, err := oc.startOperationOutcome(response, operation)
+	if err != nil {
 		return nil, err
-
-	case *matchingservice.DispatchNexusTaskResponse_RequestTimeout:
-		oc.metricsHandler = oc.metricsHandler.WithTags(metrics.OutcomeTag("handler_timeout"))
-		oc.setFailureSource(commonnexus.FailureSourceWorker)
-		return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeUpstreamTimeout, "upstream timeout")
-
-	case *matchingservice.DispatchNexusTaskResponse_Response:
-		switch t := t.Response.GetStartOperation().GetVariant().(type) {
-		case *nexuspb.StartOperationResponse_SyncSuccess:
-			oc.metricsHandler = oc.metricsHandler.WithTags(metrics.OutcomeTag("sync_success"))
-			links := parseLinks(t.SyncSuccess.GetLinks(), oc.logger)
-			nexus.AddHandlerLinks(ctx, links...)
-			return &nexus.HandlerStartOperationResultSync[any]{
-				Value: t.SyncSuccess.GetPayload(),
-			}, nil
-
-		case *nexuspb.StartOperationResponse_AsyncSuccess:
-			oc.metricsHandler = oc.metricsHandler.WithTags(metrics.OutcomeTag("async_success"))
-			token := t.AsyncSuccess.GetOperationToken()
-			if token == "" {
-				token = t.AsyncSuccess.GetOperationId()
-			}
-			links := parseLinks(t.AsyncSuccess.GetLinks(), oc.logger)
-			nexus.AddHandlerLinks(ctx, links...)
-			return &nexus.HandlerStartOperationResultAsync{
-				OperationToken: token,
-			}, nil
-
-		case *nexuspb.StartOperationResponse_OperationError:
-			oc.metricsHandler = oc.metricsHandler.WithTags(metrics.OutcomeTag("operation_error"))
-			oc.setFailureSource(commonnexus.FailureSourceWorker)
-			opErr := &nexus.OperationError{
-				Message: "operation error",
-				// nolint:staticcheck // Deprecated function still in use for backward compatibility.
-				State: nexus.OperationState(t.OperationError.GetOperationState()),
-				Cause: &nexus.FailureError{
-					// nolint:staticcheck // Deprecated function still in use for backward compatibility.
-					Failure: commonnexus.ProtoFailureToNexusFailure(t.OperationError.GetFailure()),
-				},
-			}
-			if err := nexusrpc.MarkAsWrapperError(nexusrpc.DefaultFailureConverter(), opErr); err != nil {
-				oc.logger.Error("error converting OperationError to Nexus failure", tag.Error(err), tag.Operation(operation), tag.WorkflowNamespace(oc.namespaceName))
-				return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error")
-			}
-			return nil, opErr
-
-		case *nexuspb.StartOperationResponse_Failure:
-			// Set the failure source to "worker" if we've reached this case.
-			// Failure conversions errors below are the user's fault, as it implies that malformed completions were sent from
-			// the worker.
-			oc.metricsHandler = oc.metricsHandler.WithTags(metrics.OutcomeTag("failure"))
-			oc.setFailureSource(commonnexus.FailureSourceWorker)
-			nf, err := commonnexus.TemporalFailureToNexusFailureInPlace(t.Failure)
-			if err != nil {
-				oc.logger.Error("error converting Temporal failure to Nexus failure", tag.Error(err), tag.Operation(operation), tag.WorkflowNamespace(oc.namespaceName))
-				return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error")
-			}
-			cause, err := nexusrpc.DefaultFailureConverter().FailureToError(nf)
-			if err != nil {
-				oc.logger.Error("error converting Nexus failure to Nexus OperationError", tag.Error(err), tag.Operation(operation), tag.WorkflowNamespace(oc.namespaceName))
-				return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error")
-			}
-			state := nexus.OperationStateFailed
-			if t.Failure.GetCanceledFailureInfo() != nil {
-				state = nexus.OperationStateCanceled
-			}
-			opErr := &nexus.OperationError{
-				State:   state,
-				Message: "operation error",
-				Cause:   cause,
-			}
-			if err := nexusrpc.MarkAsWrapperError(nexusrpc.DefaultFailureConverter(), opErr); err != nil {
-				oc.logger.Error("error converting OperationError to Nexus failure", tag.Error(err), tag.Operation(operation), tag.WorkflowNamespace(oc.namespaceName))
-				return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error")
-			}
-			return nil, opErr
-		}
 	}
-	// This is the worker's fault.
-	oc.metricsHandler = oc.metricsHandler.WithTags(metrics.OutcomeTag("handler_error:EMPTY_OUTCOME"))
-	oc.setFailureSource(commonnexus.FailureSourceWorker)
-
-	return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "empty outcome")
+	nexus.AddHandlerLinks(ctx, handlerLinks...)
+	return result, nil
 }
 
 func parseLinks(links []*nexuspb.Link, logger log.Logger) []nexus.Link {
@@ -704,46 +602,7 @@ func (h *nexusHandler) CancelOperation(ctx context.Context, service, operation, 
 		return commonnexus.ConvertGRPCError(err, false)
 	}
 	// Convert to standard Nexus SDK response.
-	switch t := response.GetOutcome().(type) {
-	case *matchingservice.DispatchNexusTaskResponse_Failure:
-		oc.metricsHandler = oc.metricsHandler.WithTags(metrics.OutcomeTag("handler_error:" + t.Failure.GetNexusHandlerFailureInfo().GetType()))
-		// Set the failure source to "worker" if we've reached this case.
-		// Failure conversions errors below are the user's fault, as it implies that malformed completions were sent from
-		// the worker.
-		oc.setFailureSource(commonnexus.FailureSourceWorker)
-		nf, err := commonnexus.TemporalFailureToNexusFailureInPlace(t.Failure)
-		if err != nil {
-			oc.logger.Error("error converting Temporal failure to Nexus failure", tag.Error(err), tag.Operation(operation), tag.WorkflowNamespace(oc.namespaceName))
-			return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error")
-		}
-		he, err := nexusrpc.DefaultFailureConverter().FailureToError(nf)
-		if err != nil {
-			oc.logger.Error("error converting Nexus failure to Nexus HandlerError", tag.Error(err), tag.Operation(operation), tag.WorkflowNamespace(oc.namespaceName))
-			return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "internal error")
-		}
-		return he
-
-	case *matchingservice.DispatchNexusTaskResponse_HandlerError:
-		// Deprecated case. Replaced with DispatchNexusTaskResponse_Failure
-		oc.metricsHandler = oc.metricsHandler.WithTags(metrics.OutcomeTag("handler_error:" + t.HandlerError.GetErrorType()))
-		oc.setFailureSource(commonnexus.FailureSourceWorker)
-		err := convertOutcomeToNexusHandlerError(t)
-		return err
-
-	case *matchingservice.DispatchNexusTaskResponse_RequestTimeout:
-		oc.metricsHandler = oc.metricsHandler.WithTags(metrics.OutcomeTag("handler_timeout"))
-		oc.setFailureSource(commonnexus.FailureSourceWorker)
-		return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeUpstreamTimeout, "upstream timeout")
-
-	case *matchingservice.DispatchNexusTaskResponse_Response:
-		oc.metricsHandler = oc.metricsHandler.WithTags(metrics.OutcomeTag("success"))
-		return nil
-	}
-	// This is the worker's fault.
-	oc.metricsHandler = oc.metricsHandler.WithTags(metrics.OutcomeTag("handler_error:EMPTY_OUTCOME"))
-	oc.setFailureSource(commonnexus.FailureSourceWorker)
-
-	return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "empty outcome")
+	return oc.cancelOperationOutcome(response, operation)
 }
 
 func (h *nexusHandler) forwardCancelOperation(
@@ -838,25 +697,6 @@ func (h *nexusHandler) nexusClientForActiveCluster(oc *operationContext, service
 		BaseURL:    baseURL,
 		Service:    service,
 	})
-}
-
-func convertOutcomeToNexusHandlerError(resp *matchingservice.DispatchNexusTaskResponse_HandlerError) *nexus.HandlerError {
-	var retryBehavior nexus.HandlerErrorRetryBehavior
-	// nolint:exhaustive // unspecified is the default
-	switch resp.HandlerError.RetryBehavior {
-	case enumspb.NEXUS_HANDLER_ERROR_RETRY_BEHAVIOR_RETRYABLE:
-		retryBehavior = nexus.HandlerErrorRetryBehaviorRetryable
-	case enumspb.NEXUS_HANDLER_ERROR_RETRY_BEHAVIOR_NON_RETRYABLE:
-		retryBehavior = nexus.HandlerErrorRetryBehaviorNonRetryable
-	}
-	// nolint:staticcheck // Deprecated function still in use for backward compatibility.
-	cause := commonnexus.ProtoFailureToNexusFailure(resp.HandlerError.GetFailure())
-	return &nexus.HandlerError{
-		// nolint:staticcheck // Deprecated function still in use for backward compatibility.
-		Type:          nexus.HandlerErrorType(resp.HandlerError.GetErrorType()),
-		RetryBehavior: retryBehavior,
-		Cause:         &nexus.FailureError{Failure: cause},
-	}
 }
 
 func (nc *nexusContext) setFailureSource(source string) {

--- a/service/frontend/nexus_handler.go
+++ b/service/frontend/nexus_handler.go
@@ -484,7 +484,7 @@ func (h *nexusHandler) StartOperation(
 		return nil, commonnexus.ConvertGRPCError(err, false)
 	}
 	// Convert to standard Nexus SDK response.
-	result, handlerLinks, err := oc.startOperationOutcome(response, operation)
+	result, handlerLinks, err := oc.handleStartOperationResponse(response, operation)
 	if err != nil {
 		return nil, err
 	}
@@ -602,7 +602,7 @@ func (h *nexusHandler) CancelOperation(ctx context.Context, service, operation, 
 		return commonnexus.ConvertGRPCError(err, false)
 	}
 	// Convert to standard Nexus SDK response.
-	return oc.cancelOperationOutcome(response, operation)
+	return oc.handleCancelOperationResponse(response, operation)
 }
 
 func (h *nexusHandler) forwardCancelOperation(

--- a/tests/nexus_api_test.go
+++ b/tests/nexus_api_test.go
@@ -166,32 +166,33 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Outcomes(useTemporalFailures
 				var operationError *nexus.OperationError
 				s.ErrorAs(err, &operationError)
 				s.Equal(nexus.OperationStateFailed, operationError.State)
-				if useTemporalFailures {
-					// Through the Temporal failure round-trip, the cause chain has an extra wrapper
-					// for the OperationError's ApplicationFailureInfo.
-					var failureErr *nexus.FailureError
-					s.ErrorAs(operationError.Cause, &failureErr)
-					var innerErr *nexus.FailureError
-					s.ErrorAs(failureErr.Cause, &innerErr)
-					tFailure, err := commonnexus.NexusFailureToTemporalFailure(innerErr.Failure)
-					s.NoError(err)
-					convErr := temporal.GetDefaultFailureConverter().FailureToError(tFailure)
-					var appErr *temporal.ApplicationError
-					s.ErrorAs(convErr, &appErr)
-					s.Equal("deliberate test failure", appErr.Message())
-					var details nexus.Failure
-					s.NoError(appErr.Details(&details))
-					s.Equal("v", details.Metadata["k"])
-				} else {
+
+				if !useTemporalFailures {
+					// The deprecated variant carries no message of its own, so the wrapper the server
+					// rebuilds from it repeats the worker's message.
 					s.Equal("deliberate test failure", operationError.Cause.Error())
-					var failureErr *nexus.FailureError
-					s.ErrorAs(operationError.Cause, &failureErr)
-					s.Equal(map[string]string{"k": "v"}, failureErr.Failure.Metadata)
-					var details string
-					err = json.Unmarshal(failureErr.Failure.Details, &details)
-					s.NoError(err)
-					s.Equal("details", details)
 				}
+
+				// Both response formats reach the caller as the same failure: an operation-error
+				// wrapper whose cause is the worker's own failure. The legacy variant reports the state
+				// in a field of its own, and the server rebuilds the wrapper from it.
+				var wrapper *nexus.FailureError
+				s.ErrorAs(operationError.Cause, &wrapper)
+				var workerErr *nexus.FailureError
+				s.ErrorAs(wrapper.Cause, &workerErr)
+				tFailure, err := commonnexus.NexusFailureToTemporalFailure(workerErr.Failure)
+				s.NoError(err)
+				convErr := temporal.GetDefaultFailureConverter().FailureToError(tFailure)
+				var appErr *temporal.ApplicationError
+				s.ErrorAs(convErr, &appErr)
+				s.Equal("deliberate test failure", appErr.Message())
+				// The worker's own metadata and details survive the re-encoding.
+				var workerFailure nexus.Failure
+				s.NoError(appErr.Details(&workerFailure))
+				s.Equal(map[string]string{"k": "v"}, workerFailure.Metadata)
+				var details string
+				s.NoError(json.Unmarshal(workerFailure.Details, &details))
+				s.Equal("details", details)
 			},
 		},
 		{

--- a/tests/nexus_api_test.go
+++ b/tests/nexus_api_test.go
@@ -178,20 +178,23 @@ func (s *NexusApiTestSuite) TestNexusStartOperation_Outcomes(useTemporalFailures
 				// in a field of its own, and the server rebuilds the wrapper from it.
 				var wrapper *nexus.FailureError
 				s.ErrorAs(operationError.Cause, &wrapper)
-				var workerErr *nexus.FailureError
-				s.ErrorAs(wrapper.Cause, &workerErr)
-				tFailure, err := commonnexus.NexusFailureToTemporalFailure(workerErr.Failure)
+
+				var wrapperCause *nexus.FailureError
+				s.ErrorAs(wrapper.Cause, &wrapperCause)
+				wrapperCauseTFailure, err := commonnexus.NexusFailureToTemporalFailure(wrapperCause.Failure)
 				s.NoError(err)
-				convErr := temporal.GetDefaultFailureConverter().FailureToError(tFailure)
+				wrapperCauseErr := temporal.GetDefaultFailureConverter().FailureToError(wrapperCauseTFailure)
+
 				var appErr *temporal.ApplicationError
-				s.ErrorAs(convErr, &appErr)
+				s.ErrorAs(wrapperCauseErr, &appErr)
 				s.Equal("deliberate test failure", appErr.Message())
+
 				// The worker's own metadata and details survive the re-encoding.
-				var workerFailure nexus.Failure
-				s.NoError(appErr.Details(&workerFailure))
-				s.Equal(map[string]string{"k": "v"}, workerFailure.Metadata)
+				var appErrDetails nexus.Failure
+				s.NoError(appErr.Details(&appErrDetails))
+				s.Equal(map[string]string{"k": "v"}, appErrDetails.Metadata)
 				var details string
-				s.NoError(json.Unmarshal(workerFailure.Details, &details))
+				s.NoError(json.Unmarshal(appErrDetails.Details, &details))
 				s.Equal("details", details)
 			},
 		},

--- a/tests/xdc/nexus_request_forwarding_test.go
+++ b/tests/xdc/nexus_request_forwarding_test.go
@@ -159,23 +159,25 @@ func (s *NexusRequestForwardingSuite) TestStartOperationForwardedFromStandbyToAc
 				require.ErrorAs(t, retErr, &operationError)
 				require.Equal(t, nexus.OperationStateFailed, operationError.State)
 				require.Equal(t, "deliberate test failure", operationError.Cause.Error())
+
 				// The server rebuilds the failure a current-format worker would have sent: an
 				// operation-error wrapper carrying the worker's own failure as its cause.
-				var wrapper *nexus.FailureError
-				require.ErrorAs(t, operationError.Cause, &wrapper)
-				var workerErr *nexus.FailureError
-				require.ErrorAs(t, wrapper.Cause, &workerErr)
-				tFailure, err := cnexus.NexusFailureToTemporalFailure(workerErr.Failure)
+				var wrapperErr *nexus.FailureError
+				require.ErrorAs(t, operationError.Cause, &wrapperErr)
+				var wrapperErrCause *nexus.FailureError
+				require.ErrorAs(t, wrapperErr.Cause, &wrapperErrCause)
+				tFailure, err := cnexus.NexusFailureToTemporalFailure(wrapperErrCause.Failure)
 				require.NoError(t, err)
 				convErr := temporal.GetDefaultFailureConverter().FailureToError(tFailure)
+
 				var appErr *temporal.ApplicationError
 				require.ErrorAs(t, convErr, &appErr)
 				require.Equal(t, "deliberate test failure", appErr.Message())
-				var workerFailure nexus.Failure
-				require.NoError(t, appErr.Details(&workerFailure))
-				require.Equal(t, map[string]string{"k": "v"}, workerFailure.Metadata)
+				var appErrDetails nexus.Failure
+				require.NoError(t, appErr.Details(&appErrDetails))
+				require.Equal(t, map[string]string{"k": "v"}, appErrDetails.Metadata)
 				var details string
-				require.NoError(t, json.Unmarshal(workerFailure.Details, &details))
+				require.NoError(t, json.Unmarshal(appErrDetails.Details, &details))
 				require.Equal(t, "details", details)
 				requireExpectedMetricsCaptured(t, activeSnap, ns, "StartNexusOperation", "operation_error")
 				requireExpectedMetricsCaptured(t, passiveSnap, ns, "StartNexusOperation", "forwarded_request_error")

--- a/tests/xdc/nexus_request_forwarding_test.go
+++ b/tests/xdc/nexus_request_forwarding_test.go
@@ -23,6 +23,7 @@ import (
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/server/api/matchingservice/v1"
 	"go.temporal.io/server/common/authorization"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -158,12 +159,23 @@ func (s *NexusRequestForwardingSuite) TestStartOperationForwardedFromStandbyToAc
 				require.ErrorAs(t, retErr, &operationError)
 				require.Equal(t, nexus.OperationStateFailed, operationError.State)
 				require.Equal(t, "deliberate test failure", operationError.Cause.Error())
-				var failureError *nexus.FailureError
-				require.ErrorAs(t, operationError.Cause, &failureError)
-				require.Equal(t, map[string]string{"k": "v"}, failureError.Failure.Metadata)
-				var details string
-				err := json.Unmarshal(failureError.Failure.Details, &details)
+				// The server rebuilds the failure a current-format worker would have sent: an
+				// operation-error wrapper carrying the worker's own failure as its cause.
+				var wrapper *nexus.FailureError
+				require.ErrorAs(t, operationError.Cause, &wrapper)
+				var workerErr *nexus.FailureError
+				require.ErrorAs(t, wrapper.Cause, &workerErr)
+				tFailure, err := cnexus.NexusFailureToTemporalFailure(workerErr.Failure)
 				require.NoError(t, err)
+				convErr := temporal.GetDefaultFailureConverter().FailureToError(tFailure)
+				var appErr *temporal.ApplicationError
+				require.ErrorAs(t, convErr, &appErr)
+				require.Equal(t, "deliberate test failure", appErr.Message())
+				var workerFailure nexus.Failure
+				require.NoError(t, appErr.Details(&workerFailure))
+				require.Equal(t, map[string]string{"k": "v"}, workerFailure.Metadata)
+				var details string
+				require.NoError(t, json.Unmarshal(workerFailure.Details, &details))
 				require.Equal(t, "details", details)
 				requireExpectedMetricsCaptured(t, activeSnap, ns, "StartNexusOperation", "operation_error")
 				requireExpectedMetricsCaptured(t, passiveSnap, ns, "StartNexusOperation", "forwarded_request_error")


### PR DESCRIPTION
I had the AI rewrite the changes to make them easier to review, consider looking at the changes commit-by-commit to see how things all come together.

---

## What changed?

Refactors the frontend's Nexus code relating to how it classifies `DispatchNexusTaskResponse` values into a reusable `DispatchOutcome`/`DispatchResult` types.

Exposing the exact behavior we have today would carry forward some bugs and deprecated types. So there are several intentional behavior changes with this PR (covered below.)

### Context

When making a Nexus request, the last step of the invocation is done via the Matching Service's `DispatchNexusTask` operation. The returned `DispatchNexusTaskResponse` proto has an `Outcome` field with 4x variants (`Failure`, `HandlerError`, `RequestTimeout`, and `Response`). And those variants then expand into 9x(!) distinct outcomes that each need to be handled differently.

For example, the Nexus task can complete successful, with either a sync or async result. 
Or if the handler fails, there are different formats the client can use to send back error responses: handler error or operation error? And both `nexuspb.HandlerError` and `nexuspb.UnsuccessfulOperationError` are both deprecated, and have been transitioned to use `failurepb.Failure` for newer clients!

It is sufficient to say that this isn't the type of code we want to be duplicated anywhere, given how rickety it is today.

This refactoring will allow the worker callbacks feature to reuse the same `DispatchNexusTaskResponse` classification logic, so that there won't be any discrepancies in how we extract errors arising from Nexus handlers getting invoked. e.g. now there is a single, canonical way that "outcome metric tags" will be labeled.

> Note that the metric tags we emit today are a little off. A successful _cancelation_ of a Nexus operation is labeled as `"success"`, whereas a successful synchronous operation is labeled with `"sync_success"`. And an uninterpretable response reports `handler_error:EMPTY_OUTCOME` despite they not coming from a Nexus handler.
>
> All the existing labels were kept as-is except for addressing existing bugs.

### Functional Changes

There are a few behavior changes in this PR:

**Metric Tags**

- The metric tag used for a worker failure without a handler failure info changed from `"handler_error:"` (empty suffix) to `"handler_error:UNKNOWN"` instead.
- We now map all non-spec handler error types to `handler_error:UNKNOWN`, instead of previously introducing their own `handler_error:${userText}`. Without the cap, the cardinality of the outcome metric could be unbounded.

**Error Conversion**

`commonnexus.DispatchResultToError` now properly handles the "deprecated" errors from clients sending older response Nexus protos, instead of treating them as `nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "empty or unknown dispatch outcome")` today.

The deprecated `matchingservice.DispatchNexusTaskResponse_HandlerError` and nexuspb.StartOperationResponse_OperationError` types are now converted into `failurepb.Failure` protos.

This does change what the Temporal server expects to receive from workers sending the deprecated errors.

A client emitting a failed operation is now seen as `ApplicationFailure{Type: "OperationError", NonRetryable: true}` wrapping the worker's failure. Whereas today, we'd just see the worker's failure alone. (This however aligns with what the current generation of Workers send now.)

**Everything Else**

Everything else should be just shuffling the code around and simplifying existing function signatures.

In `service/frontend/nexus_handler.go`, the `DispatchNexusTaskResponse` objects were handled by two methods:

- `func (h *nexusHandler) StartOperation(...) (...)`
- `func (h *nexusHandler) CancelOperation(...) (...)`

The logic has been moved into methods in `service/frontend/nexus_dispatch_result.go`, like `func (c *operationContext) startOperationOutcome(...)`.

## Why?

By exposing this classification logic, other parts of the codebase that deal with dispatching Nexus tasks (e.g. worker callbacks) will produce the same results. And emit the same outcome metrics.

Also, having a clearer set of possible outcomes from a `DispatchNexusTaskResponse` makes it easier to understand at a glance if the code processing the Nexus task's result is handling all the relevant cases. (e.g. multiple sources of failures, deprecated failure types, etc.)

## How did you test it?

- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential Risks

If there is some change to how Nexus results are classified or how errors are handled, it could break Nexus. That would be very bad. And AI code reviewers should confirm that there is no behavior changes outside of how metric tags are derived.
