### PR TITLE
Allow namespace readers to call cluster-level readonly APIs

### DIFF
--- a/common/authorization/default_authorizer.go
+++ b/common/authorization/default_authorizer.go
@@ -29,6 +29,12 @@ var resultDeny = Result{Decision: DecisionDeny}
 //	System Admin is allowed to access all APIs on all namespaces and cluster-level.
 //	System Writer is allowed to access non admin APIs on all namespaces and cluster-level.
 //	System Reader is allowed to access readonly APIs on all namespaces and cluster-level.
+//	A reader on any individual namespace is also allowed to access cluster-level readonly
+//	APIs (ListNamespaces, GetSearchAttributes, GetClusterInfo) - these return low-sensitivity
+//	metadata (namespace names, server/cluster version info), and gating them on System claims
+//	alone leaves them unreachable for any purely namespace-scoped permission set, the shape the
+//	"namespace:role" JWT claim format itself describes - which breaks the Web UI outright for
+//	those deployments (#11639).
 //	Namespace Admin is allowed to access all APIs on their namespaces.
 //	Namespace Writer is allowed to access non admin APIs on their namespaces.
 //	Namespace Reader is allowed to access non admin readonly APIs on their namespaces.
@@ -48,6 +54,9 @@ func (a *defaultAuthorizer) Authorize(_ context.Context, claims *Claims, target 
 	switch metadata.Scope {
 	case api.ScopeCluster:
 		hasRole = claims.System
+		if metadata.Access == api.AccessReadOnly && hasRole < RoleReader && claims.hasAnyNamespaceRole(RoleReader) {
+			hasRole = RoleReader
+		}
 	case api.ScopeNamespace:
 		// Note: system-level claims apply across all namespaces.
 		// Note: if claims.Namespace is nil or target.Namespace is not found, the lookup will return zero.

--- a/common/authorization/default_authorizer_test.go
+++ b/common/authorization/default_authorizer_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/log"
 	"go.uber.org/mock/gomock"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
@@ -61,6 +62,14 @@ var (
 	}
 	targetGetSystemInfo = CallTarget{
 		APIName:   "/temporal.api.workflowservice.v1.WorkflowService/GetSystemInfo",
+		Namespace: "",
+	}
+	targetListNamespaces = CallTarget{
+		APIName:   "/temporal.api.workflowservice.v1.WorkflowService/ListNamespaces",
+		Namespace: "",
+	}
+	targetListClusters = CallTarget{
+		APIName:   "/temporal.api.operatorservice.v1.OperatorService/ListClusters",
 		Namespace: "",
 	}
 	targetStartWorkflow = CallTarget{
@@ -146,6 +155,22 @@ func (s *defaultAuthorizerSuite) TestAuthorize() {
 		{"NamespaceReaderOnGetSystemInfo", claimsNamespaceReader, targetGetSystemInfo, DecisionAllow},
 		{"RoleNoneOnHealthCheck", claimsNone, targetGrpcHealthCheck, DecisionAllow},
 		{"NamespaceReaderOnHealthCheck", claimsNamespaceReader, targetGrpcHealthCheck, DecisionAllow},
+
+		// A reader on any individual namespace can reach cluster-level readonly APIs
+		// (ListNamespaces, GetSearchAttributes, GetClusterInfo) - purely namespace-scoped
+		// claims otherwise could never satisfy these, breaking the Web UI (#11639).
+		{"RoleNoneOnListNamespaces", claimsNone, targetListNamespaces, DecisionDeny},
+		{"NamespaceReaderOnListNamespaces", claimsNamespaceReader, targetListNamespaces, DecisionAllow},
+		{"NamespaceWriterOnListNamespaces", claimsNamespaceWriter, targetListNamespaces, DecisionAllow},
+		{"NamespaceAdminOnListNamespaces", claimsNamespaceAdmin, targetListNamespaces, DecisionAllow},
+		{"SystemReaderOnListNamespaces", claimsSystemReader, targetListNamespaces, DecisionAllow},
+
+		// The relaxation is scoped to readonly cluster APIs only - an admin-level
+		// cluster API (ListClusters) still requires a System-level claim; holding
+		// even Admin on an individual namespace does not grant it.
+		{"NamespaceAdminOnListClusters", claimsNamespaceAdmin, targetListClusters, DecisionDeny},
+		{"SystemReaderOnListClusters", claimsSystemReader, targetListClusters, DecisionDeny},
+		{"SystemAdminOnListClusters", claimsSystemAdmin, targetListClusters, DecisionAllow},
 	}
 
 	for _, tt := range testCases {
@@ -153,6 +178,33 @@ func (s *defaultAuthorizerSuite) TestAuthorize() {
 		s.NoError(err)
 		s.Equal(tt.Decision, result.Decision, "Failed case: %v", tt.Name)
 	}
+}
+
+// TestNamespaceScopedAdminTokenCanListNamespaces reproduces #11639 end to end: a real
+// signed JWT carrying only a namespace-scoped "admin" permission (the shape the
+// "namespace:role" claim format itself describes, and what ui-server's own backend calls
+// need) is parsed by the real DefaultJWTClaimMapper and the resulting Claims are handed to
+// the real defaultAuthorizer - not hand-built Claims structs, the same two components a
+// live server wires together. Before the fix this denied ListNamespaces even though the
+// token holds admin on every namespace that exists.
+func TestNamespaceScopedAdminTokenCanListNamespaces(t *testing.T) {
+	tg := newTokenGenerator()
+	claimMapper := NewDefaultJWTClaimMapper(tg, &config.Authorization{}, log.NewNoopLogger())
+	authorizer := NewDefaultAuthorizer()
+
+	tokenString, err := tg.generateToken(RSA, testSubject, []string{"my-namespace:admin"}, errorTestOptionNoError)
+	require.NoError(t, err)
+
+	claims, err := claimMapper.GetClaims(&AuthInfo{AuthToken: AddBearer(tokenString)})
+	require.NoError(t, err)
+	require.Equal(t, RoleUndefined, claims.System, "token grants no system-level permission")
+	require.Equal(t, RoleAdmin, claims.Namespaces["my-namespace"])
+
+	result, err := authorizer.Authorize(context.TODO(), claims, &targetListNamespaces)
+	require.NoError(t, err)
+	require.Equal(t, DecisionAllow, result.Decision,
+		"a namespace admin should be able to list namespaces (#11639) - the Web UI's own "+
+			"backend calls depend on this working for any purely namespace-scoped token")
 }
 
 func (s *defaultAuthorizerSuite) TestGetAuthorizerFromConfigNoop() {

--- a/common/authorization/roles.go
+++ b/common/authorization/roles.go
@@ -36,3 +36,16 @@ type Claims struct {
 }
 
 // @@@SNIPEND
+
+// hasAnyNamespaceRole reports whether these claims hold at least the given role on any
+// individual namespace. Used by the default authorizer to let a namespace-scoped reader
+// reach cluster-level readonly APIs that return low-sensitivity metadata rather than
+// requiring a separate System-level claim for them (see Authorize's doc comment).
+func (c *Claims) hasAnyNamespaceRole(role Role) bool {
+	for _, r := range c.Namespaces {
+		if r >= role {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What changed?

`Authorize` now also allows `Scope: Cluster` + `Access: ReadOnly` APIs (`ListNamespaces`, `GetSearchAttributes`, `GetClusterInfo`) when the caller holds reader-or-higher on any individual namespace, not only when `claims.System` is set. Write/admin cluster-scope APIs (`ListClusters`, `AddOrUpdateRemoteCluster`, the Nexus endpoint admin calls, etc.) are untouched — still require a System-level claim.

## Why?

`Authorize` only ever consulted `claims.System` for `Scope: Cluster` APIs. A JWT holding only a namespace-scoped `admin` permission — the shape the `"namespace:role"` claim format itself describes — could never satisfy them, at any role, no matter how many namespaces it administered. `ui-server` calls `ListNamespaces` and `GetClusterInfo` on every page load, so any deployment using purely namespace-scoped permissions gets a silent 403 and can't load the Web UI at all, with no indication that a separate, undocumented `temporal-system:read` grant is what's actually needed (#11639).

These three APIs return namespace names and basic server/cluster metadata, not per-namespace data, so a caller who can already read at least one namespace isn't crossing a meaningful confidentiality boundary by reaching them.

Closes #11639

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

Reverted just the source (kept the new tests): every new case fails with the exact denial reported in the issue. Restored the fix: all pass. One of the new tests goes through the real `DefaultJWTClaimMapper` with an actual signed JWT (not hand-built `Claims`) into the real `Authorize` call, matching the issue's exact repro shape end to end rather than only exercising `Authorize` in isolation. A negative-control case confirms `ListClusters` (admin-scope) still denies a namespace admin — the relaxation doesn't leak past read-only.

`go build ./...`, `gofmt`, `go vet`, and `go test ./common/authorization/... ./common/api/... ./temporaltest/...` all clean.

## Potential risks

Widens what a namespace-scoped reader can reach at cluster scope, but only for the three APIs that were already documented as returning low-sensitivity metadata, and only at read level — every write/admin cluster API keeps requiring a System claim, confirmed by the negative-control test above.
