### PR TITLE
Add namespace replication outcome metrics

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1527,9 +1527,17 @@ var (
 	ReplicatorLatency                                 = NewTimerDef("replicator_latency")
 	ReplicatorDLQFailures                             = NewCounterDef("replicator_dlq_enqueue_fails")
 	NamespaceReplicationEnqueueDLQCount               = NewCounterDef("namespace_replication_dlq_enqueue_requests")
-	ParentClosePolicyProcessorSuccess                 = NewCounterDef("parent_close_policy_processor_requests")
-	ParentClosePolicyProcessorFailures                = NewCounterDef("parent_close_policy_processor_errors")
-	SignalExternalWorkflowExecutionFailures           = NewCounterDef(
+	NamespaceReplicationApplyOutcomes                 = NewCounterDef(
+		"namespace_replication_apply_outcomes",
+		WithDescription("The number of terminal namespace metadata replication apply outcomes per target cluster."),
+	)
+	NamespaceReplicationApplyEndToEndLatency = NewTimerDef(
+		"namespace_replication_apply_end_to_end_latency",
+		WithDescription("Latency from source transport acceptance to a terminal namespace metadata replication apply outcome."),
+	)
+	ParentClosePolicyProcessorSuccess       = NewCounterDef("parent_close_policy_processor_requests")
+	ParentClosePolicyProcessorFailures      = NewCounterDef("parent_close_policy_processor_errors")
+	SignalExternalWorkflowExecutionFailures = NewCounterDef(
 		"signal_external_workflow_execution_failures",
 		WithDescription("The number of signal external workflow execution failures by cause."),
 	)

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1533,7 +1533,7 @@ var (
 	)
 	NamespaceReplicationApplyEndToEndLatency = NewTimerDef(
 		"namespace_replication_apply_end_to_end_latency",
-		WithDescription("Latency from source transport acceptance to a terminal namespace metadata replication apply outcome."),
+		WithDescription("Latency from source publication to a terminal namespace metadata replication apply outcome."),
 	)
 	ParentClosePolicyProcessorSuccess       = NewCounterDef("parent_close_policy_processor_requests")
 	ParentClosePolicyProcessorFailures      = NewCounterDef("parent_close_policy_processor_errors")

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -26,6 +26,7 @@ const (
 	namespaceState          = "namespace_state"
 	sourceCluster           = "source_cluster"
 	targetCluster           = "target_cluster"
+	transport               = "transport"
 	taskSourceTag           = "source"
 	forwardedTag            = "forwarded"
 	pollResultTagName       = "poll_result"
@@ -155,6 +156,14 @@ func TargetClusterTag(value string) Tag {
 		value = unknownValue
 	}
 	return Tag{Key: targetCluster, Value: value}
+}
+
+// TransportTag returns a new transport tag.
+func TransportTag(value string) Tag {
+	if len(value) == 0 {
+		value = unknownValue
+	}
+	return Tag{Key: transport, Value: value}
 }
 
 // FromClusterIDTag returns a new from cluster tag.

--- a/common/namespace/nsreplication/metrics.go
+++ b/common/namespace/nsreplication/metrics.go
@@ -78,10 +78,7 @@ func recordOutcome(
 	if metadata.VisibilityTime == nil || metadata.VisibilityTime.CheckValid() != nil {
 		return
 	}
-	latency := time.Since(metadata.VisibilityTime.AsTime())
-	if latency < 0 {
-		latency = 0
-	}
+	latency := max(time.Since(metadata.VisibilityTime.AsTime()), 0)
 	metrics.NamespaceReplicationApplyEndToEndLatency.With(metricsHandler).Record(latency, tags...)
 }
 

--- a/common/namespace/nsreplication/metrics.go
+++ b/common/namespace/nsreplication/metrics.go
@@ -1,0 +1,97 @@
+package nsreplication
+
+import (
+	"context"
+	"time"
+
+	enumsspb "go.temporal.io/server/api/enums/v1"
+	replicationspb "go.temporal.io/server/api/replication/v1"
+	"go.temporal.io/server/common/metrics"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const (
+	// LegacyMetricsTransport identifies the existing namespace replication queue.
+	LegacyMetricsTransport = "legacy"
+
+	metricsOutcomeApplied         = "applied"
+	metricsOutcomeNoChange        = "no_change"
+	metricsOutcomeNotAdmitted     = "not_admitted"
+	metricsOutcomeTerminalFailure = "terminal_failure"
+
+	metricsOperationCreate  = "create"
+	metricsOperationUpdate  = "update"
+	metricsOperationUnknown = "unknown"
+)
+
+type taskMetricsContextKey struct{}
+
+// TaskMetricsContext contains transport metadata needed to record namespace replication metrics.
+type TaskMetricsContext struct {
+	SourceCluster  string
+	TargetCluster  string
+	Transport      string
+	VisibilityTime *timestamppb.Timestamp
+}
+
+// WithTaskMetricsContext adds namespace replication metrics metadata to a context.
+func WithTaskMetricsContext(ctx context.Context, metadata TaskMetricsContext) context.Context {
+	return context.WithValue(ctx, taskMetricsContextKey{}, metadata)
+}
+
+// TaskMetricsContextFromContext returns namespace replication metrics metadata when present.
+func TaskMetricsContextFromContext(ctx context.Context) (TaskMetricsContext, bool) {
+	metadata, ok := ctx.Value(taskMetricsContextKey{}).(TaskMetricsContext)
+	return metadata, ok
+}
+
+// RecordLegacyTerminalFailure records a namespace task that was successfully written to the legacy DLQ.
+func RecordLegacyTerminalFailure(
+	ctx context.Context,
+	metricsHandler metrics.Handler,
+	task *replicationspb.NamespaceTaskAttributes,
+) {
+	recordOutcome(ctx, metricsHandler, task, metricsOutcomeTerminalFailure)
+}
+
+func recordOutcome(
+	ctx context.Context,
+	metricsHandler metrics.Handler,
+	task *replicationspb.NamespaceTaskAttributes,
+	outcome string,
+) {
+	metadata, ok := TaskMetricsContextFromContext(ctx)
+	if metricsHandler == nil || !ok {
+		return
+	}
+
+	tags := []metrics.Tag{
+		metrics.NamespaceTag(task.GetInfo().GetName()),
+		metrics.SourceClusterTag(metadata.SourceCluster),
+		metrics.TargetClusterTag(metadata.TargetCluster),
+		metrics.TransportTag(metadata.Transport),
+		metrics.OperationTag(namespaceReplicationOperation(task)),
+		metrics.OutcomeTag(outcome),
+	}
+	metrics.NamespaceReplicationApplyOutcomes.With(metricsHandler).Record(1, tags...)
+
+	if metadata.VisibilityTime == nil || metadata.VisibilityTime.CheckValid() != nil {
+		return
+	}
+	latency := time.Since(metadata.VisibilityTime.AsTime())
+	if latency < 0 {
+		latency = 0
+	}
+	metrics.NamespaceReplicationApplyEndToEndLatency.With(metricsHandler).Record(latency, tags...)
+}
+
+func namespaceReplicationOperation(task *replicationspb.NamespaceTaskAttributes) string {
+	switch task.GetNamespaceOperation() {
+	case enumsspb.NAMESPACE_OPERATION_CREATE:
+		return metricsOperationCreate
+	case enumsspb.NAMESPACE_OPERATION_UPDATE:
+		return metricsOperationUpdate
+	default:
+		return metricsOperationUnknown
+	}
+}

--- a/common/namespace/nsreplication/metrics.go
+++ b/common/namespace/nsreplication/metrics.go
@@ -66,14 +66,14 @@ func recordOutcome(
 	}
 
 	tags := []metrics.Tag{
-		metrics.NamespaceTag(task.GetInfo().GetName()),
 		metrics.SourceClusterTag(metadata.SourceCluster),
 		metrics.TargetClusterTag(metadata.TargetCluster),
 		metrics.TransportTag(metadata.Transport),
 		metrics.OperationTag(namespaceReplicationOperation(task)),
 		metrics.OutcomeTag(outcome),
 	}
-	metrics.NamespaceReplicationApplyOutcomes.With(metricsHandler).Record(1, tags...)
+	counterTags := append(tags, metrics.NamespaceTag(task.GetInfo().GetName()))
+	metrics.NamespaceReplicationApplyOutcomes.With(metricsHandler).Record(1, counterTags...)
 
 	if metadata.VisibilityTime == nil || metadata.VisibilityTime.CheckValid() != nil {
 		return

--- a/common/namespace/nsreplication/metrics_test.go
+++ b/common/namespace/nsreplication/metrics_test.go
@@ -7,28 +7,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally/v4"
-	"go.opentelemetry.io/otel/attribute"
-	otelmetric "go.opentelemetry.io/otel/metric"
-	sdkmetrics "go.opentelemetry.io/otel/sdk/metric"
-	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	namespacepb "go.temporal.io/api/namespace/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
-	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/metrics/metricstest"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
-
-type testOpenTelemetryProvider struct {
-	meter otelmetric.Meter
-}
-
-func (p *testOpenTelemetryProvider) GetMeter() otelmetric.Meter {
-	return p.meter
-}
-
-func (p *testOpenTelemetryProvider) Stop(log.Logger) {}
 
 func TestRecordNamespaceReplicationOutcome(t *testing.T) {
 	task := &replicationspb.NamespaceTaskAttributes{
@@ -67,6 +52,7 @@ func TestRecordNamespaceReplicationOutcome(t *testing.T) {
 			latencies := snapshot[metrics.NamespaceReplicationApplyEndToEndLatency.Name()]
 			require.Len(t, latencies, 1)
 			require.GreaterOrEqual(t, latencies[0].Value.(time.Duration), time.Minute)
+			require.NotContains(t, latencies[0].Tags, metrics.NamespaceTag("").Key)
 		})
 	}
 }
@@ -98,68 +84,8 @@ func TestRecordNamespaceReplicationOutcomeExcludesNamespaceTag(t *testing.T) {
 	}
 	require.Len(t, snapshot.Timers(), 1)
 	for _, timer := range snapshot.Timers() {
-		require.Equal(t, "_tag_excluded_", timer.Tags()[metrics.NamespaceTag("").Key])
+		require.NotContains(t, timer.Tags(), metrics.NamespaceTag("").Key)
 	}
-}
-
-func TestRecordNamespaceReplicationOutcomeExcludesNamespaceTagOpenTelemetry(t *testing.T) {
-	reader := sdkmetrics.NewManualReader()
-	provider := sdkmetrics.NewMeterProvider(sdkmetrics.WithReader(reader))
-	handler, err := metrics.NewOtelMetricsHandler(
-		log.NewTestLogger(),
-		&testOpenTelemetryProvider{meter: provider.Meter("test")},
-		metrics.ClientConfig{
-			ExcludeTags: map[string][]string{
-				metrics.NamespaceTag("").Key: {},
-			},
-		},
-		false,
-	)
-	require.NoError(t, err)
-	ctx := WithTaskMetricsContext(context.Background(), TaskMetricsContext{
-		SourceCluster:  "cluster-a",
-		TargetCluster:  "cluster-b",
-		Transport:      LegacyMetricsTransport,
-		VisibilityTime: timestamppb.New(time.Now().Add(-time.Minute)),
-	})
-	task := &replicationspb.NamespaceTaskAttributes{
-		NamespaceOperation: enumsspb.NAMESPACE_OPERATION_CREATE,
-		Info:               &namespacepb.NamespaceInfo{Name: "payments"},
-	}
-
-	recordOutcome(ctx, handler, task, metricsOutcomeApplied)
-
-	var resourceMetrics metricdata.ResourceMetrics
-	require.NoError(t, reader.Collect(context.Background(), &resourceMetrics))
-	found := map[string]bool{}
-	for _, scopeMetrics := range resourceMetrics.ScopeMetrics {
-		for _, metric := range scopeMetrics.Metrics {
-			switch metric.Name {
-			case metrics.NamespaceReplicationApplyOutcomes.Name():
-				data, ok := metric.Data.(metricdata.Sum[int64])
-				require.True(t, ok)
-				require.Len(t, data.DataPoints, 1)
-				requireExcludedNamespaceAttribute(t, data.DataPoints[0].Attributes)
-				found[metric.Name] = true
-			case metrics.NamespaceReplicationApplyEndToEndLatency.Name():
-				data, ok := metric.Data.(metricdata.Histogram[int64])
-				require.True(t, ok)
-				require.Len(t, data.DataPoints, 1)
-				requireExcludedNamespaceAttribute(t, data.DataPoints[0].Attributes)
-				found[metric.Name] = true
-			default:
-			}
-		}
-	}
-	require.True(t, found[metrics.NamespaceReplicationApplyOutcomes.Name()])
-	require.True(t, found[metrics.NamespaceReplicationApplyEndToEndLatency.Name()])
-}
-
-func requireExcludedNamespaceAttribute(t *testing.T, attributes attribute.Set) {
-	t.Helper()
-	value, ok := attributes.Value(attribute.Key(metrics.NamespaceTag("").Key))
-	require.True(t, ok)
-	require.Equal(t, "_tag_excluded_", value.AsString())
 }
 
 func TestRecordNamespaceReplicationOutcomeWithoutValidVisibilityTime(t *testing.T) {

--- a/common/namespace/nsreplication/metrics_test.go
+++ b/common/namespace/nsreplication/metrics_test.go
@@ -1,0 +1,115 @@
+package nsreplication
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	namespacepb "go.temporal.io/api/namespace/v1"
+	enumsspb "go.temporal.io/server/api/enums/v1"
+	replicationspb "go.temporal.io/server/api/replication/v1"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/metrics/metricstest"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestRecordNamespaceReplicationOutcome(t *testing.T) {
+	task := &replicationspb.NamespaceTaskAttributes{
+		NamespaceOperation: enumsspb.NAMESPACE_OPERATION_CREATE,
+		Info:               &namespacepb.NamespaceInfo{Name: "payments"},
+	}
+	metadata := TaskMetricsContext{
+		SourceCluster:  "cluster-a",
+		TargetCluster:  "cluster-b",
+		Transport:      LegacyMetricsTransport,
+		VisibilityTime: timestamppb.New(time.Now().Add(-time.Minute)),
+	}
+
+	for _, outcome := range []string{
+		metricsOutcomeApplied,
+		metricsOutcomeNoChange,
+		metricsOutcomeNotAdmitted,
+		metricsOutcomeTerminalFailure,
+	} {
+		t.Run(outcome, func(t *testing.T) {
+			handler := metricstest.NewCaptureHandler()
+			capture := handler.StartCapture()
+			recordOutcome(WithTaskMetricsContext(context.Background(), metadata), handler, task, outcome)
+
+			snapshot := capture.Snapshot()
+			outcomes := snapshot[metrics.NamespaceReplicationApplyOutcomes.Name()]
+			require.Len(t, outcomes, 1)
+			require.Equal(t, int64(1), outcomes[0].Value)
+			require.Equal(t, "payments", outcomes[0].Tags[metrics.NamespaceTag("").Key])
+			require.Equal(t, "cluster-a", outcomes[0].Tags[metrics.SourceClusterTag("").Key])
+			require.Equal(t, "cluster-b", outcomes[0].Tags[metrics.TargetClusterTag("").Key])
+			require.Equal(t, LegacyMetricsTransport, outcomes[0].Tags[metrics.TransportTag("").Key])
+			require.Equal(t, "create", outcomes[0].Tags[metrics.OperationTag("").Key])
+			require.Equal(t, outcome, outcomes[0].Tags[metrics.OutcomeTag("").Key])
+
+			latencies := snapshot[metrics.NamespaceReplicationApplyEndToEndLatency.Name()]
+			require.Len(t, latencies, 1)
+			require.GreaterOrEqual(t, latencies[0].Value.(time.Duration), time.Minute)
+		})
+	}
+}
+
+func TestRecordNamespaceReplicationOutcomeWithoutValidVisibilityTime(t *testing.T) {
+	task := &replicationspb.NamespaceTaskAttributes{
+		NamespaceOperation: enumsspb.NAMESPACE_OPERATION_UPDATE,
+		Info:               &namespacepb.NamespaceInfo{Name: "payments"},
+	}
+
+	tests := []struct {
+		name           string
+		visibilityTime *timestamppb.Timestamp
+	}{
+		{name: "missing"},
+		{name: "invalid", visibilityTime: &timestamppb.Timestamp{Seconds: 253402300800}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			handler := metricstest.NewCaptureHandler()
+			capture := handler.StartCapture()
+			ctx := WithTaskMetricsContext(context.Background(), TaskMetricsContext{
+				SourceCluster:  "cluster-a",
+				TargetCluster:  "cluster-b",
+				Transport:      LegacyMetricsTransport,
+				VisibilityTime: test.visibilityTime,
+			})
+
+			recordOutcome(ctx, handler, task, metricsOutcomeApplied)
+
+			snapshot := capture.Snapshot()
+			require.Len(t, snapshot[metrics.NamespaceReplicationApplyOutcomes.Name()], 1)
+			require.Empty(t, snapshot[metrics.NamespaceReplicationApplyEndToEndLatency.Name()])
+		})
+	}
+}
+
+func TestRecordNamespaceReplicationOutcomeRequiresMetricsContext(t *testing.T) {
+	handler := metricstest.NewCaptureHandler()
+	capture := handler.StartCapture()
+
+	recordOutcome(context.Background(), handler, nil, metricsOutcomeTerminalFailure)
+
+	require.Empty(t, capture.Snapshot())
+}
+
+func TestRecordNamespaceReplicationOutcomeClampsFutureVisibilityTime(t *testing.T) {
+	handler := metricstest.NewCaptureHandler()
+	capture := handler.StartCapture()
+	ctx := WithTaskMetricsContext(context.Background(), TaskMetricsContext{
+		SourceCluster:  "cluster-a",
+		TargetCluster:  "cluster-b",
+		Transport:      LegacyMetricsTransport,
+		VisibilityTime: timestamppb.New(time.Now().Add(time.Hour)),
+	})
+
+	RecordLegacyTerminalFailure(ctx, handler, nil)
+
+	latencies := capture.Snapshot()[metrics.NamespaceReplicationApplyEndToEndLatency.Name()]
+	require.Len(t, latencies, 1)
+	require.Equal(t, time.Duration(0), latencies[0].Value)
+}

--- a/common/namespace/nsreplication/metrics_test.go
+++ b/common/namespace/nsreplication/metrics_test.go
@@ -6,13 +6,29 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally/v4"
+	"go.opentelemetry.io/otel/attribute"
+	otelmetric "go.opentelemetry.io/otel/metric"
+	sdkmetrics "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	namespacepb "go.temporal.io/api/namespace/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
+	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/metrics/metricstest"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+type testOpenTelemetryProvider struct {
+	meter otelmetric.Meter
+}
+
+func (p *testOpenTelemetryProvider) GetMeter() otelmetric.Meter {
+	return p.meter
+}
+
+func (p *testOpenTelemetryProvider) Stop(log.Logger) {}
 
 func TestRecordNamespaceReplicationOutcome(t *testing.T) {
 	task := &replicationspb.NamespaceTaskAttributes{
@@ -53,6 +69,97 @@ func TestRecordNamespaceReplicationOutcome(t *testing.T) {
 			require.GreaterOrEqual(t, latencies[0].Value.(time.Duration), time.Minute)
 		})
 	}
