### PR TITLE
Avoid redundant visibility upserts during passive refresh

### DIFF
--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -7511,7 +7511,10 @@ func (ms *MutableStateImpl) UpdateWorkflowStateStatus(
 		ms.executionState.State != enumsspb.WORKFLOW_EXECUTION_STATE_ZOMBIE {
 		// Suppress and Revive workflows are cluster local operations.
 		ms.executionStateUpdated = true
-		ms.visibilityUpdated = true // workflow status & state change triggers visibility change as well
+		// Internal state changes do not affect visibility. Status changes do.
+		if status != ms.executionState.Status {
+			ms.visibilityUpdated = true
+		}
 	}
 	return true, setStateStatus(ms.executionState, state, status)
 }

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -1937,6 +1937,27 @@ func (s *mutableStateSuite) TestUpdateWorkflowStateStatus_Table() {
 	}
 }
 
+func (s *mutableStateSuite) TestUpdateWorkflowStateStatus_VisibilityTracking() {
+	s.SetupSubTest()
+	s.mutableState.executionState.State = enumsspb.WORKFLOW_EXECUTION_STATE_CREATED
+	s.mutableState.executionState.Status = enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
+
+	_, err := s.mutableState.UpdateWorkflowStateStatus(
+		enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING,
+		enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+	)
+	s.NoError(err)
+	s.True(s.mutableState.executionStateUpdated)
+	s.False(s.mutableState.visibilityUpdated)
+
+	_, err = s.mutableState.UpdateWorkflowStateStatus(
+		enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING,
+		enumspb.WORKFLOW_EXECUTION_STATUS_PAUSED,
+	)
+	s.NoError(err)
+	s.True(s.mutableState.visibilityUpdated)
+}
+
 func (s *mutableStateSuite) TestAddWorkflowExecutionPausedEvent() {
 	s.SetupSubTest()
 	s.mockEventsCache.EXPECT().PutEvent(gomock.Any(), gomock.Any()).AnyTimes()

--- a/service/history/workflow/task_refresher.go
+++ b/service/history/workflow/task_refresher.go
@@ -634,10 +634,16 @@ func (r *TaskRefresherImpl) refreshTasksForWorkflowSearchAttr(
 		return nil
 	}
 
+	visibilityVersionedTransition := mutableState.GetExecutionInfo().VisibilityLastUpdateVersionedTransition
+	// The first visibility transition is handled by StartExecutionVisibilityTask.
+	// Generating an upsert for it would create a redundant visibility task.
+	if visibilityVersionedTransition.GetTransitionCount() == 1 {
+		return nil
+	}
 	// Skip task generation if no transition since minVersionedTransition requires
 	// an update in the visibility record.
 	if transitionhistory.Compare(
-		mutableState.GetExecutionInfo().VisibilityLastUpdateVersionedTransition,
+		visibilityVersionedTransition,
 		minVersionedTransition,
 	) < 0 {
 		return nil

--- a/service/history/workflow/task_refresher_test.go
+++ b/service/history/workflow/task_refresher_test.go
@@ -1323,7 +1323,7 @@ func (s *taskRefresherSuite) TestRefreshWorkflowSearchAttributesTasks() {
 			NamespaceId: tests.NamespaceID.String(),
 			WorkflowId:  tests.WorkflowID,
 			VisibilityLastUpdateVersionedTransition: &persistencespb.VersionedTransition{
-				TransitionCount:          3,
+				TransitionCount:          1,
 				NamespaceFailoverVersion: common.EmptyVersion,
 			},
 		},
@@ -1346,6 +1346,14 @@ func (s *taskRefresherSuite) TestRefreshWorkflowSearchAttributesTasks() {
 
 	s.mockTaskGenerator.EXPECT().GenerateUpsertVisibilityTask().Return(nil).Times(1)
 
+	// Workflow start uses StartExecutionVisibilityTask and must not also produce an upsert.
+	err = s.taskRefresher.refreshTasksForWorkflowSearchAttr(mutableState, s.mockTaskGenerator, EmptyVersionedTransition)
+	s.NoError(err)
+
+	mutableState.GetExecutionInfo().VisibilityLastUpdateVersionedTransition = &persistencespb.VersionedTransition{
+		TransitionCount:          3,
+		NamespaceFailoverVersion: common.EmptyVersion,
+	}
 	err = s.taskRefresher.refreshTasksForWorkflowSearchAttr(mutableState, s.mockTaskGenerator, &persistencespb.VersionedTransition{
 		TransitionCount:          2,
 		NamespaceFailoverVersion: common.EmptyVersion,


### PR DESCRIPTION
## What changed?
The task refresher no longer creates an UpsertExecutionVisibilityTask for the initial visibility transition, which is already represented by StartExecutionVisibilityTask. Internal workflow state changes now mark visibility as updated only when the externally visible workflow status also changes.

## Why?
Scheduling the first workflow task changes the internal execution state from CREATED to RUNNING while its public status remains RUNNING. That advanced VisibilityLastUpdateVersionedTransition without producing an active visibility task, causing passive refresh to create a passive-only visibility upsert.

## How did you test it?
- [ ] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)

Ran focused mutable-state and TaskRefresher unit tests and the single-cluster passive replication workflow and parallel-activity scenarios with exact active/passive task comparison enabled.

## Potential risks
Internal execution-state-only changes no longer advance the visibility transition marker. Public workflow status changes still do, and continue to generate the corresponding visibility work.