### PR TITLE
Deterministic tie-break for pending triggers with equal ActualTime

### DIFF
--- a/chasm/lib/scheduler/migration/migration.go
+++ b/chasm/lib/scheduler/migration/migration.go
@@ -250,7 +250,9 @@ func appendSortedTriggerStarts(
 	if len(triggerStarts) == 0 {
 		return bufferedStarts
 	}
-	slices.SortFunc(triggerStarts, func(a, b *schedulespb.BufferedStart) int {
+	// Stable: preserves convertBackfillersCHASMToLegacy's deterministic (by-ID) order as the
+	// tie-break when multiple triggers share the same ActualTime.
+	slices.SortStableFunc(triggerStarts, func(a, b *schedulespb.BufferedStart) int {
 		return a.GetActualTime().AsTime().Compare(b.GetActualTime().AsTime())
 	})
 	return append(bufferedStarts, triggerStarts...)
@@ -548,7 +550,11 @@ func convertBackfillersCHASMToLegacy(
 	var ongoing []*schedulepb.BackfillRequest
 	var triggerStarts []*schedulespb.BufferedStart
 
-	for _, backfiller := range backfillers {
+	// Sorted, not raw map order: gives triggerStarts a deterministic starting order, since the
+	// backfiller ID is discarded once BufferedStart is built and can't break ties later.
+	ids := slices.Sorted(maps.Keys(backfillers))
+	for _, id := range ids {
+		backfiller := backfillers[id]
 		if request := backfiller.GetBackfillRequest(); request != nil {
 			backfill := common.CloneProto(request)
 			if backfiller.GetAttempt() > 0 && backfiller.GetLastProcessedTime() != nil {

--- a/chasm/lib/scheduler/migration/migration_test.go
+++ b/chasm/lib/scheduler/migration/migration_test.go
@@ -424,6 +424,61 @@ func TestCHASMToLegacyStartScheduleArgs_MultipleTriggersDeterministicOrder(t *te
 	}
 }
 
+// TestCHASMToLegacyStartScheduleArgs_MultipleTriggersEqualTimeDeterministicOrder verifies that
+// when multiple pending triggers share the same ActualTime -- e.g. all fall back to
+// migrationTime because LastProcessedTime is nil -- the resulting order is still deterministic
+// across runs, rather than depending on map iteration order. ActualTime comparisons alone can't
+// break this tie (they're equal); the fix sorts by backfiller ID before it's discarded during
+// conversion, and appendSortedTriggerStarts's stable sort preserves that as the tie-break.
+func TestCHASMToLegacyStartScheduleArgs_MultipleTriggersEqualTimeDeterministicOrder(t *testing.T) {
+	scheduler := &schedulerpb.SchedulerState{
+		Namespace:     "ns",
+		NamespaceId:   "ns-id",
+		ScheduleId:    "sched-id",
+		ConflictToken: 1,
+		Schedule:      newTestSchedule(),
+		Info:          &schedulepb.ScheduleInfo{},
+	}
+	migrationTime := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	// Converted trigger BufferedStarts carry no field identifying which backfiller they came
+	// from (that's exactly the gap this test guards), so distinguish the two via OverlapPolicy
+	// instead -- it's the only field that varies between them here.
+	backfillers := map[string]*schedulerpb.BackfillerState{
+		"trigger-b": {
+			BackfillId: "trigger-b",
+			// nil LastProcessedTime: both triggers fall back to the same migrationTime.
+			Request: &schedulerpb.BackfillerState_TriggerRequest{
+				TriggerRequest: &schedulepb.TriggerImmediatelyRequest{
+					OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
+				},
+			},
+		},
+		"trigger-a": {
+			BackfillId: "trigger-a",
+			Request: &schedulerpb.BackfillerState_TriggerRequest{
+				TriggerRequest: &schedulepb.TriggerImmediatelyRequest{
+					OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE,
+				},
+			},
+		},
+	}
+
+	var first []enumspb.ScheduleOverlapPolicy
+	for i := range 20 {
+		args := CHASMToLegacyStartScheduleArgs(scheduler, nil, nil, backfillers, nil, nil, nil, migrationTime)
+		require.Len(t, args.State.BufferedStarts, 2)
+		policies := []enumspb.ScheduleOverlapPolicy{
+			args.State.BufferedStarts[0].GetOverlapPolicy(),
+			args.State.BufferedStarts[1].GetOverlapPolicy(),
+		}
+		if i == 0 {
+			first = policies
+			continue
+		}
+		require.Equal(t, first, policies, "order of equal-ActualTime triggers must be deterministic across runs")
+	}
+}
+
 // TestCHASMToLegacyStartScheduleArgs_PreservesInvokerBufferedOrder verifies that two
 // already-enqueued invoker BufferedStarts keep their original relative order even when the
 // later-enqueued one has an OLDER ActualTime -- exactly what a backfill (processing a


### PR DESCRIPTION
## What changed?
- `convertBackfillersCHASMToLegacy` now iterates `backfillers` in sorted-by-ID order instead of raw map order, giving `triggerStarts` a deterministic starting order.
- `appendSortedTriggerStarts` switches from `slices.SortFunc` to `slices.SortStableFunc`, so that deterministic order survives as the tie-break when multiple triggers share the same `ActualTime` (e.g. legacy states with nil `LastProcessedTime` all fall back to `migrationTime`).

## Why?
Follow-up to #11827. A reviewer noted that when multiple pending trigger Backfillers have equal `ActualTime`, the `ActualTime` comparator returns 0 for every pair, so the randomized map iteration order still determines the resulting queue order. Since V1 `ProcessBuffer` is order-sensitive for mixed overlap policies, rollback could retain, drop, or execute different manual triggers across otherwise-identical runs.

## How did you test it?
- [x] Replaced the coverage gap with `TestCHASMToLegacyStartScheduleArgs_MultipleTriggersEqualTimeDeterministicOrder`, verified to fail against the prior plain-sort/raw-map-iteration code and pass with the fix.
- [x] `go test ./chasm/lib/scheduler/migration/...` and `go test ./chasm/...`
- [x] `make lint-code` -- golangci-lint reports 0 new issues

## Potential risks
Low. Purely a determinism fix for an edge case (equal-timestamp triggers) in the CHASM-to-V1 rollback conversion path; doesn't change behavior when triggers have distinct `ActualTime`s.
