### PR TITLE
Protect History from repetitive failed Task Queue registration

### DIFF
--- a/api/deployment/v1/message.go-helpers.pb.go
+++ b/api/deployment/v1/message.go-helpers.pb.go
@@ -2224,3 +2224,40 @@ func (this *DemoteVersionSignalArgs) Equal(that interface{}) bool {
 
 	return proto.Equal(this, that1)
 }
+
+// Marshal an object of type TooManyVersionsFailureDetails to the protobuf v3 wire format
+func (val *TooManyVersionsFailureDetails) Marshal() ([]byte, error) {
+	return proto.Marshal(val)
+}
+
+// Unmarshal an object of type TooManyVersionsFailureDetails from the protobuf v3 wire format
+func (val *TooManyVersionsFailureDetails) Unmarshal(buf []byte) error {
+	return proto.Unmarshal(buf, val)
+}
+
+// Size returns the size of the object, in bytes, once serialized
+func (val *TooManyVersionsFailureDetails) Size() int {
+	return proto.Size(val)
+}
+
+// Equal returns whether two TooManyVersionsFailureDetails values are equivalent by recursively
+// comparing the message's fields.
+// For more information see the documentation for
+// https://pkg.go.dev/google.golang.org/protobuf/proto#Equal
+func (this *TooManyVersionsFailureDetails) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	var that1 *TooManyVersionsFailureDetails
+	switch t := that.(type) {
+	case *TooManyVersionsFailureDetails:
+		that1 = t
+	case TooManyVersionsFailureDetails:
+		that1 = &t
+	default:
+		return false
+	}
+
+	return proto.Equal(this, that1)
+}

--- a/api/deployment/v1/message.pb.go
+++ b/api/deployment/v1/message.pb.go
@@ -3941,7 +3941,7 @@ func (x *DemoteVersionSignalArgs) GetRoutingConfig() *v11.RoutingConfig {
 type TooManyVersionsFailureDetails struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// A match only bypasses the cached failure; the workflow remains authoritative.
-	VersionFingerprints []uint64 `protobuf:"fixed64,1,rep,packed,name=version_fingerprints,json=versionFingerprints,proto3" json:"version_fingerprints,omitempty"`
+	VersionFingerprints []int64 `protobuf:"varint,1,rep,packed,name=version_fingerprints,json=versionFingerprints,proto3" json:"version_fingerprints,omitempty"`
 	unknownFields       protoimpl.UnknownFields
 	sizeCache           protoimpl.SizeCache
 }
@@ -3976,7 +3976,7 @@ func (*TooManyVersionsFailureDetails) Descriptor() ([]byte, []int) {
 	return file_temporal_server_api_deployment_v1_message_proto_rawDescGZIP(), []int{60}
 }
 