+}
+
+func TestRecordNamespaceReplicationOutcomeExcludesNamespaceTag(t *testing.T) {
+	scope := tally.NewTestScope("", nil)
+	handler := metrics.NewTallyMetricsHandler(metrics.ClientConfig{
+		ExcludeTags: map[string][]string{
+			metrics.NamespaceTag("").Key: {},
+		},
+	}, scope)
+	ctx := WithTaskMetricsContext(context.Background(), TaskMetricsContext{
+		SourceCluster:  "cluster-a",
+		TargetCluster:  "cluster-b",
+		Transport:      LegacyMetricsTransport,
+		VisibilityTime: timestamppb.New(time.Now().Add(-time.Minute)),
+	})
+	task := &replicationspb.NamespaceTaskAttributes{
+		NamespaceOperation: enumsspb.NAMESPACE_OPERATION_CREATE,
+		Info:               &namespacepb.NamespaceInfo{Name: "payments"},
+	}
+
+	recordOutcome(ctx, handler, task, metricsOutcomeApplied)
+
+	snapshot := scope.Snapshot()
+	require.Len(t, snapshot.Counters(), 1)
+	for _, counter := range snapshot.Counters() {
+		require.Equal(t, "_tag_excluded_", counter.Tags()[metrics.NamespaceTag("").Key])
+	}
+	require.Len(t, snapshot.Timers(), 1)
+	for _, timer := range snapshot.Timers() {
+		require.Equal(t, "_tag_excluded_", timer.Tags()[metrics.NamespaceTag("").Key])
+	}
+}
+
+func TestRecordNamespaceReplicationOutcomeExcludesNamespaceTagOpenTelemetry(t *testing.T) {
+	reader := sdkmetrics.NewManualReader()
+	provider := sdkmetrics.NewMeterProvider(sdkmetrics.WithReader(reader))
+	handler, err := metrics.NewOtelMetricsHandler(
+		log.NewTestLogger(),
+		&testOpenTelemetryProvider{meter: provider.Meter("test")},
+		metrics.ClientConfig{
+			ExcludeTags: map[string][]string{
+				metrics.NamespaceTag("").Key: {},
+			},
+		},
+		false,
+	)
+	require.NoError(t, err)
+	ctx := WithTaskMetricsContext(context.Background(), TaskMetricsContext{
+		SourceCluster:  "cluster-a",
+		TargetCluster:  "cluster-b",
+		Transport:      LegacyMetricsTransport,
+		VisibilityTime: timestamppb.New(time.Now().Add(-time.Minute)),
+	})
+	task := &replicationspb.NamespaceTaskAttributes{
+		NamespaceOperation: enumsspb.NAMESPACE_OPERATION_CREATE,
+		Info:               &namespacepb.NamespaceInfo{Name: "payments"},
+	}
+
+	recordOutcome(ctx, handler, task, metricsOutcomeApplied)
+
+	var resourceMetrics metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &resourceMetrics))
+	found := map[string]bool{}
+	for _, scopeMetrics := range resourceMetrics.ScopeMetrics {
+		for _, metric := range scopeMetrics.Metrics {
+			switch metric.Name {
+			case metrics.NamespaceReplicationApplyOutcomes.Name():
+				data, ok := metric.Data.(metricdata.Sum[int64])
+				require.True(t, ok)
+				require.Len(t, data.DataPoints, 1)
+				requireExcludedNamespaceAttribute(t, data.DataPoints[0].Attributes)
+				found[metric.Name] = true
+			case metrics.NamespaceReplicationApplyEndToEndLatency.Name():
+				data, ok := metric.Data.(metricdata.Histogram[int64])
+				require.True(t, ok)
+				require.Len(t, data.DataPoints, 1)
+				requireExcludedNamespaceAttribute(t, data.DataPoints[0].Attributes)
+				found[metric.Name] = true
+			default:
+			}
+		}
+	}
+	require.True(t, found[metrics.NamespaceReplicationApplyOutcomes.Name()])
+	require.True(t, found[metrics.NamespaceReplicationApplyEndToEndLatency.Name()])
+}
+
+func requireExcludedNamespaceAttribute(t *testing.T, attributes attribute.Set) {
+	t.Helper()
+	value, ok := attributes.Value(attribute.Key(metrics.NamespaceTag("").Key))
+	require.True(t, ok)
+	require.Equal(t, "_tag_excluded_", value.AsString())
 }
 
 func TestRecordNamespaceReplicationOutcomeWithoutValidVisibilityTime(t *testing.T) {

--- a/common/namespace/nsreplication/replication_task_executor.go
+++ b/common/namespace/nsreplication/replication_task_executor.go
@@ -15,6 +15,7 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/testing/testhooks"
@@ -62,6 +63,7 @@ type (
 		dataMerger                   NamespaceDataMerger
 		admitter                     NamespaceReplicationAdmitter
 		logger                       log.Logger
+		metricsHandler               metrics.Handler
 		eventLogger                  otellog.Logger
 		emitNamespaceLifecycleEvents dynamicconfig.BoolPropertyFn
 		testHooks                    testhooks.TestHooks
@@ -90,6 +92,13 @@ func NewTaskExecutor(
 		option(executor)
 	}
 	return executor
+}
+
+// WithNamespaceReplicationMetrics configures namespace replication outcome metrics.
+func WithNamespaceReplicationMetrics(metricsHandler metrics.Handler) TaskExecutorOption {
+	return func(executor *taskExecutorImpl) {
+		executor.metricsHandler = metricsHandler
+	}
 }
 
 // WithNamespaceReplicationLifecycleEvents configures processed lifecycle event emission.
@@ -129,6 +138,7 @@ func (h *taskExecutorImpl) executeValidatedTask(
 ) error {
 	if shouldProcess, err := h.shouldProcessTask(ctx, task); !shouldProcess || err != nil {
 		if !shouldProcess && err == nil {
+			h.recordOutcome(ctx, task, metricsOutcomeNotAdmitted)
 			h.emitNamespaceReplicationProcessed(
 				ctx,
 				wideevents.NamespaceReplicationOutcomeNotAdmitted,
@@ -271,6 +281,7 @@ func (h *taskExecutorImpl) handleNamespaceCreationReplicationTask(
 
 		if recordExists {
 			// name -> id & id -> name check pass, this is duplication request
+			h.recordOutcome(ctx, task, metricsOutcomeNoChange)
 			h.emitNamespaceReplicationProcessed(
 				ctx,
 				wideevents.NamespaceReplicationOutcomeDuplicate,
@@ -283,6 +294,7 @@ func (h *taskExecutorImpl) handleNamespaceCreationReplicationTask(
 		return err
 	}
 
+	h.recordOutcome(ctx, task, metricsOutcomeApplied)
 	h.emitNamespaceReplicationProcessed(
 		ctx,
 		wideevents.NamespaceReplicationOutcomeCreated,
@@ -378,6 +390,7 @@ func (h *taskExecutorImpl) handleNamespaceUpdateReplicationTask(
 	}
 
 	if !recordUpdated {
+		h.recordOutcome(ctx, task, metricsOutcomeNoChange)
 		if localNamespacePreMutation != nil {
 			h.emitNamespaceReplicationProcessed(
 				ctx,
@@ -393,6 +406,7 @@ func (h *taskExecutorImpl) handleNamespaceUpdateReplicationTask(
 	if err := h.metadataManager.UpdateNamespace(ctx, request); err != nil {
 		return err
 	}
+	h.recordOutcome(ctx, task, metricsOutcomeApplied)
 	if localNamespacePreMutation != nil {
 		h.emitNamespaceReplicationProcessed(
 			ctx,
@@ -403,6 +417,14 @@ func (h *taskExecutorImpl) handleNamespaceUpdateReplicationTask(
 		)
 	}
 	return nil
+}
+
+func (h *taskExecutorImpl) recordOutcome(
+	ctx context.Context,
+	task *replicationspb.NamespaceTaskAttributes,
+	outcome string,
+) {
+	recordOutcome(ctx, h.metricsHandler, task, outcome)
 }
 
 func (h *taskExecutorImpl) cloneLocalNamespaceForReplicationEvent(

--- a/common/namespace/nsreplication/replication_task_executor_test.go
+++ b/common/namespace/nsreplication/replication_task_executor_test.go
@@ -20,6 +20,8 @@ import (
 	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/metrics/metricstest"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/testing/testhooks"
 	"go.temporal.io/server/common/wideevents"
@@ -42,6 +44,7 @@ type (
 		mockMetadataMgr     *persistence.MockMetadataManager
 		namespaceReplicator *taskExecutorImpl
 		eventLogger         *replicationEventCaptureLogger
+		metricsCapture      *metricstest.Capture
 	}
 )
 
@@ -79,6 +82,8 @@ func (s *namespaceReplicationTaskExecutorSuite) SetupTest() {
 	s.mockMetadataMgr = persistence.NewMockMetadataManager(s.controller)
 	logger := log.NewTestLogger()
 	s.eventLogger = &replicationEventCaptureLogger{}
+	metricsHandler := metricstest.NewCaptureHandler()
+	s.metricsCapture = metricsHandler.StartCapture()
 	s.namespaceReplicator = NewTaskExecutor(
 		"some random standby cluster name",
 		s.mockMetadataMgr,
@@ -86,6 +91,7 @@ func (s *namespaceReplicationTaskExecutorSuite) SetupTest() {
 		NewDefaultAdmitter(),
 		logger,
 		testhooks.TestHooks{},
+		WithNamespaceReplicationMetrics(metricsHandler),
 		WithNamespaceReplicationLifecycleEvents(
 			s.eventLogger,
 			dynamicconfig.GetBoolPropertyFn(true),
@@ -109,13 +115,29 @@ func (s *namespaceReplicationTaskExecutorSuite) replicationEventContext(
 		},
 	)
 	s.Require().True(ok)
-	return wideevents.SetNamespaceReplicationTaskContext(context.Background(), wideevents.NamespaceReplicationTaskContext{
+	ctx := wideevents.SetNamespaceReplicationTaskContext(context.Background(), wideevents.NamespaceReplicationTaskContext{
 		SourceCluster: "source-cluster",
 		TargetCluster: "target-cluster",
 		SourceTaskID:  42,
 		AttemptCount:  2,
 		EventData:     eventData,
 	})
+	return WithTaskMetricsContext(ctx, TaskMetricsContext{
+		SourceCluster:  "source-cluster",
+		TargetCluster:  "target-cluster",
+		Transport:      LegacyMetricsTransport,
+		VisibilityTime: timestamppb.New(time.Now().Add(-time.Minute)),
+	})
+}
+
+func (s *namespaceReplicationTaskExecutorSuite) requireMetricOutcome(outcome string, operation string) {
+	snapshot := s.metricsCapture.Snapshot()
+	outcomes := snapshot[metrics.NamespaceReplicationApplyOutcomes.Name()]
+	s.Require().Len(outcomes, 1)
+	s.Equal(outcome, outcomes[0].Tags[metrics.OutcomeTag("").Key])
+	s.Equal(operation, outcomes[0].Tags[metrics.OperationTag("").Key])
+	s.Equal(LegacyMetricsTransport, outcomes[0].Tags[metrics.TransportTag("").Key])
+	s.Require().Len(snapshot[metrics.NamespaceReplicationApplyEndToEndLatency.Name()], 1)
 }
 
 func (s *namespaceReplicationTaskExecutorSuite) processedPersistenceRequest(
@@ -385,6 +407,7 @@ func (s *namespaceReplicationTaskExecutorSuite) TestExecute_RegisterNamespaceTas
 	})
 	err := s.namespaceReplicator.Execute(s.replicationEventContext(task), task)
 	s.Nil(err)
+	s.requireMetricOutcome(metricsOutcomeApplied, metricsOperationCreate)
 	request := s.processedPersistenceRequest(wideevents.NamespaceReplicationOutcomeCreated)
 	s.Equal("CreateNamespaceRequest", request["request_type"])
 	s.Equal(true, request["is_global_namespace"])
@@ -434,6 +457,7 @@ func (s *namespaceReplicationTaskExecutorSuite) TestExecute_RegisterNamespaceTas
 	s.mockMetadataMgr.EXPECT().CreateNamespace(gomock.Any(), gomock.Any()).Return(nil, errors.New("test"))
 	err := s.namespaceReplicator.Execute(s.replicationEventContext(task), task)
 	s.Nil(err)
+	s.requireMetricOutcome(metricsOutcomeNoChange, metricsOperationCreate)
 	s.Nil(s.processedPersistenceRequest(wideevents.NamespaceReplicationOutcomeDuplicate))
 }
 
@@ -458,6 +482,7 @@ func (s *namespaceReplicationTaskExecutorSuite) TestExecute_RegisterNamespaceTas
 
 	err := s.namespaceReplicator.Execute(s.replicationEventContext(task), task)
 	s.Require().NoError(err)
+	s.requireMetricOutcome(metricsOutcomeNotAdmitted, metricsOperationCreate)
 	s.Nil(s.processedPersistenceRequest(wideevents.NamespaceReplicationOutcomeNotAdmitted))
 }
 
@@ -650,6 +675,7 @@ func (s *namespaceReplicationTaskExecutorSuite) TestExecute_UpdateNamespaceTask_
 	}))
 	err := s.namespaceReplicator.Execute(s.replicationEventContext(updateTask), updateTask)
 	s.Nil(err)
+	s.requireMetricOutcome(metricsOutcomeApplied, metricsOperationUpdate)
 	request := s.processedPersistenceRequest(wideevents.NamespaceReplicationOutcomeUpdated)
 	s.Equal("UpdateNamespaceRequest", request["request_type"])
 	s.Equal("1", request["namespace"].(map[string]any)["config_version"])
@@ -904,6 +930,7 @@ func (s *namespaceReplicationTaskExecutorSuite) TestExecute_UpdateNamespaceTask_
 	s.mockMetadataMgr.EXPECT().UpdateNamespace(gomock.Any(), gomock.Any()).Times(0)
 	err := s.namespaceReplicator.Execute(s.replicationEventContext(updateTask), updateTask)
 	s.Nil(err)
+	s.requireMetricOutcome(metricsOutcomeNoChange, metricsOperationUpdate)
 	s.Nil(s.processedPersistenceRequest(wideevents.NamespaceReplicationOutcomeNoChange))
 	localPreMutation := s.processedLocalNamespacePreMutation()
 	s.Equal("2", localPreMutation["config_version"])

--- a/common/namespace/nsreplication/transmission_task_handler.go
+++ b/common/namespace/nsreplication/transmission_task_handler.go
@@ -14,6 +14,7 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/wideevents"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // NOTE: the counterpart of namespace replication receiving logic is in service/worker package
@@ -126,8 +127,9 @@ func (r *replicator) HandleTransmissionTask(
 	}
 
 	replicationTask := &replicationspb.ReplicationTask{
-		TaskType:   taskType,
-		Attributes: task,
+		TaskType:       taskType,
+		Attributes:     task,
+		VisibilityTime: timestamppb.Now(),
 	}
 	err := r.namespaceReplicationQueue.Publish(ctx, replicationTask)
 	if err != nil {

--- a/common/namespace/nsreplication/transmission_task_handler_test.go
+++ b/common/namespace/nsreplication/transmission_task_handler_test.go
@@ -21,6 +21,7 @@ import (
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/wideevents"
 	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
@@ -46,6 +47,17 @@ func (l *transmissionCaptureLogger) Emit(_ context.Context, record otellog.Recor
 
 func (l *transmissionCaptureLogger) Enabled(context.Context, otellog.EnabledParameters) bool {
 	return true
+}
+
+func replicationTaskWithVisibilityTime(expected *replicationspb.ReplicationTask) gomock.Matcher {
+	return gomock.Cond(func(actual *replicationspb.ReplicationTask) bool {
+		if actual == nil || actual.GetVisibilityTime() == nil || actual.GetVisibilityTime().CheckValid() != nil {
+			return false
+		}
+		actual = proto.Clone(actual).(*replicationspb.ReplicationTask)
+		actual.VisibilityTime = nil
+		return proto.Equal(actual, expected)
+	})
 }
 
 func TestTransmissionTaskSuite(t *testing.T) {
@@ -124,7 +136,7 @@ func (s *transmissionTaskSuite) TestHandleTransmissionTask_RegisterNamespaceTask
 	}
 	isGlobalNamespace := true
 
-	s.namespaceReplicationQueue.EXPECT().Publish(gomock.Any(), &replicationspb.ReplicationTask{
+	s.namespaceReplicationQueue.EXPECT().Publish(gomock.Any(), replicationTaskWithVisibilityTime(&replicationspb.ReplicationTask{
 		TaskType: taskType,
 		Attributes: &replicationspb.ReplicationTask_NamespaceTaskAttributes{
 			NamespaceTaskAttributes: &replicationspb.NamespaceTaskAttributes{
@@ -154,7 +166,7 @@ func (s *transmissionTaskSuite) TestHandleTransmissionTask_RegisterNamespaceTask
 				FailoverVersion: failoverVersion,
 			},
 		},
-	}).Return(nil)
+	})).Return(nil)
 
 	err := s.namespaceReplicator.HandleTransmissionTask(
 		context.Background(),
@@ -306,7 +318,7 @@ func (s *transmissionTaskSuite) TestHandleTransmissionTask_UpdateNamespaceTask_I
 	}
 	isGlobalNamespace := true
 
-	s.namespaceReplicationQueue.EXPECT().Publish(gomock.Any(), &replicationspb.ReplicationTask{
+	s.namespaceReplicationQueue.EXPECT().Publish(gomock.Any(), replicationTaskWithVisibilityTime(&replicationspb.ReplicationTask{
 		TaskType: taskType,
 		Attributes: &replicationspb.ReplicationTask_NamespaceTaskAttributes{
 			NamespaceTaskAttributes: &replicationspb.NamespaceTaskAttributes{
@@ -335,7 +347,7 @@ func (s *transmissionTaskSuite) TestHandleTransmissionTask_UpdateNamespaceTask_I
 				FailoverVersion: failoverVersion,
 			},
 		},
-	}).Return(nil)
+	})).Return(nil)
 
 	err := s.namespaceReplicator.HandleTransmissionTask(
 		context.Background(),
@@ -396,7 +408,7 @@ func (s *transmissionTaskSuite) TestHandleTransmissionTask_UpdateNamespaceTask_N
 	}
 	isGlobalNamespace := true
 
-	s.namespaceReplicationQueue.EXPECT().Publish(gomock.Any(), &replicationspb.ReplicationTask{
+	s.namespaceReplicationQueue.EXPECT().Publish(gomock.Any(), replicationTaskWithVisibilityTime(&replicationspb.ReplicationTask{
 		TaskType: taskType,
 		Attributes: &replicationspb.ReplicationTask_NamespaceTaskAttributes{
 			NamespaceTaskAttributes: &replicationspb.NamespaceTaskAttributes{
@@ -426,7 +438,7 @@ func (s *transmissionTaskSuite) TestHandleTransmissionTask_UpdateNamespaceTask_N
 				FailoverVersion: failoverVersion,
 			},
 		},
-	}).Return(nil)
+	})).Return(nil)
 
 	err := s.namespaceReplicator.HandleTransmissionTask(
 		context.Background(),
@@ -487,7 +499,7 @@ func (s *transmissionTaskSuite) TestHandleTransmissionTask_UpdateNamespaceTask_H
 	}
 	isGlobalNamespace := true
 
-	s.namespaceReplicationQueue.EXPECT().Publish(gomock.Any(), &replicationspb.ReplicationTask{
+	s.namespaceReplicationQueue.EXPECT().Publish(gomock.Any(), replicationTaskWithVisibilityTime(&replicationspb.ReplicationTask{
 		TaskType: taskType,
 		Attributes: &replicationspb.ReplicationTask_NamespaceTaskAttributes{
 			NamespaceTaskAttributes: &replicationspb.NamespaceTaskAttributes{
@@ -517,7 +529,7 @@ func (s *transmissionTaskSuite) TestHandleTransmissionTask_UpdateNamespaceTask_H
 				FailoverVersion: failoverVersion,
 			},
 		},
-	}).Return(nil)
+	})).Return(nil)
 
 	err := s.namespaceReplicator.HandleTransmissionTask(
 		context.Background(),
@@ -632,7 +644,7 @@ func (s *transmissionTaskSuite) TestHandleTransmissionTask_UpdateNamespaceTask_R
 
 	isGlobalNamespace := true
 
-	s.namespaceReplicationQueue.EXPECT().Publish(gomock.Any(), &replicationspb.ReplicationTask{
+	s.namespaceReplicationQueue.EXPECT().Publish(gomock.Any(), replicationTaskWithVisibilityTime(&replicationspb.ReplicationTask{
 		TaskType: taskType,
 		Attributes: &replicationspb.ReplicationTask_NamespaceTaskAttributes{
 			NamespaceTaskAttributes: &replicationspb.NamespaceTaskAttributes{
@@ -661,7 +673,7 @@ func (s *transmissionTaskSuite) TestHandleTransmissionTask_UpdateNamespaceTask_R
 				FailoverVersion: failoverVersion,
 			},
 		},
-	}).Return(nil).Times(1)
+	})).Return(nil).Times(1)
 
 	err := s.namespaceReplicator.HandleTransmissionTask(
 		context.Background(),

--- a/service/worker/fx.go
+++ b/service/worker/fx.go
@@ -94,6 +94,7 @@ var Module = fx.Options(
 		dataMerger nsreplication.NamespaceDataMerger,
 		admitter nsreplication.NamespaceReplicationAdmitter,
 		logger log.Logger,
+		metricsHandler metrics.Handler,
 		eventLogger otellog.Logger,
 		serviceConfig *Config,
 		testHooks testhooks.TestHooks,
@@ -105,6 +106,7 @@ var Module = fx.Options(
 			admitter,
 			logger,
 			testHooks,
+			nsreplication.WithNamespaceReplicationMetrics(metricsHandler),
 			nsreplication.WithNamespaceReplicationLifecycleEvents(
 				eventLogger,
 				serviceConfig.EmitNamespaceLifecycleEvents,

--- a/service/worker/replicator/replication_message_processor.go
+++ b/service/worker/replicator/replication_message_processor.go
@@ -93,6 +93,7 @@ func newReplicationMessageProcessor(
 		namespaceTaskExecutor:        namespaceTaskExecutor,
 		customTaskHandler:            customTaskHandler,
 		metricsHandler:               metricsHandler.WithTags(metrics.OperationTag(metrics.NamespaceReplicationTaskScope)),
+		namespaceMetricsHandler:      metricsHandler,
 		retryPolicyForTask:           retryPolicyForTask,
 		lastProcessedMessageID:       -1,
 		lastRetrievedMessageID:       -1,
@@ -118,6 +119,7 @@ type (
 		namespaceTaskExecutor        nsreplication.TaskExecutor
 		customTaskHandler            func(ctx context.Context, task *replicationspb.ReplicationTask) error
 		metricsHandler               metrics.Handler
+		namespaceMetricsHandler      metrics.Handler
 		retryPolicyForTask           func(*replicationspb.ReplicationTask) backoff.RetryPolicy
 		lastProcessedMessageID       int64
 		lastRetrievedMessageID       int64
@@ -189,6 +191,12 @@ func (p *replicationMessageProcessor) handleReplicationTasks() {
 	taskCtx := headers.SetCallerInfo(context.TODO(), headers.SystemPreemptableCallerInfo)
 	for taskIndex := range response.Messages.ReplicationTasks {
 		task := response.Messages.ReplicationTasks[taskIndex]
+		taskMetricsCtx := nsreplication.WithTaskMetricsContext(taskCtx, nsreplication.TaskMetricsContext{
+			SourceCluster:  p.sourceCluster,
+			TargetCluster:  p.currentCluster,
+			Transport:      nsreplication.LegacyMetricsTransport,
+			VisibilityTime: task.GetVisibilityTime(),
+		})
 		eventData, emitEvents := p.namespaceReplicationEventData(task)
 		if emitEvents {
 			p.emitNamespaceReplicationEvent(
@@ -204,9 +212,9 @@ func (p *replicationMessageProcessor) handleReplicationTasks() {
 		policy := p.retryPolicyForTask(task)
 		err := backoff.ThrottleRetry(func() error {
 			attemptCount++
-			attemptCtx := taskCtx
+			attemptCtx := taskMetricsCtx
 			if emitEvents {
-				attemptCtx = wideevents.SetNamespaceReplicationTaskContext(taskCtx, wideevents.NamespaceReplicationTaskContext{
+				attemptCtx = wideevents.SetNamespaceReplicationTaskContext(attemptCtx, wideevents.NamespaceReplicationTaskContext{
 					SourceCluster: p.sourceCluster,
 					TargetCluster: p.currentCluster,
 					SourceTaskID:  task.GetSourceTaskId(),
@@ -228,6 +236,13 @@ func (p *replicationMessageProcessor) handleReplicationTasks() {
 				p.logger.Error("Failed to put replication tasks to DLQ", tag.Error(dlqErr))
 				metrics.ReplicatorDLQFailures.With(p.metricsHandler).Record(1)
 				return
+			}
+			if task.GetTaskType() == enumsspb.REPLICATION_TASK_TYPE_NAMESPACE_TASK {
+				nsreplication.RecordLegacyTerminalFailure(
+					taskMetricsCtx,
+					p.namespaceMetricsHandler,
+					task.GetNamespaceTaskAttributes(),
+				)
 			}
 
 			if emitEvents {

--- a/service/worker/replicator/replication_message_processor_test.go
+++ b/service/worker/replicator/replication_message_processor_test.go
@@ -15,6 +15,8 @@ import (
 	"go.temporal.io/server/api/adminservice/v1"
 	"go.temporal.io/server/api/adminservicemock/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
+	"go.temporal.io/server/api/matchingservicemock/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -22,10 +24,12 @@ import (
 	"go.temporal.io/server/common/membership"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/metrics/metricstest"
+	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/namespace/nsreplication"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/wideevents"
 	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
@@ -157,6 +161,7 @@ func TestHandleNamespaceReplicationTaskEmitsDLQed(t *testing.T) {
 	metricsHandler := metricstest.NewCaptureHandler()
 	capture := metricsHandler.StartCapture()
 	p.metricsHandler = metricsHandler
+	p.namespaceMetricsHandler = metricsHandler
 	executor.EXPECT().Execute(gomock.Any(), task.GetNamespaceTaskAttributes()).Return(serviceerror.NewInvalidArgument("bad task"))
 	queue.EXPECT().PublishToDLQ(gomock.Any(), task).Return(nil)
 
@@ -170,21 +175,84 @@ func TestHandleNamespaceReplicationTaskEmitsDLQed(t *testing.T) {
 	require.Len(t, recordings, 1)
 	taskTypeTag := metrics.ReplicationTaskTypeTag(task.TaskType)
 	require.Equal(t, taskTypeTag.Value, recordings[0].Tags[taskTypeTag.Key])
+	terminalFailures := capture.Snapshot()[metrics.NamespaceReplicationApplyOutcomes.Name()]
+	require.Len(t, terminalFailures, 1)
+	require.Equal(t, "terminal_failure", terminalFailures[0].Tags[metrics.OutcomeTag("").Key])
+	require.Equal(t, "update", terminalFailures[0].Tags[metrics.OperationTag("").Key])
+	require.Equal(t, nsreplication.LegacyMetricsTransport, terminalFailures[0].Tags[metrics.TransportTag("").Key])
+	require.Len(t, capture.Snapshot()[metrics.NamespaceReplicationApplyEndToEndLatency.Name()], 1)
+}
+
+func TestHandleNamespaceReplicationTaskDLQFailureDoesNotEmitTerminalOutcome(t *testing.T) {
+	p, task, executor, queue, _ := newReplicationEventTestProcessor(t, false, 1)
+	metricsHandler := metricstest.NewCaptureHandler()
+	capture := metricsHandler.StartCapture()
+	p.metricsHandler = metricsHandler
+	p.namespaceMetricsHandler = metricsHandler
+	executor.EXPECT().Execute(gomock.Any(), task.GetNamespaceTaskAttributes()).Return(serviceerror.NewInvalidArgument("bad task"))
+	queue.EXPECT().PublishToDLQ(gomock.Any(), task).Return(serviceerror.NewInvalidArgument("dlq unavailable"))
+
+	p.handleReplicationTasks()
+
+	require.Empty(t, capture.Snapshot()[metrics.NamespaceReplicationApplyOutcomes.Name()])
+	require.Empty(t, capture.Snapshot()[metrics.NamespaceReplicationApplyEndToEndLatency.Name()])
+}
+
+func TestHandleTaskQueueUserDataDLQDoesNotEmitNamespaceApplyOutcome(t *testing.T) {
+	p, task, _, queue, _ := newReplicationEventTestProcessor(t, false, 1)
+	controller := gomock.NewController(t)
+	registry := namespace.NewMockRegistry(controller)
+	matchingClient := matchingservicemock.NewMockMatchingServiceClient(controller)
+	metricsHandler := metricstest.NewCaptureHandler()
+	capture := metricsHandler.StartCapture()
+	p.metricsHandler = metricsHandler
+	p.namespaceMetricsHandler = metricsHandler
+	p.namespaceRegistry = registry
+	p.matchingClient = matchingClient
+	task.TaskType = enumsspb.REPLICATION_TASK_TYPE_TASK_QUEUE_USER_DATA
+	task.Attributes = &replicationspb.ReplicationTask_TaskQueueUserDataAttributes{
+		TaskQueueUserDataAttributes: &replicationspb.TaskQueueUserDataAttributes{
+			NamespaceId:   "namespace-id",
+			TaskQueueName: "task-queue",
+		},
+	}
+	ns := namespace.NewLocalNamespaceForTest(
+		&persistencespb.NamespaceInfo{Id: "namespace-id", Name: "payments"},
+		nil,
+		"cluster-b",
+	)
+	registry.EXPECT().GetNamespaceByID(namespace.ID("namespace-id")).Return(ns, nil).Times(2)
+	matchingClient.EXPECT().ApplyTaskQueueUserDataReplicationEvent(gomock.Any(), gomock.Any()).
+		Return(nil, serviceerror.NewInvalidArgument("bad task queue data"))
+	queue.EXPECT().PublishToDLQ(gomock.Any(), task).Return(nil)
+
+	p.handleReplicationTasks()
+
+	require.Empty(t, capture.Snapshot()[metrics.NamespaceReplicationApplyOutcomes.Name()])
+	require.Empty(t, capture.Snapshot()[metrics.NamespaceReplicationApplyEndToEndLatency.Name()])
 }
 
 func TestHandleNamespaceReplicationTaskEventsDisabled(t *testing.T) {
 	p, task, executor, _, eventLogger := newReplicationEventTestProcessor(t, false, 1)
-	processingContextSet := false
+	wideEventContextSet := false
+	var metricsContext nsreplication.TaskMetricsContext
+	var metricsContextSet bool
 	executor.EXPECT().Execute(gomock.Any(), task.GetNamespaceTaskAttributes()).DoAndReturn(
 		func(ctx context.Context, _ *replicationspb.NamespaceTaskAttributes) error {
-			_, processingContextSet = wideevents.NamespaceReplicationTaskContextFromContext(ctx)
+			_, wideEventContextSet = wideevents.NamespaceReplicationTaskContextFromContext(ctx)
+			metricsContext, metricsContextSet = nsreplication.TaskMetricsContextFromContext(ctx)
 			return nil
 		},
 	)
 
 	p.handleReplicationTasks()
 	require.Empty(t, eventLogger.records)
-	require.False(t, processingContextSet)
+	require.False(t, wideEventContextSet)
+	require.True(t, metricsContextSet)
+	require.Equal(t, "cluster-a", metricsContext.SourceCluster)
+	require.Equal(t, "cluster-b", metricsContext.TargetCluster)
+	require.Equal(t, nsreplication.LegacyMetricsTransport, metricsContext.Transport)
+	require.Equal(t, task.GetVisibilityTime(), metricsContext.VisibilityTime)
 }
 
 func TestCustomNamespaceReplicationTaskUsesEventDataProvider(t *testing.T) {
@@ -243,6 +311,7 @@ func newReplicationEventTestProcessor(
 		remotePeer:                   remotePeer,
 		namespaceTaskExecutor:        executor,
 		metricsHandler:               metrics.NoopMetricsHandler,
+		namespaceMetricsHandler:      metrics.NoopMetricsHandler,
 		retryPolicyForTask:           func(*replicationspb.ReplicationTask) backoff.RetryPolicy { return policy },
 		lastProcessedMessageID:       -1,
 		lastRetrievedMessageID:       -1,
@@ -253,8 +322,9 @@ func newReplicationEventTestProcessor(
 
 func namespaceReplicationTaskForProcessorTest() *replicationspb.ReplicationTask {
 	return &replicationspb.ReplicationTask{
-		TaskType:     enumsspb.REPLICATION_TASK_TYPE_NAMESPACE_TASK,
-		SourceTaskId: 42,
+		TaskType:       enumsspb.REPLICATION_TASK_TYPE_NAMESPACE_TASK,
+		SourceTaskId:   42,
+		VisibilityTime: timestamppb.New(time.Now().Add(-time.Minute)),
 		Attributes: &replicationspb.ReplicationTask_NamespaceTaskAttributes{
 			NamespaceTaskAttributes: &replicationspb.NamespaceTaskAttributes{
 				NamespaceOperation: enumsspb.NAMESPACE_OPERATION_UPDATE,


### PR DESCRIPTION
## What changed?
Added metrics for final outcomes and end-to-end latency in legacy namespace metadata replication.

The receiver records applied, no_change, not_admitted, or terminal_failure with operation, source cluster, target cluster, transport, and outcome tags. The outcome counter also includes the namespace tag; the latency histogram omits it to avoid multiplying per-namespace cardinality by histogram buckets. terminal_failure is recorded only after a successful DLQ enqueue. The sender stamps the replication task visibility time immediately before publishing it.

The transport tag is `legacy` in this phase and keeps the metric contract stable for the planned period when legacy and CHASM transports coexist. Operators can suppress namespace on the outcome counter through the existing metrics excludeTags mechanism; that exclusion applies process-wide to every metric using the namespace tag. This does not change the TaskExecutor interface and is independent of wide events.

## Why?
OSS operators currently lack direct metrics for alerting on whether namespace metadata replication is being applied, ignored, rejected, or terminally failed.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

Manually validated all four outcomes with a local three-cluster setup.

## Potential risks
The outcome counter's namespace tag can create high cardinality for installations with many namespaces. Operators can suppress it through the existing process-wide excludeTags configuration; the latency histogram never includes namespace. End-to-end latency depends on clocks across source and target clusters, and a future source timestamp is clamped to zero.
