### PR TITLE
Configure CHASM internal callback namespace binding

### DIFF
--- a/chasm/lib/callback/config.go
+++ b/chasm/lib/callback/config.go
@@ -3,6 +3,7 @@ package callback
 import (
 	"time"
 
+	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/backoff"
 	commoncallbacks "go.temporal.io/server/common/callbacks"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -33,13 +34,15 @@ var RetryPolicyMaximumInterval = dynamicconfig.NewGlobalDurationSetting(
 )
 
 type Config struct {
-	RequestTimeout dynamicconfig.DurationPropertyFnWithDestinationFilter
-	RetryPolicy    func() backoff.RetryPolicy
+	RequestTimeout                          dynamicconfig.DurationPropertyFnWithDestinationFilter
+	RetryPolicy                             func() backoff.RetryPolicy
+	InternalCallbackSameNamespaceArchetypes dynamicconfig.TypedPropertyFn[[]string]
 }
 
 func configProvider(dc *dynamicconfig.Collection) *Config {
 	return &Config{
-		RequestTimeout: RequestTimeout.Get(dc),
+		RequestTimeout:                          RequestTimeout.Get(dc),
+		InternalCallbackSameNamespaceArchetypes: InternalCallbackSameNamespaceArchetypes.Get(dc),
 		RetryPolicy: func() backoff.RetryPolicy {
 			return backoff.NewExponentialRetryPolicy(
 				RetryPolicyInitialInterval.Get(dc)(),
@@ -50,6 +53,21 @@ func configProvider(dc *dynamicconfig.Collection) *Config {
 			)
 		},
 	}
+}
+
+var InternalCallbackSameNamespaceArchetypes = dynamicconfig.NewGlobalTypedSetting(
+	"callback.internal.sameNamespaceArchetypes",
+	[]string{chasm.SchedulerArchetype},
+	`The list of fully-qualified CHASM archetype names whose internal callbacks must target the callback source namespace.`,
+)
+
+func (c *Config) internalCallbackRequiresSameNamespace(archetypeID chasm.ArchetypeID) bool {
+	for _, archetype := range c.InternalCallbackSameNamespaceArchetypes() {
+		if chasm.GenerateTypeID(archetype) == archetypeID {
+			return true
+		}
+	}
+	return false
 }
 
 var EncodeInternalTokenWithEnvelope = dynamicconfig.NewNamespaceBoolSetting(

--- a/chasm/lib/callback/invocable_internal.go
+++ b/chasm/lib/callback/invocable_internal.go
@@ -18,7 +18,6 @@ import (
 	"go.temporal.io/server/common/namespace"
 	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/nexus/nexusrpc"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -77,10 +76,12 @@ func (c invocableInternal) Invoke(
 		requestID = c.requestID
 	}
 
-	// Validate that the bytes are a valid ChasmComponentRef
 	ref := &persistencespb.ChasmComponentRef{}
-	if err := proto.Unmarshal(decodedRef, ref); err != nil {
-		return invocationResultFail{logInternalError(h.logger, "failed to unmarshal CHASM ComponentRef", err)}
+	if err := ref.Unmarshal(decodedRef); err != nil || ref.GetNamespaceId() == "" || ref.GetBusinessId() == "" {
+		return invocationResultFail{logInternalError(h.logger, "invalid CHASM ComponentRef", err)}
+	}
+	if h.config.internalCallbackRequiresSameNamespace(ref.GetArchetypeId()) && ref.GetNamespaceId() != ns.ID().String() {
+		return invocationResultFail{logInternalError(h.logger, "internal callback namespace mismatch", nil)}
 	}
 
 	request, err := c.getHistoryRequest(decodedRef, requestID)

--- a/chasm/lib/callback/tasks_test.go
+++ b/chasm/lib/callback/tasks_test.go
@@ -179,6 +179,9 @@ func TestExecuteInvocationTaskNexus_Outcomes(t *testing.T) {
 			handler := &invocationTaskHandler{
 				config: &Config{
 					RequestTimeout: dynamicconfig.GetDurationPropertyFnFilteredByDestination(time.Second),
+					InternalCallbackSameNamespaceArchetypes: func() []string {
+						return []string{chasm.SchedulerArchetype}
+					},
 					RetryPolicy: func() backoff.RetryPolicy {
 						return backoff.NewExponentialRetryPolicy(time.Second)
 					},
@@ -335,16 +338,33 @@ func TestProcessBackoffTask(t *testing.T) {
 }
 
 func TestExecuteInvocationTaskChasm_Outcomes(t *testing.T) {
-	dummyRef := persistencespb.ChasmComponentRef{
-		NamespaceId: "namespace-id",
-		BusinessId:  "business-id",
-		RunId:       "run-id",
-		ArchetypeId: 1234,
+	newRef := func(namespaceID, businessID string, archetypeID chasm.ArchetypeID) *persistencespb.ChasmComponentRef {
+		return &persistencespb.ChasmComponentRef{
+			NamespaceId: namespaceID,
+			BusinessId:  businessID,
+			RunId:       "run-id",
+			ArchetypeId: archetypeID,
+		}
 	}
+	dummyRef := newRef("namespace-id", "business-id", 1234)
 
 	serializedRef, err := dummyRef.Marshal()
 	require.NoError(t, err)
 	encodedRef := base64.RawURLEncoding.EncodeToString(serializedRef)
+	crossNamespaceRef := newRef("other-namespace-id", "business-id", 1234)
+	serializedCrossNamespaceRef, err := crossNamespaceRef.Marshal()
+	require.NoError(t, err)
+	encodedCrossNamespaceRef := base64.RawURLEncoding.EncodeToString(serializedCrossNamespaceRef)
+	crossNamespaceSchedulerRef := newRef("other-namespace-id", "business-id", chasm.SchedulerArchetypeID)
+	serializedCrossNamespaceSchedulerRef, err := crossNamespaceSchedulerRef.Marshal()
+	require.NoError(t, err)
+	encodedCrossNamespaceSchedulerRef := base64.RawURLEncoding.EncodeToString(serializedCrossNamespaceSchedulerRef)
+	crossNamespaceSchedulerEnvelope, err := chasm.GenerateNexusCallback(serializedCrossNamespaceSchedulerRef, "request-id", true)
+	require.NoError(t, err)
+	encodedCrossNamespaceSchedulerEnvelope := crossNamespaceSchedulerEnvelope.GetNexus().GetHeader()[commonnexus.CallbackTokenHeader]
+	invalidRef := newRef("namespace-id", "", 1234)
+	serializedInvalidRef, err := invalidRef.Marshal()
+	require.NoError(t, err)
 	dummyTime := time.Now().UTC()
 
 	createPayloadBytes := func(data []byte) *commonpb.Payload {
@@ -499,6 +519,65 @@ func TestExecuteInvocationTaskChasm_Outcomes(t *testing.T) {
 				require.Equal(t, callbackspb.CALLBACK_STATUS_FAILED, cb.Status)
 			},
 		},
+		{
+			name: "invalid-component-ref",
+			setupHistoryClient: func(t *testing.T, ctrl *gomock.Controller) resource.HistoryClient {
+				return historyservicemock.NewMockHistoryServiceClient(ctrl)
+			},
+			completion: nexusrpc.CompleteOperationOptions{
+				Result: createPayloadBytes([]byte("result-data")),
+			},
+			headerValue: base64.RawURLEncoding.EncodeToString(serializedInvalidRef),
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				require.ErrorContains(t, err, "internal error, reference-id:")
+				require.Equal(t, callbackspb.CALLBACK_STATUS_FAILED, cb.Status)
+			},
+		},
+		{
+			name: "cross-namespace-non-scheduler-token",
+			setupHistoryClient: func(t *testing.T, ctrl *gomock.Controller) resource.HistoryClient {
+				client := historyservicemock.NewMockHistoryServiceClient(ctrl)
+				client.EXPECT().CompleteNexusOperationChasm(gomock.Any(), gomock.Any()).
+					Return(&historyservice.CompleteNexusOperationChasmResponse{}, nil)
+				return client
+			},
+			completion: nexusrpc.CompleteOperationOptions{
+				Result: createPayloadBytes([]byte("result-data")),
+			},
+			headerValue: encodedCrossNamespaceRef,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				require.NoError(t, err)
+				require.Equal(t, callbackspb.CALLBACK_STATUS_SUCCEEDED, cb.Status)
+			},
+		},
+		{
+			name: "cross-namespace-scheduler-legacy-token",
+			setupHistoryClient: func(t *testing.T, ctrl *gomock.Controller) resource.HistoryClient {
+				return historyservicemock.NewMockHistoryServiceClient(ctrl)
+			},
+			completion: nexusrpc.CompleteOperationOptions{
+				Result: createPayloadBytes([]byte("result-data")),
+			},
+			headerValue: encodedCrossNamespaceSchedulerRef,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				require.ErrorContains(t, err, "internal error, reference-id:")
+				require.Equal(t, callbackspb.CALLBACK_STATUS_FAILED, cb.Status)
+			},
+		},
+		{
+			name: "cross-namespace-scheduler-enveloped-token",
+			setupHistoryClient: func(t *testing.T, ctrl *gomock.Controller) resource.HistoryClient {
+				return historyservicemock.NewMockHistoryServiceClient(ctrl)
+			},
+			completion: nexusrpc.CompleteOperationOptions{
+				Result: createPayloadBytes([]byte("result-data")),
+			},
+			headerValue: encodedCrossNamespaceSchedulerEnvelope,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				require.ErrorContains(t, err, "internal error, reference-id:")
+				require.Equal(t, callbackspb.CALLBACK_STATUS_FAILED, cb.Status)
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -536,6 +615,9 @@ func TestExecuteInvocationTaskChasm_Outcomes(t *testing.T) {
 			handler := &invocationTaskHandler{
 				config: &Config{
 					RequestTimeout: dynamicconfig.GetDurationPropertyFnFilteredByDestination(time.Second),
+					InternalCallbackSameNamespaceArchetypes: func() []string {
+						return []string{chasm.SchedulerArchetype}
+					},
 					RetryPolicy: func() backoff.RetryPolicy {
 						return backoff.NewExponentialRetryPolicy(time.Second)
 					},


### PR DESCRIPTION
## What changed?
Added `callback.internal.sameNamespaceArchetypes`, a dynamic-config list of fully-qualified CHASM archetype names whose internal callbacks must target the callback source namespace. The default list contains the Scheduler archetype. Internal callback dispatch now applies the generic configured policy without referring to Scheduler directly. Component references are also structurally validated before dispatch.

## Why?
Some CHASM features require same-namespace callbacks while others may support cross-namespace delivery. Keeping this as an archetype policy avoids imposing Scheduler constraints on unrelated components and lets the list evolve without changing dispatch logic.

## How did you test it?
- [x] covered by existing tests
- [x] added new unit test(s)

Tested legacy and enveloped tokens for an archetype requiring same-namespace callbacks, malformed component references, same-namespace delivery, and allowed cross-namespace delivery for an archetype outside the configured list. The full callback package and targeted lint pass.

## Potential risks
Removing an archetype from the configured list permits its internal callbacks to cross namespaces. Adding an archetype rejects any of its existing cross-namespace callbacks.