### PR TITLE
allow delegation of user batch to admin batch

### DIFF
--- a/api/adminservice/v1/request_response.go-helpers.pb.go
+++ b/api/adminservice/v1/request_response.go-helpers.pb.go
@@ -3446,6 +3446,43 @@ func (this *BatchOperationRefreshTasks) Equal(that interface{}) bool {
 	return proto.Equal(this, that1)
 }
 
+// Marshal an object of type BatchOperationDelegation to the protobuf v3 wire format
+func (val *BatchOperationDelegation) Marshal() ([]byte, error) {
+	return proto.Marshal(val)
+}
+
+// Unmarshal an object of type BatchOperationDelegation from the protobuf v3 wire format
+func (val *BatchOperationDelegation) Unmarshal(buf []byte) error {
+	return proto.Unmarshal(buf, val)
+}
+
+// Size returns the size of the object, in bytes, once serialized
+func (val *BatchOperationDelegation) Size() int {
+	return proto.Size(val)
+}
+
+// Equal returns whether two BatchOperationDelegation values are equivalent by recursively
+// comparing the message's fields.
+// For more information see the documentation for
+// https://pkg.go.dev/google.golang.org/protobuf/proto#Equal
+func (this *BatchOperationDelegation) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	var that1 *BatchOperationDelegation
+	switch t := that.(type) {
+	case *BatchOperationDelegation:
+		that1 = t
+	case BatchOperationDelegation:
+		that1 = &t
+	default:
+		return false
+	}
+
+	return proto.Equal(this, that1)
+}
+
 // Marshal an object of type MigrateScheduleRequest to the protobuf v3 wire format
 func (val *MigrateScheduleRequest) Marshal() ([]byte, error) {
 	return proto.Marshal(val)

--- a/api/adminservice/v1/request_response.pb.go
+++ b/api/adminservice/v1/request_response.pb.go
@@ -100,7 +100,7 @@ func (x MigrateScheduleRequest_SchedulerTarget) Number() protoreflect.EnumNumber
 
 // Deprecated: Use MigrateScheduleRequest_SchedulerTarget.Descriptor instead.
 func (MigrateScheduleRequest_SchedulerTarget) EnumDescriptor() ([]byte, []int) {
-	return file_temporal_server_api_adminservice_v1_request_response_proto_rawDescGZIP(), []int{93, 0}
+	return file_temporal_server_api_adminservice_v1_request_response_proto_rawDescGZIP(), []int{94, 0}
 }
 
 type RebuildMutableStateRequest struct {
@@ -5508,6 +5508,7 @@ type StartAdminBatchOperationRequest struct {
 	// Types that are valid to be assigned to Operation:
 	//
 	//	*StartAdminBatchOperationRequest_RefreshTasksOperation
+	//	*StartAdminBatchOperationRequest_DelegationOperation
 	Operation     isStartAdminBatchOperationRequest_Operation `protobuf_oneof:"operation"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -5601,6 +5602,15 @@ func (x *StartAdminBatchOperationRequest) GetRefreshTasksOperation() *BatchOpera
 	return nil
 }
 
+func (x *StartAdminBatchOperationRequest) GetDelegationOperation() *BatchOperationDelegation {
+	if x != nil {
+		if x, ok := x.Operation.(*StartAdminBatchOperationRequest_DelegationOperation); ok {
+			return x.DelegationOperation
+		}
+	}
+	return nil
+}
+
 type isStartAdminBatchOperationRequest_Operation interface {
 	isStartAdminBatchOperationRequest_Operation()
 }
@@ -5609,7 +5619,14 @@ type StartAdminBatchOperationRequest_RefreshTasksOperation struct {
 	RefreshTasksOperation *BatchOperationRefreshTasks `protobuf:"bytes,10,opt,name=refresh_tasks_operation,json=refreshTasksOperation,proto3,oneof"`
 }
 
+type StartAdminBatchOperationRequest_DelegationOperation struct {
+	DelegationOperation *BatchOperationDelegation `protobuf:"bytes,11,opt,name=delegation_operation,json=delegationOperation,proto3,oneof"`
+}
+
 func (*StartAdminBatchOperationRequest_RefreshTasksOperation) isStartAdminBatchOperationRequest_Operation() {
+}
+
+func (*StartAdminBatchOperationRequest_DelegationOperation) isStartAdminBatchOperationRequest_Operation() {
 }
 
 type StartAdminBatchOperationResponse struct {
@@ -5686,6 +5703,52 @@ func (*BatchOperationRefreshTasks) Descriptor() ([]byte, []int) {
 	return file_temporal_server_api_adminservice_v1_request_response_proto_rawDescGZIP(), []int{92}
 }
 
+// BatchOperationDelegation delegates an ordinary customer-facing batch operation to the admin batcher.
+type BatchOperationDelegation struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// only temmination operations are supported
+	BatchType     v16.BatchOperationType `protobuf:"varint,1,opt,name=batch_type,json=batchType,proto3,enum=temporal.api.enums.v1.BatchOperationType" json:"batch_type,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BatchOperationDelegation) Reset() {
+	*x = BatchOperationDelegation{}
+	mi := &file_temporal_server_api_adminservice_v1_request_response_proto_msgTypes[93]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BatchOperationDelegation) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BatchOperationDelegation) ProtoMessage() {}
+
+func (x *BatchOperationDelegation) ProtoReflect() protoreflect.Message {
+	mi := &file_temporal_server_api_adminservice_v1_request_response_proto_msgTypes[93]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BatchOperationDelegation.ProtoReflect.Descriptor instead.
+func (*BatchOperationDelegation) Descriptor() ([]byte, []int) {
+	return file_temporal_server_api_adminservice_v1_request_response_proto_rawDescGZIP(), []int{93}
+}
+
+func (x *BatchOperationDelegation) GetBatchType() v16.BatchOperationType {
+	if x != nil {
+		return x.BatchType
+	}
+	return v16.BatchOperationType(0)
+}
+
 type MigrateScheduleRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Namespace name.
@@ -5704,7 +5767,7 @@ type MigrateScheduleRequest struct {
 
 func (x *MigrateScheduleRequest) Reset() {
 	*x = MigrateScheduleRequest{}
-	mi := &file_temporal_server_api_adminservice_v1_request_response_proto_msgTypes[93]
+	mi := &file_temporal_server_api_adminservice_v1_request_response_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5716,7 +5779,7 @@ func (x *MigrateScheduleRequest) String() string {
 func (*MigrateScheduleRequest) ProtoMessage() {}
 
 func (x *MigrateScheduleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_temporal_server_api_adminservice_v1_request_response_proto_msgTypes[93]
+	mi := &file_temporal_server_api_adminservice_v1_request_response_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5729,7 +5792,7 @@ func (x *MigrateScheduleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MigrateScheduleRequest.ProtoReflect.Descriptor instead.
 func (*MigrateScheduleRequest) Descriptor() ([]byte, []int) {
-	return file_temporal_server_api_adminservice_v1_request_response_proto_rawDescGZIP(), []int{93}
+	return file_temporal_server_api_adminservice_v1_request_response_proto_rawDescGZIP(), []int{94}
 }
 
 func (x *MigrateScheduleRequest) GetNamespace() string {
@@ -5775,7 +5838,7 @@ type MigrateScheduleResponse struct {
 
 func (x *MigrateScheduleResponse) Reset() {
 	*x = MigrateScheduleResponse{}
-	mi := &file_temporal_server_api_adminservice_v1_request_response_proto_msgTypes[94]
+	mi := &file_temporal_server_api_adminservice_v1_request_response_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5787,7 +5850,7 @@ func (x *MigrateScheduleResponse) String() string {
 func (*MigrateScheduleResponse) ProtoMessage() {}
 
 func (x *MigrateScheduleResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_temporal_server_api_adminservice_v1_request_response_proto_msgTypes[94]
+	mi := &file_temporal_server_api_adminservice_v1_request_response_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5800,7 +5863,7 @@ func (x *MigrateScheduleResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MigrateScheduleResponse.ProtoReflect.Descriptor instead.
 func (*MigrateScheduleResponse) Descriptor() ([]byte, []int) {
-	return file_temporal_server_api_adminservice_v1_request_response_proto_rawDescGZIP(), []int{94}
+	return file_temporal_server_api_adminservice_v1_request_response_proto_rawDescGZIP(), []int{95}
 }
 
 type AddTasksRequest_Task struct {
@@ -5813,7 +5876,7 @@ type AddTasksRequest_Task struct {
 
 func (x *AddTasksRequest_Task) Reset() {
 	*x = AddTasksRequest_Task{}
-	mi := &file_temporal_server_api_adminservice_v1_request_response_proto_msgTypes[102]
+	mi := &file_temporal_server_api_adminservice_v1_request_response_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5825,7 +5888,7 @@ func (x *AddTasksRequest_Task) String() string {
 func (*AddTasksRequest_Task) ProtoMessage() {}
 
 func (x *AddTasksRequest_Task) ProtoReflect() protoreflect.Message {
-	mi := &file_temporal_server_api_adminservice_v1_request_response_proto_msgTypes[102]
+	mi := &file_temporal_server_api_adminservice_v1_request_response_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5866,7 +5929,7 @@ type ListQueuesResponse_QueueInfo struct {
 
 func (x *ListQueuesResponse_QueueInfo) Reset() {
 	*x = ListQueuesResponse_QueueInfo{}
-	mi := &file_temporal_server_api_adminservice_v1_request_response_proto_msgTypes[103]
+	mi := &file_temporal_server_api_adminservice_v1_request_response_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5878,7 +5941,7 @@ func (x *ListQueuesResponse_QueueInfo) String() string {
 func (*ListQueuesResponse_QueueInfo) ProtoMessage() {}
 
 func (x *ListQueuesResponse_QueueInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_temporal_server_api_adminservice_v1_request_response_proto_msgTypes[103]
+	mi := &file_temporal_server_api_adminservice_v1_request_response_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5919,7 +5982,7 @@ var File_temporal_server_api_adminservice_v1_request_response_proto protoreflect
 
 const file_temporal_server_api_adminservice_v1_request_response_proto_rawDesc = "" +
 	"\n" +
-	":temporal/server/api/adminservice/v1/request_response.proto\x12#temporal.server.api.adminservice.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a$temporal/api/common/v1/message.proto\x1a\"temporal/api/enums/v1/common.proto\x1a&temporal/api/enums/v1/task_queue.proto\x1a'temporal/api/namespace/v1/message.proto\x1a)temporal/api/replication/v1/message.proto\x1a'temporal/api/taskqueue/v1/message.proto\x1a%temporal/api/version/v1/message.proto\x1a&temporal/api/workflow/v1/message.proto\x1a,temporal/server/api/cluster/v1/message.proto\x1a'temporal/server/api/common/v1/dlq.proto\x1a*temporal/server/api/enums/v1/cluster.proto\x1a)temporal/server/api/enums/v1/common.proto\x1a&temporal/server/api/enums/v1/dlq.proto\x1a'temporal/server/api/enums/v1/task.proto\x1a+temporal/server/api/health/v1/message.proto\x1a,temporal/server/api/history/v1/message.proto\x1a.temporal/server/api/namespace/v1/message.proto\x1a9temporal/server/api/persistence/v1/cluster_metadata.proto\x1a3temporal/server/api/persistence/v1/executions.proto\x1a,temporal/server/api/persistence/v1/hsm.proto\x1a4temporal/server/api/persistence/v1/task_queues.proto\x1a.temporal/server/api/persistence/v1/tasks.proto\x1a?temporal/server/api/persistence/v1/workflow_mutable_state.proto\x1a0temporal/server/api/replication/v1/message.proto\x1a.temporal/server/api/taskqueue/v1/message.proto\"\x83\x01\n" +
+	":temporal/server/api/adminservice/v1/request_response.proto\x12#temporal.server.api.adminservice.v1\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a$temporal/api/common/v1/message.proto\x1a+temporal/api/enums/v1/batch_operation.proto\x1a\"temporal/api/enums/v1/common.proto\x1a&temporal/api/enums/v1/task_queue.proto\x1a'temporal/api/namespace/v1/message.proto\x1a)temporal/api/replication/v1/message.proto\x1a'temporal/api/taskqueue/v1/message.proto\x1a%temporal/api/version/v1/message.proto\x1a&temporal/api/workflow/v1/message.proto\x1a,temporal/server/api/cluster/v1/message.proto\x1a'temporal/server/api/common/v1/dlq.proto\x1a*temporal/server/api/enums/v1/cluster.proto\x1a)temporal/server/api/enums/v1/common.proto\x1a&temporal/server/api/enums/v1/dlq.proto\x1a'temporal/server/api/enums/v1/task.proto\x1a+temporal/server/api/health/v1/message.proto\x1a,temporal/server/api/history/v1/message.proto\x1a.temporal/server/api/namespace/v1/message.proto\x1a9temporal/server/api/persistence/v1/cluster_metadata.proto\x1a3temporal/server/api/persistence/v1/executions.proto\x1a,temporal/server/api/persistence/v1/hsm.proto\x1a4temporal/server/api/persistence/v1/task_queues.proto\x1a.temporal/server/api/persistence/v1/tasks.proto\x1a?temporal/server/api/persistence/v1/workflow_mutable_state.proto\x1a0temporal/server/api/replication/v1/message.proto\x1a.temporal/server/api/taskqueue/v1/message.proto\"\x83\x01\n" +
 	"\x1aRebuildMutableStateRequest\x12\x1c\n" +
 	"\tnamespace\x18\x01 \x01(\tR\tnamespace\x12G\n" +
 	"\texecution\x18\x02 \x01(\v2).temporal.api.common.v1.WorkflowExecutionR\texecution\"\x1d\n" +
@@ -6324,7 +6387,7 @@ const file_temporal_server_api_adminservice_v1_request_response_proto_rawDesc = 
 	"\fpartition_id\x18\x04 \x01(\x05R\vpartitionId\"\x90\x01\n" +
 	"\x1cGetTaskQueueUserDataResponse\x12V\n" +
 	"\tuser_data\x18\x01 \x01(\v29.temporal.server.api.persistence.v1.TaskQueueTypeUserDataR\buserData\x12\x18\n" +
-	"\aversion\x18\x02 \x01(\x03R\aversion\"\x88\x03\n" +
+	"\aversion\x18\x02 \x01(\x03R\aversion\"\xfc\x03\n" +
 	"\x1fStartAdminBatchOperationRequest\x12\x1c\n" +
 	"\tnamespace\x18\x01 \x01(\tR\tnamespace\x12)\n" +
 	"\x10visibility_query\x18\x02 \x01(\tR\x0fvisibilityQuery\x12\x15\n" +
@@ -6335,10 +6398,14 @@ const file_temporal_server_api_adminservice_v1_request_response_proto_rawDesc = 
 	"executions\x12\x1a\n" +
 	"\bidentity\x18\x06 \x01(\tR\bidentity\x12y\n" +
 	"\x17refresh_tasks_operation\x18\n" +
-	" \x01(\v2?.temporal.server.api.adminservice.v1.BatchOperationRefreshTasksH\x00R\x15refreshTasksOperationB\v\n" +
+	" \x01(\v2?.temporal.server.api.adminservice.v1.BatchOperationRefreshTasksH\x00R\x15refreshTasksOperation\x12r\n" +
+	"\x14delegation_operation\x18\v \x01(\v2=.temporal.server.api.adminservice.v1.BatchOperationDelegationH\x00R\x13delegationOperationB\v\n" +
 	"\toperation\"\"\n" +
 	" StartAdminBatchOperationResponse\"\x1c\n" +
-	"\x1aBatchOperationRefreshTasks\"\xe7\x02\n" +
+	"\x1aBatchOperationRefreshTasks\"d\n" +
+	"\x18BatchOperationDelegation\x12H\n" +
+	"\n" +
+	"batch_type\x18\x01 \x01(\x0e2).temporal.api.enums.v1.BatchOperationTypeR\tbatchType\"\xe7\x02\n" +
 	"\x16MigrateScheduleRequest\x12\x1c\n" +
 	"\tnamespace\x18\x01 \x01(\tR\tnamespace\x12\x1f\n" +
 	"\vschedule_id\x18\x02 \x01(\tR\n" +
@@ -6366,7 +6433,7 @@ func file_temporal_server_api_adminservice_v1_request_response_proto_rawDescGZIP
 }
 
 var file_temporal_server_api_adminservice_v1_request_response_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_temporal_server_api_adminservice_v1_request_response_proto_msgTypes = make([]protoimpl.MessageInfo, 105)
+var file_temporal_server_api_adminservice_v1_request_response_proto_msgTypes = make([]protoimpl.MessageInfo, 106)
 var file_temporal_server_api_adminservice_v1_request_response_proto_goTypes = []any{
 	(MigrateScheduleRequest_SchedulerTarget)(0),         // 0: temporal.server.api.adminservice.v1.MigrateScheduleRequest.SchedulerTarget
 	(*RebuildMutableStateRequest)(nil),                  // 1: temporal.server.api.adminservice.v1.RebuildMutableStateRequest
@@ -6462,164 +6529,168 @@ var file_temporal_server_api_adminservice_v1_request_response_proto_goTypes = []
 	(*StartAdminBatchOperationRequest)(nil),             // 91: temporal.server.api.adminservice.v1.StartAdminBatchOperationRequest
 	(*StartAdminBatchOperationResponse)(nil),            // 92: temporal.server.api.adminservice.v1.StartAdminBatchOperationResponse
 	(*BatchOperationRefreshTasks)(nil),                  // 93: temporal.server.api.adminservice.v1.BatchOperationRefreshTasks
-	(*MigrateScheduleRequest)(nil),                      // 94: temporal.server.api.adminservice.v1.MigrateScheduleRequest
-	(*MigrateScheduleResponse)(nil),                     // 95: temporal.server.api.adminservice.v1.MigrateScheduleResponse
-	nil,                                                 // 96: temporal.server.api.adminservice.v1.GetReplicationMessagesResponse.ShardMessagesEntry
-	nil,                                                 // 97: temporal.server.api.adminservice.v1.AddSearchAttributesRequest.SearchAttributesEntry
-	nil,                                                 // 98: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.CustomAttributesEntry
-	nil,                                                 // 99: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.SystemAttributesEntry
-	nil,                                                 // 100: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.MappingEntry
-	nil,                                                 // 101: temporal.server.api.adminservice.v1.DescribeClusterResponse.SupportedClientsEntry
-	nil,                                                 // 102: temporal.server.api.adminservice.v1.DescribeClusterResponse.TagsEntry
-	(*AddTasksRequest_Task)(nil),                        // 103: temporal.server.api.adminservice.v1.AddTasksRequest.Task
-	(*ListQueuesResponse_QueueInfo)(nil),                // 104: temporal.server.api.adminservice.v1.ListQueuesResponse.QueueInfo
-	nil,                                                 // 105: temporal.server.api.adminservice.v1.DescribeTaskQueuePartitionResponse.VersionsInfoInternalEntry
-	(*v1.WorkflowExecution)(nil),                        // 106: temporal.api.common.v1.WorkflowExecution
-	(*v1.DataBlob)(nil),                                 // 107: temporal.api.common.v1.DataBlob
-	(*v11.VersionHistory)(nil),                          // 108: temporal.server.api.history.v1.VersionHistory
-	(*v12.WorkflowMutableState)(nil),                    // 109: temporal.server.api.persistence.v1.WorkflowMutableState
-	(*v13.NamespaceCacheInfo)(nil),                      // 110: temporal.server.api.namespace.v1.NamespaceCacheInfo
-	(*v12.ShardInfo)(nil),                               // 111: temporal.server.api.persistence.v1.ShardInfo
-	(*v11.TaskRange)(nil),                               // 112: temporal.server.api.history.v1.TaskRange
-	(v14.TaskType)(0),                                   // 113: temporal.server.api.enums.v1.TaskType
-	(*timestamppb.Timestamp)(nil),                       // 114: google.protobuf.Timestamp
-	(*v15.ReplicationToken)(nil),                        // 115: temporal.server.api.replication.v1.ReplicationToken
-	(*v15.ReplicationMessages)(nil),                     // 116: temporal.server.api.replication.v1.ReplicationMessages
-	(*v15.ReplicationTaskInfo)(nil),                     // 117: temporal.server.api.replication.v1.ReplicationTaskInfo
-	(*v15.ReplicationTask)(nil),                         // 118: temporal.server.api.replication.v1.ReplicationTask
-	(*v17.WorkflowExecutionInfo)(nil),                   // 119: temporal.api.workflow.v1.WorkflowExecutionInfo
-	(*v18.MembershipInfo)(nil),                          // 120: temporal.server.api.cluster.v1.MembershipInfo
-	(*v19.VersionInfo)(nil),                             // 121: temporal.api.version.v1.VersionInfo
-	(*v12.ClusterMetadata)(nil),                         // 122: temporal.server.api.persistence.v1.ClusterMetadata
-	(*durationpb.Duration)(nil),                         // 123: google.protobuf.Duration
-	(v14.ClusterMemberRole)(0),                          // 124: temporal.server.api.enums.v1.ClusterMemberRole
-	(*v18.ClusterMember)(nil),                           // 125: temporal.server.api.cluster.v1.ClusterMember
-	(v14.DeadLetterQueueType)(0),                        // 126: temporal.server.api.enums.v1.DeadLetterQueueType
-	(v16.TaskQueueType)(0),                              // 127: temporal.api.enums.v1.TaskQueueType
-	(*v12.AllocatedTaskInfo)(nil),                       // 128: temporal.server.api.persistence.v1.AllocatedTaskInfo
-	(*v15.SyncReplicationState)(nil),                    // 129: temporal.server.api.replication.v1.SyncReplicationState
-	(*v15.WorkflowReplicationMessages)(nil),             // 130: temporal.server.api.replication.v1.WorkflowReplicationMessages
-	(*v110.NamespaceInfo)(nil),                          // 131: temporal.api.namespace.v1.NamespaceInfo
-	(*v110.NamespaceConfig)(nil),                        // 132: temporal.api.namespace.v1.NamespaceConfig
-	(*v111.NamespaceReplicationConfig)(nil),             // 133: temporal.api.replication.v1.NamespaceReplicationConfig
-	(*v111.FailoverStatus)(nil),                         // 134: temporal.api.replication.v1.FailoverStatus
-	(*v112.HistoryDLQKey)(nil),                          // 135: temporal.server.api.common.v1.HistoryDLQKey
-	(*v112.HistoryDLQTask)(nil),                         // 136: temporal.server.api.common.v1.HistoryDLQTask
-	(*v112.HistoryDLQTaskMetadata)(nil),                 // 137: temporal.server.api.common.v1.HistoryDLQTaskMetadata
-	(v14.DLQOperationType)(0),                           // 138: temporal.server.api.enums.v1.DLQOperationType
-	(v14.DLQOperationState)(0),                          // 139: temporal.server.api.enums.v1.DLQOperationState
-	(v14.HealthState)(0),                                // 140: temporal.server.api.enums.v1.HealthState
-	(*v113.ServiceHealthDetail)(nil),                    // 141: temporal.server.api.health.v1.ServiceHealthDetail
-	(*v12.VersionedTransition)(nil),                     // 142: temporal.server.api.persistence.v1.VersionedTransition
-	(*v11.VersionHistories)(nil),                        // 143: temporal.server.api.history.v1.VersionHistories
-	(*v15.VersionedTransitionArtifact)(nil),             // 144: temporal.server.api.replication.v1.VersionedTransitionArtifact
-	(*v114.TaskQueuePartition)(nil),                     // 145: temporal.server.api.taskqueue.v1.TaskQueuePartition
-	(*v115.TaskQueueVersionSelection)(nil),              // 146: temporal.api.taskqueue.v1.TaskQueueVersionSelection
-	(*v114.PartitionScaleInfo)(nil),                     // 147: temporal.server.api.taskqueue.v1.PartitionScaleInfo
-	(*v12.TaskQueueTypeUserData)(nil),                   // 148: temporal.server.api.persistence.v1.TaskQueueTypeUserData
-	(v16.IndexedValueType)(0),                           // 149: temporal.api.enums.v1.IndexedValueType
-	(*v114.TaskQueueVersionInfoInternal)(nil),           // 150: temporal.server.api.taskqueue.v1.TaskQueueVersionInfoInternal
+	(*BatchOperationDelegation)(nil),                    // 94: temporal.server.api.adminservice.v1.BatchOperationDelegation
+	(*MigrateScheduleRequest)(nil),                      // 95: temporal.server.api.adminservice.v1.MigrateScheduleRequest
+	(*MigrateScheduleResponse)(nil),                     // 96: temporal.server.api.adminservice.v1.MigrateScheduleResponse
+	nil,                                                 // 97: temporal.server.api.adminservice.v1.GetReplicationMessagesResponse.ShardMessagesEntry
+	nil,                                                 // 98: temporal.server.api.adminservice.v1.AddSearchAttributesRequest.SearchAttributesEntry
+	nil,                                                 // 99: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.CustomAttributesEntry
+	nil,                                                 // 100: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.SystemAttributesEntry
+	nil,                                                 // 101: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.MappingEntry
+	nil,                                                 // 102: temporal.server.api.adminservice.v1.DescribeClusterResponse.SupportedClientsEntry
+	nil,                                                 // 103: temporal.server.api.adminservice.v1.DescribeClusterResponse.TagsEntry
+	(*AddTasksRequest_Task)(nil),                        // 104: temporal.server.api.adminservice.v1.AddTasksRequest.Task
+	(*ListQueuesResponse_QueueInfo)(nil),                // 105: temporal.server.api.adminservice.v1.ListQueuesResponse.QueueInfo
+	nil,                                                 // 106: temporal.server.api.adminservice.v1.DescribeTaskQueuePartitionResponse.VersionsInfoInternalEntry
+	(*v1.WorkflowExecution)(nil),                        // 107: temporal.api.common.v1.WorkflowExecution
+	(*v1.DataBlob)(nil),                                 // 108: temporal.api.common.v1.DataBlob
+	(*v11.VersionHistory)(nil),                          // 109: temporal.server.api.history.v1.VersionHistory
+	(*v12.WorkflowMutableState)(nil),                    // 110: temporal.server.api.persistence.v1.WorkflowMutableState
+	(*v13.NamespaceCacheInfo)(nil),                      // 111: temporal.server.api.namespace.v1.NamespaceCacheInfo
+	(*v12.ShardInfo)(nil),                               // 112: temporal.server.api.persistence.v1.ShardInfo
+	(*v11.TaskRange)(nil),                               // 113: temporal.server.api.history.v1.TaskRange
+	(v14.TaskType)(0),                                   // 114: temporal.server.api.enums.v1.TaskType
+	(*timestamppb.Timestamp)(nil),                       // 115: google.protobuf.Timestamp
+	(*v15.ReplicationToken)(nil),                        // 116: temporal.server.api.replication.v1.ReplicationToken
+	(*v15.ReplicationMessages)(nil),                     // 117: temporal.server.api.replication.v1.ReplicationMessages
+	(*v15.ReplicationTaskInfo)(nil),                     // 118: temporal.server.api.replication.v1.ReplicationTaskInfo
+	(*v15.ReplicationTask)(nil),                         // 119: temporal.server.api.replication.v1.ReplicationTask
+	(*v17.WorkflowExecutionInfo)(nil),                   // 120: temporal.api.workflow.v1.WorkflowExecutionInfo
+	(*v18.MembershipInfo)(nil),                          // 121: temporal.server.api.cluster.v1.MembershipInfo
+	(*v19.VersionInfo)(nil),                             // 122: temporal.api.version.v1.VersionInfo
+	(*v12.ClusterMetadata)(nil),                         // 123: temporal.server.api.persistence.v1.ClusterMetadata
+	(*durationpb.Duration)(nil),                         // 124: google.protobuf.Duration
+	(v14.ClusterMemberRole)(0),                          // 125: temporal.server.api.enums.v1.ClusterMemberRole
+	(*v18.ClusterMember)(nil),                           // 126: temporal.server.api.cluster.v1.ClusterMember
+	(v14.DeadLetterQueueType)(0),                        // 127: temporal.server.api.enums.v1.DeadLetterQueueType
+	(v16.TaskQueueType)(0),                              // 128: temporal.api.enums.v1.TaskQueueType
+	(*v12.AllocatedTaskInfo)(nil),                       // 129: temporal.server.api.persistence.v1.AllocatedTaskInfo
+	(*v15.SyncReplicationState)(nil),                    // 130: temporal.server.api.replication.v1.SyncReplicationState
+	(*v15.WorkflowReplicationMessages)(nil),             // 131: temporal.server.api.replication.v1.WorkflowReplicationMessages
+	(*v110.NamespaceInfo)(nil),                          // 132: temporal.api.namespace.v1.NamespaceInfo
+	(*v110.NamespaceConfig)(nil),                        // 133: temporal.api.namespace.v1.NamespaceConfig
+	(*v111.NamespaceReplicationConfig)(nil),             // 134: temporal.api.replication.v1.NamespaceReplicationConfig
+	(*v111.FailoverStatus)(nil),                         // 135: temporal.api.replication.v1.FailoverStatus
+	(*v112.HistoryDLQKey)(nil),                          // 136: temporal.server.api.common.v1.HistoryDLQKey
+	(*v112.HistoryDLQTask)(nil),                         // 137: temporal.server.api.common.v1.HistoryDLQTask
+	(*v112.HistoryDLQTaskMetadata)(nil),                 // 138: temporal.server.api.common.v1.HistoryDLQTaskMetadata
+	(v14.DLQOperationType)(0),                           // 139: temporal.server.api.enums.v1.DLQOperationType
+	(v14.DLQOperationState)(0),                          // 140: temporal.server.api.enums.v1.DLQOperationState
+	(v14.HealthState)(0),                                // 141: temporal.server.api.enums.v1.HealthState
+	(*v113.ServiceHealthDetail)(nil),                    // 142: temporal.server.api.health.v1.ServiceHealthDetail
+	(*v12.VersionedTransition)(nil),                     // 143: temporal.server.api.persistence.v1.VersionedTransition
+	(*v11.VersionHistories)(nil),                        // 144: temporal.server.api.history.v1.VersionHistories
+	(*v15.VersionedTransitionArtifact)(nil),             // 145: temporal.server.api.replication.v1.VersionedTransitionArtifact
+	(*v114.TaskQueuePartition)(nil),                     // 146: temporal.server.api.taskqueue.v1.TaskQueuePartition
+	(*v115.TaskQueueVersionSelection)(nil),              // 147: temporal.api.taskqueue.v1.TaskQueueVersionSelection
+	(*v114.PartitionScaleInfo)(nil),                     // 148: temporal.server.api.taskqueue.v1.PartitionScaleInfo
+	(*v12.TaskQueueTypeUserData)(nil),                   // 149: temporal.server.api.persistence.v1.TaskQueueTypeUserData
+	(v16.BatchOperationType)(0),                         // 150: temporal.api.enums.v1.BatchOperationType
+	(v16.IndexedValueType)(0),                           // 151: temporal.api.enums.v1.IndexedValueType
+	(*v114.TaskQueueVersionInfoInternal)(nil),           // 152: temporal.server.api.taskqueue.v1.TaskQueueVersionInfoInternal
 }
 var file_temporal_server_api_adminservice_v1_request_response_proto_depIdxs = []int32{
-	106, // 0: temporal.server.api.adminservice.v1.RebuildMutableStateRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	106, // 1: temporal.server.api.adminservice.v1.ImportWorkflowExecutionRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	107, // 2: temporal.server.api.adminservice.v1.ImportWorkflowExecutionRequest.history_batches:type_name -> temporal.api.common.v1.DataBlob
-	108, // 3: temporal.server.api.adminservice.v1.ImportWorkflowExecutionRequest.version_history:type_name -> temporal.server.api.history.v1.VersionHistory
-	106, // 4: temporal.server.api.adminservice.v1.DescribeMutableStateRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	109, // 5: temporal.server.api.adminservice.v1.DescribeMutableStateResponse.cache_mutable_state:type_name -> temporal.server.api.persistence.v1.WorkflowMutableState
-	109, // 6: temporal.server.api.adminservice.v1.DescribeMutableStateResponse.database_mutable_state:type_name -> temporal.server.api.persistence.v1.WorkflowMutableState
-	106, // 7: temporal.server.api.adminservice.v1.DescribeHistoryHostRequest.workflow_execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	110, // 8: temporal.server.api.adminservice.v1.DescribeHistoryHostResponse.namespace_cache:type_name -> temporal.server.api.namespace.v1.NamespaceCacheInfo
-	111, // 9: temporal.server.api.adminservice.v1.GetShardResponse.shard_info:type_name -> temporal.server.api.persistence.v1.ShardInfo
-	112, // 10: temporal.server.api.adminservice.v1.ListHistoryTasksRequest.task_range:type_name -> temporal.server.api.history.v1.TaskRange
+	107, // 0: temporal.server.api.adminservice.v1.RebuildMutableStateRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	107, // 1: temporal.server.api.adminservice.v1.ImportWorkflowExecutionRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	108, // 2: temporal.server.api.adminservice.v1.ImportWorkflowExecutionRequest.history_batches:type_name -> temporal.api.common.v1.DataBlob
+	109, // 3: temporal.server.api.adminservice.v1.ImportWorkflowExecutionRequest.version_history:type_name -> temporal.server.api.history.v1.VersionHistory
+	107, // 4: temporal.server.api.adminservice.v1.DescribeMutableStateRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	110, // 5: temporal.server.api.adminservice.v1.DescribeMutableStateResponse.cache_mutable_state:type_name -> temporal.server.api.persistence.v1.WorkflowMutableState
+	110, // 6: temporal.server.api.adminservice.v1.DescribeMutableStateResponse.database_mutable_state:type_name -> temporal.server.api.persistence.v1.WorkflowMutableState
+	107, // 7: temporal.server.api.adminservice.v1.DescribeHistoryHostRequest.workflow_execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	111, // 8: temporal.server.api.adminservice.v1.DescribeHistoryHostResponse.namespace_cache:type_name -> temporal.server.api.namespace.v1.NamespaceCacheInfo
+	112, // 9: temporal.server.api.adminservice.v1.GetShardResponse.shard_info:type_name -> temporal.server.api.persistence.v1.ShardInfo
+	113, // 10: temporal.server.api.adminservice.v1.ListHistoryTasksRequest.task_range:type_name -> temporal.server.api.history.v1.TaskRange
 	15,  // 11: temporal.server.api.adminservice.v1.ListHistoryTasksResponse.tasks:type_name -> temporal.server.api.adminservice.v1.Task
-	113, // 12: temporal.server.api.adminservice.v1.Task.task_type:type_name -> temporal.server.api.enums.v1.TaskType
-	114, // 13: temporal.server.api.adminservice.v1.Task.fire_time:type_name -> google.protobuf.Timestamp
-	114, // 14: temporal.server.api.adminservice.v1.RemoveTaskRequest.visibility_time:type_name -> google.protobuf.Timestamp
-	106, // 15: temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryV2Request.execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	107, // 16: temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryV2Response.history_batches:type_name -> temporal.api.common.v1.DataBlob
-	108, // 17: temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryV2Response.version_history:type_name -> temporal.server.api.history.v1.VersionHistory
-	106, // 18: temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	107, // 19: temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryResponse.history_batches:type_name -> temporal.api.common.v1.DataBlob
-	108, // 20: temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryResponse.version_history:type_name -> temporal.server.api.history.v1.VersionHistory
-	115, // 21: temporal.server.api.adminservice.v1.GetReplicationMessagesRequest.tokens:type_name -> temporal.server.api.replication.v1.ReplicationToken
-	96,  // 22: temporal.server.api.adminservice.v1.GetReplicationMessagesResponse.shard_messages:type_name -> temporal.server.api.adminservice.v1.GetReplicationMessagesResponse.ShardMessagesEntry
-	116, // 23: temporal.server.api.adminservice.v1.GetNamespaceReplicationMessagesResponse.messages:type_name -> temporal.server.api.replication.v1.ReplicationMessages
-	117, // 24: temporal.server.api.adminservice.v1.GetDLQReplicationMessagesRequest.task_infos:type_name -> temporal.server.api.replication.v1.ReplicationTaskInfo
-	118, // 25: temporal.server.api.adminservice.v1.GetDLQReplicationMessagesResponse.replication_tasks:type_name -> temporal.server.api.replication.v1.ReplicationTask
-	106, // 26: temporal.server.api.adminservice.v1.ReapplyEventsRequest.workflow_execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	107, // 27: temporal.server.api.adminservice.v1.ReapplyEventsRequest.events:type_name -> temporal.api.common.v1.DataBlob
-	97,  // 28: temporal.server.api.adminservice.v1.AddSearchAttributesRequest.search_attributes:type_name -> temporal.server.api.adminservice.v1.AddSearchAttributesRequest.SearchAttributesEntry
-	98,  // 29: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.custom_attributes:type_name -> temporal.server.api.adminservice.v1.GetSearchAttributesResponse.CustomAttributesEntry
-	99,  // 30: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.system_attributes:type_name -> temporal.server.api.adminservice.v1.GetSearchAttributesResponse.SystemAttributesEntry
-	100, // 31: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.mapping:type_name -> temporal.server.api.adminservice.v1.GetSearchAttributesResponse.MappingEntry
-	119, // 32: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.add_workflow_execution_info:type_name -> temporal.api.workflow.v1.WorkflowExecutionInfo
-	101, // 33: temporal.server.api.adminservice.v1.DescribeClusterResponse.supported_clients:type_name -> temporal.server.api.adminservice.v1.DescribeClusterResponse.SupportedClientsEntry
-	120, // 34: temporal.server.api.adminservice.v1.DescribeClusterResponse.membership_info:type_name -> temporal.server.api.cluster.v1.MembershipInfo
-	121, // 35: temporal.server.api.adminservice.v1.DescribeClusterResponse.version_info:type_name -> temporal.api.version.v1.VersionInfo
-	102, // 36: temporal.server.api.adminservice.v1.DescribeClusterResponse.tags:type_name -> temporal.server.api.adminservice.v1.DescribeClusterResponse.TagsEntry
-	122, // 37: temporal.server.api.adminservice.v1.ListClustersResponse.clusters:type_name -> temporal.server.api.persistence.v1.ClusterMetadata
-	123, // 38: temporal.server.api.adminservice.v1.ListClusterMembersRequest.last_heartbeat_within:type_name -> google.protobuf.Duration
-	124, // 39: temporal.server.api.adminservice.v1.ListClusterMembersRequest.role:type_name -> temporal.server.api.enums.v1.ClusterMemberRole
-	114, // 40: temporal.server.api.adminservice.v1.ListClusterMembersRequest.session_started_after_time:type_name -> google.protobuf.Timestamp
-	125, // 41: temporal.server.api.adminservice.v1.ListClusterMembersResponse.active_members:type_name -> temporal.server.api.cluster.v1.ClusterMember
-	126, // 42: temporal.server.api.adminservice.v1.GetDLQMessagesRequest.type:type_name -> temporal.server.api.enums.v1.DeadLetterQueueType
-	126, // 43: temporal.server.api.adminservice.v1.GetDLQMessagesResponse.type:type_name -> temporal.server.api.enums.v1.DeadLetterQueueType
-	118, // 44: temporal.server.api.adminservice.v1.GetDLQMessagesResponse.replication_tasks:type_name -> temporal.server.api.replication.v1.ReplicationTask
-	117, // 45: temporal.server.api.adminservice.v1.GetDLQMessagesResponse.replication_tasks_info:type_name -> temporal.server.api.replication.v1.ReplicationTaskInfo
-	126, // 46: temporal.server.api.adminservice.v1.PurgeDLQMessagesRequest.type:type_name -> temporal.server.api.enums.v1.DeadLetterQueueType
-	126, // 47: temporal.server.api.adminservice.v1.MergeDLQMessagesRequest.type:type_name -> temporal.server.api.enums.v1.DeadLetterQueueType
-	106, // 48: temporal.server.api.adminservice.v1.RefreshWorkflowTasksRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	127, // 49: temporal.server.api.adminservice.v1.GetTaskQueueTasksRequest.task_queue_type:type_name -> temporal.api.enums.v1.TaskQueueType
-	128, // 50: temporal.server.api.adminservice.v1.GetTaskQueueTasksResponse.tasks:type_name -> temporal.server.api.persistence.v1.AllocatedTaskInfo
-	106, // 51: temporal.server.api.adminservice.v1.DeleteWorkflowExecutionRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	129, // 52: temporal.server.api.adminservice.v1.StreamWorkflowReplicationMessagesRequest.sync_replication_state:type_name -> temporal.server.api.replication.v1.SyncReplicationState
-	130, // 53: temporal.server.api.adminservice.v1.StreamWorkflowReplicationMessagesResponse.messages:type_name -> temporal.server.api.replication.v1.WorkflowReplicationMessages
-	131, // 54: temporal.server.api.adminservice.v1.GetNamespaceResponse.info:type_name -> temporal.api.namespace.v1.NamespaceInfo
-	132, // 55: temporal.server.api.adminservice.v1.GetNamespaceResponse.config:type_name -> temporal.api.namespace.v1.NamespaceConfig
-	133, // 56: temporal.server.api.adminservice.v1.GetNamespaceResponse.replication_config:type_name -> temporal.api.replication.v1.NamespaceReplicationConfig
-	134, // 57: temporal.server.api.adminservice.v1.GetNamespaceResponse.failover_history:type_name -> temporal.api.replication.v1.FailoverStatus
-	135, // 58: temporal.server.api.adminservice.v1.GetDLQTasksRequest.dlq_key:type_name -> temporal.server.api.common.v1.HistoryDLQKey
-	136, // 59: temporal.server.api.adminservice.v1.GetDLQTasksResponse.dlq_tasks:type_name -> temporal.server.api.common.v1.HistoryDLQTask
-	135, // 60: temporal.server.api.adminservice.v1.PurgeDLQTasksRequest.dlq_key:type_name -> temporal.server.api.common.v1.HistoryDLQKey
-	137, // 61: temporal.server.api.adminservice.v1.PurgeDLQTasksRequest.inclusive_max_task_metadata:type_name -> temporal.server.api.common.v1.HistoryDLQTaskMetadata
-	135, // 62: temporal.server.api.adminservice.v1.MergeDLQTasksRequest.dlq_key:type_name -> temporal.server.api.common.v1.HistoryDLQKey
-	137, // 63: temporal.server.api.adminservice.v1.MergeDLQTasksRequest.inclusive_max_task_metadata:type_name -> temporal.server.api.common.v1.HistoryDLQTaskMetadata
-	135, // 64: temporal.server.api.adminservice.v1.DescribeDLQJobResponse.dlq_key:type_name -> temporal.server.api.common.v1.HistoryDLQKey
-	138, // 65: temporal.server.api.adminservice.v1.DescribeDLQJobResponse.operation_type:type_name -> temporal.server.api.enums.v1.DLQOperationType
-	139, // 66: temporal.server.api.adminservice.v1.DescribeDLQJobResponse.operation_state:type_name -> temporal.server.api.enums.v1.DLQOperationState
-	114, // 67: temporal.server.api.adminservice.v1.DescribeDLQJobResponse.start_time:type_name -> google.protobuf.Timestamp
-	114, // 68: temporal.server.api.adminservice.v1.DescribeDLQJobResponse.end_time:type_name -> google.protobuf.Timestamp
-	103, // 69: temporal.server.api.adminservice.v1.AddTasksRequest.tasks:type_name -> temporal.server.api.adminservice.v1.AddTasksRequest.Task
-	104, // 70: temporal.server.api.adminservice.v1.ListQueuesResponse.queues:type_name -> temporal.server.api.adminservice.v1.ListQueuesResponse.QueueInfo
-	140, // 71: temporal.server.api.adminservice.v1.DeepHealthCheckResponse.state:type_name -> temporal.server.api.enums.v1.HealthState
-	141, // 72: temporal.server.api.adminservice.v1.DeepHealthCheckResponse.services:type_name -> temporal.server.api.health.v1.ServiceHealthDetail
-	106, // 73: temporal.server.api.adminservice.v1.SyncWorkflowStateRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	142, // 74: temporal.server.api.adminservice.v1.SyncWorkflowStateRequest.versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
-	143, // 75: temporal.server.api.adminservice.v1.SyncWorkflowStateRequest.version_histories:type_name -> temporal.server.api.history.v1.VersionHistories
-	144, // 76: temporal.server.api.adminservice.v1.SyncWorkflowStateResponse.versioned_transition_artifact:type_name -> temporal.server.api.replication.v1.VersionedTransitionArtifact
-	106, // 77: temporal.server.api.adminservice.v1.GenerateLastHistoryReplicationTasksRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
-	145, // 78: temporal.server.api.adminservice.v1.DescribeTaskQueuePartitionRequest.task_queue_partition:type_name -> temporal.server.api.taskqueue.v1.TaskQueuePartition
-	146, // 79: temporal.server.api.adminservice.v1.DescribeTaskQueuePartitionRequest.build_ids:type_name -> temporal.api.taskqueue.v1.TaskQueueVersionSelection
-	105, // 80: temporal.server.api.adminservice.v1.DescribeTaskQueuePartitionResponse.versions_info_internal:type_name -> temporal.server.api.adminservice.v1.DescribeTaskQueuePartitionResponse.VersionsInfoInternalEntry
-	147, // 81: temporal.server.api.adminservice.v1.DescribeTaskQueuePartitionResponse.scale_info:type_name -> temporal.server.api.taskqueue.v1.PartitionScaleInfo
-	145, // 82: temporal.server.api.adminservice.v1.ForceUnloadTaskQueuePartitionRequest.task_queue_partition:type_name -> temporal.server.api.taskqueue.v1.TaskQueuePartition
-	127, // 83: temporal.server.api.adminservice.v1.GetTaskQueueUserDataRequest.task_queue_type:type_name -> temporal.api.enums.v1.TaskQueueType
-	148, // 84: temporal.server.api.adminservice.v1.GetTaskQueueUserDataResponse.user_data:type_name -> temporal.server.api.persistence.v1.TaskQueueTypeUserData
-	106, // 85: temporal.server.api.adminservice.v1.StartAdminBatchOperationRequest.executions:type_name -> temporal.api.common.v1.WorkflowExecution
+	114, // 12: temporal.server.api.adminservice.v1.Task.task_type:type_name -> temporal.server.api.enums.v1.TaskType
+	115, // 13: temporal.server.api.adminservice.v1.Task.fire_time:type_name -> google.protobuf.Timestamp
+	115, // 14: temporal.server.api.adminservice.v1.RemoveTaskRequest.visibility_time:type_name -> google.protobuf.Timestamp
+	107, // 15: temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryV2Request.execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	108, // 16: temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryV2Response.history_batches:type_name -> temporal.api.common.v1.DataBlob
+	109, // 17: temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryV2Response.version_history:type_name -> temporal.server.api.history.v1.VersionHistory
+	107, // 18: temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	108, // 19: temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryResponse.history_batches:type_name -> temporal.api.common.v1.DataBlob
+	109, // 20: temporal.server.api.adminservice.v1.GetWorkflowExecutionRawHistoryResponse.version_history:type_name -> temporal.server.api.history.v1.VersionHistory
+	116, // 21: temporal.server.api.adminservice.v1.GetReplicationMessagesRequest.tokens:type_name -> temporal.server.api.replication.v1.ReplicationToken
+	97,  // 22: temporal.server.api.adminservice.v1.GetReplicationMessagesResponse.shard_messages:type_name -> temporal.server.api.adminservice.v1.GetReplicationMessagesResponse.ShardMessagesEntry
+	117, // 23: temporal.server.api.adminservice.v1.GetNamespaceReplicationMessagesResponse.messages:type_name -> temporal.server.api.replication.v1.ReplicationMessages
+	118, // 24: temporal.server.api.adminservice.v1.GetDLQReplicationMessagesRequest.task_infos:type_name -> temporal.server.api.replication.v1.ReplicationTaskInfo
+	119, // 25: temporal.server.api.adminservice.v1.GetDLQReplicationMessagesResponse.replication_tasks:type_name -> temporal.server.api.replication.v1.ReplicationTask
+	107, // 26: temporal.server.api.adminservice.v1.ReapplyEventsRequest.workflow_execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	108, // 27: temporal.server.api.adminservice.v1.ReapplyEventsRequest.events:type_name -> temporal.api.common.v1.DataBlob
+	98,  // 28: temporal.server.api.adminservice.v1.AddSearchAttributesRequest.search_attributes:type_name -> temporal.server.api.adminservice.v1.AddSearchAttributesRequest.SearchAttributesEntry
+	99,  // 29: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.custom_attributes:type_name -> temporal.server.api.adminservice.v1.GetSearchAttributesResponse.CustomAttributesEntry
+	100, // 30: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.system_attributes:type_name -> temporal.server.api.adminservice.v1.GetSearchAttributesResponse.SystemAttributesEntry
+	101, // 31: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.mapping:type_name -> temporal.server.api.adminservice.v1.GetSearchAttributesResponse.MappingEntry
+	120, // 32: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.add_workflow_execution_info:type_name -> temporal.api.workflow.v1.WorkflowExecutionInfo
+	102, // 33: temporal.server.api.adminservice.v1.DescribeClusterResponse.supported_clients:type_name -> temporal.server.api.adminservice.v1.DescribeClusterResponse.SupportedClientsEntry
+	121, // 34: temporal.server.api.adminservice.v1.DescribeClusterResponse.membership_info:type_name -> temporal.server.api.cluster.v1.MembershipInfo
+	122, // 35: temporal.server.api.adminservice.v1.DescribeClusterResponse.version_info:type_name -> temporal.api.version.v1.VersionInfo
+	103, // 36: temporal.server.api.adminservice.v1.DescribeClusterResponse.tags:type_name -> temporal.server.api.adminservice.v1.DescribeClusterResponse.TagsEntry
+	123, // 37: temporal.server.api.adminservice.v1.ListClustersResponse.clusters:type_name -> temporal.server.api.persistence.v1.ClusterMetadata
+	124, // 38: temporal.server.api.adminservice.v1.ListClusterMembersRequest.last_heartbeat_within:type_name -> google.protobuf.Duration
+	125, // 39: temporal.server.api.adminservice.v1.ListClusterMembersRequest.role:type_name -> temporal.server.api.enums.v1.ClusterMemberRole
+	115, // 40: temporal.server.api.adminservice.v1.ListClusterMembersRequest.session_started_after_time:type_name -> google.protobuf.Timestamp
+	126, // 41: temporal.server.api.adminservice.v1.ListClusterMembersResponse.active_members:type_name -> temporal.server.api.cluster.v1.ClusterMember
+	127, // 42: temporal.server.api.adminservice.v1.GetDLQMessagesRequest.type:type_name -> temporal.server.api.enums.v1.DeadLetterQueueType
+	127, // 43: temporal.server.api.adminservice.v1.GetDLQMessagesResponse.type:type_name -> temporal.server.api.enums.v1.DeadLetterQueueType
+	119, // 44: temporal.server.api.adminservice.v1.GetDLQMessagesResponse.replication_tasks:type_name -> temporal.server.api.replication.v1.ReplicationTask
+	118, // 45: temporal.server.api.adminservice.v1.GetDLQMessagesResponse.replication_tasks_info:type_name -> temporal.server.api.replication.v1.ReplicationTaskInfo
+	127, // 46: temporal.server.api.adminservice.v1.PurgeDLQMessagesRequest.type:type_name -> temporal.server.api.enums.v1.DeadLetterQueueType
+	127, // 47: temporal.server.api.adminservice.v1.MergeDLQMessagesRequest.type:type_name -> temporal.server.api.enums.v1.DeadLetterQueueType
+	107, // 48: temporal.server.api.adminservice.v1.RefreshWorkflowTasksRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	128, // 49: temporal.server.api.adminservice.v1.GetTaskQueueTasksRequest.task_queue_type:type_name -> temporal.api.enums.v1.TaskQueueType
+	129, // 50: temporal.server.api.adminservice.v1.GetTaskQueueTasksResponse.tasks:type_name -> temporal.server.api.persistence.v1.AllocatedTaskInfo
+	107, // 51: temporal.server.api.adminservice.v1.DeleteWorkflowExecutionRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	130, // 52: temporal.server.api.adminservice.v1.StreamWorkflowReplicationMessagesRequest.sync_replication_state:type_name -> temporal.server.api.replication.v1.SyncReplicationState
+	131, // 53: temporal.server.api.adminservice.v1.StreamWorkflowReplicationMessagesResponse.messages:type_name -> temporal.server.api.replication.v1.WorkflowReplicationMessages
+	132, // 54: temporal.server.api.adminservice.v1.GetNamespaceResponse.info:type_name -> temporal.api.namespace.v1.NamespaceInfo
+	133, // 55: temporal.server.api.adminservice.v1.GetNamespaceResponse.config:type_name -> temporal.api.namespace.v1.NamespaceConfig
+	134, // 56: temporal.server.api.adminservice.v1.GetNamespaceResponse.replication_config:type_name -> temporal.api.replication.v1.NamespaceReplicationConfig
+	135, // 57: temporal.server.api.adminservice.v1.GetNamespaceResponse.failover_history:type_name -> temporal.api.replication.v1.FailoverStatus
+	136, // 58: temporal.server.api.adminservice.v1.GetDLQTasksRequest.dlq_key:type_name -> temporal.server.api.common.v1.HistoryDLQKey
+	137, // 59: temporal.server.api.adminservice.v1.GetDLQTasksResponse.dlq_tasks:type_name -> temporal.server.api.common.v1.HistoryDLQTask
+	136, // 60: temporal.server.api.adminservice.v1.PurgeDLQTasksRequest.dlq_key:type_name -> temporal.server.api.common.v1.HistoryDLQKey
+	138, // 61: temporal.server.api.adminservice.v1.PurgeDLQTasksRequest.inclusive_max_task_metadata:type_name -> temporal.server.api.common.v1.HistoryDLQTaskMetadata
+	136, // 62: temporal.server.api.adminservice.v1.MergeDLQTasksRequest.dlq_key:type_name -> temporal.server.api.common.v1.HistoryDLQKey
+	138, // 63: temporal.server.api.adminservice.v1.MergeDLQTasksRequest.inclusive_max_task_metadata:type_name -> temporal.server.api.common.v1.HistoryDLQTaskMetadata
+	136, // 64: temporal.server.api.adminservice.v1.DescribeDLQJobResponse.dlq_key:type_name -> temporal.server.api.common.v1.HistoryDLQKey
+	139, // 65: temporal.server.api.adminservice.v1.DescribeDLQJobResponse.operation_type:type_name -> temporal.server.api.enums.v1.DLQOperationType
+	140, // 66: temporal.server.api.adminservice.v1.DescribeDLQJobResponse.operation_state:type_name -> temporal.server.api.enums.v1.DLQOperationState
+	115, // 67: temporal.server.api.adminservice.v1.DescribeDLQJobResponse.start_time:type_name -> google.protobuf.Timestamp
+	115, // 68: temporal.server.api.adminservice.v1.DescribeDLQJobResponse.end_time:type_name -> google.protobuf.Timestamp
+	104, // 69: temporal.server.api.adminservice.v1.AddTasksRequest.tasks:type_name -> temporal.server.api.adminservice.v1.AddTasksRequest.Task
+	105, // 70: temporal.server.api.adminservice.v1.ListQueuesResponse.queues:type_name -> temporal.server.api.adminservice.v1.ListQueuesResponse.QueueInfo
+	141, // 71: temporal.server.api.adminservice.v1.DeepHealthCheckResponse.state:type_name -> temporal.server.api.enums.v1.HealthState
+	142, // 72: temporal.server.api.adminservice.v1.DeepHealthCheckResponse.services:type_name -> temporal.server.api.health.v1.ServiceHealthDetail
+	107, // 73: temporal.server.api.adminservice.v1.SyncWorkflowStateRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	143, // 74: temporal.server.api.adminservice.v1.SyncWorkflowStateRequest.versioned_transition:type_name -> temporal.server.api.persistence.v1.VersionedTransition
+	144, // 75: temporal.server.api.adminservice.v1.SyncWorkflowStateRequest.version_histories:type_name -> temporal.server.api.history.v1.VersionHistories
+	145, // 76: temporal.server.api.adminservice.v1.SyncWorkflowStateResponse.versioned_transition_artifact:type_name -> temporal.server.api.replication.v1.VersionedTransitionArtifact
+	107, // 77: temporal.server.api.adminservice.v1.GenerateLastHistoryReplicationTasksRequest.execution:type_name -> temporal.api.common.v1.WorkflowExecution
+	146, // 78: temporal.server.api.adminservice.v1.DescribeTaskQueuePartitionRequest.task_queue_partition:type_name -> temporal.server.api.taskqueue.v1.TaskQueuePartition
+	147, // 79: temporal.server.api.adminservice.v1.DescribeTaskQueuePartitionRequest.build_ids:type_name -> temporal.api.taskqueue.v1.TaskQueueVersionSelection
+	106, // 80: temporal.server.api.adminservice.v1.DescribeTaskQueuePartitionResponse.versions_info_internal:type_name -> temporal.server.api.adminservice.v1.DescribeTaskQueuePartitionResponse.VersionsInfoInternalEntry
+	148, // 81: temporal.server.api.adminservice.v1.DescribeTaskQueuePartitionResponse.scale_info:type_name -> temporal.server.api.taskqueue.v1.PartitionScaleInfo
+	146, // 82: temporal.server.api.adminservice.v1.ForceUnloadTaskQueuePartitionRequest.task_queue_partition:type_name -> temporal.server.api.taskqueue.v1.TaskQueuePartition
+	128, // 83: temporal.server.api.adminservice.v1.GetTaskQueueUserDataRequest.task_queue_type:type_name -> temporal.api.enums.v1.TaskQueueType
+	149, // 84: temporal.server.api.adminservice.v1.GetTaskQueueUserDataResponse.user_data:type_name -> temporal.server.api.persistence.v1.TaskQueueTypeUserData
+	107, // 85: temporal.server.api.adminservice.v1.StartAdminBatchOperationRequest.executions:type_name -> temporal.api.common.v1.WorkflowExecution
 	93,  // 86: temporal.server.api.adminservice.v1.StartAdminBatchOperationRequest.refresh_tasks_operation:type_name -> temporal.server.api.adminservice.v1.BatchOperationRefreshTasks
-	0,   // 87: temporal.server.api.adminservice.v1.MigrateScheduleRequest.target:type_name -> temporal.server.api.adminservice.v1.MigrateScheduleRequest.SchedulerTarget
-	116, // 88: temporal.server.api.adminservice.v1.GetReplicationMessagesResponse.ShardMessagesEntry.value:type_name -> temporal.server.api.replication.v1.ReplicationMessages
-	149, // 89: temporal.server.api.adminservice.v1.AddSearchAttributesRequest.SearchAttributesEntry.value:type_name -> temporal.api.enums.v1.IndexedValueType
-	149, // 90: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.CustomAttributesEntry.value:type_name -> temporal.api.enums.v1.IndexedValueType
-	149, // 91: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.SystemAttributesEntry.value:type_name -> temporal.api.enums.v1.IndexedValueType
-	107, // 92: temporal.server.api.adminservice.v1.AddTasksRequest.Task.blob:type_name -> temporal.api.common.v1.DataBlob
-	150, // 93: temporal.server.api.adminservice.v1.DescribeTaskQueuePartitionResponse.VersionsInfoInternalEntry.value:type_name -> temporal.server.api.taskqueue.v1.TaskQueueVersionInfoInternal
-	94,  // [94:94] is the sub-list for method output_type
-	94,  // [94:94] is the sub-list for method input_type
-	94,  // [94:94] is the sub-list for extension type_name
-	94,  // [94:94] is the sub-list for extension extendee
-	0,   // [0:94] is the sub-list for field type_name
+	94,  // 87: temporal.server.api.adminservice.v1.StartAdminBatchOperationRequest.delegation_operation:type_name -> temporal.server.api.adminservice.v1.BatchOperationDelegation
+	150, // 88: temporal.server.api.adminservice.v1.BatchOperationDelegation.batch_type:type_name -> temporal.api.enums.v1.BatchOperationType
+	0,   // 89: temporal.server.api.adminservice.v1.MigrateScheduleRequest.target:type_name -> temporal.server.api.adminservice.v1.MigrateScheduleRequest.SchedulerTarget
+	117, // 90: temporal.server.api.adminservice.v1.GetReplicationMessagesResponse.ShardMessagesEntry.value:type_name -> temporal.server.api.replication.v1.ReplicationMessages
+	151, // 91: temporal.server.api.adminservice.v1.AddSearchAttributesRequest.SearchAttributesEntry.value:type_name -> temporal.api.enums.v1.IndexedValueType
+	151, // 92: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.CustomAttributesEntry.value:type_name -> temporal.api.enums.v1.IndexedValueType
+	151, // 93: temporal.server.api.adminservice.v1.GetSearchAttributesResponse.SystemAttributesEntry.value:type_name -> temporal.api.enums.v1.IndexedValueType
+	108, // 94: temporal.server.api.adminservice.v1.AddTasksRequest.Task.blob:type_name -> temporal.api.common.v1.DataBlob
+	152, // 95: temporal.server.api.adminservice.v1.DescribeTaskQueuePartitionResponse.VersionsInfoInternalEntry.value:type_name -> temporal.server.api.taskqueue.v1.TaskQueueVersionInfoInternal
+	96,  // [96:96] is the sub-list for method output_type
+	96,  // [96:96] is the sub-list for method input_type
+	96,  // [96:96] is the sub-list for extension type_name
+	96,  // [96:96] is the sub-list for extension extendee
+	0,   // [0:96] is the sub-list for field type_name
 }
 
 func init() { file_temporal_server_api_adminservice_v1_request_response_proto_init() }
@@ -6639,6 +6710,7 @@ func file_temporal_server_api_adminservice_v1_request_response_proto_init() {
 	}
 	file_temporal_server_api_adminservice_v1_request_response_proto_msgTypes[90].OneofWrappers = []any{
 		(*StartAdminBatchOperationRequest_RefreshTasksOperation)(nil),
+		(*StartAdminBatchOperationRequest_DelegationOperation)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -6646,7 +6718,7 @@ func file_temporal_server_api_adminservice_v1_request_response_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_temporal_server_api_adminservice_v1_request_response_proto_rawDesc), len(file_temporal_server_api_adminservice_v1_request_response_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   105,
+			NumMessages:   106,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/adminservice/v1/request_response.pb.go
+++ b/api/adminservice/v1/request_response.pb.go
@@ -5706,7 +5706,7 @@ func (*BatchOperationRefreshTasks) Descriptor() ([]byte, []int) {
 // BatchOperationDelegation delegates an ordinary customer-facing batch operation to the admin batcher.
 type BatchOperationDelegation struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// only temmination operations are supported
+	// Supported types are workflow and activity termination and deletion.
 	BatchType     v16.BatchOperationType `protobuf:"varint,1,opt,name=batch_type,json=batchType,proto3,enum=temporal.api.enums.v1.BatchOperationType" json:"batch_type,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/proto/internal/temporal/server/api/adminservice/v1/request_response.proto
+++ b/proto/internal/temporal/server/api/adminservice/v1/request_response.proto
@@ -657,7 +657,7 @@ message BatchOperationRefreshTasks {}
 
 // BatchOperationDelegation delegates an ordinary customer-facing batch operation to the admin batcher.
 message BatchOperationDelegation {
-  // only temmination operations are supported
+  // Supported types are workflow and activity termination and deletion.
   temporal.api.enums.v1.BatchOperationType batch_type = 1;
 }
 

--- a/proto/internal/temporal/server/api/adminservice/v1/request_response.proto
+++ b/proto/internal/temporal/server/api/adminservice/v1/request_response.proto
@@ -5,6 +5,7 @@ package temporal.server.api.adminservice.v1;
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 import "temporal/api/common/v1/message.proto";
+import "temporal/api/enums/v1/batch_operation.proto";
 import "temporal/api/enums/v1/common.proto";
 import "temporal/api/enums/v1/task_queue.proto";
 import "temporal/api/namespace/v1/message.proto";
@@ -644,6 +645,7 @@ message StartAdminBatchOperationRequest {
   // The admin batch operation to perform.
   oneof operation {
     BatchOperationRefreshTasks refresh_tasks_operation = 10;
+    BatchOperationDelegation delegation_operation = 11;
   }
 }
 
@@ -652,6 +654,12 @@ message StartAdminBatchOperationResponse {}
 // BatchOperationRefreshTasks refreshes tasks for batch executions.
 // This regenerates all pending tasks for each execution.
 message BatchOperationRefreshTasks {}
+
+// BatchOperationDelegation delegates an ordinary customer-facing batch operation to the admin batcher.
+message BatchOperationDelegation {
+  // only temmination operations are supported
+  temporal.api.enums.v1.BatchOperationType batch_type = 1;
+}
 
 message MigrateScheduleRequest {
   // Target scheduler implementation for migration.

--- a/service/frontend/admin_handler.go
+++ b/service/frontend/admin_handler.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	batchpb "go.temporal.io/api/batch/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	namespacepb "go.temporal.io/api/namespace/v1"
@@ -1263,28 +1264,25 @@ func (adh *AdminHandler) RefreshWorkflowTasks(
 // StartAdminBatchOperation starts an admin batch operation.
 func (adh *AdminHandler) StartAdminBatchOperation(
 	ctx context.Context,
-	request *adminservice.StartAdminBatchOperationRequest,
+	adminRequest *adminservice.StartAdminBatchOperationRequest,
 ) (_ *adminservice.StartAdminBatchOperationResponse, retError error) {
 	defer log.CapturePanic(adh.logger, &retError)
 
-	if request == nil {
+	if adminRequest == nil {
 		return nil, errRequestNotSet
 	}
-
-	if err := validateAdminBatchOperation(request); err != nil {
+	if err := validateAdminBatchOperation(adminRequest); err != nil {
 		return nil, err
 	}
 
-	// The admin batch workflow runs in the system namespace so admin batches can operate on passive clusters
-	// of a target namespace and can operate fast when the target namespace is overloaded.
-	// The target namespace reaches the activity through the workflow input and AdminRequest.
-	targetNS := request.GetNamespace()
+	// admin batch workflows runs in the temporal-system namespace to operate on target namespaces
+	targetNS := adminRequest.GetNamespace()
 	targetNSID, err := adh.namespaceRegistry.GetNamespaceID(namespace.Name(targetNS))
 	if err != nil {
 		return nil, err
 	}
-	operateJobID := request.JobId
 	sysNS, sysNSID := primitives.SystemLocalNamespace, primitives.SystemNamespaceID
+	operateJobID := adminRequest.JobId
 
 	// Admin batch operations only run in the system namespace, so the concurrency limit is global.
 	maxConcurrentBatchOperation := adh.config.MaxConcurrentAdminBatchOperation()
@@ -1305,34 +1303,46 @@ func (adh *AdminHandler) StartAdminBatchOperation(
 		}
 	}
 
-	// batchOperation input and payload have the data namespace, and
-	// the request to start workflow will use operate namespace for routing
-	batchOperationInput := &batchspb.BatchOperationInput{
-		AdminRequest: request,
+	// prepare the batch-workflow input
+	batchWfInput := &batchspb.BatchOperationInput{
+		AdminRequest: adminRequest,
 		NamespaceId:  targetNSID.String(),
 	}
-
-	identity := request.GetIdentity()
+	identity := adminRequest.GetIdentity()
 	var batchTypeMemo string
-	switch op := request.Operation.(type) {
+	switch op := adminRequest.Operation.(type) {
 	case *adminservice.StartAdminBatchOperationRequest_RefreshTasksOperation:
 		batchTypeMemo = "refresh_tasks"
+	case *adminservice.StartAdminBatchOperationRequest_DelegationOperation:
+		// These operations mutate workflow state of the target ns,
+		// so the cluster should be active for the target namespace.
+		if err := adh.checkTargetNamespaceActive(targetNS); err != nil {
+			return nil, err
+		}
+		delegatedBatchType := op.DelegationOperation.GetBatchType()
+		delegatedBatchRequest, err := createDelegatedBatchRequest(adminRequest, delegatedBatchType)
+		if err != nil {
+			return nil, err
+		}
+		if err := batcher.ValidateBatchOperation(delegatedBatchRequest); err != nil {
+			return nil, err
+		}
+		batchWfInput.Request = delegatedBatchRequest
+		batchWfInput.BatchType = delegatedBatchType
+		batchTypeMemo = snakeCaseBatchType(delegatedBatchType)
 	default:
 		return nil, serviceerror.NewInvalidArgumentf("The operation type %T is not supported", op)
 	}
-
-	batchOperationInputPayload, err := payloads.Encode(batchOperationInput)
+	batchWfInputPayload, err := payloads.Encode(batchWfInput)
 	if err != nil {
 		return nil, err
 	}
-
 	memo := &commonpb.Memo{
 		Fields: map[string]*commonpb.Payload{
 			batcher.BatchOperationTypeMemo: payload.EncodeString(batchTypeMemo),
-			batcher.BatchReasonMemo:        payload.EncodeString(request.GetReason()),
+			batcher.BatchReasonMemo:        payload.EncodeString(adminRequest.GetReason()),
 		},
 	}
-
 	var searchAttributes *commonpb.SearchAttributes
 	searchattribute.AddSearchAttributes(
 		&searchAttributes,
@@ -1340,12 +1350,13 @@ func (adh *AdminHandler) StartAdminBatchOperation(
 		chasm.SearchAttributeTemporalNamespaceDivision.Value(batcher.AdminNamespaceDivision),
 	)
 
+	// start batch workflow
 	startReq := &workflowservice.StartWorkflowExecutionRequest{
 		Namespace:                sysNS,
 		WorkflowId:               operateJobID,
 		WorkflowType:             &commonpb.WorkflowType{Name: batcher.BatchWFTypeProtobufName},
 		TaskQueue:                &taskqueuepb.TaskQueue{Name: primitives.PerNSWorkerTaskQueue},
-		Input:                    batchOperationInputPayload,
+		Input:                    batchWfInputPayload,
 		Identity:                 identity,
 		RequestId:                uuid.NewString(),
 		WorkflowIdConflictPolicy: enumspb.WORKFLOW_ID_CONFLICT_POLICY_FAIL,
@@ -1389,9 +1400,63 @@ func validateAdminBatchOperation(params *adminservice.StartAdminBatchOperationRe
 	case *adminservice.StartAdminBatchOperationRequest_RefreshTasksOperation:
 		// No additional validation needed
 		return nil
+	case *adminservice.StartAdminBatchOperationRequest_DelegationOperation:
+		// The delegated batch type will be validated after the delegated request is built
+		return nil
 	default:
 		return serviceerror.NewInvalidArgumentf("not supported admin batch type: %T", op)
 	}
+}
+
+// checkTargetNamespaceActive reports whether this cluster may mutate the target namespace's
+// executions. The batch workflow itself runs in the system namespace, which is local and so
+// always active here, which is why the target namespace has to be checked separately.
+func (adh *AdminHandler) checkTargetNamespaceActive(targetNS string) error {
+	nsEntry, err := adh.namespaceRegistry.GetNamespace(namespace.Name(targetNS))
+	if err != nil {
+		return err
+	}
+	currentCluster := adh.clusterMetadata.GetCurrentClusterName()
+	//nolint:forbidigo // a batch spans many workflows, so there is no single businessID to route on
+	if !nsEntry.ActiveInCluster(currentCluster) {
+		return serviceerror.NewNamespaceNotActive(
+			targetNS,
+			currentCluster,
+			nsEntry.ActiveClusterName(namespace.RoutingKey{}),
+		)
+	}
+	return nil
+}
+
+func createDelegatedBatchRequest(
+	adminRequest *adminservice.StartAdminBatchOperationRequest,
+	batchType enumspb.BatchOperationType,
+) (*workflowservice.StartBatchOperationRequest, error) {
+	delegatedBatchRequest := &workflowservice.StartBatchOperationRequest{
+		Namespace:       adminRequest.GetNamespace(), // the target ns
+		JobId:           adminRequest.GetJobId(),
+		Reason:          adminRequest.GetReason(),
+		VisibilityQuery: adminRequest.GetVisibilityQuery(),
+		Executions:      adminRequest.GetExecutions(),
+	}
+	// only delegate termination to admin batch
+	switch batchType {
+	case enumspb.BATCH_OPERATION_TYPE_TERMINATE_WORKFLOW:
+		delegatedBatchRequest.Operation = &workflowservice.StartBatchOperationRequest_TerminationOperation{
+			TerminationOperation: &batchpb.BatchOperationTermination{Identity: adminRequest.GetIdentity()},
+		}
+	case enumspb.BATCH_OPERATION_TYPE_TERMINATE_ACTIVITY:
+		delegatedBatchRequest.Operation = &workflowservice.StartBatchOperationRequest_TerminateActivitiesOperation{
+			TerminateActivitiesOperation: &batchpb.BatchOperationTerminateActivities{
+				Identity: adminRequest.GetIdentity(),
+				Reason:   adminRequest.GetReason(),
+			},
+		}
+	default:
+		return nil, serviceerror.NewInvalidArgumentf(
+			"batch operation type %v cannot be delegated to the admin API", batchType)
+	}
+	return delegatedBatchRequest, nil
 }
 
 // ResendReplicationTasks requests replication task from remote cluster

--- a/service/frontend/admin_handler.go
+++ b/service/frontend/admin_handler.go
@@ -1439,7 +1439,7 @@ func createDelegatedBatchRequest(
 		VisibilityQuery: adminRequest.GetVisibilityQuery(),
 		Executions:      adminRequest.GetExecutions(),
 	}
-	// only delegate termination to admin batch
+	// Only delegate destructive operations whose fields can be derived from the admin envelope.
 	switch batchType {
 	case enumspb.BATCH_OPERATION_TYPE_TERMINATE_WORKFLOW:
 		delegatedBatchRequest.Operation = &workflowservice.StartBatchOperationRequest_TerminationOperation{
@@ -1451,6 +1451,14 @@ func createDelegatedBatchRequest(
 				Identity: adminRequest.GetIdentity(),
 				Reason:   adminRequest.GetReason(),
 			},
+		}
+	case enumspb.BATCH_OPERATION_TYPE_DELETE_WORKFLOW:
+		delegatedBatchRequest.Operation = &workflowservice.StartBatchOperationRequest_DeletionOperation{
+			DeletionOperation: &batchpb.BatchOperationDeletion{Identity: adminRequest.GetIdentity()},
+		}
+	case enumspb.BATCH_OPERATION_TYPE_DELETE_ACTIVITY:
+		delegatedBatchRequest.Operation = &workflowservice.StartBatchOperationRequest_DeleteActivitiesOperation{
+			DeleteActivitiesOperation: &batchpb.BatchOperationDeleteActivities{},
 		}
 	default:
 		return nil, serviceerror.NewInvalidArgumentf(

--- a/service/frontend/admin_handler_test.go
+++ b/service/frontend/admin_handler_test.go
@@ -2527,6 +2527,23 @@ func TestCreateDelegatedBatchRequest(t *testing.T) {
 			},
 		},
 		{
+			name:      "delete workflows",
+			batchType: enumspb.BATCH_OPERATION_TYPE_DELETE_WORKFLOW,
+			validate: func(t *testing.T, request *workflowservice.StartBatchOperationRequest) {
+				op, ok := request.GetOperation().(*workflowservice.StartBatchOperationRequest_DeletionOperation)
+				require.True(t, ok)
+				require.Equal(t, adminRequest.GetIdentity(), op.DeletionOperation.GetIdentity())
+			},
+		},
+		{
+			name:      "delete activities",
+			batchType: enumspb.BATCH_OPERATION_TYPE_DELETE_ACTIVITY,
+			validate: func(t *testing.T, request *workflowservice.StartBatchOperationRequest) {
+				_, ok := request.GetOperation().(*workflowservice.StartBatchOperationRequest_DeleteActivitiesOperation)
+				require.True(t, ok)
+			},
+		},
+		{
 			name:      "unsupported operation",
 			batchType: enumspb.BATCH_OPERATION_TYPE_SIGNAL_WORKFLOW,
 			wantError: true,

--- a/service/frontend/admin_handler_test.go
+++ b/service/frontend/admin_handler_test.go
@@ -2491,3 +2491,69 @@ func (s *adminHandlerSuite) TestGetSearchAttributes() {
 		s.ErrorAs(err, &unavailable)
 	})
 }
+
+func TestCreateDelegatedBatchRequest(t *testing.T) {
+	adminRequest := &adminservice.StartAdminBatchOperationRequest{
+		Namespace:       "target-namespace",
+		VisibilityQuery: "WorkflowType = 'test'",
+		JobId:           "job-id",
+		Reason:          "test reason",
+		Identity:        "test identity",
+	}
+
+	tests := []struct {
+		name      string
+		batchType enumspb.BatchOperationType
+		validate  func(*testing.T, *workflowservice.StartBatchOperationRequest)
+		wantError bool
+	}{
+		{
+			name:      "terminate workflows",
+			batchType: enumspb.BATCH_OPERATION_TYPE_TERMINATE_WORKFLOW,
+			validate: func(t *testing.T, request *workflowservice.StartBatchOperationRequest) {
+				op, ok := request.GetOperation().(*workflowservice.StartBatchOperationRequest_TerminationOperation)
+				require.True(t, ok)
+				require.Equal(t, adminRequest.GetIdentity(), op.TerminationOperation.GetIdentity())
+			},
+		},
+		{
+			name:      "terminate activities",
+			batchType: enumspb.BATCH_OPERATION_TYPE_TERMINATE_ACTIVITY,
+			validate: func(t *testing.T, request *workflowservice.StartBatchOperationRequest) {
+				op, ok := request.GetOperation().(*workflowservice.StartBatchOperationRequest_TerminateActivitiesOperation)
+				require.True(t, ok)
+				require.Equal(t, adminRequest.GetIdentity(), op.TerminateActivitiesOperation.GetIdentity())
+				require.Equal(t, adminRequest.GetReason(), op.TerminateActivitiesOperation.GetReason())
+			},
+		},
+		{
+			name:      "unsupported operation",
+			batchType: enumspb.BATCH_OPERATION_TYPE_SIGNAL_WORKFLOW,
+			wantError: true,
+		},
+		{
+			name:      "unspecified operation",
+			batchType: enumspb.BATCH_OPERATION_TYPE_UNSPECIFIED,
+			wantError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			request, err := createDelegatedBatchRequest(adminRequest, tc.batchType)
+			if tc.wantError {
+				var invalidArgument *serviceerror.InvalidArgument
+				require.ErrorAs(t, err, &invalidArgument)
+				require.Nil(t, request)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, adminRequest.GetNamespace(), request.GetNamespace())
+			require.Equal(t, adminRequest.GetVisibilityQuery(), request.GetVisibilityQuery())
+			require.Equal(t, adminRequest.GetJobId(), request.GetJobId())
+			require.Equal(t, adminRequest.GetReason(), request.GetReason())
+			tc.validate(t, request)
+		})
+	}
+}

--- a/service/worker/batcher/activities.go
+++ b/service/worker/batcher/activities.go
@@ -57,7 +57,7 @@ var (
 
 // batchProcessorConfig holds the configuration for batch processing
 type batchProcessorConfig struct {
-	namespace         string
+	targetNamespace   string
 	adjustedQuery     string
 	batchType         enumspb.BatchOperationType
 	concurrency       int
@@ -180,7 +180,7 @@ func fetchPage(
 	if isActivityBatchType(config.batchType) {
 		resp, err := sdkClient.WorkflowService().ListActivityExecutions(ctx,
 			&workflowservice.ListActivityExecutionsRequest{
-				Namespace:     config.namespace,
+				Namespace:     config.targetNamespace,
 				PageSize:      int32(pageSize),
 				NextPageToken: pageToken,
 				Query:         config.adjustedQuery,
@@ -405,9 +405,13 @@ func (a *activities) checkAndGetTargetNamespace(batchParams *batchspb.BatchOpera
 	return a.namespace.String(), nil
 }
 
-// todo: check if this a solid and safe way
 func isAdminRequest(batchParams *batchspb.BatchOperationInput) bool {
 	return batchParams.AdminRequest != nil
+}
+
+func isAdminDelegatedRequest(batchParams *batchspb.BatchOperationInput) bool {
+	_, ok := batchParams.GetAdminRequest().GetOperation().(*adminservice.StartAdminBatchOperationRequest_DelegationOperation)
+	return ok
 }
 
 // BatchActivityWithProtobuf is an activity for processing batch operations using protobuf as the input type.
@@ -423,12 +427,12 @@ func (a *activities) BatchActivityWithProtobuf(ctx context.Context, batchParams 
 		logger.Error("Failed to run batch operation due to namespace mismatch", tag.Error(err))
 		return hbd, err
 	}
-
 	sdkClientForTargetNS := a.ClientFactory.NewClient(sdkclient.Options{
 		Namespace:     targetNS,
 		DataConverter: sdk.PreferProtoDataConverter,
 	})
 	defer sdkClientForTargetNS.Close()
+
 	startOver := true
 	if activity.HasHeartbeatDetails(ctx) {
 		if err := activity.GetHeartbeatDetails(ctx, &hbd); err == nil {
@@ -446,11 +450,10 @@ func (a *activities) BatchActivityWithProtobuf(ctx context.Context, batchParams 
 	// Admin batch uses the host level rate limiter which applies across all namespaces and all admin batch workflows.
 	rateLimiter := quotas.RequestRateLimiter(a.AdminBatcherRateLimiter)
 
-	if batchParams.AdminRequest != nil {
+	if isAdminRequest(batchParams) {
 		ctx = headers.SetCallerType(ctx, headers.CallerTypePreemptable)
-		adminReq := batchParams.AdminRequest
-		visibilityQuery = adminReq.GetVisibilityQuery()
-		executions = adminReq.GetExecutions()
+		visibilityQuery = a.adjustQueryAdminBatchType(batchParams)
+		executions = batchParams.GetAdminRequest().GetExecutions()
 	} else {
 		visibilityQuery = a.adjustQueryBatchTypeEnum(batchParams.Request.VisibilityQuery, batchParams.BatchType)
 		//nolint:staticcheck // SA1019: Executions is deprecated but still needed for backward compatibility
@@ -502,7 +505,7 @@ func (a *activities) BatchActivityWithProtobuf(ctx context.Context, batchParams 
 
 	// Prepare configuration for shared processing function
 	config := batchProcessorConfig{
-		namespace:               targetNS,
+		targetNamespace:         targetNS,
 		adjustedQuery:           visibilityQuery,
 		batchType:               batchParams.BatchType,
 		concurrency:             a.getOperationConcurrency(int(batchParams.Concurrency)),
@@ -558,7 +561,16 @@ func (a *activities) adjustQueryBatchTypeEnum(query string, batchType enumspb.Ba
 	}
 }
 
-func (a *activities) adjustQueryAdminBatchType(adminReq *adminservice.StartAdminBatchOperationRequest) string {
+func (a *activities) adjustQueryAdminBatchType(
+	batchParams *batchspb.BatchOperationInput,
+) string {
+	adminReq := batchParams.GetAdminRequest()
+	// if a user batch is delegated as an admin batch
+	if isAdminDelegatedRequest(batchParams) {
+		batchType := batchParams.BatchType
+		return a.adjustQueryBatchTypeEnum(adminReq.GetVisibilityQuery(), batchType)
+	}
+	// other admin batch:
 	// RefreshWorkflowTasks applies to both open and closed workflows,
 	// so no additional filter is needed - return query as-is.
 	return adminReq.GetVisibilityQuery()
@@ -585,7 +597,7 @@ func taskTimeoutContext(ctx context.Context) (context.Context, context.CancelFun
 func (a *activities) startTaskProcessor(
 	ctx context.Context,
 	batchOperation *batchspb.BatchOperationInput,
-	namespace string,
+	targetNamespace string,
 	taskCh chan task,
 	respCh chan taskResponse,
 	limiter quotas.RequestRateLimiter,
@@ -607,7 +619,7 @@ func (a *activities) startTaskProcessor(
 				continue
 			}
 
-			a.processTaskWithRetries(ctx, batchOperation, namespace, task, respCh, limiter, sdkClient, frontendClient, metricsHandler, logger)
+			a.processTaskWithRetries(ctx, batchOperation, targetNamespace, task, respCh, limiter, sdkClient, frontendClient, metricsHandler, logger)
 		}
 	}
 }
@@ -629,7 +641,7 @@ func deterministicRequestID(jobID string, parts ...string) string {
 func (a *activities) processSingleTask(
 	ctx context.Context,
 	batchOperation *batchspb.BatchOperationInput,
-	namespace string,
+	targetNamespace string,
 	task task,
 	limiter quotas.RequestRateLimiter,
 	sdkClient sdkclient.Client,
@@ -643,8 +655,7 @@ func (a *activities) processSingleTask(
 	ctx, cancel := taskTimeoutContext(ctx)
 	defer cancel()
 
-	// Handle admin batch operations
-	if batchOperation.AdminRequest != nil {
+	if isAdminRequest(batchOperation) && !isAdminDelegatedRequest(batchOperation) {
 		return a.processAdminTask(ctx, batchOperation, task, limiter)
 	}
 
@@ -653,7 +664,7 @@ func (a *activities) processSingleTask(
 		err = processTargetTask(ctx, limiter, task,
 			func(execution *commonpb.Execution) error {
 				_, err := frontendClient.TerminateActivityExecution(ctx, &workflowservice.TerminateActivityExecutionRequest{
-					Namespace:  namespace,
+					Namespace:  targetNamespace,
 					ActivityId: execution.GetBusinessId(),
 					RunId:      execution.GetRunId(),
 					Identity:   operation.TerminateActivitiesOperation.GetIdentity(),
@@ -666,7 +677,7 @@ func (a *activities) processSingleTask(
 		err = processTargetTask(ctx, limiter, task,
 			func(execution *commonpb.Execution) error {
 				_, err := frontendClient.DeleteActivityExecution(ctx, &workflowservice.DeleteActivityExecutionRequest{
-					Namespace:  namespace,
+					Namespace:  targetNamespace,
 					ActivityId: execution.GetBusinessId(),
 					RunId:      execution.GetRunId(),
 				})
@@ -676,7 +687,7 @@ func (a *activities) processSingleTask(
 		err = processTargetTask(ctx, limiter, task,
 			func(execution *commonpb.Execution) error {
 				_, err := frontendClient.RequestCancelActivityExecution(ctx, &workflowservice.RequestCancelActivityExecutionRequest{
-					Namespace:  namespace,
+					Namespace:  targetNamespace,
 					ActivityId: execution.GetBusinessId(),
 					RunId:      execution.GetRunId(),
 					Identity:   operation.CancelActivitiesOperation.GetIdentity(),
@@ -699,7 +710,7 @@ func (a *activities) processSingleTask(
 		err = processTask(ctx, limiter, task,
 			func(executionInfo *workflowpb.WorkflowExecutionInfo) error {
 				_, err := frontendClient.SignalWorkflowExecution(ctx, &workflowservice.SignalWorkflowExecutionRequest{
-					Namespace:         namespace,
+					Namespace:         targetNamespace,
 					WorkflowExecution: executionInfo.Execution,
 					SignalName:        operation.SignalOperation.GetSignal(),
 					Input:             operation.SignalOperation.GetInput(),
@@ -713,7 +724,7 @@ func (a *activities) processSingleTask(
 		err = processTask(ctx, limiter, task,
 			func(executionInfo *workflowpb.WorkflowExecutionInfo) error {
 				_, err := frontendClient.DeleteWorkflowExecution(ctx, &workflowservice.DeleteWorkflowExecutionRequest{
-					Namespace:         namespace,
+					Namespace:         targetNamespace,
 					WorkflowExecution: executionInfo.Execution,
 				})
 				return err
@@ -730,7 +741,7 @@ func (a *activities) processSingleTask(
 					// Using ResetOptions
 					// Note: getResetEventIDByOptions may modify workflowExecution.RunId, if reset should be to a prior run
 					//nolint:staticcheck // SA1019: worker versioning v0.31
-					eventID, err = getResetEventIDByOptions(ctx, operation.ResetOperation.Options, namespace, executionInfo.Execution, frontendClient, logger)
+					eventID, err = getResetEventIDByOptions(ctx, operation.ResetOperation.Options, targetNamespace, executionInfo.Execution, frontendClient, logger)
 					//nolint:staticcheck // SA1019: worker versioning v0.31
 					resetReapplyType = operation.ResetOperation.Options.ResetReapplyType
 					//nolint:staticcheck // SA1019: worker versioning v0.31
@@ -738,7 +749,7 @@ func (a *activities) processSingleTask(
 				} else {
 					// Old fields
 					//nolint:staticcheck // SA1019: worker versioning v0.31
-					eventID, err = getResetEventIDByType(ctx, operation.ResetOperation.ResetType, namespace, executionInfo.Execution, frontendClient, logger)
+					eventID, err = getResetEventIDByType(ctx, operation.ResetOperation.ResetType, targetNamespace, executionInfo.Execution, frontendClient, logger)
 					//nolint:staticcheck // SA1019: worker versioning v0.31
 					resetReapplyType = operation.ResetOperation.ResetReapplyType
 				}
@@ -746,7 +757,7 @@ func (a *activities) processSingleTask(
 					return err
 				}
 				_, err = frontendClient.ResetWorkflowExecution(ctx, &workflowservice.ResetWorkflowExecutionRequest{
-					Namespace:         namespace,
+					Namespace:         targetNamespace,
 					WorkflowExecution: executionInfo.Execution,
 					Reason:            batchOperation.Request.Reason,
 					RequestId: deterministicRequestID(batchOperation.Request.GetJobId(), "reset",
@@ -763,7 +774,7 @@ func (a *activities) processSingleTask(
 		err = processTask(ctx, limiter, task,
 			func(executionInfo *workflowpb.WorkflowExecutionInfo) error {
 				unpauseRequest := &workflowservice.UnpauseActivityRequest{
-					Namespace:      namespace,
+					Namespace:      targetNamespace,
 					Execution:      executionInfo.Execution,
 					Identity:       operation.UnpauseActivitiesOperation.Identity,
 					ResetAttempts:  operation.UnpauseActivitiesOperation.ResetAttempts,
@@ -790,7 +801,7 @@ func (a *activities) processSingleTask(
 		err = processTask(ctx, limiter, task,
 			func(executionInfo *workflowpb.WorkflowExecutionInfo) error {
 				_, err := frontendClient.UpdateWorkflowExecutionOptions(ctx, &workflowservice.UpdateWorkflowExecutionOptionsRequest{
-					Namespace:                namespace,
+					Namespace:                targetNamespace,
 					WorkflowExecution:        executionInfo.Execution,
 					WorkflowExecutionOptions: operation.UpdateWorkflowOptionsOperation.WorkflowExecutionOptions,
 					UpdateMask:               &fieldmaskpb.FieldMask{Paths: operation.UpdateWorkflowOptionsOperation.UpdateMask.Paths},
@@ -802,7 +813,7 @@ func (a *activities) processSingleTask(
 		err = processTask(ctx, limiter, task,
 			func(executionInfo *workflowpb.WorkflowExecutionInfo) error {
 				resetRequest := &workflowservice.ResetActivityRequest{
-					Namespace:              namespace,
+					Namespace:              targetNamespace,
 					Execution:              executionInfo.Execution,
 					Identity:               operation.ResetActivitiesOperation.Identity,
 					ResetHeartbeat:         operation.ResetActivitiesOperation.ResetHeartbeat,
@@ -827,7 +838,7 @@ func (a *activities) processSingleTask(
 		err = processTask(ctx, limiter, task,
 			func(executionInfo *workflowpb.WorkflowExecutionInfo) error {
 				updateRequest := &workflowservice.UpdateActivityOptionsRequest{
-					Namespace:       namespace,
+					Namespace:       targetNamespace,
 					Execution:       executionInfo.Execution,
 					UpdateMask:      &fieldmaskpb.FieldMask{Paths: operation.UpdateActivityOptionsOperation.UpdateMask.Paths},
 					RestoreOriginal: operation.UpdateActivityOptionsOperation.RestoreOriginal,

--- a/service/worker/batcher/activities_test.go
+++ b/service/worker/batcher/activities_test.go
@@ -30,6 +30,8 @@ import (
 	"go.temporal.io/server/api/historyservicemock/v1"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/quotas"
 	"go.temporal.io/server/common/testing/mockapi/workflowservicemock/v1"
@@ -527,7 +529,9 @@ func (s *activitiesSuite) TestAdjustQueryAdminBatchType() {
 				RefreshTasksOperation: &adminservice.BatchOperationRefreshTasks{},
 			},
 		}
-		adjustedQuery := a.adjustQueryAdminBatchType(adminReq)
+		adjustedQuery := a.adjustQueryAdminBatchType(&batchspb.BatchOperationInput{
+			AdminRequest: adminReq,
+		})
 		s.Empty(adjustedQuery)
 	})
 
@@ -539,7 +543,9 @@ func (s *activitiesSuite) TestAdjustQueryAdminBatchType() {
 				RefreshTasksOperation: &adminservice.BatchOperationRefreshTasks{},
 			},
 		}
-		adjustedQuery := a.adjustQueryAdminBatchType(adminReq)
+		adjustedQuery := a.adjustQueryAdminBatchType(&batchspb.BatchOperationInput{
+			AdminRequest: adminReq,
+		})
 		// RefreshWorkflowTasks applies to both open and closed workflows, no filter added
 		s.Equal("WorkflowType='MyWorkflow'", adjustedQuery)
 	})
@@ -551,7 +557,9 @@ func (s *activitiesSuite) TestAdjustQueryAdminBatchType() {
 				RefreshTasksOperation: &adminservice.BatchOperationRefreshTasks{},
 			},
 		}
-		adjustedQuery := a.adjustQueryAdminBatchType(adminReq)
+		adjustedQuery := a.adjustQueryAdminBatchType(&batchspb.BatchOperationInput{
+			AdminRequest: adminReq,
+		})
 		// RefreshWorkflowTasks applies to both open and closed workflows, no filter added
 		s.Equal("(WorkflowType='MyWorkflow') OR (WorkflowType='OtherWorkflow')", adjustedQuery)
 	})
@@ -560,9 +568,29 @@ func (s *activitiesSuite) TestAdjustQueryAdminBatchType() {
 		adminReq := &adminservice.StartAdminBatchOperationRequest{
 			VisibilityQuery: "WorkflowType='MyWorkflow'",
 		}
-		adjustedQuery := a.adjustQueryAdminBatchType(adminReq)
+		adjustedQuery := a.adjustQueryAdminBatchType(&batchspb.BatchOperationInput{
+			AdminRequest: adminReq,
+		})
 		s.Equal("WorkflowType='MyWorkflow'", adjustedQuery)
 	})
+
+	s.Run("Delegated terminate filters to running executions", func() {
+		adminReq := &adminservice.StartAdminBatchOperationRequest{
+			VisibilityQuery: "WorkflowType='MyWorkflow'",
+			Operation: &adminservice.StartAdminBatchOperationRequest_DelegationOperation{
+				DelegationOperation: &adminservice.BatchOperationDelegation{
+					BatchType: enumspb.BATCH_OPERATION_TYPE_TERMINATE_WORKFLOW,
+				},
+			},
+		}
+		adjustedQuery := a.adjustQueryAdminBatchType(&batchspb.BatchOperationInput{
+			AdminRequest: adminReq,
+			//nolint:staticcheck // SA1019: the batcher persists legacy enum values
+			BatchType: enumspb.BATCH_OPERATION_TYPE_TERMINATE,
+		})
+		s.Equal("(WorkflowType='MyWorkflow') AND (ExecutionStatus='Running')", adjustedQuery)
+	})
+
 }
 
 func (s *activitiesSuite) TestProcessAdminTask_RefreshWorkflowTasks() {
@@ -839,6 +867,129 @@ func (s *activitiesSuite) TestStartTaskProcessor_SignalUsesWorkerNamespace() {
 
 	resp := <-respCh
 	s.NoError(resp.err)
+}
+
+func (s *activitiesSuite) TestStartTaskProcessor_AdminBatchRouting() {
+	targetNamespace := "target-namespace"
+
+	testTask := func(batchType enumspb.BatchOperationType) task {
+		if isActivityBatchType(batchType) {
+			testPage := &page{
+				targetExecutionInfo: []*commonpb.Execution{{
+					Type:       enumspb.EXECUTION_TYPE_ACTIVITY,
+					BusinessId: "test-activity-id",
+					RunId:      "test-run-id",
+				}},
+			}
+			return task{
+				targetExecution: testPage.targetExecutionInfo[0],
+				attempts:        1,
+				page:            testPage,
+			}
+		}
+
+		testPage := &page{
+			executionInfos: []*workflowpb.WorkflowExecutionInfo{
+				{
+					Execution: &commonpb.WorkflowExecution{
+						WorkflowId: "test-workflow-id",
+						RunId:      "test-run-id",
+					},
+				},
+			},
+		}
+		return task{
+			executionInfo: testPage.executionInfos[0],
+			attempts:      1,
+			page:          testPage,
+		}
+	}
+
+	run := func(a *activities, batchOperation *batchspb.BatchOperationInput) taskResponse {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		taskCh := make(chan task, 1)
+		respCh := make(chan taskResponse, 1)
+		limiter := quotas.NewRequestRateLimiterAdapter(quotas.NewDefaultOutgoingRateLimiter(func() float64 { return 100 }))
+		taskCh <- testTask(batchOperation.GetBatchType())
+
+		go a.startTaskProcessor(ctx, batchOperation, targetNamespace, taskCh, respCh, limiter, nil, s.mockFrontendClient, metrics.NoopMetricsHandler, log.NewTestLogger())
+
+		return <-respCh
+	}
+
+	// The worker is bound to temporal-system while the batch targets another namespace.
+	s.Run("Delegated activity termination targets the requested namespace", func() {
+		a := &activities{
+			activityDeps: activityDeps{
+				FrontendClient: s.mockFrontendClient,
+				Logger:         log.NewTestLogger(),
+				MetricsHandler: metrics.NoopMetricsHandler,
+			},
+			namespace:   namespace.Name(primitives.SystemLocalNamespace),
+			namespaceID: namespace.ID(primitives.SystemNamespaceID),
+		}
+
+		batchOperation := &batchspb.BatchOperationInput{
+			NamespaceId: "target-namespace-id",
+			BatchType:   enumspb.BATCH_OPERATION_TYPE_TERMINATE_ACTIVITY,
+			Request: &workflowservice.StartBatchOperationRequest{
+				Namespace: targetNamespace,
+				Operation: &workflowservice.StartBatchOperationRequest_TerminateActivitiesOperation{
+					TerminateActivitiesOperation: &batchpb.BatchOperationTerminateActivities{Identity: "test"},
+				},
+			},
+			AdminRequest: &adminservice.StartAdminBatchOperationRequest{
+				Namespace: targetNamespace,
+				Operation: &adminservice.StartAdminBatchOperationRequest_DelegationOperation{
+					DelegationOperation: &adminservice.BatchOperationDelegation{
+						BatchType: enumspb.BATCH_OPERATION_TYPE_TERMINATE_ACTIVITY,
+					},
+				},
+			},
+		}
+
+		s.mockFrontendClient.EXPECT().
+			TerminateActivityExecution(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req *workflowservice.TerminateActivityExecutionRequest, _ ...any) (*workflowservice.TerminateActivityExecutionResponse, error) {
+				s.Equal(targetNamespace, req.Namespace)
+				s.NotEqual(primitives.SystemLocalNamespace, req.Namespace)
+				return &workflowservice.TerminateActivityExecutionResponse{}, nil
+			})
+
+		s.NoError(run(a, batchOperation).err)
+	})
+
+	s.Run("Refresh tasks operation still routes to the admin path", func() {
+		mockHistoryClient := historyservicemock.NewMockHistoryServiceClient(s.controller)
+		a := &activities{
+			activityDeps: activityDeps{
+				FrontendClient: s.mockFrontendClient,
+				HistoryClient:  mockHistoryClient,
+				Logger:         log.NewTestLogger(),
+				MetricsHandler: metrics.NoopMetricsHandler,
+			},
+			namespace:   namespace.Name(primitives.SystemLocalNamespace),
+			namespaceID: namespace.ID(primitives.SystemNamespaceID),
+		}
+
+		batchOperation := &batchspb.BatchOperationInput{
+			NamespaceId: "target-namespace-id",
+			AdminRequest: &adminservice.StartAdminBatchOperationRequest{
+				Namespace: targetNamespace,
+				Operation: &adminservice.StartAdminBatchOperationRequest_RefreshTasksOperation{
+					RefreshTasksOperation: &adminservice.BatchOperationRefreshTasks{},
+				},
+			},
+		}
+
+		mockHistoryClient.EXPECT().
+			RefreshWorkflowTasks(gomock.Any(), gomock.Any()).
+			Return(&historyservice.RefreshWorkflowTasksResponse{}, nil)
+
+		s.NoError(run(a, batchOperation).err)
+	})
 }
 
 // TestStartTaskProcessor_RetryableErrorsDoNotDeadlock verifies that repeated retryable
@@ -1178,10 +1329,10 @@ func (s *activitiesSuite) TestProcessWorkflowsWithProactiveFetching_ProcessesAll
 
 	a := &activities{}
 	config := batchProcessorConfig{
-		namespace:     "test-namespace",
-		adjustedQuery: "ActivityType = 'test-activity'",
-		batchType:     enumspb.BATCH_OPERATION_TYPE_TERMINATE_ACTIVITY,
-		concurrency:   3,
+		targetNamespace: "test-namespace",
+		adjustedQuery:   "ActivityType = 'test-activity'",
+		batchType:       enumspb.BATCH_OPERATION_TYPE_TERMINATE_ACTIVITY,
+		concurrency:     3,
 	}
 	limiter := quotas.NewRequestRateLimiterAdapter(quotas.NewDefaultOutgoingRateLimiter(func() float64 { return 10000 }))
 

--- a/tests/activity_api_batch_unpause_test.go
+++ b/tests/activity_api_batch_unpause_test.go
@@ -338,7 +338,7 @@ func (s *ActivityApiBatchUnpauseClientTestSuite) TestActivityBatchUnpause_Failed
 
 // TestBatchTerminate_NamespaceIsolation verifies that a batch terminate operation
 // scoped to the primary namespace does not affect workflows in a separate namespace.
-// This is an end-to-end complement to the unit-level checkNamespace tests: it
+// This is an end-to-end complement to the unit-level checkAndGetTargetNamespace tests: it
 // exercises the full path from StartBatchOperation through the batcher worker.
 func (s *ActivityApiBatchUnpauseClientTestSuite) TestBatchTerminate_NamespaceIsolation() {
 	env := testcore.NewEnv(s.T())

--- a/tests/admin_batch_delegation_test.go
+++ b/tests/admin_batch_delegation_test.go
@@ -35,7 +35,7 @@ func (s *AdminBatchDelegationTestSuite) newTestEnv(opts ...testcore.TestOption) 
 	baseOpts := []testcore.TestOption{
 		// The batch workflow runs on the system namespace's per-namespace worker.
 		testcore.WithWorkerService("batch operations"),
-		testcore.WithDynamicConfig(dynamicconfig.FrontendMaxConcurrentAdminBatchOperationPerNamespace, 10),
+		testcore.WithDynamicConfig(dynamicconfig.FrontendMaxConcurrentAdminBatchOperation, 10),
 	}
 	return testcore.NewEnv(s.T(), append(baseOpts, opts...)...)
 }

--- a/tests/admin_batch_delegation_test.go
+++ b/tests/admin_batch_delegation_test.go
@@ -1,0 +1,184 @@
+package tests
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	sdkclient "go.temporal.io/sdk/client"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/primitives"
+	"go.temporal.io/server/common/testing/parallelsuite"
+	"go.temporal.io/server/service/worker/batcher"
+	"go.temporal.io/server/tests/testcore"
+	"go.temporal.io/server/tools/tdbg"
+	"go.temporal.io/server/tools/tdbg/tdbgtest"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+type AdminBatchDelegationTestSuite struct {
+	parallelsuite.Suite[*AdminBatchDelegationTestSuite]
+}
+
+func TestAdminBatchDelegationTestSuite(t *testing.T) {
+	parallelsuite.Run(t, &AdminBatchDelegationTestSuite{})
+}
+
+func (s *AdminBatchDelegationTestSuite) newTestEnv(opts ...testcore.TestOption) *testcore.TestEnv {
+	baseOpts := []testcore.TestOption{
+		// The batch workflow runs on the system namespace's per-namespace worker.
+		testcore.WithWorkerService("batch operations"),
+		testcore.WithDynamicConfig(dynamicconfig.FrontendMaxConcurrentAdminBatchOperationPerNamespace, 10),
+	}
+	return testcore.NewEnv(s.T(), append(baseOpts, opts...)...)
+}
+
+func (s *AdminBatchDelegationTestSuite) runTdbg(env *testcore.TestEnv, args ...string) error {
+	var out bytes.Buffer
+	return tdbgtest.NewCliApp(
+		func(params *tdbg.Params) {
+			params.ClientFactory = tdbg.NewClientFactory(tdbg.WithFrontendAddress(env.FrontendGRPCAddress()))
+			params.Writer = &out
+			params.ErrWriter = &out
+		},
+	).RunContext(s.Context(), append([]string{"tdbg"}, args...))
+}
+
+// startUnworkedWorkflows starts workflows on a task queue no worker polls, so they stay running
+// until the batch operation acts on them.
+func (s *AdminBatchDelegationTestSuite) startUnworkedWorkflows(
+	env *testcore.TestEnv,
+	namespace string,
+	workflowTypeName string,
+	count int,
+) []*commonpb.WorkflowExecution {
+	executions := make([]*commonpb.WorkflowExecution, 0, count)
+	for i := range count {
+		workflowID := fmt.Sprintf("admin-batch-delegation-%d-%s", i, uuid.NewString())
+		resp, err := env.FrontendClient().StartWorkflowExecution(s.Context(), &workflowservice.StartWorkflowExecutionRequest{
+			RequestId:          uuid.NewString(),
+			Namespace:          namespace,
+			WorkflowId:         workflowID,
+			WorkflowType:       &commonpb.WorkflowType{Name: workflowTypeName},
+			TaskQueue:          &taskqueuepb.TaskQueue{Name: "admin-batch-delegation-tq", Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+			Identity:           "test",
+			WorkflowRunTimeout: durationpb.New(time.Hour),
+		})
+		s.NoError(err)
+		executions = append(executions, &commonpb.WorkflowExecution{WorkflowId: workflowID, RunId: resp.GetRunId()})
+	}
+	return executions
+}
+
+func (s *AdminBatchDelegationTestSuite) awaitVisibilityCount(
+	env *testcore.TestEnv,
+	namespace string,
+	query string,
+	expected int64,
+) {
+	s.Await(func(s *AdminBatchDelegationTestSuite) {
+		resp, err := env.FrontendClient().CountWorkflowExecutions(s.Context(), &workflowservice.CountWorkflowExecutionsRequest{
+			Namespace: namespace,
+			Query:     query,
+		})
+		s.NoError(err)
+		s.Equal(expected, resp.GetCount())
+	}, 20*time.Second, 500*time.Millisecond)
+}
+
+// TestTdbgBatchTerminate_RunsInSystemNamespaceAgainstTargetNamespace is the case the feature
+// exists for: the batch workflow runs on the system namespace's per-namespace worker, and its
+// per-execution calls target another namespace.
+func (s *AdminBatchDelegationTestSuite) TestTdbgBatchTerminate_RunsInSystemNamespaceAgainstTargetNamespace() {
+	env := s.newTestEnv()
+
+	ns := env.Namespace().String()
+	workflowTypeName := "admin-batch-delegation-wf-" + uuid.NewString()
+	query := fmt.Sprintf("WorkflowType = '%s'", workflowTypeName)
+
+	executions := s.startUnworkedWorkflows(env, ns, workflowTypeName, 2)
+	nonMatchingWorkflowType := workflowTypeName + "-non-matching-batch-query"
+	nonMatchingExecution := s.startUnworkedWorkflows(env, ns, nonMatchingWorkflowType, 1)[0]
+	systemExecution := s.startUnworkedWorkflows(env, primitives.SystemLocalNamespace, workflowTypeName, 1)[0]
+	s.awaitVisibilityCount(env, ns, query, 2)
+	s.awaitVisibilityCount(env, ns, fmt.Sprintf("WorkflowType = '%s'", nonMatchingWorkflowType), 1)
+	s.awaitVisibilityCount(env, primitives.SystemLocalNamespace, query, 1)
+
+	jobID := uuid.NewString()
+	s.NoError(s.runTdbg(env,
+		"--"+tdbg.FlagYes,
+		"--"+tdbg.FlagNamespace, ns,
+		"delegated-batch", "start",
+		"--"+tdbg.FlagBatchType, "terminate-workflows",
+		"--"+tdbg.FlagVisibilityQuery, query,
+		"--"+tdbg.FlagReason, "test batch terminate from the system namespace",
+		"--"+tdbg.FlagJobID, jobID,
+	))
+
+	// tdbg qualifies the job ID with the namespace: the batch workflow runs in the system namespace,
+	// where job IDs from every namespace share one workflow ID space.
+	batchWorkflowID := jobID + ":" + ns
+
+	s.Await(func(s *AdminBatchDelegationTestSuite) {
+		resp, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: primitives.SystemLocalNamespace,
+			Execution: &commonpb.WorkflowExecution{WorkflowId: batchWorkflowID},
+		})
+		s.NoError(err)
+		s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, resp.GetWorkflowExecutionInfo().GetStatus())
+		s.Equal(primitives.PerNSWorkerTaskQueue, resp.GetExecutionConfig().GetTaskQueue().GetName())
+	}, 60*time.Second, time.Second)
+
+	_, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+		Namespace: ns,
+		Execution: &commonpb.WorkflowExecution{WorkflowId: batchWorkflowID},
+	})
+	var notFound *serviceerror.NotFound
+	s.ErrorAs(err, &notFound)
+
+	// The operation reached the target namespace.
+	for _, execution := range executions {
+		resp, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: ns,
+			Execution: execution,
+		})
+		s.NoError(err)
+		s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED, resp.GetWorkflowExecutionInfo().GetStatus())
+	}
+
+	// Query selection is scoped to the target namespace and does not affect non-matching workflows.
+	for namespace, execution := range map[string]*commonpb.WorkflowExecution{
+		ns:                              nonMatchingExecution,
+		primitives.SystemLocalNamespace: systemExecution,
+	} {
+		resp, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: namespace,
+			Execution: execution,
+		})
+		s.NoError(err)
+		s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, resp.GetWorkflowExecutionInfo().GetStatus())
+	}
+
+	// The estimate and counts come from the target namespace's visibility, not the system namespace's.
+	systemClient, err := sdkclient.Dial(sdkclient.Options{
+		HostPort:  env.FrontendGRPCAddress(),
+		Namespace: primitives.SystemLocalNamespace,
+	})
+	s.NoError(err)
+	if err == nil {
+		defer systemClient.Close()
+
+		var hbd batcher.HeartBeatDetails
+		s.NoError(systemClient.GetWorkflow(s.Context(), batchWorkflowID, "").Get(s.Context(), &hbd))
+		s.Equal(int64(2), hbd.TotalEstimate)
+		s.Equal(2, hbd.SuccessCount)
+		s.Equal(0, hbd.ErrorCount)
+	}
+}

--- a/tests/admin_batch_delegation_test.go
+++ b/tests/admin_batch_delegation_test.go
@@ -93,6 +93,22 @@ func (s *AdminBatchDelegationTestSuite) awaitVisibilityCount(
 	}, 20*time.Second, 500*time.Millisecond)
 }
 
+func (s *AdminBatchDelegationTestSuite) awaitActivityVisibilityCount(
+	env *testcore.TestEnv,
+	namespace string,
+	query string,
+	expected int64,
+) {
+	s.Await(func(s *AdminBatchDelegationTestSuite) {
+		resp, err := env.FrontendClient().CountActivityExecutions(s.Context(), &workflowservice.CountActivityExecutionsRequest{
+			Namespace: namespace,
+			Query:     query,
+		})
+		s.NoError(err)
+		s.Equal(expected, resp.GetCount())
+	}, 20*time.Second, 500*time.Millisecond)
+}
+
 // TestTdbgBatchTerminate_RunsInSystemNamespaceAgainstTargetNamespace is the case the feature
 // exists for: the batch workflow runs on the system namespace's per-namespace worker, and its
 // per-execution calls target another namespace.
@@ -181,4 +197,148 @@ func (s *AdminBatchDelegationTestSuite) TestTdbgBatchTerminate_RunsInSystemNames
 		s.Equal(2, hbd.SuccessCount)
 		s.Equal(0, hbd.ErrorCount)
 	}
+}
+
+func (s *AdminBatchDelegationTestSuite) TestTdbgBatchDelete_RunsInSystemNamespaceAgainstTargetNamespace() {
+	env := s.newTestEnv()
+
+	ns := env.Namespace().String()
+	workflowTypeName := "admin-batch-delete-wf-" + uuid.NewString()
+	query := fmt.Sprintf("WorkflowType = '%s'", workflowTypeName)
+
+	executions := s.startUnworkedWorkflows(env, ns, workflowTypeName, 2)
+	nonMatchingExecution := s.startUnworkedWorkflows(env, ns, workflowTypeName+"-non-matching", 1)[0]
+	systemExecution := s.startUnworkedWorkflows(env, primitives.SystemLocalNamespace, workflowTypeName, 1)[0]
+	s.awaitVisibilityCount(env, ns, query, 2)
+	s.awaitVisibilityCount(env, primitives.SystemLocalNamespace, query, 1)
+
+	jobID := uuid.NewString()
+	s.NoError(s.runTdbg(env,
+		"--"+tdbg.FlagYes,
+		"--"+tdbg.FlagNamespace, ns,
+		"delegated-batch", "start",
+		"--"+tdbg.FlagBatchType, "delete-workflows",
+		"--"+tdbg.FlagVisibilityQuery, query,
+		"--"+tdbg.FlagReason, "test batch delete from the system namespace",
+		"--"+tdbg.FlagJobID, jobID,
+	))
+
+	batchWorkflowID := jobID + ":" + ns
+	s.Await(func(s *AdminBatchDelegationTestSuite) {
+		resp, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: primitives.SystemLocalNamespace,
+			Execution: &commonpb.WorkflowExecution{WorkflowId: batchWorkflowID},
+		})
+		s.NoError(err)
+		s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, resp.GetWorkflowExecutionInfo().GetStatus())
+	}, 60*time.Second, time.Second)
+
+	for _, execution := range executions {
+		s.Await(func(s *AdminBatchDelegationTestSuite) {
+			_, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+				Namespace: ns,
+				Execution: execution,
+			})
+			var notFound *serviceerror.NotFound
+			s.ErrorAs(err, &notFound)
+		}, 20*time.Second, 500*time.Millisecond)
+	}
+	s.awaitVisibilityCount(env, ns, query, 0)
+
+	resp, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+		Namespace: ns,
+		Execution: nonMatchingExecution,
+	})
+	s.NoError(err)
+	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, resp.GetWorkflowExecutionInfo().GetStatus())
+
+	resp, err = env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+		Namespace: primitives.SystemLocalNamespace,
+		Execution: systemExecution,
+	})
+	s.NoError(err)
+	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, resp.GetWorkflowExecutionInfo().GetStatus())
+	s.awaitVisibilityCount(env, primitives.SystemLocalNamespace, query, 1)
+}
+
+func (s *AdminBatchDelegationTestSuite) TestTdbgBatchDeleteActivities_RunsInSystemNamespaceAgainstTargetNamespace() {
+	env := newStandaloneActivityBatchEnv(s.T())
+
+	ns := env.Namespace().String()
+	activityIDPrefix := "admin-batch-delete-activity-" + uuid.NewString()
+	query := fmt.Sprintf("ActivityId STARTS_WITH '%s'", activityIDPrefix)
+
+	activities := make([]startedActivity, 0, 2)
+	for i := range 2 {
+		activityID := fmt.Sprintf("%s-%d", activityIDPrefix, i)
+		resp := env.startAndValidateActivity(s.Context(), s.T(), activityID, testcore.RandomizeStr(s.T().Name()))
+		activities = append(activities, startedActivity{activityID: activityID, runID: resp.GetRunId()})
+	}
+	nonMatchingActivityID := "non-matching-" + uuid.NewString()
+	nonMatchingResp := env.startAndValidateActivity(
+		s.Context(),
+		s.T(),
+		nonMatchingActivityID,
+		testcore.RandomizeStr(s.T().Name()+"-non-matching"),
+	)
+	externalNS := env.ExternalNamespace().String()
+	externalActivityID := activityIDPrefix + "-external-namespace"
+	externalActivityResp, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
+		Namespace:    externalNS,
+		ActivityId:   externalActivityID,
+		ActivityType: env.Tv().ActivityType(),
+		Identity:     env.Tv().WorkerIdentity(),
+		Input:        defaultInput,
+		TaskQueue: &taskqueuepb.TaskQueue{
+			Name: testcore.RandomizeStr(s.T().Name() + "-external-namespace"),
+		},
+		StartToCloseTimeout: durationpb.New(time.Hour),
+		RequestId:           uuid.NewString(),
+	})
+	s.NoError(err)
+	s.awaitActivityVisibilityCount(env.TestEnv, ns, query, 2)
+	s.awaitActivityVisibilityCount(env.TestEnv, externalNS, query, 1)
+
+	jobID := uuid.NewString()
+	s.NoError(s.runTdbg(env.TestEnv,
+		"--"+tdbg.FlagYes,
+		"--"+tdbg.FlagNamespace, ns,
+		"delegated-batch", "start",
+		"--"+tdbg.FlagBatchType, "delete-activities",
+		"--"+tdbg.FlagVisibilityQuery, query,
+		"--"+tdbg.FlagReason, "test batch activity delete from the system namespace",
+		"--"+tdbg.FlagJobID, jobID,
+	))
+
+	batchWorkflowID := jobID + ":" + ns
+	s.Await(func(s *AdminBatchDelegationTestSuite) {
+		resp, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: primitives.SystemLocalNamespace,
+			Execution: &commonpb.WorkflowExecution{WorkflowId: batchWorkflowID},
+		})
+		s.NoError(err)
+		s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, resp.GetWorkflowExecutionInfo().GetStatus())
+	}, 60*time.Second, time.Second)
+
+	for _, activity := range activities {
+		env.eventuallyDeleted(s.Context(), s.T(), activity.activityID, activity.runID)
+	}
+	s.awaitActivityVisibilityCount(env.TestEnv, ns, query, 0)
+
+	resp, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+		Namespace:  ns,
+		ActivityId: nonMatchingActivityID,
+		RunId:      nonMatchingResp.GetRunId(),
+	})
+	s.NoError(err)
+	s.Equal(enumspb.ACTIVITY_EXECUTION_STATUS_RUNNING, resp.GetInfo().GetStatus())
+
+	resp, err = env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+		Namespace:  externalNS,
+		ActivityId: externalActivityID,
+		RunId:      externalActivityResp.GetRunId(),
+	})
+	s.NoError(err)
+	s.Equal(enumspb.ACTIVITY_EXECUTION_STATUS_RUNNING, resp.GetInfo().GetStatus())
+	s.awaitActivityVisibilityCount(env.TestEnv, externalNS, query, 1)
 }

--- a/tests/xdc/admin_batch_delegation_test.go
+++ b/tests/xdc/admin_batch_delegation_test.go
@@ -1,0 +1,97 @@
+package xdc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/suite"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/api/adminservice/v1"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/tests/testcore"
+)
+
+type AdminBatchDelegationTestSuite struct {
+	xdcBaseSuite
+}
+
+func TestAdminBatchDelegationTestSuite(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, &AdminBatchDelegationTestSuite{})
+}
+
+func (s *AdminBatchDelegationTestSuite) SetupSuite() {
+	if s.dynamicConfigOverrides == nil {
+		s.dynamicConfigOverrides = make(map[dynamicconfig.Key]any)
+	}
+	s.dynamicConfigOverrides[dynamicconfig.FrontendMaxConcurrentAdminBatchOperationPerNamespace.Key()] = 10
+	s.setupSuite()
+}
+
+func (s *AdminBatchDelegationTestSuite) SetupTest() {
+	s.setupTest()
+}
+
+func (s *AdminBatchDelegationTestSuite) TearDownSuite() {
+	s.tearDownSuite()
+}
+
+// TestDelegatedBatchOperation_OnlyInActiveCluster covers the constraint that separates a
+// delegated operation from refresh tasks: terminate mutates workflow state, so only the cluster
+// that is active for the target namespace may run it. Refresh tasks, by contrast, is reachable
+// from the passive cluster, which is why admin batches exist at all.
+func (s *AdminBatchDelegationTestSuite) TestDelegatedBatchOperation_OnlyInActiveCluster() {
+	ctx := testcore.NewContext()
+	ns := s.createGlobalNamespace()
+
+	// The premise: cluster 0 is active for ns, cluster 1 is passive.
+	for _, cluster := range s.clusters {
+		resp, err := cluster.FrontendClient().DescribeNamespace(ctx, &workflowservice.DescribeNamespaceRequest{Namespace: ns})
+		s.NoError(err)
+		s.Equal(s.clusters[0].ClusterName(), resp.GetReplicationConfig().GetActiveClusterName(),
+			"%s should see %s as active for %s", cluster.ClusterName(), s.clusters[0].ClusterName(), ns)
+	}
+
+	visibilityQuery := fmt.Sprintf("WorkflowType = 'admin-batch-user-op-%s'", uuid.NewString())
+
+	terminateRequest := func() *adminservice.StartAdminBatchOperationRequest {
+		return &adminservice.StartAdminBatchOperationRequest{
+			Namespace:       ns,
+			VisibilityQuery: visibilityQuery,
+			JobId:           "user-batch-" + uuid.NewString(),
+			Reason:          "xdc admin delegated batch",
+			Identity:        "test",
+			Operation: &adminservice.StartAdminBatchOperationRequest_DelegationOperation{
+				DelegationOperation: &adminservice.BatchOperationDelegation{
+					BatchType: enumspb.BATCH_OPERATION_TYPE_TERMINATE_WORKFLOW,
+				},
+			},
+		}
+	}
+
+	_, err := s.clusters[1].AdminClient().StartAdminBatchOperation(ctx, terminateRequest())
+	var notActive *serviceerror.NamespaceNotActive
+	s.ErrorAs(err, &notActive,
+		"the passive cluster %s must reject a delegated batch operation on %s", s.clusters[1].ClusterName(), ns)
+
+	_, err = s.clusters[0].AdminClient().StartAdminBatchOperation(ctx, terminateRequest())
+	s.NoError(err,
+		"the active cluster %s must accept a delegated batch operation on %s", s.clusters[0].ClusterName(), ns)
+
+	// Refresh tasks stays reachable from the passive cluster.
+	_, err = s.clusters[1].AdminClient().StartAdminBatchOperation(ctx, &adminservice.StartAdminBatchOperationRequest{
+		Namespace:       ns,
+		VisibilityQuery: visibilityQuery,
+		JobId:           "refresh-" + uuid.NewString(),
+		Reason:          "xdc admin batch refresh tasks",
+		Identity:        "test",
+		Operation: &adminservice.StartAdminBatchOperationRequest_RefreshTasksOperation{
+			RefreshTasksOperation: &adminservice.BatchOperationRefreshTasks{},
+		},
+	})
+	s.NoError(err,
+		"refresh tasks must stay reachable from the passive cluster %s", s.clusters[1].ClusterName())
+}

--- a/tests/xdc/admin_batch_delegation_test.go
+++ b/tests/xdc/admin_batch_delegation_test.go
@@ -27,7 +27,7 @@ func (s *AdminBatchDelegationTestSuite) SetupSuite() {
 	if s.dynamicConfigOverrides == nil {
 		s.dynamicConfigOverrides = make(map[dynamicconfig.Key]any)
 	}
-	s.dynamicConfigOverrides[dynamicconfig.FrontendMaxConcurrentAdminBatchOperationPerNamespace.Key()] = 10
+	s.dynamicConfigOverrides[dynamicconfig.FrontendMaxConcurrentAdminBatchOperation.Key()] = 10
 	s.setupSuite()
 }
 

--- a/tools/tdbg/batch_commands.go
+++ b/tools/tdbg/batch_commands.go
@@ -15,19 +15,23 @@ import (
 
 const (
 	batchTypeTerminateWorkflows  = "terminate-workflows"
+	batchTypeDeleteWorkflows     = "delete-workflows"
 	batchTypeTerminateActivities = "terminate-activities"
+	batchTypeDeleteActivities    = "delete-activities"
 )
 
 var batchTypes = []string{
 	batchTypeTerminateWorkflows,
+	batchTypeDeleteWorkflows,
 	batchTypeTerminateActivities,
+	batchTypeDeleteActivities,
 }
 
 func newAdminBatchCommands(clientFactory ClientFactory, prompterFactory PrompterFactory) []*cli.Command {
 	return []*cli.Command{
 		{
 			Name:  "start",
-			Usage: "Delegate termination in a user namespace to a batch workflow in temporal-system",
+			Usage: "Delegate a destructive operation in a user namespace to a batch workflow in temporal-system",
 			Flags: []cli.Flag{
 				&cli.StringFlag{
 					Name:     FlagBatchType,
@@ -114,9 +118,9 @@ func AdminBatchStart(c *cli.Context, clientFactory ClientFactory, prompter *Prom
 			"Operation: %s\n"+
 			"Visibility query: %q\n"+
 			"Currently matching: %d %s\n\n"+
-			"This delegates termination of matching %s in user namespace %q to a batch workflow running in %q.\n"+
+			"This delegates the %s operation on matching %s in user namespace %q to a batch workflow running in %q.\n"+
 			"For a global namespace, this operation must be submitted through its active cluster.\n"+
-			"Supported operations are limited to %s and %s.\n\n"+
+			"Supported operations are limited to: %s.\n\n"+
 			"Review the user namespace, visibility query, and current match count carefully.\n"+
 			"Visibility results can change while the batch is running.",
 		nsName,
@@ -125,16 +129,16 @@ func AdminBatchStart(c *cli.Context, clientFactory ClientFactory, prompter *Prom
 		query,
 		matchCount,
 		targetKind,
+		batchType,
 		targetKind,
 		nsName,
 		primitives.SystemLocalNamespace,
-		batchTypeTerminateWorkflows,
-		batchTypeTerminateActivities,
+		strings.Join(batchTypes, ", "),
 	)
 	if _, err := fmt.Fprintln(c.App.Writer, summary); err != nil {
 		return fmt.Errorf("unable to write batch operation summary: %w", err)
 	}
-	prompter.Prompt(fmt.Sprintf("Proceed with terminating the currently matching %d %s?", matchCount, targetKind))
+	prompter.Prompt(fmt.Sprintf("Proceed with %s on the currently matching %d %s?", batchType, matchCount, targetKind))
 
 	_, err = adminClient.StartAdminBatchOperation(ctx, &adminservice.StartAdminBatchOperationRequest{
 		Namespace:       nsName,
@@ -165,7 +169,8 @@ func countDelegatedBatchExecutions(
 	batchType enumspb.BatchOperationType,
 ) (int64, string, error) {
 	switch batchType {
-	case enumspb.BATCH_OPERATION_TYPE_TERMINATE_WORKFLOW:
+	case enumspb.BATCH_OPERATION_TYPE_TERMINATE_WORKFLOW,
+		enumspb.BATCH_OPERATION_TYPE_DELETE_WORKFLOW:
 		resp, err := workflowClient.CountWorkflowExecutions(ctx, &workflowservice.CountWorkflowExecutionsRequest{
 			Namespace: nsName,
 			Query:     query,
@@ -174,7 +179,8 @@ func countDelegatedBatchExecutions(
 			return 0, "", fmt.Errorf("unable to count workflow executions: %w", err)
 		}
 		return resp.GetCount(), "workflows", nil
-	case enumspb.BATCH_OPERATION_TYPE_TERMINATE_ACTIVITY:
+	case enumspb.BATCH_OPERATION_TYPE_TERMINATE_ACTIVITY,
+		enumspb.BATCH_OPERATION_TYPE_DELETE_ACTIVITY:
 		resp, err := workflowClient.CountActivityExecutions(ctx, &workflowservice.CountActivityExecutionsRequest{
 			Namespace: nsName,
 			Query:     query,
@@ -228,8 +234,12 @@ func delegatedBatchType(batchType string) (enumspb.BatchOperationType, error) {
 	switch batchType {
 	case batchTypeTerminateWorkflows:
 		return enumspb.BATCH_OPERATION_TYPE_TERMINATE_WORKFLOW, nil
+	case batchTypeDeleteWorkflows:
+		return enumspb.BATCH_OPERATION_TYPE_DELETE_WORKFLOW, nil
 	case batchTypeTerminateActivities:
 		return enumspb.BATCH_OPERATION_TYPE_TERMINATE_ACTIVITY, nil
+	case batchTypeDeleteActivities:
+		return enumspb.BATCH_OPERATION_TYPE_DELETE_ACTIVITY, nil
 	default:
 		return enumspb.BATCH_OPERATION_TYPE_UNSPECIFIED,
 			fmt.Errorf("unknown batch type %q, expected one of: %s", batchType, strings.Join(batchTypes, ", "))

--- a/tools/tdbg/batch_commands.go
+++ b/tools/tdbg/batch_commands.go
@@ -1,0 +1,237 @@
+package tdbg
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/urfave/cli/v2"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/api/adminservice/v1"
+	"go.temporal.io/server/common/primitives"
+)
+
+const (
+	batchTypeTerminateWorkflows  = "terminate-workflows"
+	batchTypeTerminateActivities = "terminate-activities"
+)
+
+var batchTypes = []string{
+	batchTypeTerminateWorkflows,
+	batchTypeTerminateActivities,
+}
+
+func newAdminBatchCommands(clientFactory ClientFactory, prompterFactory PrompterFactory) []*cli.Command {
+	return []*cli.Command{
+		{
+			Name:  "start",
+			Usage: "Delegate termination in a user namespace to a batch workflow in temporal-system",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:     FlagBatchType,
+					Usage:    fmt.Sprintf("Batch operation to run, one of: %s", strings.Join(batchTypes, ", ")),
+					Required: true,
+				},
+				&cli.StringFlag{
+					Name:  FlagVisibilityQuery,
+					Usage: "Visibility query selecting the executions to operate on",
+				},
+				&cli.StringFlag{
+					Name:  FlagReason,
+					Usage: "Reason for starting the batch job",
+				},
+				&cli.StringFlag{
+					Name:  FlagJobID,
+					Usage: "Optional job ID (auto-generated if not provided)",
+				},
+			},
+			Action: func(c *cli.Context) error {
+				return AdminBatchStart(c, clientFactory, prompterFactory(c))
+			},
+		},
+	}
+}
+
+// AdminBatchStart starts a batch operation whose workflow runs in the system namespace and
+// whose per-execution calls target the namespace given by --namespace. Unlike
+// StartBatchOperation, this does not require the target namespace to have a per-namespace
+// worker in this cluster.
+func AdminBatchStart(c *cli.Context, clientFactory ClientFactory, prompter *Prompter) error {
+	adminClient := clientFactory.AdminClient(c)
+	workflowClient := clientFactory.WorkflowClient(c)
+
+	nsName, err := getRequiredOption(c, FlagNamespace)
+	if err != nil {
+		return err
+	}
+
+	query, err := getRequiredOption(c, FlagVisibilityQuery)
+	if err != nil {
+		return err
+	}
+
+	reason, err := getRequiredOption(c, FlagReason)
+	if err != nil {
+		return err
+	}
+
+	batchType, err := getRequiredOption(c, FlagBatchType)
+	if err != nil {
+		return err
+	}
+
+	delegatedType, err := delegatedBatchType(batchType)
+	if err != nil {
+		return err
+	}
+
+	jobID := c.String(FlagJobID)
+	if jobID == "" {
+		jobID = fmt.Sprintf("batch-%s-%d", batchType, time.Now().UnixNano())
+	}
+	// The workflow ID lives in the system namespace, so it has to distinguish target namespaces.
+	jobIDWithNS := fmt.Sprintf("%s:%s", jobID, nsName)
+
+	ctx, cancel := newContext(c)
+	defer cancel()
+
+	if err := checkTargetNamespaceActive(ctx, adminClient, workflowClient, nsName); err != nil {
+		return err
+	}
+
+	matchCount, targetKind, err := countDelegatedBatchExecutions(ctx, workflowClient, nsName, query, delegatedType)
+	if err != nil {
+		return err
+	}
+
+	summary := fmt.Sprintf(
+		"DANGER: destructive delegated batch operation\n\n"+
+			"User namespace: %q\n"+
+			"Batch workflow namespace: %q\n"+
+			"Cluster eligibility: passed\n"+
+			"Operation: %s\n"+
+			"Visibility query: %q\n"+
+			"Currently matching: %d %s\n\n"+
+			"This delegates termination of matching %s in user namespace %q to a batch workflow running in %q.\n"+
+			"For a global namespace, this operation must be submitted through its active cluster.\n"+
+			"Supported operations are limited to %s and %s.\n\n"+
+			"Review the user namespace, visibility query, and current match count carefully.\n"+
+			"Visibility results can change while the batch is running.",
+		nsName,
+		primitives.SystemLocalNamespace,
+		batchType,
+		query,
+		matchCount,
+		targetKind,
+		targetKind,
+		nsName,
+		primitives.SystemLocalNamespace,
+		batchTypeTerminateWorkflows,
+		batchTypeTerminateActivities,
+	)
+	if _, err := fmt.Fprintln(c.App.Writer, summary); err != nil {
+		return fmt.Errorf("unable to write batch operation summary: %w", err)
+	}
+	prompter.Prompt(fmt.Sprintf("Proceed with terminating the currently matching %d %s?", matchCount, targetKind))
+
+	_, err = adminClient.StartAdminBatchOperation(ctx, &adminservice.StartAdminBatchOperationRequest{
+		Namespace:       nsName,
+		VisibilityQuery: query,
+		JobId:           jobIDWithNS,
+		Reason:          reason,
+		Identity:        getCurrentUserFromEnv(),
+		Operation: &adminservice.StartAdminBatchOperationRequest_DelegationOperation{
+			DelegationOperation: &adminservice.BatchOperationDelegation{BatchType: delegatedType},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("unable to start batch operation: %w", err)
+	}
+
+	// nolint:errcheck // assuming that write will succeed.
+	fmt.Fprintf(c.App.Writer,
+		"Batch operation %q started successfully in namespace %s, targeting namespace %q, with Job ID: %s\n",
+		batchType, primitives.SystemLocalNamespace, nsName, jobIDWithNS)
+	return nil
+}
+
+func countDelegatedBatchExecutions(
+	ctx context.Context,
+	workflowClient workflowservice.WorkflowServiceClient,
+	nsName string,
+	query string,
+	batchType enumspb.BatchOperationType,
+) (int64, string, error) {
+	switch batchType {
+	case enumspb.BATCH_OPERATION_TYPE_TERMINATE_WORKFLOW:
+		resp, err := workflowClient.CountWorkflowExecutions(ctx, &workflowservice.CountWorkflowExecutionsRequest{
+			Namespace: nsName,
+			Query:     query,
+		})
+		if err != nil {
+			return 0, "", fmt.Errorf("unable to count workflow executions: %w", err)
+		}
+		return resp.GetCount(), "workflows", nil
+	case enumspb.BATCH_OPERATION_TYPE_TERMINATE_ACTIVITY:
+		resp, err := workflowClient.CountActivityExecutions(ctx, &workflowservice.CountActivityExecutionsRequest{
+			Namespace: nsName,
+			Query:     query,
+		})
+		if err != nil {
+			return 0, "", fmt.Errorf("unable to count activity executions: %w", err)
+		}
+		return resp.GetCount(), "activities", nil
+	default:
+		return 0, "", fmt.Errorf("unsupported delegated batch operation: %v", batchType)
+	}
+}
+
+// checkTargetNamespaceActive fails before the job is started if this cluster is not active for
+// the target namespace. StartAdminBatchOperation rejects it too; checking here names both
+// clusters and avoids prompting for a job that cannot run.
+func checkTargetNamespaceActive(
+	ctx context.Context,
+	adminClient adminservice.AdminServiceClient,
+	workflowClient workflowservice.WorkflowServiceClient,
+	nsName string,
+) error {
+	nsResp, err := workflowClient.DescribeNamespace(ctx, &workflowservice.DescribeNamespaceRequest{
+		Namespace: nsName,
+	})
+	if err != nil {
+		return fmt.Errorf("unable to describe namespace %q: %w", nsName, err)
+	}
+	// A local namespace is active in every cluster it exists in.
+	if !nsResp.GetIsGlobalNamespace() {
+		return nil
+	}
+
+	clusterResp, err := adminClient.DescribeCluster(ctx, &adminservice.DescribeClusterRequest{})
+	if err != nil {
+		return fmt.Errorf("unable to describe cluster: %w", err)
+	}
+
+	activeCluster := nsResp.GetReplicationConfig().GetActiveClusterName()
+	if activeCluster != clusterResp.GetClusterName() {
+		return fmt.Errorf(
+			"namespace %q is active in cluster %q, but this cluster is %q: a batch operation must be started in the active cluster",
+			nsName, activeCluster, clusterResp.GetClusterName())
+	}
+	return nil
+}
+
+// delegatedBatchType maps the --batch-type value to the batch operation the admin API delegates.
+// The operation itself needs no parameters here: identity and reason travel on the envelope.
+func delegatedBatchType(batchType string) (enumspb.BatchOperationType, error) {
+	switch batchType {
+	case batchTypeTerminateWorkflows:
+		return enumspb.BATCH_OPERATION_TYPE_TERMINATE_WORKFLOW, nil
+	case batchTypeTerminateActivities:
+		return enumspb.BATCH_OPERATION_TYPE_TERMINATE_ACTIVITY, nil
+	default:
+		return enumspb.BATCH_OPERATION_TYPE_UNSPECIFIED,
+			fmt.Errorf("unknown batch type %q, expected one of: %s", batchType, strings.Join(batchTypes, ", "))
+	}
+}

--- a/tools/tdbg/batch_commands_test.go
+++ b/tools/tdbg/batch_commands_test.go
@@ -163,6 +163,32 @@ func (s *batchCommandTestSuite) TestAdminBatchStart() {
 		s.Contains(s.output.String(), "Currently matching: 5 activities")
 	})
 
+	s.Run("Delete workflows delegates the workflow delete batch type", func() {
+		s.NoError(s.run(
+			"--batch-type", batchTypeDeleteWorkflows,
+			"--query", "WorkflowType='ExpiredWorkflow'",
+			"--reason", "retention cleanup",
+		))
+
+		request := s.client.admin.lastRequest
+		s.Equal(enumspb.BATCH_OPERATION_TYPE_DELETE_WORKFLOW, request.GetDelegationOperation().GetBatchType())
+		s.Contains(s.output.String(), "Operation: delete-workflows")
+		s.Contains(s.output.String(), "Currently matching: 3 workflows")
+	})
+
+	s.Run("Delete activities delegates the activity delete batch type", func() {
+		s.NoError(s.run(
+			"--batch-type", batchTypeDeleteActivities,
+			"--query", "ActivityType='ExpiredActivity'",
+			"--reason", "retention cleanup",
+		))
+
+		request := s.client.admin.lastRequest
+		s.Equal(enumspb.BATCH_OPERATION_TYPE_DELETE_ACTIVITY, request.GetDelegationOperation().GetBatchType())
+		s.Contains(s.output.String(), "Operation: delete-activities")
+		s.Contains(s.output.String(), "Currently matching: 5 activities")
+	})
+
 	s.Run("Unknown batch type is rejected", func() {
 		s.ErrorContains(s.run("--batch-type", "nonsense", "--query", "A=B", "--reason", "r"), "unknown batch type")
 	})

--- a/tools/tdbg/batch_commands_test.go
+++ b/tools/tdbg/batch_commands_test.go
@@ -1,0 +1,192 @@
+package tdbg
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"github.com/urfave/cli/v2"
+	enumspb "go.temporal.io/api/enums/v1"
+	replicationpb "go.temporal.io/api/replication/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/api/adminservice/v1"
+	"google.golang.org/grpc"
+)
+
+type (
+	batchTestAdminClient struct {
+		adminservice.AdminServiceClient
+		currentCluster string
+		lastRequest    *adminservice.StartAdminBatchOperationRequest
+	}
+
+	batchTestWorkflowClient struct {
+		workflowservice.WorkflowServiceClient
+		isGlobalNamespace bool
+		activeCluster     string
+	}
+
+	batchTestClient struct {
+		admin    *batchTestAdminClient
+		workflow *batchTestWorkflowClient
+	}
+
+	batchCommandTestSuite struct {
+		*require.Assertions
+		suite.Suite
+		app    *cli.App
+		client *batchTestClient
+		output bytes.Buffer
+	}
+)
+
+func (t *batchTestClient) AdminClient(*cli.Context) adminservice.AdminServiceClient {
+	return t.admin
+}
+
+func (t *batchTestClient) WorkflowClient(*cli.Context) workflowservice.WorkflowServiceClient {
+	return t.workflow
+}
+
+func (t *batchTestWorkflowClient) DescribeNamespace(
+	context.Context,
+	*workflowservice.DescribeNamespaceRequest,
+	...grpc.CallOption,
+) (*workflowservice.DescribeNamespaceResponse, error) {
+	return &workflowservice.DescribeNamespaceResponse{
+		IsGlobalNamespace: t.isGlobalNamespace,
+		ReplicationConfig: &replicationpb.NamespaceReplicationConfig{
+			ActiveClusterName: t.activeCluster,
+		},
+	}, nil
+}
+
+func (t *batchTestAdminClient) DescribeCluster(
+	context.Context,
+	*adminservice.DescribeClusterRequest,
+	...grpc.CallOption,
+) (*adminservice.DescribeClusterResponse, error) {
+	return &adminservice.DescribeClusterResponse{ClusterName: t.currentCluster}, nil
+}
+
+func (t *batchTestWorkflowClient) CountWorkflowExecutions(
+	context.Context,
+	*workflowservice.CountWorkflowExecutionsRequest,
+	...grpc.CallOption,
+) (*workflowservice.CountWorkflowExecutionsResponse, error) {
+	return &workflowservice.CountWorkflowExecutionsResponse{Count: 3}, nil
+}
+
+func (t *batchTestWorkflowClient) CountActivityExecutions(
+	context.Context,
+	*workflowservice.CountActivityExecutionsRequest,
+	...grpc.CallOption,
+) (*workflowservice.CountActivityExecutionsResponse, error) {
+	return &workflowservice.CountActivityExecutionsResponse{Count: 5}, nil
+}
+
+func (t *batchTestAdminClient) StartAdminBatchOperation(
+	_ context.Context,
+	request *adminservice.StartAdminBatchOperationRequest,
+	_ ...grpc.CallOption,
+) (*adminservice.StartAdminBatchOperationResponse, error) {
+	t.lastRequest = request
+	return &adminservice.StartAdminBatchOperationResponse{}, nil
+}
+
+const testCurrentCluster = "active-cluster"
+
+func TestBatchCommandSuite(t *testing.T) {
+	suite.Run(t, new(batchCommandTestSuite))
+}
+
+func (s *batchCommandTestSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+	s.client = &batchTestClient{
+		admin:    &batchTestAdminClient{currentCluster: testCurrentCluster},
+		workflow: &batchTestWorkflowClient{activeCluster: testCurrentCluster},
+	}
+	s.app = NewCliApp(func(params *Params) {
+		params.ClientFactory = s.client
+		params.Writer = &s.output
+		params.ErrWriter = &s.output
+	})
+	s.app.ExitErrHandler = func(*cli.Context, error) {}
+}
+
+func (s *batchCommandTestSuite) run(args ...string) error {
+	s.output.Reset()
+	return s.app.Run(append([]string{"tdbg", "--namespace", "target-ns", "--yes", "delegated-batch", "start"}, args...))
+}
+
+func (s *batchCommandTestSuite) TestAdminBatchStart() {
+	s.Run("Terminate populates the admin envelope", func() {
+		s.NoError(s.run(
+			"--batch-type", batchTypeTerminateWorkflows,
+			"--query", "WorkflowType='MyWorkflow'",
+			"--reason", "cleanup",
+			"--job-id", "my-job",
+		))
+
+		request := s.client.admin.lastRequest
+		s.NotNil(request)
+		if request == nil {
+			return
+		}
+		s.Equal("target-ns", request.GetNamespace())
+		s.Equal("WorkflowType='MyWorkflow'", request.GetVisibilityQuery())
+		s.Equal("cleanup", request.GetReason())
+		s.Equal("my-job:target-ns", request.GetJobId())
+		s.Equal(enumspb.BATCH_OPERATION_TYPE_TERMINATE_WORKFLOW, request.GetDelegationOperation().GetBatchType())
+		s.Contains(s.output.String(), "DANGER: destructive delegated batch operation")
+		s.Contains(s.output.String(), "User namespace: \"target-ns\"")
+		s.Contains(s.output.String(), "Batch workflow namespace: \"temporal-system\"")
+		s.Contains(s.output.String(), "Operation: terminate-workflows")
+		s.Contains(s.output.String(), "Currently matching: 3 workflows")
+	})
+
+	s.Run("Terminate activities delegates the activity batch type", func() {
+		s.NoError(s.run(
+			"--batch-type", batchTypeTerminateActivities,
+			"--query", "A=B",
+			"--reason", "stuck activities",
+		))
+
+		request := s.client.admin.lastRequest
+		s.Equal(enumspb.BATCH_OPERATION_TYPE_TERMINATE_ACTIVITY, request.GetDelegationOperation().GetBatchType())
+		// The operation itself needs no payload: identity and reason travel on the envelope.
+		s.Equal("stuck activities", request.GetReason())
+		s.NotEmpty(request.GetIdentity())
+		s.Contains(s.output.String(), "Operation: terminate-activities")
+		s.Contains(s.output.String(), "Currently matching: 5 activities")
+	})
+
+	s.Run("Unknown batch type is rejected", func() {
+		s.ErrorContains(s.run("--batch-type", "nonsense", "--query", "A=B", "--reason", "r"), "unknown batch type")
+	})
+
+	s.Run("Query is required", func() {
+		s.ErrorContains(s.run("--batch-type", batchTypeTerminateWorkflows, "--reason", "r"), FlagVisibilityQuery)
+	})
+
+	s.Run("Reason is required", func() {
+		s.ErrorContains(s.run("--batch-type", batchTypeTerminateWorkflows, "--query", "A=B"), FlagReason)
+	})
+
+	s.Run("Global namespace active in this cluster is allowed", func() {
+		s.client.workflow.isGlobalNamespace = true
+		s.client.workflow.activeCluster = testCurrentCluster
+		s.NoError(s.run("--batch-type", batchTypeTerminateWorkflows, "--query", "A=B", "--reason", "r"))
+	})
+
+	s.Run("Global namespace active in another cluster is rejected", func() {
+		s.client.workflow.isGlobalNamespace = true
+		s.client.workflow.activeCluster = "other-cluster"
+		s.client.admin.lastRequest = nil
+		err := s.run("--batch-type", batchTypeTerminateWorkflows, "--query", "A=B", "--reason", "r")
+		s.ErrorContains(err, "must be started in the active cluster")
+		s.Nil(s.client.admin.lastRequest, "the job must not be started")
+	})
+}

--- a/tools/tdbg/flags.go
+++ b/tools/tdbg/flags.go
@@ -84,6 +84,7 @@ var (
 	FlagExecute                    = "execute"
 	FlagWorkers                    = "workers"
 	FlagOutputLog                  = "output-log"
+	FlagBatchType                  = "batch-type"
 )
 
 const defaultMigrateWorkers = 5

--- a/tools/tdbg/tdbg_commands.go
+++ b/tools/tdbg/tdbg_commands.go
@@ -71,6 +71,11 @@ func getCommands(
 			Subcommands: newAdminScheduleCommands(clientFactory),
 		},
 		{
+			Name:        "delegated-batch",
+			Usage:       "Delegate workflow or activity termination from a user namespace to temporal-system",
+			Subcommands: newAdminBatchCommands(clientFactory, prompterFactory),
+		},
+		{
 			Name:        "decode",
 			Usage:       "Decode payload",
 			Subcommands: newDecodeCommands(taskBlobEncoder),


### PR DESCRIPTION
## What changed?
add user batch operations to tdbg

## Why?
tdbg can run user batch operations in temporal-system ns to help cancel workflows etc in rare cases like user ns is under rate limiting

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)
