### PR TITLE
VLN-1587: remediate claude-code-action-unhardened

### DIFF
--- a/.github/workflows/claude-review-teams.yml
+++ b/.github/workflows/claude-review-teams.yml
@@ -227,18 +227,22 @@ jobs:
       issues: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          persist-credentials: false
           ref: ${{ needs.check-review-eligibility.outputs.head_sha }}
           path: pr-head
       - name: Claude PR review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
         with:
           github_token: ${{ github.token }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Always on, so label- and auto-triggered reviews produce the same output.
           track_progress: true
           include_fix_links: false
+          show_full_output: false
           prompt: |
             ## Review task
 
@@ -264,4 +268,4 @@ jobs:
             formatted like an inline finding.
             Only post GitHub comments - don't submit review text as messages.
           claude_args: |
-            --add-dir pr-head --allowedTools "Read,Grep,Glob,mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --add-dir pr-head --max-turns 6 --disallowedTools WebFetch,WebSearch --allowedTools "Read,Grep,Glob,mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
> 🏕️ This pull request was created by [camper](https://github.com/temporalio/camper), an automated security campaign tool.

## Finding

<table>
  <tr><td><strong>Rule</strong></td><td><code>claude-code-action-unhardened</code></td></tr>
  <tr><td><strong>Severity</strong></td><td>MEDIUM</td></tr>
  <tr><td><strong>Repository</strong></td><td><code>temporalio/temporal</code></td></tr>
  <tr><td><strong>Ticket</strong></td><td><a href="https://temporalio.atlassian.net/browse/VLN-1587">VLN-1587</a></td></tr>
</table>

## Summary

- `.github/workflows/claude-review-teams.yml`: Pinned `anthropics/claude-code-action` to the vetted v1.0.183 commit, disabled full output, prevented checkout credential persistence, and added explicit Claude turn and web-tool restrictions while preserving the existing review-only tool scope.

## Instructions

- **Approve** to merge this fix
- **Request changes** to trigger a new remediation attempt
- `/camper rebase` — rebase onto the base branch
- `/camper close` — close this PR without merging
- `/camper retry` — regenerate the fix from scratch against the current base