### PR TITLE
Fix PostgreSQL visibility filters on values containing a question mark

### DIFF
--- a/common/persistence/sql/sqlplugin/postgresql/db.go
+++ b/common/persistence/sql/sqlplugin/postgresql/db.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/jmoiron/sqlx"
 	"go.temporal.io/server/common/config"
@@ -173,5 +175,36 @@ func (pdb *db) QueryContext(ctx context.Context, query string, args ...any) (*sq
 }
 
 func (pdb *db) Rebind(query string) string {
-	return pdb.conn().Rebind(query)
+	return rebind(query)
+}
+
+// rebind replaces the `?` bind variable placeholders of a query with the
+// positional `$N` placeholders that PostgreSQL expects.
+//
+// It exists instead of sqlx.Rebind because sqlx rewrites every question mark it
+// finds, including those inside string literals. Visibility filters embed
+// user-supplied values directly in the query text, so a value such as
+// 'foo?-value' would have its question mark turned into a placeholder, leaving a
+// positional parameter that is never bound.
+func rebind(query string) string {
+	var sb strings.Builder
+	sb.Grow(len(query))
+	inLiteral := false
+	argNum := 0
+	for i := 0; i < len(query); i++ {
+		switch c := query[i]; {
+		case c == '\'':
+			// A doubled quote, the escape for a quote inside a literal, leaves
+			// and immediately re-enters the literal, which is equivalent.
+			inLiteral = !inLiteral
+			sb.WriteByte(c)
+		case c == '?' && !inLiteral:
+			argNum++
+			sb.WriteByte('$')
+			sb.WriteString(strconv.Itoa(argNum))
+		default:
+			sb.WriteByte(c)
+		}
+	}
+	return sb.String()
 }

--- a/common/persistence/sql/sqlplugin/postgresql/db_test.go
+++ b/common/persistence/sql/sqlplugin/postgresql/db_test.go
@@ -1,0 +1,70 @@
+package postgresql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRebind(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name  string
+		query string
+		out   string
+	}{
+		{
+			name:  "no placeholder",
+			query: "SELECT * FROM executions_visibility",
+			out:   "SELECT * FROM executions_visibility",
+		},
+		{
+			name:  "single placeholder",
+			query: "SELECT * FROM executions_visibility WHERE namespace_id = ?",
+			out:   "SELECT * FROM executions_visibility WHERE namespace_id = $1",
+		},
+		{
+			name:  "multiple placeholders",
+			query: "SELECT * FROM executions_visibility WHERE namespace_id = ? AND run_id = ? LIMIT ?",
+			out:   "SELECT * FROM executions_visibility WHERE namespace_id = $1 AND run_id = $2 LIMIT $3",
+		},
+		{
+			name:  "question mark inside string literal is not a placeholder",
+			query: "SELECT * FROM executions_visibility WHERE workflow_id = 'foo?-value' LIMIT ?",
+			out:   "SELECT * FROM executions_visibility WHERE workflow_id = 'foo?-value' LIMIT $1",
+		},
+		{
+			name:  "placeholders around a string literal are numbered consecutively",
+			query: "SELECT * FROM executions_visibility WHERE namespace_id = ? AND workflow_id = '?' LIMIT ?",
+			out:   "SELECT * FROM executions_visibility WHERE namespace_id = $1 AND workflow_id = '?' LIMIT $2",
+		},
+		{
+			name:  "multiple question marks inside one string literal",
+			query: "SELECT * FROM executions_visibility WHERE workflow_id = '??a?' LIMIT ?",
+			out:   "SELECT * FROM executions_visibility WHERE workflow_id = '??a?' LIMIT $1",
+		},
+		{
+			name:  "escaped quote inside string literal",
+			query: "SELECT * FROM executions_visibility WHERE workflow_id = 'it''s a ? value' LIMIT ?",
+			out:   "SELECT * FROM executions_visibility WHERE workflow_id = 'it''s a ? value' LIMIT $1",
+		},
+		{
+			name:  "question mark between two adjacent string literals is a placeholder",
+			query: "SELECT * FROM executions_visibility WHERE workflow_id = 'a' AND run_id = ? AND task_queue = 'b'",
+			out:   "SELECT * FROM executions_visibility WHERE workflow_id = 'a' AND run_id = $1 AND task_queue = 'b'",
+		},
+		{
+			name:  "question mark inside a json containment literal",
+			query: "SELECT * FROM executions_visibility WHERE KeywordList01 @> jsonb_build_array('foo?') LIMIT ?",
+			out:   "SELECT * FROM executions_visibility WHERE KeywordList01 @> jsonb_build_array('foo?') LIMIT $1",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.out, rebind(tc.query))
+		})
+	}
+}

