### PR TITLE
Test context caching (2/2): Cache contexts in test drivers

### DIFF
--- a/common/testing/parallelsuite/suite.go
+++ b/common/testing/parallelsuite/suite.go
@@ -122,8 +122,6 @@ func (s *Suite[T]) AssertionT() require.TestingT {
 
 // Context returns the test-scoped context (created from [testcontext]).
 // Inside an [Await] callback, it returns the await-scoped context.
-//
-// The result is deliberately not cached; see [testcontext.EnsureRemaining].
 func (s *Suite[T]) Context() context.Context {
 	if s.ctx != nil {
 		return s.ctx

--- a/tests/activity_driver.go
+++ b/tests/activity_driver.go
@@ -306,8 +306,6 @@ func (a *activityDriverState) driverState() *activityDriverState {
 // drivenActivity is what the shared event driver needs from either implementation.
 type drivenActivity interface {
 	driverState() *activityDriverState
-	// testContext returns the driver's current test context, fetched fresh per
-	// call rather than cached, so a later timeout extension is visible.
 	testContext() context.Context
 	pollForTask(require.TestingT, time.Duration) *workflowservice.PollActivityTaskQueueResponse
 	awaitDispatchDelay(testing.TB, model.Event)

--- a/tests/activity_standalone_driver.go
+++ b/tests/activity_standalone_driver.go
@@ -30,7 +30,7 @@ import (
 
 type saaDriver struct {
 	env              *testcore.TestEnv
-	t                *testing.T
+	ctx              context.Context
 	cfg              activityConfig
 	numStarted       int
 	activityIDPrefix string
@@ -40,16 +40,10 @@ type saaDriver struct {
 func newSAADriver(t *testing.T, env *testcore.TestEnv, cfg activityConfig) *saaDriver {
 	return &saaDriver{
 		env:              env,
-		t:                t,
+		ctx:              testcontext.For(t),
 		cfg:              cfg,
 		activityIDPrefix: t.Name(),
 	}
-}
-
-// testContext returns the driver's current test context, deliberately not cached;
-// see [testcontext.EnsureRemaining].
-func (d *saaDriver) testContext() context.Context {
-	return testcontext.For(d.t)
 }
 
 // saaHandle is a handle to an activity instance.
@@ -77,7 +71,7 @@ func (a *saaHandle) driveEvent(t testing.TB, e model.Event) {
 }
 
 func (a *saaHandle) testContext() context.Context {
-	return a.d.testContext()
+	return a.d.ctx
 }
 
 func (a *saaHandle) awaitTimeout(t testing.TB, e model.Event, deadline time.Time) {
@@ -116,7 +110,7 @@ func (a *saaHandle) awaitDispatchDelay(t testing.TB, e model.Event) {
 func (d *saaDriver) start(t require.TestingT, cfg activityConfig) *saaHandle {
 	d.numStarted++
 	id := fmt.Sprintf("%s-%d", d.activityIDPrefix, d.numStarted)
-	resp, err := d.env.FrontendClient().StartActivityExecution(d.testContext(), d.startRequest(cfg, id, id))
+	resp, err := d.env.FrontendClient().StartActivityExecution(d.ctx, d.startRequest(cfg, id, id))
 	require.NoError(t, err)
 	return &saaHandle{
 		activityDriverState: activityDriverState{cfg: cfg},

--- a/tests/activity_standalone_driver.go
+++ b/tests/activity_standalone_driver.go
@@ -38,6 +38,8 @@ type saaDriver struct {
 
 // newSAADriver builds a driver.
 func newSAADriver(t *testing.T, env *testcore.TestEnv, cfg activityConfig) *saaDriver {
+	// Snapshot only after all decorators are attached: AttachDecorator replaces
+	// the context, while EnsureRemaining preserves its identity.
 	return &saaDriver{
 		env:              env,
 		ctx:              testcontext.For(t),

--- a/tests/activity_workflow_driver.go
+++ b/tests/activity_workflow_driver.go
@@ -42,7 +42,13 @@ type wfaDriver struct {
 // newWFADriver builds a driver. cfg.StartDelay is ignored: a workflow activity has no per-activity
 // start delay.
 func newWFADriver(t *testing.T, env *testcore.TestEnv, cfg activityConfig) *wfaDriver {
-	return &wfaDriver{env: env, ctx: testcontext.For(t), cfg: cfg}
+	// Snapshot only after all decorators are attached: AttachDecorator replaces
+	// the context, while EnsureRemaining preserves its identity.
+	return &wfaDriver{
+		env: env,
+		ctx: testcontext.For(t),
+		cfg: cfg,
+	}
 }
 
 // wfaHandle is a handle to a workflow-scheduled activity.

--- a/tests/activity_workflow_driver.go
+++ b/tests/activity_workflow_driver.go
@@ -35,20 +35,14 @@ import (
 
 type wfaDriver struct {
 	env *testcore.TestEnv
-	t   *testing.T
+	ctx context.Context
 	cfg activityConfig
 }
 
 // newWFADriver builds a driver. cfg.StartDelay is ignored: a workflow activity has no per-activity
 // start delay.
 func newWFADriver(t *testing.T, env *testcore.TestEnv, cfg activityConfig) *wfaDriver {
-	return &wfaDriver{env: env, t: t, cfg: cfg}
-}
-
-// testContext returns the driver's current test context, deliberately not cached;
-// see [testcontext.EnsureRemaining].
-func (d *wfaDriver) testContext() context.Context {
-	return testcontext.For(d.t)
+	return &wfaDriver{env: env, ctx: testcontext.For(t), cfg: cfg}
 }
 
 // wfaHandle is a handle to a workflow-scheduled activity.
@@ -78,7 +72,7 @@ func (a *wfaHandle) driveEvent(t testing.TB, e model.Event) {
 }
 
 func (a *wfaHandle) testContext() context.Context {
-	return a.d.testContext()
+	return a.d.ctx
 }
 
 func (a *wfaHandle) awaitTimeout(t testing.TB, e model.Event, deadline time.Time) {
@@ -129,7 +123,7 @@ func (d *wfaDriver) start(t *testing.T, cfg activityConfig) *wfaHandle {
 	t.Cleanup(w.Stop)
 
 	wfID := testcore.RandomizeStr("wfa-run")
-	run, err := d.env.SdkClient().ExecuteWorkflow(d.testContext(),
+	run, err := d.env.SdkClient().ExecuteWorkflow(d.ctx,
 		sdkclient.StartWorkflowOptions{ID: wfID, TaskQueue: wfTQ},
 		wfaSingleActivityWorkflow, wfaActivityParams{Cfg: cfg, ActivityTQ: actTQ, ActivityID: actID})
 	require.NoError(t, err)
@@ -143,7 +137,7 @@ func (d *wfaDriver) start(t *testing.T, cfg activityConfig) *wfaHandle {
 		taskQueue:           actTQ,
 	}
 	// The workflow schedules the activity, so it does not exist yet when ExecuteWorkflow returns.
-	await.Require(d.testContext(), t, func(t *await.T) {
+	await.Require(d.ctx, t, func(t *await.T) {
 		_, activityInProgress := a.activityInfoIfInProgress(t)
 		t.Require().True(activityInProgress, "the workflow has not scheduled its activity")
 	}, activityDriverTimeout, activityDriverPollInterval)

--- a/tests/testcore/test_env.go
+++ b/tests/testcore/test_env.go
@@ -315,7 +315,8 @@ func NewEnv(t *testing.T, opts ...TestOption) *TestEnv {
 		tv = options.testVars(tv)
 	}
 
-	// Attach version headers decorator to the test context.
+	// Attach version headers decorator to the test context, then re-read it:
+	// AttachDecorator replaces the context that For returns.
 	testcontext.AttachDecorator(t, versionHeadersContextKey{}, headers.SetVersions)
 	ctx = testcontext.For(t)
 

--- a/tests/testcore/test_env.go
+++ b/tests/testcore/test_env.go
@@ -74,6 +74,7 @@ type TestEnv struct {
 	Logger log.Logger
 
 	cluster        *TestCluster
+	ctx            context.Context
 	nsName         namespace.Name
 	nsID           namespace.ID
 	taskPoller     *taskpoller.TaskPoller
@@ -316,15 +317,17 @@ func NewEnv(t *testing.T, opts ...TestOption) *TestEnv {
 
 	// Attach version headers decorator to the test context.
 	testcontext.AttachDecorator(t, versionHeadersContextKey{}, headers.SetVersions)
+	ctx = testcontext.For(t)
 
 	// Restore as much of the test's timeout budget as the context's ceiling
 	// allows, now that setup is done.
-	testcontext.EnsureRemaining(testcontext.For(t), t, testcontext.DefaultTimeout())
+	testcontext.EnsureRemaining(ctx, t, testcontext.DefaultTimeout())
 
 	env := &TestEnv{
 		FunctionalTestBase: base,
 		Assertions:         require.New(t),
 		cluster:            cluster,
+		ctx:                ctx,
 		nsName:             ns,
 		nsID:               nsID,
 		Logger:             base.Logger,
@@ -509,11 +512,9 @@ func (e *TestEnv) InjectResponseFault(fault ResponseFault) func() {
 //	ctx, cancel := context.WithTimeout(env.Context(), 10*time.Second)
 //	defer cancel()
 //
-// The context is deliberately not cached; see [testcontext.EnsureRemaining].
-//
 // Deprecated: use the suite's Context() method instead.
 func (e *TestEnv) Context() context.Context {
-	return testcontext.For(e.t)
+	return e.ctx
 }
 
 // SdkClient returns the SDK client. It is lazily initialized on the first call.

--- a/tests/testcore/test_env_test.go
+++ b/tests/testcore/test_env_test.go
@@ -3,11 +3,15 @@ package testcore
 import (
 	"sync"
 	"testing"
+	"time"
 
+	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/testing/parallelsuite"
+	"go.temporal.io/server/common/testing/testcontext"
 	"go.temporal.io/server/common/testing/testlogger"
+	"google.golang.org/grpc/metadata"
 )
 
 type TestEnvSuite struct {
@@ -83,4 +87,16 @@ func (s *TestEnvSuite) TestStartNamespaceLogCapture() {
 			Tags:    []tag.Tag{tag.WorkflowNamespaceID("primary-id")},
 		},
 	}, capture.Snapshot())
+}
+
+func (s *TestEnvSuite) TestContextCachesVersionHeadersAcrossExtension() {
+	env := NewEnv(s.T())
+	ctx := env.Context()
+	md, ok := metadata.FromOutgoingContext(ctx)
+	s.Require().True(ok)
+	s.Require().Equal([]string{headers.ClientNameServer}, md.Get(headers.ClientNameHeaderName))
+	s.Require().Equal([]string{headers.ServerVersion}, md.Get(headers.ClientVersionHeaderName))
+
+	testcontext.EnsureRemaining(ctx, s.T(), testcontext.DefaultTimeout()+time.Second)
+	s.Require().Same(ctx, env.Context())
 }


### PR DESCRIPTION
## What changed?

Caches stable test contexts in activity drivers, test environments, and parallel suites. Removes the per-call context accessors and refresh plumbing that #11830 makes unnecessary.

## Why?

Consumers can keep one context for their lifetime now that extensions reset its managed timer in place. Keeping adoption separate makes the context implementation and integration-driver cleanup independently reviewable.
