### PR TITLE
Make worker commands timeout and max attempts configurable

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -210,6 +210,16 @@ in the consistent hash ring used by ringpop. Changing it may cause service disru
 		false,
 		`EnableCancelActivityWorkerCommand enables pushing activity cancellation to workers via Nexus worker commands`,
 	)
+	WorkerCommandsDispatchTimeout = NewGlobalDurationSetting(
+		"system.workerCommandsDispatchTimeout",
+		10*time.Second*debug.TimeoutMultiplier,
+		`WorkerCommandsDispatchTimeout is the timeout for dispatching worker commands to a worker via Nexus.`,
+	)
+	WorkerCommandsMaxAttempts = NewGlobalIntSetting(
+		"system.workerCommandsMaxAttempts",
+		3,
+		`WorkerCommandsMaxAttempts is the maximum number of dispatch attempts for a worker commands task before dropping it.`,
+	)
 	NamespaceMinRetentionGlobal = NewGlobalDurationSetting(
 		"system.namespaceMinRetentionGlobal",
 		24*time.Hour,

--- a/common/workercommands/dispatcher.go
+++ b/common/workercommands/dispatcher.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/nexus-rpc/sdk-go/nexus"
 	commonpb "go.temporal.io/api/common/v1"
@@ -14,7 +13,6 @@ import (
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	workerpb "go.temporal.io/api/worker/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
-	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
@@ -26,9 +24,6 @@ import (
 )
 
 const (
-	DispatchTimeout = time.Second * 10 * debug.TimeoutMultiplier
-	MaxTaskAttempts = 3
-
 	// Nexus service and operation names for worker commands.
 	// TODO: Replace with workerservicepb.WorkerService.ServiceName and
 	// workerservicepb.WorkerService.ExecuteCommands.Name() once the Nexus service
@@ -51,7 +46,7 @@ const (
 //     *temporal.CanceledError. Permanent — the worker contract requires success for all
 //     defined commands, so this indicates a bug or version incompatibility.
 //
-// Callers are responsible for enforcing retry limits (see MaxTaskAttempts).
+// Callers are responsible for enforcing retry limits (see WorkerCommandsMaxAttempts dynamic config).
 // These commands are best-effort — the activity will eventually time out anyway —
 // so excessive retries waste resources.
 type Dispatcher struct {
@@ -95,7 +90,7 @@ func (d *Dispatcher) Execute(
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, DispatchTimeout)
+	ctx, cancel := context.WithTimeout(ctx, d.config.WorkerCommandsDispatchTimeout())
 	defer cancel()
 
 	return d.dispatchToWorker(ctx, task, namespaceName)

--- a/common/workercommands/dispatcher_test.go
+++ b/common/workercommands/dispatcher_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/nexus-rpc/sdk-go/nexus"
 	"github.com/stretchr/testify/require"
@@ -46,7 +47,8 @@ func requireMetricValue(t *testing.T, snap map[string][]*metricstest.CapturedRec
 func TestExecute_FeatureFlagOff_DropsTask(t *testing.T) {
 	d := &Dispatcher{
 		config: &configs.Config{
-			EnableCancelActivityWorkerCommand: func(string) bool { return false },
+			EnableCancelActivityWorkerCommand:  func(string) bool { return false },
+			WorkerCommandsDispatchTimeout:     func() time.Duration { return 10 * time.Second },
 		},
 		logger: log.NewNoopLogger(),
 	}
@@ -59,7 +61,8 @@ func TestExecute_FeatureFlagOff_DropsTask(t *testing.T) {
 func TestExecute_EmptyCommands_DropsTask(t *testing.T) {
 	d := &Dispatcher{
 		config: &configs.Config{
-			EnableCancelActivityWorkerCommand: func(string) bool { return true },
+			EnableCancelActivityWorkerCommand:  func(string) bool { return true },
+			WorkerCommandsDispatchTimeout:     func() time.Duration { return 10 * time.Second },
 		},
 		logger: log.NewNoopLogger(),
 	}
@@ -80,7 +83,8 @@ func TestExecute_DispatchSuccess(t *testing.T) {
 	d := &Dispatcher{
 		matchingClient: mockClient,
 		config: &configs.Config{
-			EnableCancelActivityWorkerCommand: func(string) bool { return true },
+			EnableCancelActivityWorkerCommand:  func(string) bool { return true },
+			WorkerCommandsDispatchTimeout:     func() time.Duration { return 10 * time.Second },
 		},
 		metricsHandler: metricsHandler,
 		logger:         log.NewNoopLogger(),
@@ -127,7 +131,8 @@ func TestExecute_DispatchRPCError(t *testing.T) {
 	d := &Dispatcher{
 		matchingClient: mockClient,
 		config: &configs.Config{
-			EnableCancelActivityWorkerCommand: func(string) bool { return true },
+			EnableCancelActivityWorkerCommand:  func(string) bool { return true },
+			WorkerCommandsDispatchTimeout:     func() time.Duration { return 10 * time.Second },
 		},
 		metricsHandler: metricsHandler,
 		logger:         log.NewNoopLogger(),
@@ -154,7 +159,8 @@ func TestExecute_UpstreamTimeout(t *testing.T) {
 	d := &Dispatcher{
 		matchingClient: mockClient,
 		config: &configs.Config{
-			EnableCancelActivityWorkerCommand: func(string) bool { return true },
+			EnableCancelActivityWorkerCommand:  func(string) bool { return true },
+			WorkerCommandsDispatchTimeout:     func() time.Duration { return 10 * time.Second },
 		},
 		metricsHandler: metricsHandler,
 		logger:         log.NewNoopLogger(),

--- a/common/workercommands/dispatcher_test.go
+++ b/common/workercommands/dispatcher_test.go
@@ -47,7 +47,7 @@ func requireMetricValue(t *testing.T, snap map[string][]*metricstest.CapturedRec
 func TestExecute_FeatureFlagOff_DropsTask(t *testing.T) {
 	d := &Dispatcher{
 		config: &configs.Config{
-			EnableCancelActivityWorkerCommand:  func(string) bool { return false },
+			EnableCancelActivityWorkerCommand: func(string) bool { return false },
 			WorkerCommandsDispatchTimeout:     func() time.Duration { return 10 * time.Second },
 		},
 		logger: log.NewNoopLogger(),
@@ -61,7 +61,7 @@ func TestExecute_FeatureFlagOff_DropsTask(t *testing.T) {
 func TestExecute_EmptyCommands_DropsTask(t *testing.T) {
 	d := &Dispatcher{
 		config: &configs.Config{
-			EnableCancelActivityWorkerCommand:  func(string) bool { return true },
+			EnableCancelActivityWorkerCommand: func(string) bool { return true },
 			WorkerCommandsDispatchTimeout:     func() time.Duration { return 10 * time.Second },
 		},
 		logger: log.NewNoopLogger(),
@@ -83,7 +83,7 @@ func TestExecute_DispatchSuccess(t *testing.T) {
 	d := &Dispatcher{
 		matchingClient: mockClient,
 		config: &configs.Config{
-			EnableCancelActivityWorkerCommand:  func(string) bool { return true },
+			EnableCancelActivityWorkerCommand: func(string) bool { return true },
 			WorkerCommandsDispatchTimeout:     func() time.Duration { return 10 * time.Second },
 		},
 		metricsHandler: metricsHandler,
@@ -131,7 +131,7 @@ func TestExecute_DispatchRPCError(t *testing.T) {
 	d := &Dispatcher{
 		matchingClient: mockClient,
 		config: &configs.Config{
-			EnableCancelActivityWorkerCommand:  func(string) bool { return true },
+			EnableCancelActivityWorkerCommand: func(string) bool { return true },
 			WorkerCommandsDispatchTimeout:     func() time.Duration { return 10 * time.Second },
 		},
 		metricsHandler: metricsHandler,
@@ -159,7 +159,7 @@ func TestExecute_UpstreamTimeout(t *testing.T) {
 	d := &Dispatcher{
 		matchingClient: mockClient,
 		config: &configs.Config{
-			EnableCancelActivityWorkerCommand:  func(string) bool { return true },
+			EnableCancelActivityWorkerCommand: func(string) bool { return true },
 			WorkerCommandsDispatchTimeout:     func() time.Duration { return 10 * time.Second },
 		},
 		metricsHandler: metricsHandler,

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -396,7 +396,7 @@ type Config struct {
 	EnableCrossNamespaceCommands      dynamicconfig.BoolPropertyFn
 	EnableActivityEagerExecution      dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	EnableActivityRetryStampIncrement dynamicconfig.BoolPropertyFn
-	EnableCancelActivityWorkerCommand  dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	EnableCancelActivityWorkerCommand dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	WorkerCommandsDispatchTimeout     dynamicconfig.DurationPropertyFn
 	WorkerCommandsMaxAttempts         dynamicconfig.IntPropertyFn
 	EnableEagerWorkflowStart          dynamicconfig.BoolPropertyFnWithNamespaceFilter
@@ -809,7 +809,7 @@ func NewConfig(
 		EnableCrossNamespaceCommands:      dynamicconfig.EnableCrossNamespaceCommands.Get(dc),
 		EnableActivityEagerExecution:      dynamicconfig.EnableActivityEagerExecution.Get(dc),
 		EnableActivityRetryStampIncrement: dynamicconfig.EnableActivityRetryStampIncrement.Get(dc),
-		EnableCancelActivityWorkerCommand:  dynamicconfig.EnableCancelActivityWorkerCommand.Get(dc),
+		EnableCancelActivityWorkerCommand: dynamicconfig.EnableCancelActivityWorkerCommand.Get(dc),
 		WorkerCommandsDispatchTimeout:     dynamicconfig.WorkerCommandsDispatchTimeout.Get(dc),
 		WorkerCommandsMaxAttempts:         dynamicconfig.WorkerCommandsMaxAttempts.Get(dc),
 		EnableEagerWorkflowStart:          dynamicconfig.EnableEagerWorkflowStart.Get(dc),

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -396,7 +396,9 @@ type Config struct {
 	EnableCrossNamespaceCommands      dynamicconfig.BoolPropertyFn
 	EnableActivityEagerExecution      dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	EnableActivityRetryStampIncrement dynamicconfig.BoolPropertyFn
-	EnableCancelActivityWorkerCommand dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	EnableCancelActivityWorkerCommand  dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	WorkerCommandsDispatchTimeout     dynamicconfig.DurationPropertyFn
+	WorkerCommandsMaxAttempts         dynamicconfig.IntPropertyFn
 	EnableEagerWorkflowStart          dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	NamespaceCacheRefreshInterval     dynamicconfig.DurationPropertyFn
 
@@ -807,7 +809,9 @@ func NewConfig(
 		EnableCrossNamespaceCommands:      dynamicconfig.EnableCrossNamespaceCommands.Get(dc),
 		EnableActivityEagerExecution:      dynamicconfig.EnableActivityEagerExecution.Get(dc),
 		EnableActivityRetryStampIncrement: dynamicconfig.EnableActivityRetryStampIncrement.Get(dc),
-		EnableCancelActivityWorkerCommand: dynamicconfig.EnableCancelActivityWorkerCommand.Get(dc),
+		EnableCancelActivityWorkerCommand:  dynamicconfig.EnableCancelActivityWorkerCommand.Get(dc),
+		WorkerCommandsDispatchTimeout:     dynamicconfig.WorkerCommandsDispatchTimeout.Get(dc),
+		WorkerCommandsMaxAttempts:         dynamicconfig.WorkerCommandsMaxAttempts.Get(dc),
 		EnableEagerWorkflowStart:          dynamicconfig.EnableEagerWorkflowStart.Get(dc),
 		NamespaceCacheRefreshInterval:     dynamicconfig.NamespaceCacheRefreshInterval.Get(dc),
 

--- a/service/history/outbound_queue_active_task_executor.go
+++ b/service/history/outbound_queue_active_task_executor.go
@@ -107,7 +107,7 @@ func (e *outboundQueueActiveTaskExecutor) Execute(
 		task.Attempt = executable.Attempt()
 		return respond(e.executeChasmSideEffectTask(ctx, task))
 	case *tasks.WorkerCommandsTask:
-		if executable.Attempt() > workercommands.MaxTaskAttempts {
+		if executable.Attempt() > e.shardContext.GetConfig().WorkerCommandsMaxAttempts() {
 			e.logger.Info("Worker commands task exceeded max attempts, dropping",
 				tag.WorkflowID(task.WorkflowID),
 				tag.WorkflowRunID(task.RunID),

--- a/service/history/outbound_queue_active_task_executor_test.go
+++ b/service/history/outbound_queue_active_task_executor_test.go
@@ -12,6 +12,7 @@ import (
 	"go.temporal.io/server/api/matchingservicemock/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
@@ -292,8 +293,9 @@ func (s *outboundQueueActiveTaskExecutorSuite) TestExecute_WorkerCommandsTask_Ex
 		},
 	}
 
+	s.mockShard.GetConfig().WorkerCommandsMaxAttempts = dynamicconfig.GetIntPropertyFn(3)
 	s.mockExecutable.EXPECT().GetTask().Return(task).AnyTimes()
-	s.mockExecutable.EXPECT().Attempt().Return(workercommands.MaxTaskAttempts + 1).AnyTimes()
+	s.mockExecutable.EXPECT().Attempt().Return(4).AnyTimes()
 	s.mockExecutable.EXPECT().GetWorkflowID().Return("").AnyTimes()
 
 	result := s.executor.Execute(ctx, s.mockExecutable)


### PR DESCRIPTION
## What

Convert `DispatchTimeout` and `MaxTaskAttempts` from compile-time constants to dynamic config settings (`WorkerCommandsDispatchTimeout` and `WorkerCommandsMaxAttempts`).

## Why

Makes these values tunable at runtime without redeploying. Default values are unchanged (10s timeout, 3 max attempts).

## How did you test it?

- Updated unit tests