--- a/common/persistence/sql/sqlplugin/postgresql/visibility.go
+++ b/common/persistence/sql/sqlplugin/postgresql/visibility.go
@@ -96,7 +96,7 @@ func (pdb *db) SelectFromVisibility(
 	if err != nil {
 		return nil, err
 	}
-	filter.Query = db.Rebind(filter.Query)
+	filter.Query = pdb.Rebind(filter.Query)
 	var rows []sqlplugin.VisibilityRow
 	err = db.SelectContext(ctx, &rows, filter.Query, filter.QueryArgs...)
 	if err != nil {

--- a/common/persistence/tests/visibility_persistence_suite.go
+++ b/common/persistence/tests/visibility_persistence_suite.go
@@ -830,6 +830,69 @@ func (s *VisibilityPersistenceSuite) TestFilteringByWorkflowID() {
 	)
 }
 
+// TestFilteringByValueWithQuestionMark verifies that a filter value containing a
+// question mark is treated as data rather than as a bind variable placeholder.
+// See https://github.com/temporalio/temporal/issues/11797.
+func (s *VisibilityPersistenceSuite) TestFilteringByValueWithQuestionMark() {
+	testNamespaceUUID := namespace.ID(uuid.NewString())
+	startTime := time.Now()
+
+	const workflowIDWithQuestionMark = "visibility-filtering-foo?-value"
+	openRecord := s.createOpenWorkflowRecord(
+		testNamespaceUUID,
+		workflowIDWithQuestionMark,
+		"visibility-workflow",
+		startTime,
+		startTime,
+		"test-queue",
+	)
+	s.createOpenWorkflowRecord(
+		testNamespaceUUID,
+		"visibility-filtering-foo-value",
+		"visibility-workflow",
+		startTime,
+		startTime,
+		"test-queue",
+	)
+
+	query := fmt.Sprintf("%s = '%s'", sadefs.WorkflowID, workflowIDWithQuestionMark)
+
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    2,
+			Query:       query,
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertOpenExecutionEquals(t, openRecord, resp.Executions[0])
+		},
+	)
+
+	s.assertCountWorkflowExecutions(
+		&manager.CountWorkflowExecutionsRequest{
+			NamespaceID: testNamespaceUUID,
+			Query:       query,
+		},
+		func(t require.TestingT, resp *manager.CountWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Equal(t, int64(1), resp.Count)
+		},
+	)
+
+	s.assertCountWorkflowExecutions(
+		&manager.CountWorkflowExecutionsRequest{
+			NamespaceID: testNamespaceUUID,
+			Query:       query + " GROUP BY ExecutionStatus",
+		},
+		func(t require.TestingT, resp *manager.CountWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Equal(t, int64(1), resp.Count)
+		},
+	)
+}
+
 // TestFilteringByStatus test
 func (s *VisibilityPersistenceSuite) TestFilteringByStatus() {
 	testNamespaceUUID := namespace.ID(uuid.NewString())


### PR DESCRIPTION
## What changed?

Listing workflows with a filter value containing a question mark, such as
`WorkflowId = 'foo?-value'`, fails on PostgreSQL. The client sees a context
cancellation and the server logs:

```
pq: could not determine data type of parameter $1 (42P18)
```

The visibility converter embeds filter values in the query text as string
literals rather than passing them as arguments, and that text was handed to
`sqlx.Rebind`, which rewrites every question mark into a positional `$N` with
no awareness of literals. The value's own question mark became a parameter
nothing binds, and shifted the numbering of the real one after it.

This adds a rewrite that tracks single-quoted literals and renumbers only the
question marks outside them. `SelectFromVisibility` used the shared helper
rather than the plugin's own `Rebind`, so it now goes through the plugin,
covering the list, count, and count-group-by paths.

Fixes https://github.com/temporalio/temporal/issues/11797

## Why?

Question marks are ordinary characters in workflow IDs and keyword values, and
nothing in the list filter or the visibility docs suggests otherwise, so this
reads as a broken query rather than unsupported input. Today any search
attribute value containing one is unusable on PostgreSQL.

Before: `WorkflowId = 'foo?-value'` returns an error.
After: it returns the matching executions.

## How did you test it?

- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)

Against PostgreSQL 16.15 in Docker. `TestFilteringByValueWithQuestionMark`
covers list, count, and count-group-by against a second record that must not
match. Applied to `main` alone, it reproduces the reported error:

```
$ go test ./common/persistence/tests/ \
    -run 'TestPQ/TestPostgreSQLVisibilityPersistenceSuite/TestFilteringByValueWithQuestionMark'
error  Operation failed with an error.  {"error": "ListWorkflowExecutions
operation failed.: pq: could not determine data type of parameter $1 (42P18)"}
--- FAIL: TestPQ (4.72s)
FAIL    go.temporal.io/server/common/persistence/tests   5.581s
```

On this branch, the same command:

```
--- PASS: TestPQ/TestPostgreSQLVisibilityPersistenceSuite/TestFilteringByValueWithQuestionMark (0.02s)
ok      go.temporal.io/server/common/persistence/tests   9.689s
```

Unit tests cover the rewrite directly, including renumbering across a literal,
repeats within one, the doubled-quote escape, adjacent literals, and a
`jsonb_build_array` value:

```
$ go test ./common/persistence/sql/sqlplugin/postgresql/ -run TestRebind
ok      go.temporal.io/server/common/persistence/sql/sqlplugin/postgresql  0.466s
```

## Potential risks

The plugin now owns placeholder numbering instead of delegating to `sqlx`. It
handles the doubled-quote escape, but not dollar-quoted or E-prefixed strings,
which the visibility converter does not emit. Queries with no question mark
inside a literal are rewritten exactly as before.
