### PR TITLE
all: fix typos in code comments

### DIFF
--- a/chasm/lib/scheduler/scheduler.go
+++ b/chasm/lib/scheduler/scheduler.go
@@ -386,7 +386,7 @@ func (s *Scheduler) Terminate(
 	return chasm.TerminateComponentResponse{}, nil
 }
 
-// NewRangeBackfiller returns an intialized Backfiller component, which should
+// NewRangeBackfiller returns an initialized Backfiller component, which should
 // be parented under a Scheduler root node.
 func (s *Scheduler) NewRangeBackfiller(
 	ctx chasm.MutableContext,
@@ -399,7 +399,7 @@ func (s *Scheduler) NewRangeBackfiller(
 	return backfiller
 }
 
-// NewImmediateBackfiller returns an intialized Backfiller component, which should
+// NewImmediateBackfiller returns an initialized Backfiller component, which should
 // be parented under a Scheduler root node.
 func (s *Scheduler) NewImmediateBackfiller(
 	ctx chasm.MutableContext,
@@ -699,7 +699,7 @@ func (s *Scheduler) recordIgnoredCallback(
 }
 
 // HandleNexusCompletion allows Scheduler to record workflow completions from
-// worfklows started by the same scheduler tree's Invoker.
+// workflows started by the same scheduler tree's Invoker.
 func (s *Scheduler) HandleNexusCompletion(
 	ctx chasm.MutableContext,
 	info *persistencespb.ChasmNexusCompletion,

--- a/chasm/ref.go
+++ b/chasm/ref.go
@@ -32,7 +32,7 @@ type ComponentRef struct {
 	// is not specified in the ExecutionKey.
 	archetypeID ArchetypeID
 	// executionGoType is used for determining the ComponetRef's archetype.
-	// When CHASM deverloper needs to create a ComponentRef, they will only provide the component type,
+	// When CHASM developer needs to create a ComponentRef, they will only provide the component type,
 	// and leave the work of determining archetypeID to the CHASM framework.
 	executionGoType reflect.Type
 

--- a/chasm/registrable_component.go
+++ b/chasm/registrable_component.go
@@ -164,7 +164,7 @@ func WithSearchAttributes(
 // via the Value() method whenever the chasm framework starts, updates, reads, polls, executes or
 // validates tasks on a component.
 //
-// This is useful for propagating values needed for those processing logic but are not avaiable via the
+// This is useful for propagating values needed for those processing logic but are not available via the
 // component's struct definition, such as configurations.
 //
 // Keys need to be globally unique across components. Conflicting keys across will cause component registration to fail.

--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -357,7 +357,7 @@ func newTreeInitSearchAttributesAndMemo(
 		return err
 	}
 
-	// Theoritically we should check if the root node has a Visibility component or not.
+	// Theoretically we should check if the root node has a Visibility component or not.
 	// But that doesn't really matter. Even if it doesn't have one, currentSearchAttributes
 	// and currentMemo will just never be used.
 
@@ -1926,7 +1926,7 @@ func (n *Node) closeTransactionForceUpdateVisibility(
 	visibility.generateTask(mutableContext)
 	visibilityNode.setValueState(valueStateNeedSerialize)
 
-	// We don't need to sync tree structure here for the visiblity node because we only generated a task without
+	// We don't need to sync tree structure here for the visibility node because we only generated a task without
 	// changing any component fields.
 	return nil
 }
@@ -3005,7 +3005,7 @@ func (n *Node) delete(isSystemDelete bool) error {
 	// if the same node is updated and then deleted in the same transaction.
 	//
 	// That's not a problem today though and DeletedNodes entries are always added
-	// before UpdatedNodes entires.
+	// before UpdatedNodes entries.
 	// - For active logic, DeletedNodes are added upon syncSubComponents(),
 	//   and UpdatedNodes are added when closing transaction and serializing nodes.
 	// - For standby replication logic, mutable state calls ApplyMutation() twice,
@@ -3405,7 +3405,7 @@ func deserializeTask(
 		return taskValue, nil
 	}
 
-	// TODO: consider pre-calculating the proto field num when registring the task type.
+	// TODO: consider pre-calculating the proto field num when registering the task type.
 
 	protoMessageFound := false
 	for i := 0; i < taskGoType.NumField(); i++ {
@@ -3453,7 +3453,7 @@ func serializeTask(
 		return encodeChasmBlob(nil)
 	}
 
-	// TODO: consider pre-calculating the proto field num when registring the task type.
+	// TODO: consider pre-calculating the proto field num when registering the task type.
 
 	var blob *commonpb.DataBlob
 	protoMessageFound := false

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -969,7 +969,7 @@ type SpanExporterInputs struct {
 
 // TraceExportModule holds process-global telemetry fx state defining the set of
 // OTEL trace/span exporters used by tracing instrumentation. The following
-// types can be overriden/augmented with fx.Replace/fx.Decorate:
+// types can be overridden/augmented with fx.Replace/fx.Decorate:
 //
 // - []go.opentelemetry.io/otel/sdk/trace.SpanExporter
 var TraceExportModule = fx.Options(
@@ -1008,7 +1008,7 @@ var TraceExportModule = fx.Options(
 )
 
 // ServiceTracingModule holds per-service (i.e. frontend/history/matching/worker) fx
-// state. The following types can be overriden with fx.Replace/fx.Decorate:
+// state. The following types can be overridden with fx.Replace/fx.Decorate:
 //
 //   - []go.opentelemetry.io/otel/sdk/trace.BatchSpanProcessorOption
 //     default: empty slice

--- a/tools/tdbg/app.go
+++ b/tools/tdbg/app.go
@@ -117,7 +117,7 @@ func NewCliApp(opts ...Option) *cli.App {
 		case "never":
 			color.NoColor = true
 		default:
-			// fatih/color will inspect the enviroment and terminal and set a reasonable default.
+			// fatih/color will inspect the environment and terminal and set a reasonable default.
 		}
 		return nil
 	}

--- a/tools/testrunner/testrunner.go
+++ b/tools/testrunner/testrunner.go
@@ -395,7 +395,7 @@ func (r *runner) runTests(ctx context.Context, args []string) {
 		// attempt but before the next one completes).
 		r.writeCurrentReport()
 
-		// If the run completely successfull, no need to retry.
+		// If the run completely successful, no need to retry.
 		if currentAttempt.exitErr == nil {
 			break
 		}


### PR DESCRIPTION
Comment-only typo fixes found with codespell. No functional changes, no identifiers or string literals touched.

- `overriden` -> `overridden` (temporal/fx.go)
- `successfull` -> `successful` (tools/testrunner)
- `enviroment` -> `environment` (tools/tdbg)
- `deverloper` -> `developer` (chasm/ref.go)
- `avaiable` -> `available` (chasm/registrable_component.go)
- `Theoritically`, `visiblity`, `entires`, `registring` (chasm/tree.go)
- `intialized`, `worfklows` (chasm/lib/scheduler/scheduler.go)