-func (x *TooManyVersionsFailureDetails) GetVersionFingerprints() []uint64 {
+func (x *TooManyVersionsFailureDetails) GetVersionFingerprints() []int64 {
 	if x != nil {
 		return x.VersionFingerprints
 	}
@@ -4454,7 +4454,7 @@ const file_temporal_server_api_deployment_v1_message_proto_rawDesc = "" +
 	"\x17DemoteVersionSignalArgs\x12P\n" +
 	"\x0erouting_config\x18\x01 \x01(\v2).temporal.api.deployment.v1.RoutingConfigR\rroutingConfig\"R\n" +
 	"\x1dTooManyVersionsFailureDetails\x121\n" +
-	"\x14version_fingerprints\x18\x01 \x03(\x06R\x13versionFingerprintsB4Z2go.temporal.io/server/api/deployment/v1;deploymentb\x06proto3"
+	"\x14version_fingerprints\x18\x01 \x03(\x03R\x13versionFingerprintsB4Z2go.temporal.io/server/api/deployment/v1;deploymentb\x06proto3"
 
 var (
 	file_temporal_server_api_deployment_v1_message_proto_rawDescOnce sync.Once

--- a/api/deployment/v1/message.pb.go
+++ b/api/deployment/v1/message.pb.go
@@ -3937,6 +3937,52 @@ func (x *DemoteVersionSignalArgs) GetRoutingConfig() *v11.RoutingConfig {
 	return nil
 }
 
+// Version membership hints returned with an errTooManyVersions failure.
+type TooManyVersionsFailureDetails struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// A match only bypasses the cached failure; the workflow remains authoritative.
+	VersionFingerprints []uint64 `protobuf:"fixed64,1,rep,packed,name=version_fingerprints,json=versionFingerprints,proto3" json:"version_fingerprints,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
+}
+
+func (x *TooManyVersionsFailureDetails) Reset() {
+	*x = TooManyVersionsFailureDetails{}
+	mi := &file_temporal_server_api_deployment_v1_message_proto_msgTypes[60]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TooManyVersionsFailureDetails) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TooManyVersionsFailureDetails) ProtoMessage() {}
+
+func (x *TooManyVersionsFailureDetails) ProtoReflect() protoreflect.Message {
+	mi := &file_temporal_server_api_deployment_v1_message_proto_msgTypes[60]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TooManyVersionsFailureDetails.ProtoReflect.Descriptor instead.
+func (*TooManyVersionsFailureDetails) Descriptor() ([]byte, []int) {
+	return file_temporal_server_api_deployment_v1_message_proto_rawDescGZIP(), []int{60}
+}
+
+func (x *TooManyVersionsFailureDetails) GetVersionFingerprints() []uint64 {
+	if x != nil {
+		return x.VersionFingerprints
+	}
+	return nil
+}
+
 type VersionLocalState_TaskQueueFamilyData struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Key: Task Queue Type
@@ -3947,7 +3993,7 @@ type VersionLocalState_TaskQueueFamilyData struct {
 
 func (x *VersionLocalState_TaskQueueFamilyData) Reset() {
 	*x = VersionLocalState_TaskQueueFamilyData{}
-	mi := &file_temporal_server_api_deployment_v1_message_proto_msgTypes[61]
+	mi := &file_temporal_server_api_deployment_v1_message_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3959,7 +4005,7 @@ func (x *VersionLocalState_TaskQueueFamilyData) String() string {
 func (*VersionLocalState_TaskQueueFamilyData) ProtoMessage() {}
 
 func (x *VersionLocalState_TaskQueueFamilyData) ProtoReflect() protoreflect.Message {
-	mi := &file_temporal_server_api_deployment_v1_message_proto_msgTypes[61]
+	mi := &file_temporal_server_api_deployment_v1_message_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3993,7 +4039,7 @@ type SyncDeploymentVersionUserDataRequest_SyncUserData struct {
 
 func (x *SyncDeploymentVersionUserDataRequest_SyncUserData) Reset() {
 	*x = SyncDeploymentVersionUserDataRequest_SyncUserData{}
-	mi := &file_temporal_server_api_deployment_v1_message_proto_msgTypes[65]
+	mi := &file_temporal_server_api_deployment_v1_message_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4005,7 +4051,7 @@ func (x *SyncDeploymentVersionUserDataRequest_SyncUserData) String() string {
 func (*SyncDeploymentVersionUserDataRequest_SyncUserData) ProtoMessage() {}
 
 func (x *SyncDeploymentVersionUserDataRequest_SyncUserData) ProtoReflect() protoreflect.Message {
-	mi := &file_temporal_server_api_deployment_v1_message_proto_msgTypes[65]
+	mi := &file_temporal_server_api_deployment_v1_message_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4051,7 +4097,7 @@ type CheckTaskQueuesHavePollersActivityArgs_TaskQueueTypes struct {
 
 func (x *CheckTaskQueuesHavePollersActivityArgs_TaskQueueTypes) Reset() {
 	*x = CheckTaskQueuesHavePollersActivityArgs_TaskQueueTypes{}
-	mi := &file_temporal_server_api_deployment_v1_message_proto_msgTypes[71]
+	mi := &file_temporal_server_api_deployment_v1_message_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4063,7 +4109,7 @@ func (x *CheckTaskQueuesHavePollersActivityArgs_TaskQueueTypes) String() string 
 func (*CheckTaskQueuesHavePollersActivityArgs_TaskQueueTypes) ProtoMessage() {}
 
 func (x *CheckTaskQueuesHavePollersActivityArgs_TaskQueueTypes) ProtoReflect() protoreflect.Message {
-	mi := &file_temporal_server_api_deployment_v1_message_proto_msgTypes[71]
+	mi := &file_temporal_server_api_deployment_v1_message_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4406,7 +4452,9 @@ const file_temporal_server_api_deployment_v1_message_proto_rawDesc = "" +
 	"\x19ForceCANVersionSignalArgs\x12[\n" +
 	"\x0eoverride_state\x18\x01 \x01(\v24.temporal.server.api.deployment.v1.VersionLocalStateR\roverrideState\"k\n" +
 	"\x17DemoteVersionSignalArgs\x12P\n" +
-	"\x0erouting_config\x18\x01 \x01(\v2).temporal.api.deployment.v1.RoutingConfigR\rroutingConfigB4Z2go.temporal.io/server/api/deployment/v1;deploymentb\x06proto3"
+	"\x0erouting_config\x18\x01 \x01(\v2).temporal.api.deployment.v1.RoutingConfigR\rroutingConfig\"R\n" +
+	"\x1dTooManyVersionsFailureDetails\x121\n" +
+	"\x14version_fingerprints\x18\x01 \x03(\x06R\x13versionFingerprintsB4Z2go.temporal.io/server/api/deployment/v1;deploymentb\x06proto3"
 
 var (
 	file_temporal_server_api_deployment_v1_message_proto_rawDescOnce sync.Once
@@ -4420,7 +4468,7 @@ func file_temporal_server_api_deployment_v1_message_proto_rawDescGZIP() []byte {
 	return file_temporal_server_api_deployment_v1_message_proto_rawDescData
 }
 
-var file_temporal_server_api_deployment_v1_message_proto_msgTypes = make([]protoimpl.MessageInfo, 75)
+var file_temporal_server_api_deployment_v1_message_proto_msgTypes = make([]protoimpl.MessageInfo, 76)
 var file_temporal_server_api_deployment_v1_message_proto_goTypes = []any{
 	(*WorkerDeploymentVersion)(nil),                           // 0: temporal.server.api.deployment.v1.WorkerDeploymentVersion
 	(*DeploymentVersionData)(nil),                             // 1: temporal.server.api.deployment.v1.DeploymentVersionData
@@ -4482,142 +4530,143 @@ var file_temporal_server_api_deployment_v1_message_proto_goTypes = []any{
 	(*ForceCANDeploymentSignalArgs)(nil),                      // 57: temporal.server.api.deployment.v1.ForceCANDeploymentSignalArgs
 	(*ForceCANVersionSignalArgs)(nil),                         // 58: temporal.server.api.deployment.v1.ForceCANVersionSignalArgs
 	(*DemoteVersionSignalArgs)(nil),                           // 59: temporal.server.api.deployment.v1.DemoteVersionSignalArgs
-	nil,                                                       // 60: temporal.server.api.deployment.v1.VersionLocalState.TaskQueueFamiliesEntry
-	(*VersionLocalState_TaskQueueFamilyData)(nil),             // 61: temporal.server.api.deployment.v1.VersionLocalState.TaskQueueFamilyData
-	nil, // 62: temporal.server.api.deployment.v1.VersionLocalState.TaskQueueFamilyData.TaskQueuesEntry
-	nil, // 63: temporal.server.api.deployment.v1.WorkerDeploymentLocalState.VersionsEntry
-	nil, // 64: temporal.server.api.deployment.v1.WorkerDeploymentLocalState.PropagatingRevisionsEntry
-	(*SyncDeploymentVersionUserDataRequest_SyncUserData)(nil), // 65: temporal.server.api.deployment.v1.SyncDeploymentVersionUserDataRequest.SyncUserData
-	nil, // 66: temporal.server.api.deployment.v1.SyncDeploymentVersionUserDataResponse.TaskQueueMaxVersionsEntry
-	nil, // 67: temporal.server.api.deployment.v1.CheckWorkerDeploymentUserDataPropagationRequest.TaskQueueMaxVersionsEntry
-	nil, // 68: temporal.server.api.deployment.v1.SyncUnversionedRampActivityResponse.TaskQueueMaxVersionsEntry
-	nil, // 69: temporal.server.api.deployment.v1.UpdateVersionMetadataArgs.UpsertEntriesEntry
-	nil, // 70: temporal.server.api.deployment.v1.CheckTaskQueuesHavePollersActivityArgs.TaskQueuesAndTypesEntry
-	(*CheckTaskQueuesHavePollersActivityArgs_TaskQueueTypes)(nil), // 71: temporal.server.api.deployment.v1.CheckTaskQueuesHavePollersActivityArgs.TaskQueueTypes
-	nil,                                   // 72: temporal.server.api.deployment.v1.ValidateWorkerControllerInstanceSpecInput.ScalingGroupsEntry
-	nil,                                   // 73: temporal.server.api.deployment.v1.UpdateWorkerControllerInstanceInput.UpsertScalingGroupsEntry
-	nil,                                   // 74: temporal.server.api.deployment.v1.UpdateComputeConfigArgs.UpsertScalingGroupsEntry
-	(*timestamppb.Timestamp)(nil),         // 75: google.protobuf.Timestamp
-	(v1.WorkerDeploymentVersionStatus)(0), // 76: temporal.api.enums.v1.WorkerDeploymentVersionStatus
-	(*v11.VersionDrainageInfo)(nil),       // 77: temporal.api.deployment.v1.VersionDrainageInfo
-	(*v11.VersionMetadata)(nil),           // 78: temporal.api.deployment.v1.VersionMetadata
-	(*v12.ComputeConfigSummary)(nil),      // 79: temporal.api.compute.v1.ComputeConfigSummary
-	(*v11.ComputeStatus)(nil),             // 80: temporal.api.deployment.v1.ComputeStatus
-	(*v11.RoutingConfig)(nil),             // 81: temporal.api.deployment.v1.RoutingConfig
-	(v1.VersionDrainageStatus)(0),         // 82: temporal.api.enums.v1.VersionDrainageStatus
-	(v1.TaskQueueType)(0),                 // 83: temporal.api.enums.v1.TaskQueueType
-	(*v11.WorkerDeploymentVersionInfo_VersionTaskQueueInfo)(nil),    // 84: temporal.api.deployment.v1.WorkerDeploymentVersionInfo.VersionTaskQueueInfo
-	(*v12.ComputeConfig)(nil),                                       // 85: temporal.api.compute.v1.ComputeConfig
-	(*v11.WorkerDeploymentInfo_WorkerDeploymentVersionSummary)(nil), // 86: temporal.api.deployment.v1.WorkerDeploymentInfo.WorkerDeploymentVersionSummary
-	(*v11.WorkerDeploymentVersion)(nil),                             // 87: temporal.api.deployment.v1.WorkerDeploymentVersion
-	(*v13.Payload)(nil),                                             // 88: temporal.api.common.v1.Payload
-	(*v12.ComputeConfigScalingGroup)(nil),                           // 89: temporal.api.compute.v1.ComputeConfigScalingGroup
-	(*v12.ComputeConfigScalingGroupUpdate)(nil),                     // 90: temporal.api.compute.v1.ComputeConfigScalingGroupUpdate
+	(*TooManyVersionsFailureDetails)(nil),                     // 60: temporal.server.api.deployment.v1.TooManyVersionsFailureDetails
+	nil,                                                       // 61: temporal.server.api.deployment.v1.VersionLocalState.TaskQueueFamiliesEntry
+	(*VersionLocalState_TaskQueueFamilyData)(nil),             // 62: temporal.server.api.deployment.v1.VersionLocalState.TaskQueueFamilyData
+	nil, // 63: temporal.server.api.deployment.v1.VersionLocalState.TaskQueueFamilyData.TaskQueuesEntry
+	nil, // 64: temporal.server.api.deployment.v1.WorkerDeploymentLocalState.VersionsEntry
+	nil, // 65: temporal.server.api.deployment.v1.WorkerDeploymentLocalState.PropagatingRevisionsEntry
+	(*SyncDeploymentVersionUserDataRequest_SyncUserData)(nil), // 66: temporal.server.api.deployment.v1.SyncDeploymentVersionUserDataRequest.SyncUserData
+	nil, // 67: temporal.server.api.deployment.v1.SyncDeploymentVersionUserDataResponse.TaskQueueMaxVersionsEntry
+	nil, // 68: temporal.server.api.deployment.v1.CheckWorkerDeploymentUserDataPropagationRequest.TaskQueueMaxVersionsEntry
+	nil, // 69: temporal.server.api.deployment.v1.SyncUnversionedRampActivityResponse.TaskQueueMaxVersionsEntry
+	nil, // 70: temporal.server.api.deployment.v1.UpdateVersionMetadataArgs.UpsertEntriesEntry
+	nil, // 71: temporal.server.api.deployment.v1.CheckTaskQueuesHavePollersActivityArgs.TaskQueuesAndTypesEntry
+	(*CheckTaskQueuesHavePollersActivityArgs_TaskQueueTypes)(nil), // 72: temporal.server.api.deployment.v1.CheckTaskQueuesHavePollersActivityArgs.TaskQueueTypes
+	nil,                                   // 73: temporal.server.api.deployment.v1.ValidateWorkerControllerInstanceSpecInput.ScalingGroupsEntry
+	nil,                                   // 74: temporal.server.api.deployment.v1.UpdateWorkerControllerInstanceInput.UpsertScalingGroupsEntry
+	nil,                                   // 75: temporal.server.api.deployment.v1.UpdateComputeConfigArgs.UpsertScalingGroupsEntry
+	(*timestamppb.Timestamp)(nil),         // 76: google.protobuf.Timestamp
+	(v1.WorkerDeploymentVersionStatus)(0), // 77: temporal.api.enums.v1.WorkerDeploymentVersionStatus
+	(*v11.VersionDrainageInfo)(nil),       // 78: temporal.api.deployment.v1.VersionDrainageInfo
+	(*v11.VersionMetadata)(nil),           // 79: temporal.api.deployment.v1.VersionMetadata
+	(*v12.ComputeConfigSummary)(nil),      // 80: temporal.api.compute.v1.ComputeConfigSummary
+	(*v11.ComputeStatus)(nil),             // 81: temporal.api.deployment.v1.ComputeStatus
+	(*v11.RoutingConfig)(nil),             // 82: temporal.api.deployment.v1.RoutingConfig
+	(v1.VersionDrainageStatus)(0),         // 83: temporal.api.enums.v1.VersionDrainageStatus
+	(v1.TaskQueueType)(0),                 // 84: temporal.api.enums.v1.TaskQueueType
+	(*v11.WorkerDeploymentVersionInfo_VersionTaskQueueInfo)(nil),    // 85: temporal.api.deployment.v1.WorkerDeploymentVersionInfo.VersionTaskQueueInfo
+	(*v12.ComputeConfig)(nil),                                       // 86: temporal.api.compute.v1.ComputeConfig
+	(*v11.WorkerDeploymentInfo_WorkerDeploymentVersionSummary)(nil), // 87: temporal.api.deployment.v1.WorkerDeploymentInfo.WorkerDeploymentVersionSummary
+	(*v11.WorkerDeploymentVersion)(nil),                             // 88: temporal.api.deployment.v1.WorkerDeploymentVersion
+	(*v13.Payload)(nil),                                             // 89: temporal.api.common.v1.Payload
+	(*v12.ComputeConfigScalingGroup)(nil),                           // 90: temporal.api.compute.v1.ComputeConfigScalingGroup
+	(*v12.ComputeConfigScalingGroupUpdate)(nil),                     // 91: temporal.api.compute.v1.ComputeConfigScalingGroupUpdate
 }
 var file_temporal_server_api_deployment_v1_message_proto_depIdxs = []int32{
 	0,   // 0: temporal.server.api.deployment.v1.DeploymentVersionData.version:type_name -> temporal.server.api.deployment.v1.WorkerDeploymentVersion
-	75,  // 1: temporal.server.api.deployment.v1.DeploymentVersionData.routing_update_time:type_name -> google.protobuf.Timestamp
-	75,  // 2: temporal.server.api.deployment.v1.DeploymentVersionData.current_since_time:type_name -> google.protobuf.Timestamp
-	75,  // 3: temporal.server.api.deployment.v1.DeploymentVersionData.ramping_since_time:type_name -> google.protobuf.Timestamp
-	76,  // 4: temporal.server.api.deployment.v1.DeploymentVersionData.status:type_name -> temporal.api.enums.v1.WorkerDeploymentVersionStatus
-	75,  // 5: temporal.server.api.deployment.v1.WorkerDeploymentVersionData.update_time:type_name -> google.protobuf.Timestamp
-	76,  // 6: temporal.server.api.deployment.v1.WorkerDeploymentVersionData.status:type_name -> temporal.api.enums.v1.WorkerDeploymentVersionStatus
+	76,  // 1: temporal.server.api.deployment.v1.DeploymentVersionData.routing_update_time:type_name -> google.protobuf.Timestamp
+	76,  // 2: temporal.server.api.deployment.v1.DeploymentVersionData.current_since_time:type_name -> google.protobuf.Timestamp
+	76,  // 3: temporal.server.api.deployment.v1.DeploymentVersionData.ramping_since_time:type_name -> google.protobuf.Timestamp
+	77,  // 4: temporal.server.api.deployment.v1.DeploymentVersionData.status:type_name -> temporal.api.enums.v1.WorkerDeploymentVersionStatus
+	76,  // 5: temporal.server.api.deployment.v1.WorkerDeploymentVersionData.update_time:type_name -> google.protobuf.Timestamp
+	77,  // 6: temporal.server.api.deployment.v1.WorkerDeploymentVersionData.status:type_name -> temporal.api.enums.v1.WorkerDeploymentVersionStatus
 	0,   // 7: temporal.server.api.deployment.v1.VersionLocalState.version:type_name -> temporal.server.api.deployment.v1.WorkerDeploymentVersion
-	75,  // 8: temporal.server.api.deployment.v1.VersionLocalState.create_time:type_name -> google.protobuf.Timestamp
-	75,  // 9: temporal.server.api.deployment.v1.VersionLocalState.routing_update_time:type_name -> google.protobuf.Timestamp
-	75,  // 10: temporal.server.api.deployment.v1.VersionLocalState.current_since_time:type_name -> google.protobuf.Timestamp
-	75,  // 11: temporal.server.api.deployment.v1.VersionLocalState.ramping_since_time:type_name -> google.protobuf.Timestamp
-	75,  // 12: temporal.server.api.deployment.v1.VersionLocalState.first_activation_time:type_name -> google.protobuf.Timestamp
-	75,  // 13: temporal.server.api.deployment.v1.VersionLocalState.last_current_time:type_name -> google.protobuf.Timestamp
-	75,  // 14: temporal.server.api.deployment.v1.VersionLocalState.last_deactivation_time:type_name -> google.protobuf.Timestamp
-	77,  // 15: temporal.server.api.deployment.v1.VersionLocalState.drainage_info:type_name -> temporal.api.deployment.v1.VersionDrainageInfo
-	78,  // 16: temporal.server.api.deployment.v1.VersionLocalState.metadata:type_name -> temporal.api.deployment.v1.VersionMetadata
-	60,  // 17: temporal.server.api.deployment.v1.VersionLocalState.task_queue_families:type_name -> temporal.server.api.deployment.v1.VersionLocalState.TaskQueueFamiliesEntry
-	76,  // 18: temporal.server.api.deployment.v1.VersionLocalState.status:type_name -> temporal.api.enums.v1.WorkerDeploymentVersionStatus
-	79,  // 19: temporal.server.api.deployment.v1.VersionLocalState.compute_config:type_name -> temporal.api.compute.v1.ComputeConfigSummary
-	80,  // 20: temporal.server.api.deployment.v1.VersionLocalState.compute_status:type_name -> temporal.api.deployment.v1.ComputeStatus
+	76,  // 8: temporal.server.api.deployment.v1.VersionLocalState.create_time:type_name -> google.protobuf.Timestamp
+	76,  // 9: temporal.server.api.deployment.v1.VersionLocalState.routing_update_time:type_name -> google.protobuf.Timestamp
+	76,  // 10: temporal.server.api.deployment.v1.VersionLocalState.current_since_time:type_name -> google.protobuf.Timestamp
+	76,  // 11: temporal.server.api.deployment.v1.VersionLocalState.ramping_since_time:type_name -> google.protobuf.Timestamp
+	76,  // 12: temporal.server.api.deployment.v1.VersionLocalState.first_activation_time:type_name -> google.protobuf.Timestamp
+	76,  // 13: temporal.server.api.deployment.v1.VersionLocalState.last_current_time:type_name -> google.protobuf.Timestamp
+	76,  // 14: temporal.server.api.deployment.v1.VersionLocalState.last_deactivation_time:type_name -> google.protobuf.Timestamp
+	78,  // 15: temporal.server.api.deployment.v1.VersionLocalState.drainage_info:type_name -> temporal.api.deployment.v1.VersionDrainageInfo
+	79,  // 16: temporal.server.api.deployment.v1.VersionLocalState.metadata:type_name -> temporal.api.deployment.v1.VersionMetadata
+	61,  // 17: temporal.server.api.deployment.v1.VersionLocalState.task_queue_families:type_name -> temporal.server.api.deployment.v1.VersionLocalState.TaskQueueFamiliesEntry
+	77,  // 18: temporal.server.api.deployment.v1.VersionLocalState.status:type_name -> temporal.api.enums.v1.WorkerDeploymentVersionStatus
+	80,  // 19: temporal.server.api.deployment.v1.VersionLocalState.compute_config:type_name -> temporal.api.compute.v1.ComputeConfigSummary
+	81,  // 20: temporal.server.api.deployment.v1.VersionLocalState.compute_status:type_name -> temporal.api.deployment.v1.ComputeStatus
 	3,   // 21: temporal.server.api.deployment.v1.WorkerDeploymentVersionWorkflowArgs.version_state:type_name -> temporal.server.api.deployment.v1.VersionLocalState
 	7,   // 22: temporal.server.api.deployment.v1.WorkerDeploymentWorkflowArgs.state:type_name -> temporal.server.api.deployment.v1.WorkerDeploymentLocalState
-	75,  // 23: temporal.server.api.deployment.v1.WorkerDeploymentLocalState.create_time:type_name -> google.protobuf.Timestamp
-	81,  // 24: temporal.server.api.deployment.v1.WorkerDeploymentLocalState.routing_config:type_name -> temporal.api.deployment.v1.RoutingConfig
-	63,  // 25: temporal.server.api.deployment.v1.WorkerDeploymentLocalState.versions:type_name -> temporal.server.api.deployment.v1.WorkerDeploymentLocalState.VersionsEntry
-	64,  // 26: temporal.server.api.deployment.v1.WorkerDeploymentLocalState.propagating_revisions:type_name -> temporal.server.api.deployment.v1.WorkerDeploymentLocalState.PropagatingRevisionsEntry
-	75,  // 27: temporal.server.api.deployment.v1.WorkerDeploymentVersionSummary.create_time:type_name -> google.protobuf.Timestamp
-	82,  // 28: temporal.server.api.deployment.v1.WorkerDeploymentVersionSummary.drainage_status:type_name -> temporal.api.enums.v1.VersionDrainageStatus
-	77,  // 29: temporal.server.api.deployment.v1.WorkerDeploymentVersionSummary.drainage_info:type_name -> temporal.api.deployment.v1.VersionDrainageInfo
-	75,  // 30: temporal.server.api.deployment.v1.WorkerDeploymentVersionSummary.routing_update_time:type_name -> google.protobuf.Timestamp
-	75,  // 31: temporal.server.api.deployment.v1.WorkerDeploymentVersionSummary.current_since_time:type_name -> google.protobuf.Timestamp
-	75,  // 32: temporal.server.api.deployment.v1.WorkerDeploymentVersionSummary.ramping_since_time:type_name -> google.protobuf.Timestamp
-	75,  // 33: temporal.server.api.deployment.v1.WorkerDeploymentVersionSummary.first_activation_time:type_name -> google.protobuf.Timestamp
-	75,  // 34: temporal.server.api.deployment.v1.WorkerDeploymentVersionSummary.last_current_time:type_name -> google.protobuf.Timestamp
-	75,  // 35: temporal.server.api.deployment.v1.WorkerDeploymentVersionSummary.last_deactivation_time:type_name -> google.protobuf.Timestamp
-	76,  // 36: temporal.server.api.deployment.v1.WorkerDeploymentVersionSummary.status:type_name -> temporal.api.enums.v1.WorkerDeploymentVersionStatus
-	79,  // 37: temporal.server.api.deployment.v1.WorkerDeploymentVersionSummary.compute_config:type_name -> temporal.api.compute.v1.ComputeConfigSummary
-	80,  // 38: temporal.server.api.deployment.v1.WorkerDeploymentVersionSummary.compute_status:type_name -> temporal.api.deployment.v1.ComputeStatus
-	83,  // 39: temporal.server.api.deployment.v1.RegisterWorkerInVersionArgs.task_queue_type:type_name -> temporal.api.enums.v1.TaskQueueType
-	81,  // 40: temporal.server.api.deployment.v1.RegisterWorkerInVersionArgs.routing_config:type_name -> temporal.api.deployment.v1.RoutingConfig
-	83,  // 41: temporal.server.api.deployment.v1.RegisterWorkerInWorkerDeploymentArgs.task_queue_type:type_name -> temporal.api.enums.v1.TaskQueueType
+	76,  // 23: temporal.server.api.deployment.v1.WorkerDeploymentLocalState.create_time:type_name -> google.protobuf.Timestamp
+	82,  // 24: temporal.server.api.deployment.v1.WorkerDeploymentLocalState.routing_config:type_name -> temporal.api.deployment.v1.RoutingConfig
+	64,  // 25: temporal.server.api.deployment.v1.WorkerDeploymentLocalState.versions:type_name -> temporal.server.api.deployment.v1.WorkerDeploymentLocalState.VersionsEntry
+	65,  // 26: temporal.server.api.deployment.v1.WorkerDeploymentLocalState.propagating_revisions:type_name -> temporal.server.api.deployment.v1.WorkerDeploymentLocalState.PropagatingRevisionsEntry
+	76,  // 27: temporal.server.api.deployment.v1.WorkerDeploymentVersionSummary.create_time:type_name -> google.protobuf.Timestamp
+	83,  // 28: temporal.server.api.deployment.v1.WorkerDeploymentVersionSummary.drainage_status:type_name -> temporal.api.enums.v1.VersionDrainageStatus
+	78,  // 29: temporal.server.api.deployment.v1.WorkerDeploymentVersionSummary.drainage_info:type_name -> temporal.api.deployment.v1.VersionDrainageInfo
+	76,  // 30: temporal.server.api.deployment.v1.WorkerDeploymentVersionSummary.routing_update_time:type_name -> google.protobuf.Timestamp
+	76,  // 31: temporal.server.api.deployment.v1.WorkerDeploymentVersionSummary.current_since_time:type_name -> google.protobuf.Timestamp
+	76,  // 32: temporal.server.api.deployment.v1.WorkerDeploymentVersionSummary.ramping_since_time:type_name -> google.protobuf.Timestamp
+	76,  // 33: temporal.server.api.deployment.v1.WorkerDeploymentVersionSummary.first_activation_time:type_name -> google.protobuf.Timestamp
+	76,  // 34: temporal.server.api.deployment.v1.WorkerDeploymentVersionSummary.last_current_time:type_name -> google.protobuf.Timestamp
+	76,  // 35: temporal.server.api.deployment.v1.WorkerDeploymentVersionSummary.last_deactivation_time:type_name -> google.protobuf.Timestamp
+	77,  // 36: temporal.server.api.deployment.v1.WorkerDeploymentVersionSummary.status:type_name -> temporal.api.enums.v1.WorkerDeploymentVersionStatus
+	80,  // 37: temporal.server.api.deployment.v1.WorkerDeploymentVersionSummary.compute_config:type_name -> temporal.api.compute.v1.ComputeConfigSummary
+	81,  // 38: temporal.server.api.deployment.v1.WorkerDeploymentVersionSummary.compute_status:type_name -> temporal.api.deployment.v1.ComputeStatus
+	84,  // 39: temporal.server.api.deployment.v1.RegisterWorkerInVersionArgs.task_queue_type:type_name -> temporal.api.enums.v1.TaskQueueType
+	82,  // 40: temporal.server.api.deployment.v1.RegisterWorkerInVersionArgs.routing_config:type_name -> temporal.api.deployment.v1.RoutingConfig
+	84,  // 41: temporal.server.api.deployment.v1.RegisterWorkerInWorkerDeploymentArgs.task_queue_type:type_name -> temporal.api.enums.v1.TaskQueueType
 	0,   // 42: temporal.server.api.deployment.v1.RegisterWorkerInWorkerDeploymentArgs.version:type_name -> temporal.server.api.deployment.v1.WorkerDeploymentVersion
-	84,  // 43: temporal.server.api.deployment.v1.DescribeVersionFromWorkerDeploymentActivityResult.task_queue_infos:type_name -> temporal.api.deployment.v1.WorkerDeploymentVersionInfo.VersionTaskQueueInfo
-	75,  // 44: temporal.server.api.deployment.v1.SyncVersionStateUpdateArgs.routing_update_time:type_name -> google.protobuf.Timestamp
-	75,  // 45: temporal.server.api.deployment.v1.SyncVersionStateUpdateArgs.current_since_time:type_name -> google.protobuf.Timestamp
-	75,  // 46: temporal.server.api.deployment.v1.SyncVersionStateUpdateArgs.ramping_since_time:type_name -> google.protobuf.Timestamp
-	81,  // 47: temporal.server.api.deployment.v1.SyncVersionStateUpdateArgs.routing_config:type_name -> temporal.api.deployment.v1.RoutingConfig
+	85,  // 43: temporal.server.api.deployment.v1.DescribeVersionFromWorkerDeploymentActivityResult.task_queue_infos:type_name -> temporal.api.deployment.v1.WorkerDeploymentVersionInfo.VersionTaskQueueInfo
+	76,  // 44: temporal.server.api.deployment.v1.SyncVersionStateUpdateArgs.routing_update_time:type_name -> google.protobuf.Timestamp
+	76,  // 45: temporal.server.api.deployment.v1.SyncVersionStateUpdateArgs.current_since_time:type_name -> google.protobuf.Timestamp
+	76,  // 46: temporal.server.api.deployment.v1.SyncVersionStateUpdateArgs.ramping_since_time:type_name -> google.protobuf.Timestamp
+	82,  // 47: temporal.server.api.deployment.v1.SyncVersionStateUpdateArgs.routing_config:type_name -> temporal.api.deployment.v1.RoutingConfig
 	3,   // 48: temporal.server.api.deployment.v1.SyncVersionStateResponse.version_state:type_name -> temporal.server.api.deployment.v1.VersionLocalState
 	9,   // 49: temporal.server.api.deployment.v1.SyncVersionStateResponse.summary:type_name -> temporal.server.api.deployment.v1.WorkerDeploymentVersionSummary
-	75,  // 50: temporal.server.api.deployment.v1.AddVersionUpdateArgs.create_time:type_name -> google.protobuf.Timestamp
-	77,  // 51: temporal.server.api.deployment.v1.SyncDrainageInfoSignalArgs.drainage_info:type_name -> temporal.api.deployment.v1.VersionDrainageInfo
-	82,  // 52: temporal.server.api.deployment.v1.SyncDrainageStatusSignalArgs.drainage_status:type_name -> temporal.api.enums.v1.VersionDrainageStatus
+	76,  // 50: temporal.server.api.deployment.v1.AddVersionUpdateArgs.create_time:type_name -> google.protobuf.Timestamp
+	78,  // 51: temporal.server.api.deployment.v1.SyncDrainageInfoSignalArgs.drainage_info:type_name -> temporal.api.deployment.v1.VersionDrainageInfo
+	83,  // 52: temporal.server.api.deployment.v1.SyncDrainageStatusSignalArgs.drainage_status:type_name -> temporal.api.enums.v1.VersionDrainageStatus
 	3,   // 53: temporal.server.api.deployment.v1.QueryDescribeVersionResponse.version_state:type_name -> temporal.server.api.deployment.v1.VersionLocalState
 	7,   // 54: temporal.server.api.deployment.v1.QueryDescribeWorkerDeploymentResponse.state:type_name -> temporal.server.api.deployment.v1.WorkerDeploymentLocalState
-	79,  // 55: temporal.server.api.deployment.v1.StartWorkerDeploymentVersionRequest.compute_config:type_name -> temporal.api.compute.v1.ComputeConfigSummary
+	80,  // 55: temporal.server.api.deployment.v1.StartWorkerDeploymentVersionRequest.compute_config:type_name -> temporal.api.compute.v1.ComputeConfigSummary
 	0,   // 56: temporal.server.api.deployment.v1.SyncDeploymentVersionUserDataRequest.version:type_name -> temporal.server.api.deployment.v1.WorkerDeploymentVersion
-	65,  // 57: temporal.server.api.deployment.v1.SyncDeploymentVersionUserDataRequest.sync:type_name -> temporal.server.api.deployment.v1.SyncDeploymentVersionUserDataRequest.SyncUserData
-	81,  // 58: temporal.server.api.deployment.v1.SyncDeploymentVersionUserDataRequest.update_routing_config:type_name -> temporal.api.deployment.v1.RoutingConfig
+	66,  // 57: temporal.server.api.deployment.v1.SyncDeploymentVersionUserDataRequest.sync:type_name -> temporal.server.api.deployment.v1.SyncDeploymentVersionUserDataRequest.SyncUserData
+	82,  // 58: temporal.server.api.deployment.v1.SyncDeploymentVersionUserDataRequest.update_routing_config:type_name -> temporal.api.deployment.v1.RoutingConfig
 	2,   // 59: temporal.server.api.deployment.v1.SyncDeploymentVersionUserDataRequest.upsert_version_data:type_name -> temporal.server.api.deployment.v1.WorkerDeploymentVersionData
-	66,  // 60: temporal.server.api.deployment.v1.SyncDeploymentVersionUserDataResponse.task_queue_max_versions:type_name -> temporal.server.api.deployment.v1.SyncDeploymentVersionUserDataResponse.TaskQueueMaxVersionsEntry
-	67,  // 61: temporal.server.api.deployment.v1.CheckWorkerDeploymentUserDataPropagationRequest.task_queue_max_versions:type_name -> temporal.server.api.deployment.v1.CheckWorkerDeploymentUserDataPropagationRequest.TaskQueueMaxVersionsEntry
+	67,  // 60: temporal.server.api.deployment.v1.SyncDeploymentVersionUserDataResponse.task_queue_max_versions:type_name -> temporal.server.api.deployment.v1.SyncDeploymentVersionUserDataResponse.TaskQueueMaxVersionsEntry
+	68,  // 61: temporal.server.api.deployment.v1.CheckWorkerDeploymentUserDataPropagationRequest.task_queue_max_versions:type_name -> temporal.server.api.deployment.v1.CheckWorkerDeploymentUserDataPropagationRequest.TaskQueueMaxVersionsEntry
 	14,  // 62: temporal.server.api.deployment.v1.SyncUnversionedRampActivityArgs.update_args:type_name -> temporal.server.api.deployment.v1.SyncVersionStateUpdateArgs
-	68,  // 63: temporal.server.api.deployment.v1.SyncUnversionedRampActivityResponse.task_queue_max_versions:type_name -> temporal.server.api.deployment.v1.SyncUnversionedRampActivityResponse.TaskQueueMaxVersionsEntry
-	69,  // 64: temporal.server.api.deployment.v1.UpdateVersionMetadataArgs.upsert_entries:type_name -> temporal.server.api.deployment.v1.UpdateVersionMetadataArgs.UpsertEntriesEntry
-	78,  // 65: temporal.server.api.deployment.v1.UpdateVersionMetadataResponse.metadata:type_name -> temporal.api.deployment.v1.VersionMetadata
-	85,  // 66: temporal.server.api.deployment.v1.CreateWorkerDeploymentVersionArgs.compute_config:type_name -> temporal.api.compute.v1.ComputeConfig
-	70,  // 67: temporal.server.api.deployment.v1.CheckTaskQueuesHavePollersActivityArgs.task_queues_and_types:type_name -> temporal.server.api.deployment.v1.CheckTaskQueuesHavePollersActivityArgs.TaskQueuesAndTypesEntry
+	69,  // 63: temporal.server.api.deployment.v1.SyncUnversionedRampActivityResponse.task_queue_max_versions:type_name -> temporal.server.api.deployment.v1.SyncUnversionedRampActivityResponse.TaskQueueMaxVersionsEntry
+	70,  // 64: temporal.server.api.deployment.v1.UpdateVersionMetadataArgs.upsert_entries:type_name -> temporal.server.api.deployment.v1.UpdateVersionMetadataArgs.UpsertEntriesEntry
+	79,  // 65: temporal.server.api.deployment.v1.UpdateVersionMetadataResponse.metadata:type_name -> temporal.api.deployment.v1.VersionMetadata
+	86,  // 66: temporal.server.api.deployment.v1.CreateWorkerDeploymentVersionArgs.compute_config:type_name -> temporal.api.compute.v1.ComputeConfig
+	71,  // 67: temporal.server.api.deployment.v1.CheckTaskQueuesHavePollersActivityArgs.task_queues_and_types:type_name -> temporal.server.api.deployment.v1.CheckTaskQueuesHavePollersActivityArgs.TaskQueuesAndTypesEntry
 	0,   // 68: temporal.server.api.deployment.v1.CheckTaskQueuesHavePollersActivityArgs.worker_deployment_version:type_name -> temporal.server.api.deployment.v1.WorkerDeploymentVersion
 	14,  // 69: temporal.server.api.deployment.v1.SyncVersionStateActivityArgs.update_args:type_name -> temporal.server.api.deployment.v1.SyncVersionStateUpdateArgs
 	3,   // 70: temporal.server.api.deployment.v1.SyncVersionStateActivityResult.version_state:type_name -> temporal.server.api.deployment.v1.VersionLocalState
 	9,   // 71: temporal.server.api.deployment.v1.SyncVersionStateActivityResult.summary:type_name -> temporal.server.api.deployment.v1.WorkerDeploymentVersionSummary
-	75,  // 72: temporal.server.api.deployment.v1.WorkerDeploymentWorkflowMemo.create_time:type_name -> google.protobuf.Timestamp
-	81,  // 73: temporal.server.api.deployment.v1.WorkerDeploymentWorkflowMemo.routing_config:type_name -> temporal.api.deployment.v1.RoutingConfig
-	86,  // 74: temporal.server.api.deployment.v1.WorkerDeploymentWorkflowMemo.latest_version_summary:type_name -> temporal.api.deployment.v1.WorkerDeploymentInfo.WorkerDeploymentVersionSummary
-	86,  // 75: temporal.server.api.deployment.v1.WorkerDeploymentWorkflowMemo.current_version_summary:type_name -> temporal.api.deployment.v1.WorkerDeploymentInfo.WorkerDeploymentVersionSummary
-	86,  // 76: temporal.server.api.deployment.v1.WorkerDeploymentWorkflowMemo.ramping_version_summary:type_name -> temporal.api.deployment.v1.WorkerDeploymentInfo.WorkerDeploymentVersionSummary
-	75,  // 77: temporal.server.api.deployment.v1.WorkerDeploymentSummary.create_time:type_name -> google.protobuf.Timestamp
-	81,  // 78: temporal.server.api.deployment.v1.WorkerDeploymentSummary.routing_config:type_name -> temporal.api.deployment.v1.RoutingConfig
-	86,  // 79: temporal.server.api.deployment.v1.WorkerDeploymentSummary.latest_version_summary:type_name -> temporal.api.deployment.v1.WorkerDeploymentInfo.WorkerDeploymentVersionSummary
-	86,  // 80: temporal.server.api.deployment.v1.WorkerDeploymentSummary.current_version_summary:type_name -> temporal.api.deployment.v1.WorkerDeploymentInfo.WorkerDeploymentVersionSummary
-	86,  // 81: temporal.server.api.deployment.v1.WorkerDeploymentSummary.ramping_version_summary:type_name -> temporal.api.deployment.v1.WorkerDeploymentInfo.WorkerDeploymentVersionSummary
-	72,  // 82: temporal.server.api.deployment.v1.ValidateWorkerControllerInstanceSpecInput.scaling_groups:type_name -> temporal.server.api.deployment.v1.ValidateWorkerControllerInstanceSpecInput.ScalingGroupsEntry
-	87,  // 83: temporal.server.api.deployment.v1.UpdateWorkerControllerInstanceInput.version:type_name -> temporal.api.deployment.v1.WorkerDeploymentVersion
-	73,  // 84: temporal.server.api.deployment.v1.UpdateWorkerControllerInstanceInput.upsert_scaling_groups:type_name -> temporal.server.api.deployment.v1.UpdateWorkerControllerInstanceInput.UpsertScalingGroupsEntry
-	87,  // 85: temporal.server.api.deployment.v1.DeleteWorkerControllerInstanceInput.version:type_name -> temporal.api.deployment.v1.WorkerDeploymentVersion
-	74,  // 86: temporal.server.api.deployment.v1.UpdateComputeConfigArgs.upsert_scaling_groups:type_name -> temporal.server.api.deployment.v1.UpdateComputeConfigArgs.UpsertScalingGroupsEntry
+	76,  // 72: temporal.server.api.deployment.v1.WorkerDeploymentWorkflowMemo.create_time:type_name -> google.protobuf.Timestamp
+	82,  // 73: temporal.server.api.deployment.v1.WorkerDeploymentWorkflowMemo.routing_config:type_name -> temporal.api.deployment.v1.RoutingConfig
+	87,  // 74: temporal.server.api.deployment.v1.WorkerDeploymentWorkflowMemo.latest_version_summary:type_name -> temporal.api.deployment.v1.WorkerDeploymentInfo.WorkerDeploymentVersionSummary
+	87,  // 75: temporal.server.api.deployment.v1.WorkerDeploymentWorkflowMemo.current_version_summary:type_name -> temporal.api.deployment.v1.WorkerDeploymentInfo.WorkerDeploymentVersionSummary
+	87,  // 76: temporal.server.api.deployment.v1.WorkerDeploymentWorkflowMemo.ramping_version_summary:type_name -> temporal.api.deployment.v1.WorkerDeploymentInfo.WorkerDeploymentVersionSummary
+	76,  // 77: temporal.server.api.deployment.v1.WorkerDeploymentSummary.create_time:type_name -> google.protobuf.Timestamp
+	82,  // 78: temporal.server.api.deployment.v1.WorkerDeploymentSummary.routing_config:type_name -> temporal.api.deployment.v1.RoutingConfig
+	87,  // 79: temporal.server.api.deployment.v1.WorkerDeploymentSummary.latest_version_summary:type_name -> temporal.api.deployment.v1.WorkerDeploymentInfo.WorkerDeploymentVersionSummary
+	87,  // 80: temporal.server.api.deployment.v1.WorkerDeploymentSummary.current_version_summary:type_name -> temporal.api.deployment.v1.WorkerDeploymentInfo.WorkerDeploymentVersionSummary
+	87,  // 81: temporal.server.api.deployment.v1.WorkerDeploymentSummary.ramping_version_summary:type_name -> temporal.api.deployment.v1.WorkerDeploymentInfo.WorkerDeploymentVersionSummary
+	73,  // 82: temporal.server.api.deployment.v1.ValidateWorkerControllerInstanceSpecInput.scaling_groups:type_name -> temporal.server.api.deployment.v1.ValidateWorkerControllerInstanceSpecInput.ScalingGroupsEntry
+	88,  // 83: temporal.server.api.deployment.v1.UpdateWorkerControllerInstanceInput.version:type_name -> temporal.api.deployment.v1.WorkerDeploymentVersion
+	74,  // 84: temporal.server.api.deployment.v1.UpdateWorkerControllerInstanceInput.upsert_scaling_groups:type_name -> temporal.server.api.deployment.v1.UpdateWorkerControllerInstanceInput.UpsertScalingGroupsEntry
+	88,  // 85: temporal.server.api.deployment.v1.DeleteWorkerControllerInstanceInput.version:type_name -> temporal.api.deployment.v1.WorkerDeploymentVersion
+	75,  // 86: temporal.server.api.deployment.v1.UpdateComputeConfigArgs.upsert_scaling_groups:type_name -> temporal.server.api.deployment.v1.UpdateComputeConfigArgs.UpsertScalingGroupsEntry
 	7,   // 87: temporal.server.api.deployment.v1.ForceCANDeploymentSignalArgs.override_state:type_name -> temporal.server.api.deployment.v1.WorkerDeploymentLocalState
 	3,   // 88: temporal.server.api.deployment.v1.ForceCANVersionSignalArgs.override_state:type_name -> temporal.server.api.deployment.v1.VersionLocalState
-	81,  // 89: temporal.server.api.deployment.v1.DemoteVersionSignalArgs.routing_config:type_name -> temporal.api.deployment.v1.RoutingConfig
-	61,  // 90: temporal.server.api.deployment.v1.VersionLocalState.TaskQueueFamiliesEntry.value:type_name -> temporal.server.api.deployment.v1.VersionLocalState.TaskQueueFamilyData
-	62,  // 91: temporal.server.api.deployment.v1.VersionLocalState.TaskQueueFamilyData.task_queues:type_name -> temporal.server.api.deployment.v1.VersionLocalState.TaskQueueFamilyData.TaskQueuesEntry
+	82,  // 89: temporal.server.api.deployment.v1.DemoteVersionSignalArgs.routing_config:type_name -> temporal.api.deployment.v1.RoutingConfig
+	62,  // 90: temporal.server.api.deployment.v1.VersionLocalState.TaskQueueFamiliesEntry.value:type_name -> temporal.server.api.deployment.v1.VersionLocalState.TaskQueueFamilyData
+	63,  // 91: temporal.server.api.deployment.v1.VersionLocalState.TaskQueueFamilyData.task_queues:type_name -> temporal.server.api.deployment.v1.VersionLocalState.TaskQueueFamilyData.TaskQueuesEntry
 	4,   // 92: temporal.server.api.deployment.v1.VersionLocalState.TaskQueueFamilyData.TaskQueuesEntry.value:type_name -> temporal.server.api.deployment.v1.TaskQueueVersionData
 	9,   // 93: temporal.server.api.deployment.v1.WorkerDeploymentLocalState.VersionsEntry.value:type_name -> temporal.server.api.deployment.v1.WorkerDeploymentVersionSummary
 	8,   // 94: temporal.server.api.deployment.v1.WorkerDeploymentLocalState.PropagatingRevisionsEntry.value:type_name -> temporal.server.api.deployment.v1.PropagatingRevisions
-	83,  // 95: temporal.server.api.deployment.v1.SyncDeploymentVersionUserDataRequest.SyncUserData.types:type_name -> temporal.api.enums.v1.TaskQueueType
+	84,  // 95: temporal.server.api.deployment.v1.SyncDeploymentVersionUserDataRequest.SyncUserData.types:type_name -> temporal.api.enums.v1.TaskQueueType
 	1,   // 96: temporal.server.api.deployment.v1.SyncDeploymentVersionUserDataRequest.SyncUserData.data:type_name -> temporal.server.api.deployment.v1.DeploymentVersionData
-	88,  // 97: temporal.server.api.deployment.v1.UpdateVersionMetadataArgs.UpsertEntriesEntry.value:type_name -> temporal.api.common.v1.Payload
-	71,  // 98: temporal.server.api.deployment.v1.CheckTaskQueuesHavePollersActivityArgs.TaskQueuesAndTypesEntry.value:type_name -> temporal.server.api.deployment.v1.CheckTaskQueuesHavePollersActivityArgs.TaskQueueTypes
-	83,  // 99: temporal.server.api.deployment.v1.CheckTaskQueuesHavePollersActivityArgs.TaskQueueTypes.types:type_name -> temporal.api.enums.v1.TaskQueueType
-	89,  // 100: temporal.server.api.deployment.v1.ValidateWorkerControllerInstanceSpecInput.ScalingGroupsEntry.value:type_name -> temporal.api.compute.v1.ComputeConfigScalingGroup
-	90,  // 101: temporal.server.api.deployment.v1.UpdateWorkerControllerInstanceInput.UpsertScalingGroupsEntry.value:type_name -> temporal.api.compute.v1.ComputeConfigScalingGroupUpdate
-	90,  // 102: temporal.server.api.deployment.v1.UpdateComputeConfigArgs.UpsertScalingGroupsEntry.value:type_name -> temporal.api.compute.v1.ComputeConfigScalingGroupUpdate
+	89,  // 97: temporal.server.api.deployment.v1.UpdateVersionMetadataArgs.UpsertEntriesEntry.value:type_name -> temporal.api.common.v1.Payload
+	72,  // 98: temporal.server.api.deployment.v1.CheckTaskQueuesHavePollersActivityArgs.TaskQueuesAndTypesEntry.value:type_name -> temporal.server.api.deployment.v1.CheckTaskQueuesHavePollersActivityArgs.TaskQueueTypes
+	84,  // 99: temporal.server.api.deployment.v1.CheckTaskQueuesHavePollersActivityArgs.TaskQueueTypes.types:type_name -> temporal.api.enums.v1.TaskQueueType
+	90,  // 100: temporal.server.api.deployment.v1.ValidateWorkerControllerInstanceSpecInput.ScalingGroupsEntry.value:type_name -> temporal.api.compute.v1.ComputeConfigScalingGroup
+	91,  // 101: temporal.server.api.deployment.v1.UpdateWorkerControllerInstanceInput.UpsertScalingGroupsEntry.value:type_name -> temporal.api.compute.v1.ComputeConfigScalingGroupUpdate
+	91,  // 102: temporal.server.api.deployment.v1.UpdateComputeConfigArgs.UpsertScalingGroupsEntry.value:type_name -> temporal.api.compute.v1.ComputeConfigScalingGroupUpdate
 	103, // [103:103] is the sub-list for method output_type
 	103, // [103:103] is the sub-list for method input_type
 	103, // [103:103] is the sub-list for extension type_name
@@ -4636,7 +4685,7 @@ func file_temporal_server_api_deployment_v1_message_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_temporal_server_api_deployment_v1_message_proto_rawDesc), len(file_temporal_server_api_deployment_v1_message_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   75,
+			NumMessages:   76,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -3336,10 +3336,17 @@ but existing callbacks will still be processed and fired.`,
 		target version workflow.`,
 	)
 
-	WorkerDeploymentRegisterTaskQueueErrorCacheTTL = NewGlobalDurationSetting(
-		"matching.registerTaskQueueErrorCacheTTL",
+	WorkerDeploymentRegistrationErrorCacheTTL = NewGlobalDurationSetting(
+		"matching.workerDeploymentRegistrationErrorCacheTTL",
 		30*time.Second,
-		`TTL for errors cached by RegisterTaskQueueWorker. Set to zero to disable caching.`,
+		`TTL for errors cached by worker deployment registration operations. Set to zero to disable caching.`,
+	)
+
+	WorkerDeploymentRegistrationErrorCacheMaxSize = NewGlobalIntSetting(
+		"matching.workerDeploymentRegistrationErrorCacheMaxSize",
+		10000,
+		`Maximum number of worker deployment registration errors cached per worker service instance.
+Set to zero to disable caching. Requires a worker service restart to take effect.`,
 	)
 
 	EnableVersionReactivationSignals = NewGlobalBoolSetting(

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -3336,6 +3336,12 @@ but existing callbacks will still be processed and fired.`,
 		target version workflow.`,
 	)
 
+	WorkerDeploymentRegisterTaskQueueErrorCacheTTL = NewGlobalDurationSetting(
+		"matching.registerTaskQueueErrorCacheTTL",
+		30*time.Second,
+		`TTL for errors cached by RegisterTaskQueueWorker. Set to zero to disable caching.`,
+	)
+
 	EnableVersionReactivationSignals = NewGlobalBoolSetting(
 		"history.enableVersionReactivationSignals",
 		true,

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -5,6 +5,7 @@ const (
 	OperationTagName               = "operation"
 	ServiceRoleTagName             = "service_role"
 	CacheTypeTagName               = "cache_type"
+	CacheHitTagName                = "cache_hit"
 	FailureTagName                 = "failure"
 	FailureSourceTagName           = "failure_source"
 	TaskCategoryTagName            = "task_category"
@@ -1655,6 +1656,7 @@ var (
 	WorkerDeploymentVersioningOverrideCounter         = NewCounterDef("worker_deployment_versioning_override_count")
 	WorkerDeploymentVersioningOneTimeOverrideCounter  = NewCounterDef("worker_deployment_versioning_one_time_override_count")
 	WorkerDeploymentVersionDeletePropagationFailure   = NewCounterDef("worker_deployment_version_delete_propagation_failure")
+	WorkerDeploymentRegisterTaskQueueErrors           = NewCounterDef("worker_deployment_register_task_queue_errors")
 	StartDeploymentTransitionCounter                  = NewCounterDef("start_deployment_transition_count")
 	VersioningDataPropagationLatency                  = NewTimerDef("versioning_data_propagation_latency")
 	SlowVersioningDataPropagationCounter              = NewCounterDef("slow_versioning_data_propagation")

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1656,7 +1656,7 @@ var (
 	WorkerDeploymentVersioningOverrideCounter         = NewCounterDef("worker_deployment_versioning_override_count")
 	WorkerDeploymentVersioningOneTimeOverrideCounter  = NewCounterDef("worker_deployment_versioning_one_time_override_count")
 	WorkerDeploymentVersionDeletePropagationFailure   = NewCounterDef("worker_deployment_version_delete_propagation_failure")
-	WorkerDeploymentRegisterTaskQueueErrors           = NewCounterDef("worker_deployment_register_task_queue_errors")
+	WorkerDeploymentRegistrationErrors                = NewCounterDef("worker_deployment_registration_errors")
 	StartDeploymentTransitionCounter                  = NewCounterDef("start_deployment_transition_count")
 	VersioningDataPropagationLatency                  = NewTimerDef("versioning_data_propagation_latency")
 	SlowVersioningDataPropagationCounter              = NewCounterDef("slow_versioning_data_propagation")

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -467,6 +467,14 @@ func CacheTypeTag(value string) Tag {
 	return Tag{Key: CacheTypeTagName, Value: value}
 }
 
+func CacheHitTag(cacheHit bool) Tag {
+	value := falseValue
+	if cacheHit {
+		value = trueValue
+	}
+	return Tag{Key: CacheHitTagName, Value: value}
+}
+
 func PriorityTag(value locks.Priority) Tag {
 	return Tag{Key: PriorityTagName, Value: strconv.Itoa(int(value))}
 }

--- a/proto/internal/temporal/server/api/deployment/v1/message.proto
+++ b/proto/internal/temporal/server/api/deployment/v1/message.proto
@@ -629,5 +629,5 @@ message DemoteVersionSignalArgs {
 // Version membership hints returned with an errTooManyVersions failure.
 message TooManyVersionsFailureDetails {
   // A match only bypasses the cached failure; the workflow remains authoritative.
-  repeated fixed64 version_fingerprints = 1;
+  repeated int64 version_fingerprints = 1;
 }

--- a/proto/internal/temporal/server/api/deployment/v1/message.proto
+++ b/proto/internal/temporal/server/api/deployment/v1/message.proto
@@ -625,3 +625,9 @@ message ForceCANVersionSignalArgs {
 message DemoteVersionSignalArgs {
   temporal.api.deployment.v1.RoutingConfig routing_config = 1;
 }
+
+// Version membership hints returned with an errTooManyVersions failure.
+message TooManyVersionsFailureDetails {
+  // A match only bypasses the cached failure; the workflow remains authoritative.
+  repeated fixed64 version_fingerprints = 1;
+}

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -820,9 +820,9 @@ func (h *Handler) ImportWorkflowExecution(ctx context.Context, request *historys
 		return nil, h.convertError(err)
 	}
 
-	//if !shardContext.GetClusterMetadata().IsGlobalNamespaceEnabled() {
-	//	return nil, serviceerror.NewUnimplemented("ImportWorkflowExecution must be used in global namespace mode")
-	//}
+	if !shardContext.GetClusterMetadata().IsGlobalNamespaceEnabled() {
+		return nil, serviceerror.NewUnimplemented("ImportWorkflowExecution must be used in global namespace mode")
+	}
 	resp, err := engine.ImportWorkflowExecution(ctx, request)
 	if err != nil {
 		return nil, h.convertError(err)

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -820,9 +820,9 @@ func (h *Handler) ImportWorkflowExecution(ctx context.Context, request *historys
 		return nil, h.convertError(err)
 	}
 
-	if !shardContext.GetClusterMetadata().IsGlobalNamespaceEnabled() {
-		return nil, serviceerror.NewUnimplemented("ImportWorkflowExecution must be used in global namespace mode")
-	}
+	//if !shardContext.GetClusterMetadata().IsGlobalNamespaceEnabled() {
+	//	return nil, serviceerror.NewUnimplemented("ImportWorkflowExecution must be used in global namespace mode")
+	//}
 	resp, err := engine.ImportWorkflowExecution(ctx, request)
 	if err != nil {
 		return nil, h.convertError(err)

--- a/service/matching/configs/quotas.go
+++ b/service/matching/configs/quotas.go
@@ -10,6 +10,7 @@ var (
 	APIToPriority = map[string]int{
 		"/temporal.server.api.matchingservice.v1.MatchingService/AddActivityTask":                        1,
 		"/temporal.server.api.matchingservice.v1.MatchingService/AddWorkflowTask":                        1,
+		"/temporal.server.api.matchingservice.v1.MatchingService/GrantEagerDispatch":                     1,
 		"/temporal.server.api.matchingservice.v1.MatchingService/CancelOutstandingPoll":                  1,
 		"/temporal.server.api.matchingservice.v1.MatchingService/CancelOutstandingWorkerPolls":           2,
 		"/temporal.server.api.matchingservice.v1.MatchingService/CancelOutstandingWorkerPollsPartition":  2,

--- a/service/worker/workerdeployment/client.go
+++ b/service/worker/workerdeployment/client.go
@@ -252,7 +252,7 @@ type maxTaskQueuesInVersionCacheKey struct {
 type registrationErrorCacheValue struct {
 	err                 error
 	expiresAt           time.Time
-	versionFingerprints map[uint64]struct{}
+	versionFingerprints map[int64]struct{}
 }
 
 // ClientImpl implements Client
@@ -429,6 +429,7 @@ func (d *ClientImpl) RegisterTaskQueueWorker(
 		d.cacheTooManyVersionsFailure(namespaceEntry.ID().String(), deploymentName, outcome.GetFailure(), retErr)
 	case errMaxTaskQueuesInVersionType:
 		d.cacheMaxTaskQueuesInVersionError(namespaceEntry.ID().String(), deploymentName, buildId, retErr)
+	default:
 	}
 	return retErr
 }
@@ -489,7 +490,7 @@ func (d *ClientImpl) cacheTooManyVersionsError(
 	namespaceID string,
 	deploymentName string,
 	err error,
-	versionFingerprints map[uint64]struct{},
+	versionFingerprints map[int64]struct{},
 ) {
 	if err == nil || versionFingerprints == nil || d.registrationErrorCache == nil {
 		return
@@ -532,7 +533,7 @@ func (d *ClientImpl) cacheTooManyDeploymentsError(namespaceID string, err error)
 	d.putRegistrationError(tooManyDeploymentsCacheKey{namespaceID: namespaceID}, err, nil)
 }
 
-func (d *ClientImpl) putRegistrationError(key any, err error, versionFingerprints map[uint64]struct{}) {
+func (d *ClientImpl) putRegistrationError(key any, err error, versionFingerprints map[int64]struct{}) {
 	cachedErr := registrationErrorCacheValue{
 		err:                 err,
 		versionFingerprints: versionFingerprints,
@@ -567,7 +568,7 @@ func (d *ClientImpl) cachedErrorRemainingTTL(cachedErr *registrationErrorCacheVa
 	return max(time.Second, ((remainingTTL+time.Second-1)/time.Second)*time.Second)
 }
 
-func (d *ClientImpl) getVersionFingerprintsFromFailure(failure *failurepb.Failure) (map[uint64]struct{}, error) {
+func (d *ClientImpl) getVersionFingerprintsFromFailure(failure *failurepb.Failure) (map[int64]struct{}, error) {
 	detailsPayloads := failure.GetApplicationFailureInfo().GetDetails()
 	if detailsPayloads == nil {
 		return nil, nil
@@ -577,7 +578,7 @@ func (d *ClientImpl) getVersionFingerprintsFromFailure(failure *failurepb.Failur
 	if err := sdk.PreferProtoDataConverter.FromPayloads(detailsPayloads, &details); err != nil {
 		return nil, err
 	}
-	fingerprints := make(map[uint64]struct{}, len(details.GetVersionFingerprints()))
+	fingerprints := make(map[int64]struct{}, len(details.GetVersionFingerprints()))
 	for _, fingerprint := range details.GetVersionFingerprints() {
 		fingerprints[fingerprint] = struct{}{}
 	}

--- a/service/worker/workerdeployment/client.go
+++ b/service/worker/workerdeployment/client.go
@@ -232,6 +232,29 @@ type ErrRegister struct{ error }
 
 var retryPolicy = backoff.NewExponentialRetryPolicy(100 * time.Millisecond).WithExpirationInterval(1 * time.Minute)
 
+const registerTaskQueueWorkerErrorCacheMaxSize = 10000
+
+type registerTaskQueueWorkerErrorCacheScope int
+
+const (
+	registerTaskQueueWorkerErrorCacheScopeNamespace registerTaskQueueWorkerErrorCacheScope = iota
+	registerTaskQueueWorkerErrorCacheScopeDeployment
+	registerTaskQueueWorkerErrorCacheScopeVersion
+	registerTaskQueueWorkerErrorCacheScopeOther
+)
+
+type registerTaskQueueWorkerErrorCacheKey struct {
+	scope          registerTaskQueueWorkerErrorCacheScope
+	namespaceID    string
+	deploymentName string
+	buildID        string
+}
+
+type registerTaskQueueWorkerCachedError struct {
+	err       error
+	errorType string
+}
+
 // ClientImpl implements Client
 // reactivationVersionKey identifies one target version workflow for reactivation-signal dedup.
 type reactivationVersionKey struct {
@@ -260,6 +283,8 @@ type ClientImpl struct {
 	// hygiene, not part of the dedup contract. Cross-pod deduplication is handled
 	// separately by the deterministic UUID RequestId on each signal.
 	highestRevSignaledToVersionWf cache.Cache
+
+	registerTaskQueueWorkerErrorCache cache.Cache
 }
 
 func (d *ClientImpl) SetManager(
@@ -350,6 +375,19 @@ func (d *ClientImpl) RegisterTaskQueueWorker(
 	//revive:disable-next-line:defer
 	defer d.convertAndRecordError("RegisterTaskQueueWorker", deploymentName, &retErr, taskQueueName, taskQueueType, identity)()
 
+	if cachedErrorType, cachedErr := d.getRegisterTaskQueueWorkerError(namespaceEntry.ID().String(), deploymentName, buildId); cachedErr != nil {
+		d.recordRegisterTaskQueueWorkerError(namespaceEntry.Name().String(), cachedErrorType, cachedErr, true)
+		return cachedErr
+	}
+
+	errorType := ""
+	defer func() {
+		d.cacheRegisterTaskQueueWorkerError(namespaceEntry.ID().String(), deploymentName, buildId, errorType, retErr)
+		if retErr != nil {
+			d.recordRegisterTaskQueueWorkerError(namespaceEntry.Name().String(), errorType, retErr, false)
+		}
+	}()
+
 	// Creating request ID out of build ID + TQ name + TQ type. Many updates may come from multiple
 	// matching partitions, we do not want them to create new update requests.
 	requestID := fmt.Sprintf("%s%v-%v-%d", AutoCreateRequestIDPrefix, farm.Fingerprint64([]byte(buildId)), farm.Fingerprint64([]byte(taskQueueName)), taskQueueType)
@@ -378,9 +416,91 @@ func (d *ClientImpl) RegisterTaskQueueWorker(
 		Meta:  &updatepb.Meta{UpdateId: requestID, Identity: identity},
 	}, identity, requestID, d.getSyncBatchSize())
 	if err != nil {
+		var resourceExhausted *serviceerror.ResourceExhausted
+		if errors.As(err, &resourceExhausted) && resourceExhausted.Cause == enumspb.RESOURCE_EXHAUSTED_CAUSE_WORKER_DEPLOYMENT_LIMITS {
+			errorType = errTooManyDeployments
+		}
 		return err
 	}
+	if failure := outcome.GetFailure(); failure != nil {
+		errorType = failure.GetApplicationFailureInfo().GetType()
+	}
 	return d.handleRegisterVersionFailures(outcome)
+}
+
+func (d *ClientImpl) getRegisterTaskQueueWorkerError(namespaceID, deploymentName, buildID string) (string, error) {
+	if d.registerTaskQueueWorkerErrorCache == nil {
+		return "", nil
+	}
+
+	keys := []registerTaskQueueWorkerErrorCacheKey{
+		{
+			scope:       registerTaskQueueWorkerErrorCacheScopeNamespace,
+			namespaceID: namespaceID,
+		},
+		{
+			scope:          registerTaskQueueWorkerErrorCacheScopeVersion,
+			namespaceID:    namespaceID,
+			deploymentName: deploymentName,
+			buildID:        buildID,
+		},
+		{
+			scope:          registerTaskQueueWorkerErrorCacheScopeDeployment,
+			namespaceID:    namespaceID,
+			deploymentName: deploymentName,
+		},
+		{
+			scope:          registerTaskQueueWorkerErrorCacheScopeOther,
+			namespaceID:    namespaceID,
+			deploymentName: deploymentName,
+		},
+	}
+	for _, key := range keys {
+		if cachedErr, ok := d.registerTaskQueueWorkerErrorCache.Get(key).(registerTaskQueueWorkerCachedError); ok {
+			return cachedErr.errorType, cachedErr.err
+		}
+	}
+	return "", nil
+}
+
+func (d *ClientImpl) cacheRegisterTaskQueueWorkerError(namespaceID, deploymentName, buildID, errorType string, err error) {
+	if err == nil || d.registerTaskQueueWorkerErrorCache == nil {
+		return
+	}
+
+	key := registerTaskQueueWorkerErrorCacheKey{
+		namespaceID:    namespaceID,
+		deploymentName: deploymentName,
+	}
+	switch errorType {
+	case errTooManyDeployments:
+		key.scope = registerTaskQueueWorkerErrorCacheScopeNamespace
+		key.deploymentName = ""
+	case errTooManyVersions:
+		key.scope = registerTaskQueueWorkerErrorCacheScopeDeployment
+	case errMaxTaskQueuesInVersionType:
+		key.scope = registerTaskQueueWorkerErrorCacheScopeVersion
+		key.buildID = buildID
+	default:
+		key.scope = registerTaskQueueWorkerErrorCacheScopeOther
+	}
+	d.registerTaskQueueWorkerErrorCache.Put(key, registerTaskQueueWorkerCachedError{
+		err:       err,
+		errorType: errorType,
+	})
+}
+
+func (d *ClientImpl) recordRegisterTaskQueueWorkerError(namespaceName, errorType string, err error, cacheHit bool) {
+	errorTypeTag := metrics.StringTag(metrics.ErrorTypeTagName, errorType)
+	if errorType == "" {
+		errorTypeTag = metrics.ServiceErrorTypeTag(err)
+	}
+	metrics.WorkerDeploymentRegisterTaskQueueErrors.With(d.metricsHandler).Record(
+		1,
+		metrics.NamespaceTag(namespaceName),
+		errorTypeTag,
+		metrics.CacheHitTag(cacheHit),
+	)
 }
 
 func (d *ClientImpl) handleRegisterVersionFailures(outcome *updatepb.Outcome) error {

--- a/service/worker/workerdeployment/client.go
+++ b/service/worker/workerdeployment/client.go
@@ -15,6 +15,7 @@ import (
 	computepb "go.temporal.io/api/compute/v1"
 	deploymentpb "go.temporal.io/api/deployment/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	failurepb "go.temporal.io/api/failure/v1"
 	querypb "go.temporal.io/api/query/v1"
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
@@ -29,6 +30,7 @@ import (
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/cache"
+	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
@@ -232,27 +234,25 @@ type ErrRegister struct{ error }
 
 var retryPolicy = backoff.NewExponentialRetryPolicy(100 * time.Millisecond).WithExpirationInterval(1 * time.Minute)
 
-const registerTaskQueueWorkerErrorCacheMaxSize = 10000
+type tooManyDeploymentsCacheKey struct {
+	namespaceID string
+}
 
-type registerTaskQueueWorkerErrorCacheScope int
+type tooManyVersionsCacheKey struct {
+	namespaceID    string
+	deploymentName string
+}
 
-const (
-	registerTaskQueueWorkerErrorCacheScopeNamespace registerTaskQueueWorkerErrorCacheScope = iota
-	registerTaskQueueWorkerErrorCacheScopeDeployment
-	registerTaskQueueWorkerErrorCacheScopeVersion
-	registerTaskQueueWorkerErrorCacheScopeOther
-)
-
-type registerTaskQueueWorkerErrorCacheKey struct {
-	scope          registerTaskQueueWorkerErrorCacheScope
+type maxTaskQueuesInVersionCacheKey struct {
 	namespaceID    string
 	deploymentName string
 	buildID        string
 }
 
-type registerTaskQueueWorkerCachedError struct {
-	err       error
-	errorType string
+type registrationErrorCacheValue struct {
+	err                 error
+	expiresAt           time.Time
+	versionFingerprints map[uint64]struct{}
 }
 
 // ClientImpl implements Client
@@ -284,7 +284,9 @@ type ClientImpl struct {
 	// separately by the deterministic UUID RequestId on each signal.
 	highestRevSignaledToVersionWf cache.Cache
 
-	registerTaskQueueWorkerErrorCache cache.Cache
+	registrationErrorCache                    cache.Cache
+	workerDeploymentRegistrationErrorCacheTTL time.Duration
+	registrationErrorCacheTimeSource          clock.TimeSource
 }
 
 func (d *ClientImpl) SetManager(
@@ -374,19 +376,19 @@ func (d *ClientImpl) RegisterTaskQueueWorker(
 ) (retErr error) {
 	//revive:disable-next-line:defer
 	defer d.convertAndRecordError("RegisterTaskQueueWorker", deploymentName, &retErr, taskQueueName, taskQueueType, identity)()
-
-	if cachedErrorType, cachedErr := d.getRegisterTaskQueueWorkerError(namespaceEntry.ID().String(), deploymentName, buildId); cachedErr != nil {
-		d.recordRegisterTaskQueueWorkerError(namespaceEntry.Name().String(), cachedErrorType, cachedErr, true)
-		return cachedErr
-	}
-
 	errorType := ""
+	cacheHit := false
 	defer func() {
-		d.cacheRegisterTaskQueueWorkerError(namespaceEntry.ID().String(), deploymentName, buildId, errorType, retErr)
 		if retErr != nil {
-			d.recordRegisterTaskQueueWorkerError(namespaceEntry.Name().String(), errorType, retErr, false)
+			d.recordRegistrationError("RegisterTaskQueueWorker", namespaceEntry.Name().String(), errorType, retErr, cacheHit)
 		}
 	}()
+
+	if cachedErrorType, cachedErr := d.getCachedTooManyVersionsOrTaskQueuesError(namespaceEntry.ID().String(), deploymentName, buildId); cachedErr != nil {
+		errorType = cachedErrorType
+		cacheHit = true
+		return cachedErr
+	}
 
 	// Creating request ID out of build ID + TQ name + TQ type. Many updates may come from multiple
 	// matching partitions, we do not want them to create new update requests.
@@ -411,92 +413,185 @@ func (d *ClientImpl) RegisterTaskQueueWorker(
 	}
 
 	// starting and updating the deployment version workflow, which in turn starts a deployment workflow.
-	outcome, err := d.updateWithStartWorkerDeployment(ctx, namespaceEntry, deploymentName, &updatepb.Request{
+	outcome, cacheHit, errorType, err := d.updateWithStartWorkerDeployment(ctx, namespaceEntry, deploymentName, &updatepb.Request{
 		Input: &updatepb.Input{Name: RegisterWorkerInWorkerDeployment, Args: updatePayload},
 		Meta:  &updatepb.Meta{UpdateId: requestID, Identity: identity},
 	}, identity, requestID, d.getSyncBatchSize())
 	if err != nil {
-		var resourceExhausted *serviceerror.ResourceExhausted
-		if errors.As(err, &resourceExhausted) && resourceExhausted.Cause == enumspb.RESOURCE_EXHAUSTED_CAUSE_WORKER_DEPLOYMENT_LIMITS {
-			errorType = errTooManyDeployments
-		}
 		return err
 	}
 	if failure := outcome.GetFailure(); failure != nil {
 		errorType = failure.GetApplicationFailureInfo().GetType()
 	}
-	return d.handleRegisterVersionFailures(outcome)
+	retErr = d.handleRegisterVersionFailures(outcome)
+	switch errorType {
+	case errTooManyVersions:
+		d.cacheTooManyVersionsFailure(namespaceEntry.ID().String(), deploymentName, outcome.GetFailure(), retErr)
+	case errMaxTaskQueuesInVersionType:
+		d.cacheMaxTaskQueuesInVersionError(namespaceEntry.ID().String(), deploymentName, buildId, retErr)
+	}
+	return retErr
 }
 
-func (d *ClientImpl) getRegisterTaskQueueWorkerError(namespaceID, deploymentName, buildID string) (string, error) {
-	if d.registerTaskQueueWorkerErrorCache == nil {
+func (d *ClientImpl) getCachedTooManyVersionsOrTaskQueuesError(namespaceID, deploymentName, buildID string) (string, error) {
+	if d.registrationErrorCache == nil {
 		return "", nil
 	}
 
-	keys := []registerTaskQueueWorkerErrorCacheKey{
-		{
-			scope:       registerTaskQueueWorkerErrorCacheScopeNamespace,
-			namespaceID: namespaceID,
-		},
-		{
-			scope:          registerTaskQueueWorkerErrorCacheScopeVersion,
-			namespaceID:    namespaceID,
-			deploymentName: deploymentName,
-			buildID:        buildID,
-		},
-		{
-			scope:          registerTaskQueueWorkerErrorCacheScopeDeployment,
-			namespaceID:    namespaceID,
-			deploymentName: deploymentName,
-		},
-		{
-			scope:          registerTaskQueueWorkerErrorCacheScopeOther,
-			namespaceID:    namespaceID,
-			deploymentName: deploymentName,
-		},
+	versionKey := maxTaskQueuesInVersionCacheKey{
+		namespaceID:    namespaceID,
+		deploymentName: deploymentName,
+		buildID:        buildID,
 	}
-	for _, key := range keys {
-		if cachedErr, ok := d.registerTaskQueueWorkerErrorCache.Get(key).(registerTaskQueueWorkerCachedError); ok {
-			return cachedErr.errorType, cachedErr.err
-		}
+	if cachedErr, ok := d.registrationErrorCache.Get(versionKey).(registrationErrorCacheValue); ok {
+		return errMaxTaskQueuesInVersionType, cachedErr.err
+	}
+	if cachedErr := d.getCachedTooManyVersionsError(namespaceID, deploymentName, buildID); cachedErr != nil {
+		return errTooManyVersions, d.cachedTooManyVersionsError(cachedErr)
 	}
 	return "", nil
 }
 
-func (d *ClientImpl) cacheRegisterTaskQueueWorkerError(namespaceID, deploymentName, buildID, errorType string, err error) {
-	if err == nil || d.registerTaskQueueWorkerErrorCache == nil {
-		return
+func (d *ClientImpl) getCachedTooManyVersionsError(namespaceID, deploymentName, buildID string) *registrationErrorCacheValue {
+	if d.registrationErrorCache == nil {
+		return nil
 	}
 
-	key := registerTaskQueueWorkerErrorCacheKey{
+	key := tooManyVersionsCacheKey{
 		namespaceID:    namespaceID,
 		deploymentName: deploymentName,
 	}
-	switch errorType {
-	case errTooManyDeployments:
-		key.scope = registerTaskQueueWorkerErrorCacheScopeNamespace
-		key.deploymentName = ""
-	case errTooManyVersions:
-		key.scope = registerTaskQueueWorkerErrorCacheScopeDeployment
-	case errMaxTaskQueuesInVersionType:
-		key.scope = registerTaskQueueWorkerErrorCacheScopeVersion
-		key.buildID = buildID
-	default:
-		key.scope = registerTaskQueueWorkerErrorCacheScopeOther
+	cachedErr, ok := d.registrationErrorCache.Get(key).(registrationErrorCacheValue)
+	if !ok {
+		return nil
 	}
-	d.registerTaskQueueWorkerErrorCache.Put(key, registerTaskQueueWorkerCachedError{
-		err:       err,
-		errorType: errorType,
-	})
+	if _, exists := cachedErr.versionFingerprints[workerDeploymentVersionFingerprint(deploymentName, buildID)]; exists {
+		return nil
+	}
+	return &cachedErr
 }
 
-func (d *ClientImpl) recordRegisterTaskQueueWorkerError(namespaceName, errorType string, err error, cacheHit bool) {
+func (d *ClientImpl) getCachedTooManyDeploymentsError(namespaceID string) *registrationErrorCacheValue {
+	if d.registrationErrorCache == nil {
+		return nil
+	}
+
+	key := tooManyDeploymentsCacheKey{
+		namespaceID: namespaceID,
+	}
+	if cachedErr, ok := d.registrationErrorCache.Get(key).(registrationErrorCacheValue); ok {
+		return &cachedErr
+	}
+	return nil
+}
+
+func (d *ClientImpl) cacheTooManyVersionsError(
+	namespaceID string,
+	deploymentName string,
+	err error,
+	versionFingerprints map[uint64]struct{},
+) {
+	if err == nil || versionFingerprints == nil || d.registrationErrorCache == nil {
+		return
+	}
+	d.putRegistrationError(tooManyVersionsCacheKey{
+		namespaceID:    namespaceID,
+		deploymentName: deploymentName,
+	}, err, versionFingerprints)
+}
+
+func (d *ClientImpl) cacheTooManyVersionsFailure(
+	namespaceID string,
+	deploymentName string,
+	failure *failurepb.Failure,
+	registrationErr error,
+) {
+	versionFingerprints, err := d.getVersionFingerprintsFromFailure(failure)
+	if err != nil {
+		d.logger.Error("failed to decode too-many-versions failure details", tag.Error(err))
+		return
+	}
+	d.cacheTooManyVersionsError(namespaceID, deploymentName, registrationErr, versionFingerprints)
+}
+
+func (d *ClientImpl) cacheMaxTaskQueuesInVersionError(namespaceID, deploymentName, buildID string, err error) {
+	if err == nil || d.registrationErrorCache == nil {
+		return
+	}
+	d.putRegistrationError(maxTaskQueuesInVersionCacheKey{
+		namespaceID:    namespaceID,
+		deploymentName: deploymentName,
+		buildID:        buildID,
+	}, err, nil)
+}
+
+func (d *ClientImpl) cacheTooManyDeploymentsError(namespaceID string, err error) {
+	if err == nil || d.registrationErrorCache == nil {
+		return
+	}
+	d.putRegistrationError(tooManyDeploymentsCacheKey{namespaceID: namespaceID}, err, nil)
+}
+
+func (d *ClientImpl) putRegistrationError(key any, err error, versionFingerprints map[uint64]struct{}) {
+	cachedErr := registrationErrorCacheValue{
+		err:                 err,
+		versionFingerprints: versionFingerprints,
+	}
+	if d.registrationErrorCacheTimeSource != nil && d.workerDeploymentRegistrationErrorCacheTTL > 0 {
+		cachedErr.expiresAt = d.registrationErrorCacheTimeSource.Now().Add(d.workerDeploymentRegistrationErrorCacheTTL)
+	}
+	d.registrationErrorCache.Put(key, cachedErr)
+}
+
+func (d *ClientImpl) cachedTooManyDeploymentsError(cachedErr *registrationErrorCacheValue) error {
+	return newResourceExhaustedError(fmt.Sprintf(
+		"%s; this cached result may not reflect a recent deletion, retry in up to %s",
+		cachedErr.err.Error(),
+		d.cachedErrorRemainingTTL(cachedErr),
+	))
+}
+
+func (d *ClientImpl) cachedTooManyVersionsError(cachedErr *registrationErrorCacheValue) error {
+	return newResourceExhaustedError(fmt.Sprintf(
+		"%s; this cached result may not reflect recent version changes, retry in up to %s",
+		cachedErr.err.Error(),
+		d.cachedErrorRemainingTTL(cachedErr),
+	))
+}
+
+func (d *ClientImpl) cachedErrorRemainingTTL(cachedErr *registrationErrorCacheValue) time.Duration {
+	remainingTTL := d.workerDeploymentRegistrationErrorCacheTTL
+	if d.registrationErrorCacheTimeSource != nil && !cachedErr.expiresAt.IsZero() {
+		remainingTTL = cachedErr.expiresAt.Sub(d.registrationErrorCacheTimeSource.Now())
+	}
+	return max(time.Second, ((remainingTTL+time.Second-1)/time.Second)*time.Second)
+}
+
+func (d *ClientImpl) getVersionFingerprintsFromFailure(failure *failurepb.Failure) (map[uint64]struct{}, error) {
+	detailsPayloads := failure.GetApplicationFailureInfo().GetDetails()
+	if detailsPayloads == nil {
+		return nil, nil
+	}
+
+	var details deploymentspb.TooManyVersionsFailureDetails
+	if err := sdk.PreferProtoDataConverter.FromPayloads(detailsPayloads, &details); err != nil {
+		return nil, err
+	}
+	fingerprints := make(map[uint64]struct{}, len(details.GetVersionFingerprints()))
+	for _, fingerprint := range details.GetVersionFingerprints() {
+		fingerprints[fingerprint] = struct{}{}
+	}
+	return fingerprints, nil
+}
+
+func (d *ClientImpl) recordRegistrationError(operation, namespaceName, errorType string, err error, cacheHit bool) {
 	errorTypeTag := metrics.StringTag(metrics.ErrorTypeTagName, errorType)
 	if errorType == "" {
 		errorTypeTag = metrics.ServiceErrorTypeTag(err)
 	}
-	metrics.WorkerDeploymentRegisterTaskQueueErrors.With(d.metricsHandler).Record(
+	metrics.WorkerDeploymentRegistrationErrors.With(d.metricsHandler).Record(
 		1,
+		metrics.OperationTag(operation),
 		metrics.NamespaceTag(namespaceName),
 		errorTypeTag,
 		metrics.CacheHitTag(cacheHit),
@@ -941,6 +1036,13 @@ func (d *ClientImpl) SetCurrentVersion(
 ) (_ *deploymentspb.SetCurrentVersionResponse, retErr error) {
 	//revive:disable-next-line:defer
 	defer d.convertAndRecordError("SetCurrentVersion", deploymentName, &retErr, namespaceEntry.Name(), version, identity)()
+	errorType := ""
+	cacheHit := false
+	defer func() {
+		if allowNoPollers && retErr != nil {
+			d.recordRegistrationError("SetCurrentVersion", namespaceEntry.Name().String(), errorType, retErr, cacheHit)
+		}
+	}()
 
 	versionObj, err := worker_versioning.WorkerDeploymentVersionFromStringV31(version)
 	if err != nil {
@@ -978,7 +1080,7 @@ func (d *ClientImpl) SetCurrentVersion(
 				return nil, err
 			}
 		}
-		outcome, err = d.updateWithStartWorkerDeployment(
+		outcome, cacheHit, errorType, err = d.updateWithStartWorkerDeployment(
 			ctx,
 			namespaceEntry,
 			deploymentName,
@@ -1024,6 +1126,11 @@ func (d *ClientImpl) SetCurrentVersion(
 			res.ConflictToken = details[0].GetData()
 		}
 		return &res, nil
+	} else if allowNoPollers && failure.GetApplicationFailureInfo().GetType() == errTooManyVersions {
+		errorType = errTooManyVersions
+		retErr = newResourceExhaustedError(failure.GetMessage())
+		d.cacheTooManyVersionsFailure(namespaceEntry.ID().String(), deploymentName, failure, retErr)
+		return nil, retErr
 	} else if updateErr := d.handleUpdateVersionFailures(outcome, deploymentName, versionObj.GetBuildId()); updateErr != nil {
 		return nil, updateErr
 	} else if registerErr := d.handleRegisterVersionFailures(outcome); registerErr != nil {
@@ -1051,6 +1158,13 @@ func (d *ClientImpl) SetRampingVersion(
 ) (_ *deploymentspb.SetRampingVersionResponse, retErr error) {
 	//revive:disable-next-line:defer
 	defer d.convertAndRecordError("SetRampingVersion", deploymentName, &retErr, namespaceEntry.Name(), version, percentage, identity)()
+	errorType := ""
+	cacheHit := false
+	defer func() {
+		if allowNoPollers && retErr != nil {
+			d.recordRegistrationError("SetRampingVersion", namespaceEntry.Name().String(), errorType, retErr, cacheHit)
+		}
+	}()
 
 	var err error
 	var versionObj *deploymentspb.WorkerDeploymentVersion
@@ -1097,7 +1211,7 @@ func (d *ClientImpl) SetRampingVersion(
 				return nil, err
 			}
 		}
-		outcome, err = d.updateWithStartWorkerDeployment(
+		outcome, cacheHit, errorType, err = d.updateWithStartWorkerDeployment(
 			ctx,
 			namespaceEntry,
 			deploymentName,
@@ -1143,6 +1257,11 @@ func (d *ClientImpl) SetRampingVersion(
 		}
 
 		return &res, nil
+	} else if allowNoPollers && failure.GetApplicationFailureInfo().GetType() == errTooManyVersions {
+		errorType = errTooManyVersions
+		retErr = newResourceExhaustedError(failure.GetMessage())
+		d.cacheTooManyVersionsFailure(namespaceEntry.ID().String(), deploymentName, failure, retErr)
+		return nil, retErr
 	} else if updateErr := d.handleUpdateVersionFailures(outcome, deploymentName, versionObj.GetBuildId()); updateErr != nil {
 		return nil, updateErr
 	} else if registerErr := d.handleRegisterVersionFailures(outcome); registerErr != nil {
@@ -1285,6 +1404,13 @@ func (d *ClientImpl) CreateWorkerDeployment(
 ) (_ []byte, retErr error) {
 	//revive:disable-next-line:defer
 	defer d.convertAndRecordError("CreateWorkerDeployment", deploymentName, &retErr, namespaceEntry.Name(), identity)()
+	errorType := ""
+	cacheHit := false
+	defer func() {
+		if retErr != nil {
+			d.recordRegistrationError("CreateWorkerDeployment", namespaceEntry.Name().String(), errorType, retErr, cacheHit)
+		}
+	}()
 
 	// Validate deployment name
 	err := validateVersionWfParams(worker_versioning.WorkerDeploymentNameFieldName, deploymentName, d.maxIDLengthLimit())
@@ -1302,14 +1428,9 @@ func (d *ClientImpl) CreateWorkerDeployment(
 		return conflictToken, nil
 	}
 
-	// Check resource limits
-	count, err := d.countWorkerDeployments(ctx, namespaceEntry)
+	cacheHit, errorType, err = d.checkWorkerDeploymentLimit(ctx, namespaceEntry)
 	if err != nil {
 		return nil, err
-	}
-	limit := d.maxDeployments(namespaceEntry.Name().String())
-	if count >= int64(limit) {
-		return nil, newResourceExhaustedError(fmt.Sprintf("reached maximum deployments in namespace (%d)", limit))
 	}
 
 	// Start the deployment workflow
@@ -1422,6 +1543,13 @@ func (d *ClientImpl) CreateWorkerDeploymentVersion(
 ) (retErr error) {
 	//revive:disable-next-line:defer
 	defer d.convertAndRecordError("CreateWorkerDeploymentVersion", deploymentName, &retErr, namespaceEntry.Name(), identity)()
+	errorType := ""
+	cacheHit := false
+	defer func() {
+		if retErr != nil {
+			d.recordRegistrationError("CreateWorkerDeploymentVersion", namespaceEntry.Name().String(), errorType, retErr, cacheHit)
+		}
+	}()
 
 	err := validateVersionWfParams(worker_versioning.WorkerDeploymentNameFieldName, deploymentName, d.maxIDLengthLimit())
 	if err != nil {
@@ -1454,6 +1582,12 @@ func (d *ClientImpl) CreateWorkerDeploymentVersion(
 		Meta:  &updatepb.Meta{UpdateId: "_create_version_" + requestID, Identity: identity},
 	}
 
+	if cachedErr := d.getCachedTooManyVersionsError(namespaceEntry.ID().String(), deploymentName, buildID); cachedErr != nil {
+		errorType = errTooManyVersions
+		cacheHit = true
+		return d.cachedTooManyVersionsError(cachedErr)
+	}
+
 	outcome, err := updateWorkflow(
 		ctx,
 		d.historyClient,
@@ -1472,7 +1606,10 @@ func (d *ClientImpl) CreateWorkerDeploymentVersion(
 			return serviceerror.NewAlreadyExists(fmt.Sprintf(ErrWorkerDeploymentVersionAlreadyExists, version))
 		}
 		if failure.GetApplicationFailureInfo().GetType() == errTooManyVersions {
-			return newResourceExhaustedError(failure.GetMessage())
+			errorType = errTooManyVersions
+			retErr = newResourceExhaustedError(failure.GetMessage())
+			d.cacheTooManyVersionsFailure(namespaceEntry.ID().String(), deploymentName, failure, retErr)
+			return retErr
 		}
 		if failure.GetApplicationFailureInfo().GetType() == errInvalidComputeConfig {
 			return serviceerror.NewInvalidArgument(failure.GetMessage())
@@ -1619,27 +1756,22 @@ func (d *ClientImpl) updateWithStartWorkerDeployment(
 	identity string,
 	requestID string,
 	syncBatchSize int32,
-) (*updatepb.Outcome, error) {
+) (*updatepb.Outcome, bool, string, error) {
 	err := validateVersionWfParams(worker_versioning.WorkerDeploymentNameFieldName, deploymentName, d.maxIDLengthLimit())
 	if err != nil {
-		return nil, err
+		return nil, false, "", err
 	}
 
 	workflowID := GenerateDeploymentWorkflowID(deploymentName)
 
 	exists, err := d.workerDeploymentExists(ctx, namespaceEntry, deploymentName)
 	if err != nil {
-		return nil, err
+		return nil, false, "", err
 	}
 	if !exists {
-		// New deployment, make sure we're not exceeding the limit
-		count, err := d.countWorkerDeployments(ctx, namespaceEntry)
+		cacheHit, errorType, err := d.checkWorkerDeploymentLimit(ctx, namespaceEntry)
 		if err != nil {
-			return nil, err
-		}
-		limit := d.maxDeployments(namespaceEntry.Name().String())
-		if count >= int64(limit) {
-			return nil, newResourceExhaustedError(fmt.Sprintf("reached maximum deployments in namespace (%d)", limit))
+			return nil, cacheHit, errorType, err
 		}
 	}
 
@@ -1653,10 +1785,10 @@ func (d *ClientImpl) updateWithStartWorkerDeployment(
 		},
 	})
 	if err != nil {
-		return nil, err
+		return nil, false, "", err
 	}
 
-	return updateWorkflowWithStart(
+	outcome, err := updateWorkflowWithStart(
 		ctx,
 		d.historyClient,
 		namespaceEntry,
@@ -1668,6 +1800,7 @@ func (d *ClientImpl) updateWithStartWorkerDeployment(
 		identity,
 		requestID,
 	)
+	return outcome, false, "", err
 }
 
 // TODO: this is an expensive query that is called every time a new deployment name is seen.
@@ -1691,6 +1824,27 @@ func (d *ClientImpl) countWorkerDeployments(
 		return 0, err
 	}
 	return persistenceResp.Count, nil
+}
+
+func (d *ClientImpl) checkWorkerDeploymentLimit(
+	ctx context.Context,
+	namespaceEntry *namespace.Namespace,
+) (bool, string, error) {
+	if cachedErr := d.getCachedTooManyDeploymentsError(namespaceEntry.ID().String()); cachedErr != nil {
+		return true, errTooManyDeployments, d.cachedTooManyDeploymentsError(cachedErr)
+	}
+
+	count, err := d.countWorkerDeployments(ctx, namespaceEntry)
+	if err != nil {
+		return false, "", err
+	}
+	limit := d.maxDeployments(namespaceEntry.Name().String())
+	if count < int64(limit) {
+		return false, "", nil
+	}
+	err = newResourceExhaustedError(fmt.Sprintf("reached maximum deployments in namespace (%d)", limit))
+	d.cacheTooManyDeploymentsError(namespaceEntry.ID().String(), err)
+	return false, errTooManyDeployments, err
 }
 
 func (d *ClientImpl) updateWithStartWorkerDeploymentVersion(

--- a/service/worker/workerdeployment/client_test.go
+++ b/service/worker/workerdeployment/client_test.go
@@ -1,43 +1,63 @@
 package workerdeployment
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	failurepb "go.temporal.io/api/failure/v1"
+	"go.temporal.io/api/serviceerror"
+	updatepb "go.temporal.io/api/update/v1"
+	workflowpb "go.temporal.io/api/workflow/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	deploymentspb "go.temporal.io/server/api/deployment/v1"
+	"go.temporal.io/server/api/historyservice/v1"
+	"go.temporal.io/server/api/historyservicemock/v1"
 	"go.temporal.io/server/common/cache"
 	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/metrics/metricstest"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/persistence/visibility/manager"
+	"go.temporal.io/server/common/sdk"
+	"go.temporal.io/server/common/worker_versioning"
+	"go.uber.org/mock/gomock"
 )
 
-func TestRegisterTaskQueueWorkerErrorCacheScopes(t *testing.T) {
+func TestRegistrationErrorCacheScopes(t *testing.T) {
 	t.Parallel()
 
+	type cacheLookup struct {
+		namespaceID    string
+		deploymentName string
+		buildID        string
+	}
 	tests := []struct {
-		name      string
-		errorType string
-		hits      []registerTaskQueueWorkerErrorCacheKey
-		misses    []registerTaskQueueWorkerErrorCacheKey
+		name       string
+		errorType  string
+		cacheError func(*ClientImpl, error)
+		hits       []cacheLookup
+		misses     []cacheLookup
 	}{
-		{
-			name:      "too many deployments",
-			errorType: errTooManyDeployments,
-			hits: []registerTaskQueueWorkerErrorCacheKey{
-				{namespaceID: "namespace-a", deploymentName: "deployment-b", buildID: "build-b"},
-			},
-			misses: []registerTaskQueueWorkerErrorCacheKey{
-				{namespaceID: "namespace-b", deploymentName: "deployment-a", buildID: "build-a"},
-			},
-		},
 		{
 			name:      "too many versions",
 			errorType: errTooManyVersions,
-			hits: []registerTaskQueueWorkerErrorCacheKey{
+			cacheError: func(client *ClientImpl, err error) {
+				client.cacheTooManyVersionsError(
+					"namespace-a", "deployment-a", err, versionFingerprintSet("deployment-a", "build-existing"),
+				)
+			},
+			hits: []cacheLookup{
 				{namespaceID: "namespace-a", deploymentName: "deployment-a", buildID: "build-b"},
 			},
-			misses: []registerTaskQueueWorkerErrorCacheKey{
+			misses: []cacheLookup{
+				{namespaceID: "namespace-a", deploymentName: "deployment-a", buildID: "build-existing"},
 				{namespaceID: "namespace-a", deploymentName: "deployment-b", buildID: "build-a"},
 				{namespaceID: "namespace-b", deploymentName: "deployment-a", buildID: "build-a"},
 			},
@@ -45,22 +65,14 @@ func TestRegisterTaskQueueWorkerErrorCacheScopes(t *testing.T) {
 		{
 			name:      "too many task queues",
 			errorType: errMaxTaskQueuesInVersionType,
-			hits: []registerTaskQueueWorkerErrorCacheKey{
+			cacheError: func(client *ClientImpl, err error) {
+				client.cacheMaxTaskQueuesInVersionError("namespace-a", "deployment-a", "build-a", err)
+			},
+			hits: []cacheLookup{
 				{namespaceID: "namespace-a", deploymentName: "deployment-a", buildID: "build-a"},
 			},
-			misses: []registerTaskQueueWorkerErrorCacheKey{
+			misses: []cacheLookup{
 				{namespaceID: "namespace-a", deploymentName: "deployment-a", buildID: "build-b"},
-				{namespaceID: "namespace-a", deploymentName: "deployment-b", buildID: "build-a"},
-				{namespaceID: "namespace-b", deploymentName: "deployment-a", buildID: "build-a"},
-			},
-		},
-		{
-			name:      "other error",
-			errorType: "other",
-			hits: []registerTaskQueueWorkerErrorCacheKey{
-				{namespaceID: "namespace-a", deploymentName: "deployment-a", buildID: "build-b"},
-			},
-			misses: []registerTaskQueueWorkerErrorCacheKey{
 				{namespaceID: "namespace-a", deploymentName: "deployment-b", buildID: "build-a"},
 				{namespaceID: "namespace-b", deploymentName: "deployment-a", buildID: "build-a"},
 			},
@@ -71,20 +83,32 @@ func TestRegisterTaskQueueWorkerErrorCacheScopes(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			errorCache := cache.New(100, &cache.Options{TTL: time.Minute})
+			timeSource := clock.NewEventTimeSource()
+			errorCache := cache.New(100, &cache.Options{TTL: time.Minute, TimeSource: timeSource})
 			t.Cleanup(errorCache.Stop)
-			client := &ClientImpl{registerTaskQueueWorkerErrorCache: errorCache}
+			client := &ClientImpl{
+				registrationErrorCache:                    errorCache,
+				workerDeploymentRegistrationErrorCacheTTL: time.Minute,
+				registrationErrorCacheTimeSource:          timeSource,
+			}
 			cachedErr := errors.New(test.name)
 
-			client.cacheRegisterTaskQueueWorkerError("namespace-a", "deployment-a", "build-a", test.errorType, cachedErr)
+			test.cacheError(client, cachedErr)
 
 			for _, key := range test.hits {
-				actualErrorType, actualErr := client.getRegisterTaskQueueWorkerError(key.namespaceID, key.deploymentName, key.buildID)
-				require.ErrorIs(t, actualErr, cachedErr)
+				actualErrorType, actualErr := client.getCachedTooManyVersionsOrTaskQueuesError(key.namespaceID, key.deploymentName, key.buildID)
+				if test.errorType == errTooManyVersions {
+					require.EqualError(t, actualErr, "too many versions; this cached result may not reflect recent version changes, retry in up to 1m0s")
+					var resourceExhaustedErr *serviceerror.ResourceExhausted
+					require.ErrorAs(t, actualErr, &resourceExhaustedErr)
+					require.Equal(t, enumspb.RESOURCE_EXHAUSTED_CAUSE_WORKER_DEPLOYMENT_LIMITS, resourceExhaustedErr.Cause)
+				} else {
+					require.ErrorIs(t, actualErr, cachedErr)
+				}
 				require.Equal(t, test.errorType, actualErrorType)
 			}
 			for _, key := range test.misses {
-				actualErrorType, actualErr := client.getRegisterTaskQueueWorkerError(key.namespaceID, key.deploymentName, key.buildID)
+				actualErrorType, actualErr := client.getCachedTooManyVersionsOrTaskQueuesError(key.namespaceID, key.deploymentName, key.buildID)
 				require.NoError(t, actualErr)
 				require.Empty(t, actualErrorType)
 			}
@@ -92,7 +116,462 @@ func TestRegisterTaskQueueWorkerErrorCacheScopes(t *testing.T) {
 	}
 }
 
-func TestRegisterTaskQueueWorkerErrorCacheOnlyCachesErrorsUntilTTL(t *testing.T) {
+func TestTooManyDeploymentsErrorCacheScope(t *testing.T) {
+	t.Parallel()
+
+	errorCache := cache.New(100, &cache.Options{TTL: time.Minute})
+	t.Cleanup(errorCache.Stop)
+	client := &ClientImpl{registrationErrorCache: errorCache}
+	cachedErr := errors.New("too many deployments")
+
+	client.cacheTooManyDeploymentsError("namespace-a", cachedErr)
+
+	actualCachedErr := client.getCachedTooManyDeploymentsError("namespace-a")
+	require.NotNil(t, actualCachedErr)
+	require.ErrorIs(t, actualCachedErr.err, cachedErr)
+	require.Nil(t, client.getCachedTooManyDeploymentsError("namespace-b"))
+	errorType, actualErr := client.getCachedTooManyVersionsOrTaskQueuesError("namespace-a", "deployment-a", "build-a")
+	require.NoError(t, actualErr)
+	require.Empty(t, errorType)
+}
+
+func TestCheckWorkerDeploymentLimitCachesDetectedError(t *testing.T) {
+	t.Parallel()
+
+	controller := gomock.NewController(t)
+	ns, _ := createMockNamespaceCache(controller, namespace.Name("namespace-a"))
+	visibilityManager := manager.NewMockVisibilityManager(controller)
+	timeSource := clock.NewEventTimeSource()
+	cacheTTL := 10 * time.Second
+	errorCache := cache.New(100, &cache.Options{
+		TTL:        cacheTTL,
+		TimeSource: timeSource,
+	})
+	t.Cleanup(errorCache.Stop)
+	client := &ClientImpl{
+		visibilityManager:                         visibilityManager,
+		maxDeployments:                            dynamicconfig.GetIntPropertyFnFilteredByNamespace(1),
+		metricsHandler:                            metrics.NoopMetricsHandler,
+		registrationErrorCache:                    errorCache,
+		workerDeploymentRegistrationErrorCacheTTL: cacheTTL,
+		registrationErrorCacheTimeSource:          timeSource,
+	}
+	visibilityManager.EXPECT().CountWorkflowExecutions(gomock.Any(), gomock.Any()).Return(
+		&manager.CountWorkflowExecutionsResponse{Count: 1},
+		nil,
+	)
+
+	cacheHit, errorType, err := client.checkWorkerDeploymentLimit(context.Background(), ns)
+
+	require.False(t, cacheHit)
+	require.Equal(t, errTooManyDeployments, errorType)
+	require.EqualError(t, err, "reached maximum deployments in namespace (1)")
+	timeSource.Advance(3 * time.Second)
+
+	cacheHit, errorType, err = client.checkWorkerDeploymentLimit(context.Background(), ns)
+
+	require.True(t, cacheHit)
+	require.Equal(t, errTooManyDeployments, errorType)
+	require.EqualError(
+		t,
+		err,
+		"reached maximum deployments in namespace (1); this cached result may not reflect a recent deletion, retry in up to 7s",
+	)
+}
+
+func TestUpdateWithStartWorkerDeploymentChecksDeploymentLimitCacheOnlyForNewDeployment(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                string
+		deploymentIsRunning bool
+		wantCacheHit        bool
+		wantErrorType       string
+	}{
+		{
+			name:          "new deployment uses cached error",
+			wantCacheHit:  true,
+			wantErrorType: errTooManyDeployments,
+		},
+		{
+			name:                "existing deployment bypasses cached error",
+			deploymentIsRunning: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			controller := gomock.NewController(t)
+			ns, _ := createMockNamespaceCache(controller, namespace.Name("namespace-a"))
+			historyClient := historyservicemock.NewMockHistoryServiceClient(controller)
+			timeSource := clock.NewEventTimeSource()
+			cacheTTL := 10 * time.Second
+			errorCache := cache.New(100, &cache.Options{
+				TTL:        cacheTTL,
+				TimeSource: timeSource,
+			})
+			t.Cleanup(errorCache.Stop)
+			client := &ClientImpl{
+				historyClient:                             historyClient,
+				maxIDLengthLimit:                          dynamicconfig.GetIntPropertyFn(testMaxIDLengthLimit),
+				registrationErrorCache:                    errorCache,
+				workerDeploymentRegistrationErrorCacheTTL: cacheTTL,
+				registrationErrorCacheTimeSource:          timeSource,
+			}
+			cachedErr := newResourceExhaustedError("reached maximum deployments in namespace (100)")
+			client.cacheTooManyDeploymentsError(ns.ID().String(), cachedErr)
+			timeSource.Advance(3 * time.Second)
+
+			if test.deploymentIsRunning {
+				historyClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).Return(
+					&historyservice.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &workflowpb.WorkflowExecutionInfo{
+							Status: enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+						},
+					},
+					nil,
+				)
+				rpcErr := errors.New("execute multi operation")
+				historyClient.EXPECT().ExecuteMultiOperation(gomock.Any(), gomock.Any()).Return(nil, rpcErr)
+				_, cacheHit, errorType, err := client.updateWithStartWorkerDeployment(
+					context.Background(), ns, "deployment-a", &updatepb.Request{}, "identity", "request-id", 1,
+				)
+				require.ErrorIs(t, err, rpcErr)
+				require.False(t, cacheHit)
+				require.Empty(t, errorType)
+				return
+			}
+
+			historyClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNotFound("not found"))
+			_, cacheHit, errorType, err := client.updateWithStartWorkerDeployment(
+				context.Background(), ns, "deployment-a", &updatepb.Request{}, "identity", "request-id", 1,
+			)
+			require.EqualError(t, err, "reached maximum deployments in namespace (100); this cached result may not reflect a recent deletion, retry in up to 7s")
+			var resourceExhaustedErr *serviceerror.ResourceExhausted
+			require.ErrorAs(t, err, &resourceExhaustedErr)
+			require.Equal(t, enumspb.RESOURCE_EXHAUSTED_CAUSE_WORKER_DEPLOYMENT_LIMITS, resourceExhaustedErr.Cause)
+			require.Equal(t, test.wantCacheHit, cacheHit)
+			require.Equal(t, test.wantErrorType, errorType)
+		})
+	}
+}
+
+func TestAllowNoPollersPathsRecordAndCacheTooManyVersionsError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		operation string
+		call      func(*ClientImpl, *namespace.Namespace, string) error
+	}{
+		{
+			operation: "SetCurrentVersion",
+			call: func(client *ClientImpl, ns *namespace.Namespace, version string) error {
+				_, err := client.SetCurrentVersion(
+					context.Background(), ns, "deployment-a", version, "identity", false, nil, true,
+				)
+				return err
+			},
+		},
+		{
+			operation: "SetRampingVersion",
+			call: func(client *ClientImpl, ns *namespace.Namespace, version string) error {
+				_, err := client.SetRampingVersion(
+					context.Background(), ns, "deployment-a", version, 10, "identity", false, nil, true,
+				)
+				return err
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.operation, func(t *testing.T) {
+			t.Parallel()
+
+			controller := gomock.NewController(t)
+			ns, _ := createMockNamespaceCache(controller, namespace.Name("namespace-a"))
+			historyClient := historyservicemock.NewMockHistoryServiceClient(controller)
+			timeSource := clock.NewEventTimeSource()
+			cacheTTL := 10 * time.Second
+			errorCache := cache.New(100, &cache.Options{TTL: cacheTTL, TimeSource: timeSource})
+			t.Cleanup(errorCache.Stop)
+			metricsHandler := metricstest.NewCaptureHandler()
+			capture := metricsHandler.StartCapture()
+			t.Cleanup(func() { metricsHandler.StopCapture(capture) })
+			client := &ClientImpl{
+				logger:                 log.NewNoopLogger(),
+				historyClient:          historyClient,
+				maxIDLengthLimit:       dynamicconfig.GetIntPropertyFn(testMaxIDLengthLimit),
+				metricsHandler:         metricsHandler,
+				registrationErrorCache: errorCache,
+				workerDeploymentRegistrationErrorCacheTTL: cacheTTL,
+				registrationErrorCacheTimeSource:          timeSource,
+			}
+			version := worker_versioning.WorkerDeploymentVersionToStringV31(&deploymentspb.WorkerDeploymentVersion{
+				DeploymentName: "deployment-a",
+				BuildId:        "build-new",
+			})
+			details, err := sdk.PreferProtoDataConverter.ToPayloads(&deploymentspb.TooManyVersionsFailureDetails{
+				VersionFingerprints: []uint64{workerDeploymentVersionFingerprint("deployment-a", "build-existing")},
+			})
+			require.NoError(t, err)
+			failure := &failurepb.Failure{
+				Message: "reached maximum versions in deployment (100)",
+				FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+					ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
+						Type:    errTooManyVersions,
+						Details: details,
+					},
+				},
+			}
+			historyClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).Return(
+				&historyservice.DescribeWorkflowExecutionResponse{
+					WorkflowExecutionInfo: &workflowpb.WorkflowExecutionInfo{
+						Status: enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+					},
+				},
+				nil,
+			)
+			historyClient.EXPECT().ExecuteMultiOperation(gomock.Any(), gomock.Any()).Return(
+				&historyservice.ExecuteMultiOperationResponse{
+					Responses: []*historyservice.ExecuteMultiOperationResponse_Response{
+						{
+							Response: &historyservice.ExecuteMultiOperationResponse_Response_StartWorkflow{
+								StartWorkflow: &historyservice.StartWorkflowExecutionResponse{},
+							},
+						},
+						{
+							Response: &historyservice.ExecuteMultiOperationResponse_Response_UpdateWorkflow{
+								UpdateWorkflow: &historyservice.UpdateWorkflowExecutionResponse{
+									Response: &workflowservice.UpdateWorkflowExecutionResponse{
+										Stage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED,
+										Outcome: &updatepb.Outcome{Value: &updatepb.Outcome_Failure{
+											Failure: failure,
+										}},
+									},
+								},
+							},
+						},
+					},
+				},
+				nil,
+			)
+
+			err = test.call(client, ns, version)
+
+			require.EqualError(t, err, "reached maximum versions in deployment (100)")
+			require.NotNil(t, client.getCachedTooManyVersionsError(ns.ID().String(), "deployment-a", "build-new"))
+			require.Nil(t, client.getCachedTooManyVersionsError(ns.ID().String(), "deployment-a", "build-existing"))
+			recordings := capture.Snapshot()[metrics.WorkerDeploymentRegistrationErrors.Name()]
+			require.Len(t, recordings, 1)
+			require.Equal(t, map[string]string{
+				"namespace":              "namespace-a",
+				metrics.OperationTagName: test.operation,
+				metrics.ErrorTypeTagName: errTooManyVersions,
+				metrics.CacheHitTagName:  "false",
+			}, recordings[0].Tags)
+		})
+	}
+}
+
+func TestCreateWorkerDeploymentChecksCachedDeploymentLimitBeforeCounting(t *testing.T) {
+	t.Parallel()
+
+	controller := gomock.NewController(t)
+	ns, _ := createMockNamespaceCache(controller, namespace.Name("namespace-a"))
+	historyClient := historyservicemock.NewMockHistoryServiceClient(controller)
+	timeSource := clock.NewEventTimeSource()
+	cacheTTL := 10 * time.Second
+	errorCache := cache.New(100, &cache.Options{
+		TTL:        cacheTTL,
+		TimeSource: timeSource,
+	})
+	t.Cleanup(errorCache.Stop)
+	metricsHandler := metricstest.NewCaptureHandler()
+	capture := metricsHandler.StartCapture()
+	t.Cleanup(func() { metricsHandler.StopCapture(capture) })
+	client := &ClientImpl{
+		logger:                 log.NewNoopLogger(),
+		historyClient:          historyClient,
+		maxIDLengthLimit:       dynamicconfig.GetIntPropertyFn(testMaxIDLengthLimit),
+		metricsHandler:         metricsHandler,
+		registrationErrorCache: errorCache,
+		workerDeploymentRegistrationErrorCacheTTL: cacheTTL,
+		registrationErrorCacheTimeSource:          timeSource,
+	}
+	cachedErr := newResourceExhaustedError("reached maximum deployments in namespace (100)")
+	client.cacheTooManyDeploymentsError(ns.ID().String(), cachedErr)
+	timeSource.Advance(3 * time.Second)
+	historyClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNotFound("not found"))
+
+	_, err := client.CreateWorkerDeployment(context.Background(), ns, "deployment-a", "identity", "request-id")
+
+	require.EqualError(
+		t,
+		err,
+		"reached maximum deployments in namespace (100); this cached result may not reflect a recent deletion, retry in up to 7s",
+	)
+	recordings := capture.Snapshot()[metrics.WorkerDeploymentRegistrationErrors.Name()]
+	require.Len(t, recordings, 1)
+	require.Equal(t, map[string]string{
+		"namespace":              "namespace-a",
+		metrics.OperationTagName: "CreateWorkerDeployment",
+		metrics.ErrorTypeTagName: errTooManyDeployments,
+		metrics.CacheHitTagName:  "true",
+	}, recordings[0].Tags)
+}
+
+func TestCreateWorkerDeploymentVersionCachesVersionLimitError(t *testing.T) {
+	t.Parallel()
+
+	controller := gomock.NewController(t)
+	ns, _ := createMockNamespaceCache(controller, namespace.Name("namespace-a"))
+	historyClient := historyservicemock.NewMockHistoryServiceClient(controller)
+	timeSource := clock.NewEventTimeSource()
+	cacheTTL := 10 * time.Second
+	errorCache := cache.New(100, &cache.Options{TTL: cacheTTL, TimeSource: timeSource})
+	t.Cleanup(errorCache.Stop)
+	metricsHandler := metricstest.NewCaptureHandler()
+	capture := metricsHandler.StartCapture()
+	t.Cleanup(func() { metricsHandler.StopCapture(capture) })
+	client := &ClientImpl{
+		logger:                 log.NewNoopLogger(),
+		historyClient:          historyClient,
+		maxIDLengthLimit:       dynamicconfig.GetIntPropertyFn(testMaxIDLengthLimit),
+		metricsHandler:         metricsHandler,
+		registrationErrorCache: errorCache,
+		workerDeploymentRegistrationErrorCacheTTL: cacheTTL,
+		registrationErrorCacheTimeSource:          timeSource,
+	}
+	details, err := sdk.PreferProtoDataConverter.ToPayloads(&deploymentspb.TooManyVersionsFailureDetails{
+		VersionFingerprints: []uint64{workerDeploymentVersionFingerprint("deployment-a", "build-existing")},
+	})
+	require.NoError(t, err)
+	failure := &failurepb.Failure{
+		Message: "reached maximum versions in deployment (100)",
+		FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+			ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
+				Type:    errTooManyVersions,
+				Details: details,
+			},
+		},
+	}
+	historyClient.EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).Return(
+		&historyservice.UpdateWorkflowExecutionResponse{
+			Response: &workflowservice.UpdateWorkflowExecutionResponse{
+				Stage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED,
+				Outcome: &updatepb.Outcome{Value: &updatepb.Outcome_Failure{
+					Failure: failure,
+				}},
+			},
+		},
+		nil,
+	)
+
+	err = client.CreateWorkerDeploymentVersion(
+		context.Background(), ns, "deployment-a", "build-new", "identity", "request-id", nil,
+	)
+
+	require.EqualError(t, err, "reached maximum versions in deployment (100)")
+	require.NotNil(t, client.getCachedTooManyVersionsError(ns.ID().String(), "deployment-a", "build-new"))
+	require.Nil(t, client.getCachedTooManyVersionsError(ns.ID().String(), "deployment-a", "build-existing"))
+	recordings := capture.Snapshot()[metrics.WorkerDeploymentRegistrationErrors.Name()]
+	require.Len(t, recordings, 1)
+	require.Equal(t, map[string]string{
+		"namespace":              "namespace-a",
+		metrics.OperationTagName: "CreateWorkerDeploymentVersion",
+		metrics.ErrorTypeTagName: errTooManyVersions,
+		metrics.CacheHitTagName:  "false",
+	}, recordings[0].Tags)
+}
+
+func TestCreateWorkerDeploymentVersionChecksCachedVersionLimit(t *testing.T) {
+	t.Parallel()
+
+	controller := gomock.NewController(t)
+	ns, _ := createMockNamespaceCache(controller, namespace.Name("namespace-a"))
+	timeSource := clock.NewEventTimeSource()
+	cacheTTL := 10 * time.Second
+	errorCache := cache.New(100, &cache.Options{TTL: cacheTTL, TimeSource: timeSource})
+	t.Cleanup(errorCache.Stop)
+	metricsHandler := metricstest.NewCaptureHandler()
+	capture := metricsHandler.StartCapture()
+	t.Cleanup(func() { metricsHandler.StopCapture(capture) })
+	client := &ClientImpl{
+		logger:                 log.NewNoopLogger(),
+		maxIDLengthLimit:       dynamicconfig.GetIntPropertyFn(testMaxIDLengthLimit),
+		metricsHandler:         metricsHandler,
+		registrationErrorCache: errorCache,
+		workerDeploymentRegistrationErrorCacheTTL: cacheTTL,
+		registrationErrorCacheTimeSource:          timeSource,
+	}
+	client.cacheTooManyVersionsError(
+		ns.ID().String(),
+		"deployment-a",
+		newResourceExhaustedError("reached maximum versions in deployment (100)"),
+		versionFingerprintSet("deployment-a", "build-existing"),
+	)
+	timeSource.Advance(3 * time.Second)
+
+	err := client.CreateWorkerDeploymentVersion(
+		context.Background(), ns, "deployment-a", "build-new", "identity", "request-id", nil,
+	)
+
+	require.EqualError(
+		t,
+		err,
+		"reached maximum versions in deployment (100); this cached result may not reflect recent version changes, retry in up to 7s",
+	)
+	recordings := capture.Snapshot()[metrics.WorkerDeploymentRegistrationErrors.Name()]
+	require.Len(t, recordings, 1)
+	require.Equal(t, map[string]string{
+		"namespace":              "namespace-a",
+		metrics.OperationTagName: "CreateWorkerDeploymentVersion",
+		metrics.ErrorTypeTagName: errTooManyVersions,
+		metrics.CacheHitTagName:  "true",
+	}, recordings[0].Tags)
+}
+
+func TestCreateWorkerDeploymentVersionBypassesCachedVersionLimitForExistingVersion(t *testing.T) {
+	t.Parallel()
+
+	controller := gomock.NewController(t)
+	ns, _ := createMockNamespaceCache(controller, namespace.Name("namespace-a"))
+	historyClient := historyservicemock.NewMockHistoryServiceClient(controller)
+	errorCache := cache.New(100, &cache.Options{TTL: time.Minute})
+	t.Cleanup(errorCache.Stop)
+	client := &ClientImpl{
+		logger:                 log.NewNoopLogger(),
+		historyClient:          historyClient,
+		maxIDLengthLimit:       dynamicconfig.GetIntPropertyFn(testMaxIDLengthLimit),
+		metricsHandler:         metrics.NoopMetricsHandler,
+		registrationErrorCache: errorCache,
+	}
+	client.cacheTooManyVersionsError(
+		ns.ID().String(),
+		"deployment-a",
+		newResourceExhaustedError("reached maximum versions in deployment (100)"),
+		versionFingerprintSet("deployment-a", "build-existing"),
+	)
+	historyClient.EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).Return(
+		&historyservice.UpdateWorkflowExecutionResponse{
+			Response: &workflowservice.UpdateWorkflowExecutionResponse{
+				Stage:   enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED,
+				Outcome: &updatepb.Outcome{Value: &updatepb.Outcome_Success{Success: &commonpb.Payloads{}}},
+			},
+		},
+		nil,
+	)
+
+	err := client.CreateWorkerDeploymentVersion(
+		context.Background(), ns, "deployment-a", "build-existing", "identity", "request-id", nil,
+	)
+
+	require.NoError(t, err)
+}
+
+func TestRegistrationErrorCacheOnlyCachesErrorsUntilTTL(t *testing.T) {
 	t.Parallel()
 
 	timeSource := clock.NewEventTimeSource()
@@ -102,22 +581,71 @@ func TestRegisterTaskQueueWorkerErrorCacheOnlyCachesErrorsUntilTTL(t *testing.T)
 		TimeSource: timeSource,
 	})
 	t.Cleanup(errorCache.Stop)
-	client := &ClientImpl{registerTaskQueueWorkerErrorCache: errorCache}
-
-	client.cacheRegisterTaskQueueWorkerError("namespace-a", "deployment-a", "build-a", "", nil)
-	require.Zero(t, errorCache.Size())
+	client := &ClientImpl{
+		registrationErrorCache:                    errorCache,
+		workerDeploymentRegistrationErrorCacheTTL: ttl,
+		registrationErrorCacheTimeSource:          timeSource,
+	}
 
 	cachedErr := errors.New("cached error")
-	client.cacheRegisterTaskQueueWorkerError("namespace-a", "deployment-a", "build-a", "", cachedErr)
-	_, actualErr := client.getRegisterTaskQueueWorkerError("namespace-a", "deployment-a", "build-b")
-	require.ErrorIs(t, actualErr, cachedErr)
+	client.cacheTooManyVersionsError("namespace-a", "deployment-a", nil, nil)
+	require.Zero(t, errorCache.Size())
+
+	client.cacheTooManyVersionsError("namespace-a", "deployment-a", cachedErr, nil)
+	require.Zero(t, errorCache.Size())
+
+	client.cacheTooManyVersionsError(
+		"namespace-a",
+		"deployment-a",
+		cachedErr,
+		versionFingerprintSet("deployment-a", "build-existing"),
+	)
+	_, actualErr := client.getCachedTooManyVersionsOrTaskQueuesError("namespace-a", "deployment-a", "build-b")
+	require.Error(t, actualErr)
+	_, actualErr = client.getCachedTooManyVersionsOrTaskQueuesError("namespace-a", "deployment-a", "build-existing")
+	require.NoError(t, actualErr)
 
 	timeSource.Advance(ttl + time.Nanosecond)
-	_, actualErr = client.getRegisterTaskQueueWorkerError("namespace-a", "deployment-a", "build-b")
+	_, actualErr = client.getCachedTooManyVersionsOrTaskQueuesError("namespace-a", "deployment-a", "build-b")
 	require.NoError(t, actualErr)
 }
 
-func TestRecordRegisterTaskQueueWorkerError(t *testing.T) {
+func TestGetVersionFingerprintsFromFailure(t *testing.T) {
+	t.Parallel()
+
+	payloads, err := sdk.PreferProtoDataConverter.ToPayloads(&deploymentspb.TooManyVersionsFailureDetails{
+		VersionFingerprints: []uint64{11, 22},
+	})
+	require.NoError(t, err)
+	client := &ClientImpl{}
+
+	fingerprints, err := client.getVersionFingerprintsFromFailure(&failurepb.Failure{
+		FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+			ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{Details: payloads},
+		},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, map[uint64]struct{}{11: {}, 22: {}}, fingerprints)
+
+	fingerprints, err = client.getVersionFingerprintsFromFailure(&failurepb.Failure{
+		FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+			ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{},
+		},
+	})
+	require.NoError(t, err)
+	require.Nil(t, fingerprints)
+}
+
+func versionFingerprintSet(deploymentName string, buildIDs ...string) map[uint64]struct{} {
+	fingerprints := make(map[uint64]struct{}, len(buildIDs))
+	for _, buildID := range buildIDs {
+		fingerprints[workerDeploymentVersionFingerprint(deploymentName, buildID)] = struct{}{}
+	}
+	return fingerprints
+}
+
+func TestRecordWorkerDeploymentRegistrationError(t *testing.T) {
 	t.Parallel()
 
 	metricsHandler := metricstest.NewCaptureHandler()
@@ -126,20 +654,22 @@ func TestRecordRegisterTaskQueueWorkerError(t *testing.T) {
 	client := &ClientImpl{metricsHandler: metricsHandler}
 	err := errors.New("registration failed")
 
-	client.recordRegisterTaskQueueWorkerError("namespace-a", errTooManyVersions, err, false)
-	client.recordRegisterTaskQueueWorkerError("namespace-a", errTooManyVersions, err, true)
+	client.recordRegistrationError("RegisterTaskQueueWorker", "namespace-a", errTooManyVersions, err, false)
+	client.recordRegistrationError("RegisterTaskQueueWorker", "namespace-a", errTooManyVersions, err, true)
 
-	recordings := capture.Snapshot()[metrics.WorkerDeploymentRegisterTaskQueueErrors.Name()]
+	recordings := capture.Snapshot()[metrics.WorkerDeploymentRegistrationErrors.Name()]
 	require.Len(t, recordings, 2)
 	require.Equal(t, int64(1), recordings[0].Value)
 	require.Equal(t, map[string]string{
 		"namespace":              "namespace-a",
+		metrics.OperationTagName: "RegisterTaskQueueWorker",
 		metrics.ErrorTypeTagName: errTooManyVersions,
 		metrics.CacheHitTagName:  "false",
 	}, recordings[0].Tags)
 	require.Equal(t, int64(1), recordings[1].Value)
 	require.Equal(t, map[string]string{
 		"namespace":              "namespace-a",
+		metrics.OperationTagName: "RegisterTaskQueueWorker",
 		metrics.ErrorTypeTagName: errTooManyVersions,
 		metrics.CacheHitTagName:  "true",
 	}, recordings[1].Tags)

--- a/service/worker/workerdeployment/client_test.go
+++ b/service/worker/workerdeployment/client_test.go
@@ -1,0 +1,146 @@
+package workerdeployment
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/cache"
+	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/metrics/metricstest"
+)
+
+func TestRegisterTaskQueueWorkerErrorCacheScopes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		errorType string
+		hits      []registerTaskQueueWorkerErrorCacheKey
+		misses    []registerTaskQueueWorkerErrorCacheKey
+	}{
+		{
+			name:      "too many deployments",
+			errorType: errTooManyDeployments,
+			hits: []registerTaskQueueWorkerErrorCacheKey{
+				{namespaceID: "namespace-a", deploymentName: "deployment-b", buildID: "build-b"},
+			},
+			misses: []registerTaskQueueWorkerErrorCacheKey{
+				{namespaceID: "namespace-b", deploymentName: "deployment-a", buildID: "build-a"},
+			},
+		},
+		{
+			name:      "too many versions",
+			errorType: errTooManyVersions,
+			hits: []registerTaskQueueWorkerErrorCacheKey{
+				{namespaceID: "namespace-a", deploymentName: "deployment-a", buildID: "build-b"},
+			},
+			misses: []registerTaskQueueWorkerErrorCacheKey{
+				{namespaceID: "namespace-a", deploymentName: "deployment-b", buildID: "build-a"},
+				{namespaceID: "namespace-b", deploymentName: "deployment-a", buildID: "build-a"},
+			},
+		},
+		{
+			name:      "too many task queues",
+			errorType: errMaxTaskQueuesInVersionType,
+			hits: []registerTaskQueueWorkerErrorCacheKey{
+				{namespaceID: "namespace-a", deploymentName: "deployment-a", buildID: "build-a"},
+			},
+			misses: []registerTaskQueueWorkerErrorCacheKey{
+				{namespaceID: "namespace-a", deploymentName: "deployment-a", buildID: "build-b"},
+				{namespaceID: "namespace-a", deploymentName: "deployment-b", buildID: "build-a"},
+				{namespaceID: "namespace-b", deploymentName: "deployment-a", buildID: "build-a"},
+			},
+		},
+		{
+			name:      "other error",
+			errorType: "other",
+			hits: []registerTaskQueueWorkerErrorCacheKey{
+				{namespaceID: "namespace-a", deploymentName: "deployment-a", buildID: "build-b"},
+			},
+			misses: []registerTaskQueueWorkerErrorCacheKey{
+				{namespaceID: "namespace-a", deploymentName: "deployment-b", buildID: "build-a"},
+				{namespaceID: "namespace-b", deploymentName: "deployment-a", buildID: "build-a"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			errorCache := cache.New(100, &cache.Options{TTL: time.Minute})
+			t.Cleanup(errorCache.Stop)
+			client := &ClientImpl{registerTaskQueueWorkerErrorCache: errorCache}
+			cachedErr := errors.New(test.name)
+
+			client.cacheRegisterTaskQueueWorkerError("namespace-a", "deployment-a", "build-a", test.errorType, cachedErr)
+
+			for _, key := range test.hits {
+				actualErrorType, actualErr := client.getRegisterTaskQueueWorkerError(key.namespaceID, key.deploymentName, key.buildID)
+				require.ErrorIs(t, actualErr, cachedErr)
+				require.Equal(t, test.errorType, actualErrorType)
+			}
+			for _, key := range test.misses {
+				actualErrorType, actualErr := client.getRegisterTaskQueueWorkerError(key.namespaceID, key.deploymentName, key.buildID)
+				require.NoError(t, actualErr)
+				require.Empty(t, actualErrorType)
+			}
+		})
+	}
+}
+
+func TestRegisterTaskQueueWorkerErrorCacheOnlyCachesErrorsUntilTTL(t *testing.T) {
+	t.Parallel()
+
+	timeSource := clock.NewEventTimeSource()
+	ttl := 10 * time.Second
+	errorCache := cache.New(100, &cache.Options{
+		TTL:        ttl,
+		TimeSource: timeSource,
+	})
+	t.Cleanup(errorCache.Stop)
+	client := &ClientImpl{registerTaskQueueWorkerErrorCache: errorCache}
+
+	client.cacheRegisterTaskQueueWorkerError("namespace-a", "deployment-a", "build-a", "", nil)
+	require.Zero(t, errorCache.Size())
+
+	cachedErr := errors.New("cached error")
+	client.cacheRegisterTaskQueueWorkerError("namespace-a", "deployment-a", "build-a", "", cachedErr)
+	_, actualErr := client.getRegisterTaskQueueWorkerError("namespace-a", "deployment-a", "build-b")
+	require.ErrorIs(t, actualErr, cachedErr)
+
+	timeSource.Advance(ttl + time.Nanosecond)
+	_, actualErr = client.getRegisterTaskQueueWorkerError("namespace-a", "deployment-a", "build-b")
+	require.NoError(t, actualErr)
+}
+
+func TestRecordRegisterTaskQueueWorkerError(t *testing.T) {
+	t.Parallel()
+
+	metricsHandler := metricstest.NewCaptureHandler()
+	capture := metricsHandler.StartCapture()
+	t.Cleanup(func() { metricsHandler.StopCapture(capture) })
+	client := &ClientImpl{metricsHandler: metricsHandler}
+	err := errors.New("registration failed")
+
+	client.recordRegisterTaskQueueWorkerError("namespace-a", errTooManyVersions, err, false)
+	client.recordRegisterTaskQueueWorkerError("namespace-a", errTooManyVersions, err, true)
+
+	recordings := capture.Snapshot()[metrics.WorkerDeploymentRegisterTaskQueueErrors.Name()]
+	require.Len(t, recordings, 2)
+	require.Equal(t, int64(1), recordings[0].Value)
+	require.Equal(t, map[string]string{
+		"namespace":              "namespace-a",
+		metrics.ErrorTypeTagName: errTooManyVersions,
+		metrics.CacheHitTagName:  "false",
+	}, recordings[0].Tags)
+	require.Equal(t, int64(1), recordings[1].Value)
+	require.Equal(t, map[string]string{
+		"namespace":              "namespace-a",
+		metrics.ErrorTypeTagName: errTooManyVersions,
+		metrics.CacheHitTagName:  "true",
+	}, recordings[1].Tags)
+}

--- a/service/worker/workerdeployment/client_test.go
+++ b/service/worker/workerdeployment/client_test.go
@@ -313,7 +313,7 @@ func TestAllowNoPollersPathsRecordAndCacheTooManyVersionsError(t *testing.T) {
 				BuildId:        "build-new",
 			})
 			details, err := sdk.PreferProtoDataConverter.ToPayloads(&deploymentspb.TooManyVersionsFailureDetails{
-				VersionFingerprints: []uint64{workerDeploymentVersionFingerprint("deployment-a", "build-existing")},
+				VersionFingerprints: []int64{workerDeploymentVersionFingerprint("deployment-a", "build-existing")},
 			})
 			require.NoError(t, err)
 			failure := &failurepb.Failure{
@@ -445,7 +445,7 @@ func TestCreateWorkerDeploymentVersionCachesVersionLimitError(t *testing.T) {
 		registrationErrorCacheTimeSource:          timeSource,
 	}
 	details, err := sdk.PreferProtoDataConverter.ToPayloads(&deploymentspb.TooManyVersionsFailureDetails{
-		VersionFingerprints: []uint64{workerDeploymentVersionFingerprint("deployment-a", "build-existing")},
+		VersionFingerprints: []int64{workerDeploymentVersionFingerprint("deployment-a", "build-existing")},
 	})
 	require.NoError(t, err)
 	failure := &failurepb.Failure{
@@ -614,7 +614,7 @@ func TestGetVersionFingerprintsFromFailure(t *testing.T) {
 	t.Parallel()
 
 	payloads, err := sdk.PreferProtoDataConverter.ToPayloads(&deploymentspb.TooManyVersionsFailureDetails{
-		VersionFingerprints: []uint64{11, 22},
+		VersionFingerprints: []int64{11, 22},
 	})
 	require.NoError(t, err)
 	client := &ClientImpl{}
@@ -626,7 +626,7 @@ func TestGetVersionFingerprintsFromFailure(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	require.Equal(t, map[uint64]struct{}{11: {}, 22: {}}, fingerprints)
+	require.Equal(t, map[int64]struct{}{11: {}, 22: {}}, fingerprints)
 
 	fingerprints, err = client.getVersionFingerprintsFromFailure(&failurepb.Failure{
 		FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
@@ -637,8 +637,8 @@ func TestGetVersionFingerprintsFromFailure(t *testing.T) {
 	require.Nil(t, fingerprints)
 }
 
-func versionFingerprintSet(deploymentName string, buildIDs ...string) map[uint64]struct{} {
-	fingerprints := make(map[uint64]struct{}, len(buildIDs))
+func versionFingerprintSet(deploymentName string, buildIDs ...string) map[int64]struct{} {
+	fingerprints := make(map[int64]struct{}, len(buildIDs))
 	for _, buildID := range buildIDs {
 		fingerprints[workerDeploymentVersionFingerprint(deploymentName, buildID)] = struct{}{}
 	}

--- a/service/worker/workerdeployment/fx.go
+++ b/service/worker/workerdeployment/fx.go
@@ -9,6 +9,7 @@ import (
 	"go.temporal.io/sdk/workflow"
 	deploymentspb "go.temporal.io/server/api/deployment/v1"
 	"go.temporal.io/server/common/cache"
+	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
@@ -80,35 +81,39 @@ func ClientProvider(
 	metricsHandler metrics.Handler,
 ) Client {
 	highestRevSignaledToVersionWf := cache.New(dynamicconfig.ReactivationSignalDedupCacheMaxSize.Get(dc)(), nil)
-	registerTaskQueueWorkerErrorCacheTTL := dynamicconfig.WorkerDeploymentRegisterTaskQueueErrorCacheTTL.Get(dc)()
-	registerTaskQueueWorkerErrorCacheSize := registerTaskQueueWorkerErrorCacheMaxSize
-	if registerTaskQueueWorkerErrorCacheTTL <= 0 {
-		registerTaskQueueWorkerErrorCacheSize = 0
+	workerDeploymentRegistrationErrorCacheTTL := dynamicconfig.WorkerDeploymentRegistrationErrorCacheTTL.Get(dc)()
+	registrationErrorCacheSize := dynamicconfig.WorkerDeploymentRegistrationErrorCacheMaxSize.Get(dc)()
+	if workerDeploymentRegistrationErrorCacheTTL <= 0 {
+		registrationErrorCacheSize = 0
 	}
-	registerTaskQueueWorkerErrorCache := cache.New(registerTaskQueueWorkerErrorCacheSize, &cache.Options{
-		TTL: registerTaskQueueWorkerErrorCacheTTL,
+	registrationErrorCacheTimeSource := clock.NewRealTimeSource()
+	registrationErrorCache := cache.New(registrationErrorCacheSize, &cache.Options{
+		TTL:        workerDeploymentRegistrationErrorCacheTTL,
+		TimeSource: registrationErrorCacheTimeSource,
 	})
 	lc.Append(fx.Hook{
 		OnStop: func(context.Context) error {
 			highestRevSignaledToVersionWf.Stop()
-			registerTaskQueueWorkerErrorCache.Stop()
+			registrationErrorCache.Stop()
 			return nil
 		},
 	})
 	return &ClientImpl{
-		logger:                            logger,
-		historyClient:                     historyClient,
-		visibilityManager:                 visibilityManager,
-		matchingClient:                    matchingClient,
-		workerControllerInstanceClient:    workerControllerInstanceClient,
-		maxIDLengthLimit:                  dynamicconfig.MaxIDLengthLimit.Get(dc),
-		visibilityMaxPageSize:             dynamicconfig.FrontendVisibilityMaxPageSize.Get(dc),
-		maxTaskQueuesInDeploymentVersion:  dynamicconfig.MatchingMaxTaskQueuesInDeploymentVersion.Get(dc),
-		maxDeployments:                    dynamicconfig.MatchingMaxDeployments.Get(dc),
-		testHooks:                         testHooks,
-		metricsHandler:                    metricsHandler,
-		highestRevSignaledToVersionWf:     highestRevSignaledToVersionWf,
-		registerTaskQueueWorkerErrorCache: registerTaskQueueWorkerErrorCache,
+		logger:                                    logger,
+		historyClient:                             historyClient,
+		visibilityManager:                         visibilityManager,
+		matchingClient:                            matchingClient,
+		workerControllerInstanceClient:            workerControllerInstanceClient,
+		maxIDLengthLimit:                          dynamicconfig.MaxIDLengthLimit.Get(dc),
+		visibilityMaxPageSize:                     dynamicconfig.FrontendVisibilityMaxPageSize.Get(dc),
+		maxTaskQueuesInDeploymentVersion:          dynamicconfig.MatchingMaxTaskQueuesInDeploymentVersion.Get(dc),
+		maxDeployments:                            dynamicconfig.MatchingMaxDeployments.Get(dc),
+		testHooks:                                 testHooks,
+		metricsHandler:                            metricsHandler,
+		highestRevSignaledToVersionWf:             highestRevSignaledToVersionWf,
+		registrationErrorCache:                    registrationErrorCache,
+		workerDeploymentRegistrationErrorCacheTTL: workerDeploymentRegistrationErrorCacheTTL,
+		registrationErrorCacheTimeSource:          registrationErrorCacheTimeSource,
 	}
 }
 

--- a/service/worker/workerdeployment/fx.go
+++ b/service/worker/workerdeployment/fx.go
@@ -80,25 +80,35 @@ func ClientProvider(
 	metricsHandler metrics.Handler,
 ) Client {
 	highestRevSignaledToVersionWf := cache.New(dynamicconfig.ReactivationSignalDedupCacheMaxSize.Get(dc)(), nil)
+	registerTaskQueueWorkerErrorCacheTTL := dynamicconfig.WorkerDeploymentRegisterTaskQueueErrorCacheTTL.Get(dc)()
+	registerTaskQueueWorkerErrorCacheSize := registerTaskQueueWorkerErrorCacheMaxSize
+	if registerTaskQueueWorkerErrorCacheTTL <= 0 {
+		registerTaskQueueWorkerErrorCacheSize = 0
+	}
+	registerTaskQueueWorkerErrorCache := cache.New(registerTaskQueueWorkerErrorCacheSize, &cache.Options{
+		TTL: registerTaskQueueWorkerErrorCacheTTL,
+	})
 	lc.Append(fx.Hook{
 		OnStop: func(context.Context) error {
 			highestRevSignaledToVersionWf.Stop()
+			registerTaskQueueWorkerErrorCache.Stop()
 			return nil
 		},
 	})
 	return &ClientImpl{
-		logger:                           logger,
-		historyClient:                    historyClient,
-		visibilityManager:                visibilityManager,
-		matchingClient:                   matchingClient,
-		workerControllerInstanceClient:   workerControllerInstanceClient,
-		maxIDLengthLimit:                 dynamicconfig.MaxIDLengthLimit.Get(dc),
-		visibilityMaxPageSize:            dynamicconfig.FrontendVisibilityMaxPageSize.Get(dc),
-		maxTaskQueuesInDeploymentVersion: dynamicconfig.MatchingMaxTaskQueuesInDeploymentVersion.Get(dc),
-		maxDeployments:                   dynamicconfig.MatchingMaxDeployments.Get(dc),
-		testHooks:                        testHooks,
-		metricsHandler:                   metricsHandler,
-		highestRevSignaledToVersionWf:    highestRevSignaledToVersionWf,
+		logger:                            logger,
+		historyClient:                     historyClient,
+		visibilityManager:                 visibilityManager,
+		matchingClient:                    matchingClient,
+		workerControllerInstanceClient:    workerControllerInstanceClient,
+		maxIDLengthLimit:                  dynamicconfig.MaxIDLengthLimit.Get(dc),
+		visibilityMaxPageSize:             dynamicconfig.FrontendVisibilityMaxPageSize.Get(dc),
+		maxTaskQueuesInDeploymentVersion:  dynamicconfig.MatchingMaxTaskQueuesInDeploymentVersion.Get(dc),
+		maxDeployments:                    dynamicconfig.MatchingMaxDeployments.Get(dc),
+		testHooks:                         testHooks,
+		metricsHandler:                    metricsHandler,
+		highestRevSignaledToVersionWf:     highestRevSignaledToVersionWf,
+		registerTaskQueueWorkerErrorCache: registerTaskQueueWorkerErrorCache,
 	}
 }
 

--- a/service/worker/workerdeployment/util.go
+++ b/service/worker/workerdeployment/util.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dgryski/go-farm"
 	commonpb "go.temporal.io/api/common/v1"
 	computepb "go.temporal.io/api/compute/v1"
 	deploymentpb "go.temporal.io/api/deployment/v1"
@@ -120,6 +121,14 @@ var (
 		enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING.String(),
 	)
 )
+
+func workerDeploymentVersionFingerprint(deploymentName, buildID string) uint64 {
+	version := worker_versioning.WorkerDeploymentVersionToStringV32(&deploymentspb.WorkerDeploymentVersion{
+		DeploymentName: deploymentName,
+		BuildId:        buildID,
+	})
+	return farm.Fingerprint64([]byte(version))
+}
 
 var (
 	defaultActivityOptions = workflow.ActivityOptions{

--- a/service/worker/workerdeployment/util.go
+++ b/service/worker/workerdeployment/util.go
@@ -122,12 +122,12 @@ var (
 	)
 )
 
-func workerDeploymentVersionFingerprint(deploymentName, buildID string) uint64 {
+func workerDeploymentVersionFingerprint(deploymentName, buildID string) int64 {
 	version := worker_versioning.WorkerDeploymentVersionToStringV32(&deploymentspb.WorkerDeploymentVersion{
 		DeploymentName: deploymentName,
 		BuildId:        buildID,
 	})
-	return farm.Fingerprint64([]byte(version))
+	return int64(farm.Fingerprint64([]byte(version)))
 }
 
 var (

--- a/service/worker/workerdeployment/workflow.go
+++ b/service/worker/workerdeployment/workflow.go
@@ -592,9 +592,8 @@ func (d *WorkflowRunner) handleCreateWorkerDeploymentVersion(ctx workflow.Contex
 	if len(d.State.Versions) >= maxVersions {
 		err := d.tryDeleteVersion(ctx)
 		if err != nil {
-			return nil, temporal.NewApplicationError(
+			return nil, d.newTooManyVersionsError(
 				fmt.Sprintf("cannot add version %s since maximum number of versions (%d) have been registered in the deployment", args.GetVersion(), maxVersions),
-				errTooManyVersions,
 			)
 		}
 	}
@@ -680,7 +679,7 @@ func (d *WorkflowRunner) addVersionToWorkerDeployment(ctx workflow.Context, args
 	if len(d.State.Versions) >= maxVersions {
 		err := d.tryDeleteVersion(ctx)
 		if err != nil {
-			return temporal.NewApplicationError(fmt.Sprintf("cannot add version %s since maximum number of versions (%d) have been registered in the deployment", args.Version, maxVersions), errTooManyVersions)
+			return d.newTooManyVersionsError(fmt.Sprintf("cannot add version %s since maximum number of versions (%d) have been registered in the deployment", args.Version, maxVersions))
 		}
 	}
 
@@ -691,6 +690,26 @@ func (d *WorkflowRunner) addVersionToWorkerDeployment(ctx workflow.Context, args
 	}
 	d.metrics.Counter(metrics.WorkerDeploymentVersionCreated.Name()).Inc(1)
 	return nil
+}
+
+func (d *WorkflowRunner) newTooManyVersionsError(message string) error {
+	versions := workflow.DeterministicKeys(d.State.Versions)
+	fingerprints := make([]uint64, 0, len(versions))
+	for _, version := range versions {
+		versionObj, err := worker_versioning.WorkerDeploymentVersionFromStringV31(version)
+		if err != nil {
+			d.logger.Error("failed to parse version while creating too-many-versions failure details", "version", version, "error", err)
+			continue
+		}
+		if versionObj == nil {
+			d.logger.Error("unexpected unversioned entry while creating too-many-versions failure details", "version", version)
+			continue
+		}
+		fingerprints = append(fingerprints, workerDeploymentVersionFingerprint(versionObj.GetDeploymentName(), versionObj.GetBuildId()))
+	}
+	return temporal.NewApplicationError(message, errTooManyVersions, &deploymentspb.TooManyVersionsFailureDetails{
+		VersionFingerprints: fingerprints,
+	})
 }
 
 func (d *WorkflowRunner) handleRegisterWorker(ctx workflow.Context, args *deploymentspb.RegisterWorkerInWorkerDeploymentArgs) error {

--- a/service/worker/workerdeployment/workflow.go
+++ b/service/worker/workerdeployment/workflow.go
@@ -694,7 +694,7 @@ func (d *WorkflowRunner) addVersionToWorkerDeployment(ctx workflow.Context, args
 
 func (d *WorkflowRunner) newTooManyVersionsError(message string) error {
 	versions := workflow.DeterministicKeys(d.State.Versions)
-	fingerprints := make([]uint64, 0, len(versions))
+	fingerprints := make([]int64, 0, len(versions))
 	for _, version := range versions {
 		versionObj, err := worker_versioning.WorkerDeploymentVersionFromStringV31(version)
 		if err != nil {

--- a/service/worker/workerdeployment/workflow_test.go
+++ b/service/worker/workerdeployment/workflow_test.go
@@ -57,7 +57,7 @@ func TestTooManyVersionsFailureDetails(t *testing.T) {
 	require.True(t, appErr.HasDetails())
 	var details *deploymentspb.TooManyVersionsFailureDetails
 	require.NoError(t, appErr.Details(&details))
-	require.ElementsMatch(t, []uint64{
+	require.ElementsMatch(t, []int64{
 		workerDeploymentVersionFingerprint("deployment-a", "build-a"),
 		workerDeploymentVersionFingerprint("deployment-a", "build-b"),
 	}, details.GetVersionFingerprints())

--- a/service/worker/workerdeployment/workflow_test.go
+++ b/service/worker/workerdeployment/workflow_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	computepb "go.temporal.io/api/compute/v1"
 	deploymentpb "go.temporal.io/api/deployment/v1"
@@ -35,6 +36,31 @@ type WorkerDeploymentSuite struct {
 func TestWorkerDeploymentSuite(t *testing.T) {
 	t.Parallel()
 	suite.Run(t, &WorkerDeploymentSuite{workflowVersion: VersionDataRevisionNumber})
+}
+
+func TestTooManyVersionsFailureDetails(t *testing.T) {
+	t.Parallel()
+
+	versions := map[string]*deploymentspb.WorkerDeploymentVersionSummary{
+		"deployment-a.build-a": {},
+		"deployment-a.build-b": {},
+	}
+	runner := &WorkflowRunner{
+		WorkerDeploymentWorkflowArgs: &deploymentspb.WorkerDeploymentWorkflowArgs{
+			State: &deploymentspb.WorkerDeploymentLocalState{Versions: versions},
+		},
+	}
+
+	err := runner.newTooManyVersionsError("too many versions")
+	var appErr *temporal.ApplicationError
+	require.ErrorAs(t, err, &appErr)
+	require.True(t, appErr.HasDetails())
+	var details *deploymentspb.TooManyVersionsFailureDetails
+	require.NoError(t, appErr.Details(&details))
+	require.ElementsMatch(t, []uint64{
+		workerDeploymentVersionFingerprint("deployment-a", "build-a"),
+		workerDeploymentVersionFingerprint("deployment-a", "build-b"),
+	}, details.GetVersionFingerprints())
 }
 
 func (s *WorkerDeploymentSuite) SetupTest() {

--- a/tests/worker_deployment_version_test.go
+++ b/tests/worker_deployment_version_test.go
@@ -1151,8 +1151,11 @@ func (s *DeploymentVersionSuite) waitForNoPollers(env *testcore.TestEnv, tv *tes
 
 func (s *DeploymentVersionSuite) TestVersionScavenger_DeleteOnAdd() {
 	env := s.newTestEnv(
+		// TODO: remove WithWorkerService once legacy suite-scoped cluster behavior is removed.
+		testcore.WithWorkerService("worker-deployment version scavenger test"),
 		testcore.WithDynamicConfig(dynamicconfig.PollerHistoryTTL, 3*time.Second),
 		testcore.WithDynamicConfig(dynamicconfig.MatchingMaxVersionsInDeployment, testMaxVersionsInDeployment),
+		testcore.WithDynamicConfig(dynamicconfig.WorkerDeploymentRegistrationErrorCacheTTL, 0),
 		// we don't want the version to drain in this test
 		testcore.WithDynamicConfig(dynamicconfig.VersionDrainageStatusVisibilityGracePeriod, 60*time.Second),
 		testcore.WithDynamicConfig(dynamicconfig.TaskQueueInfoByBuildIdTTL, 0),


### PR DESCRIPTION
## What changed?
Cache worker-deployment registration limit errors in the Worker Deployment client using a bounded, per-service-instance TTL cache.

### Caching mechanism
- Successful responses and non-limit errors are not cached.
- Too-many-deployments errors are keyed by namespace. The cache is checked only after confirming that the deployment does not already exist, so an existing deployment is never rejected by a stale namespace limit error.
- Too-many-versions errors are keyed by namespace and deployment. The failure includes fingerprints for the deployment's existing versions; requests for one of those versions bypass the cached error, while requests that would add a version are rejected from cache.
- Too-many-task-queues errors are keyed by namespace, deployment, and version.
- Deployment-limit checks are shared by CreateWorkerDeployment and update-with-start registration paths. Too-many-versions errors also populate the cache from RegisterTaskQueueWorker, CreateWorkerDeploymentVersion, and the allow-no-pollers Set Current/Ramping paths.
- Cache hits return the original limit plus a message that the result may be stale and the maximum remaining retry delay.
- TTL is controlled by `matching.workerDeploymentRegistrationErrorCacheTTL` (default 30s), and capacity by `matching.workerDeploymentRegistrationErrorCacheMaxSize` (default 10,000). Setting either to zero disables caching.
- `worker_deployment_registration_errors` records the namespace, operation, error type, and cache hit/miss.

## Why?
To avoid repeatedly hitting History and per-namespace workers during sustained limit conditions, such as too many unique task queues, versions, or deployments.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
With a high cache TTL, new deployment or version creation can continue receiving a cached limit error briefly after the underlying condition is fixed. Error messages identify cached results and include the maximum remaining retry delay; registrations for existing deployments and versions bypass the relevant stale limit entries.
