### PR TITLE
New metric for retry attempts

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -35,7 +35,7 @@ const (
 	ChasmTaskTypeTagName           = "chasm_task_type"
 	timeoutTypeTagName             = "timeout_type"
 	LastAttemptCauseTagName        = "last_attempt_cause"
-	StageTagName                   = "stage"
+	AttemptStageTagName            = "attempt_stage"
 )
 
 // This package should hold all the metrics and tags for temporal

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -34,6 +34,8 @@ const (
 	ArchetypeTagName               = "archetype"
 	ChasmTaskTypeTagName           = "chasm_task_type"
 	timeoutTypeTagName             = "timeout_type"
+	LastAttemptCauseTagName        = "last_attempt_cause"
+	StageTagName                   = "stage"
 )
 
 // This package should hold all the metrics and tags for temporal
@@ -890,6 +892,10 @@ var (
 	TaskAttempt = NewDimensionlessHistogramDef(
 		"task_attempt",
 		WithDescription("The number of attempts took to complete a history task."),
+	)
+	TaskAlertableAttempt = NewDimensionlessHistogramDef(
+		"task_alertable_attempt",
+		WithDescription("The number of attempts, among a history task's total, caused by an alertable (system-side) error."),
 	)
 	TaskFailures = NewCounterDef(
 		"task_errors",

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -445,9 +445,17 @@ func LastAttemptCauseTag(value string) Tag {
 	return Tag{Key: LastAttemptCauseTagName, Value: value}
 }
 
-func StageTag(value string) Tag {
-	return Tag{Key: StageTagName, Value: value}
-}
+// Values for AttemptStageTagName, identifying whether TaskAlertableAttempt was recorded
+// mid-retry or at the attempt's final resolution.
+const (
+	AttemptStageInFlight = "in_flight"
+	AttemptStageTerminal = "terminal"
+)
+
+var (
+	AttemptStageInFlightTag = Tag{Key: AttemptStageTagName, Value: AttemptStageInFlight}
+	AttemptStageTerminalTag = Tag{Key: AttemptStageTagName, Value: AttemptStageTerminal}
+)
 
 func ServiceNameTag(value primitives.ServiceName) Tag {
 	return Tag{Key: serviceName, Value: string(value)}

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -441,6 +441,14 @@ func ResourceExhaustedScopeTag(scope enumspb.ResourceExhaustedScope) Tag {
 	return Tag{Key: resourceExhaustedScopeTag, Value: scope.String()}
 }
 
+func LastAttemptCauseTag(value string) Tag {
+	return Tag{Key: LastAttemptCauseTagName, Value: value}
+}
+
+func StageTag(value string) Tag {
+	return Tag{Key: StageTagName, Value: value}
+}
+
 func ServiceNameTag(value primitives.ServiceName) Tag {
 	return Tag{Key: serviceName, Value: string(value)}
 }

--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -242,6 +242,7 @@ func NewExecutable(
 		maxUnexpectedErrorAttempts: params.MaxUnexpectedErrorAttempts,
 		dlqInternalErrors:          params.DLQInternalErrors,
 		dlqErrorPattern:            params.DLQErrorPattern,
+		alertableErrorCauseTag:     metrics.LastAttemptCauseTag("none"),
 	}
 	e.refreshMetricsHandlers(nil)
 	e.attempt.Store(1)

--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -141,6 +141,8 @@ type (
 		dlqEnabled                 dynamicconfig.BoolPropertyFn
 		terminalFailureCause       error
 		unexpectedErrorAttempts    int
+		alertableAttempts          int
+		alertableErrorCauseTag     metrics.Tag
 		maxUnexpectedErrorAttempts dynamicconfig.IntPropertyFn
 		dlqInternalErrors          dynamicconfig.BoolPropertyFn
 		dlqErrorPattern            dynamicconfig.StringPropertyFn
@@ -467,6 +469,28 @@ func (e *executableImpl) isSafeToDropError(err error) bool {
 	return false
 }
 
+// classifyAlertableError answers both whether err should count toward alertableAttempts and,
+// if so, what cause tag it should carry.
+func classifyAlertableError(err error) (alertable bool, causeTag metrics.Tag) {
+	if resourceExhaustedErr, ok := errors.AsType[*serviceerror.ResourceExhausted](err); ok {
+		alertable = resourceExhaustedErr.Scope != enumspb.RESOURCE_EXHAUSTED_SCOPE_NAMESPACE ||
+			resourceExhaustedErr.Cause == enumspb.RESOURCE_EXHAUSTED_CAUSE_BUSY_WORKFLOW
+		if alertable {
+			causeTag = metrics.LastAttemptCauseTag(resourceExhaustedErr.Cause.String())
+		}
+		return alertable, causeTag
+	}
+	if _, ok := err.(*serviceerror.NamespaceNotActive); ok {
+		return false, causeTag
+	}
+	if err == consts.ErrDependencyTaskNotCompleted ||
+		err == consts.ErrTaskRetry ||
+		err.Error() == consts.ErrNamespaceHandover.Error() {
+		return false, causeTag
+	}
+	return true, metrics.LastAttemptCauseTag(metrics.ServiceErrorTypeTag(err).Value)
+}
+
 // Returns true when the error is expected and should be retried. You're expected to return
 // an error in this case, as that possible-rewritten-error is what we'll return
 func (e *executableImpl) isExpectedRetryableError(err error) (isRetryable bool, retErr error) {
@@ -571,6 +595,15 @@ func (e *executableImpl) HandleErr(err error) (retErr error) {
 	}
 
 	e.incAttempt()
+
+	if alertable, causeTag := classifyAlertableError(err); alertable {
+		e.alertableAttempts++
+		e.alertableErrorCauseTag = causeTag
+		if e.attempt.Load() > taskCriticalLogMetricAttempts {
+			metrics.TaskAlertableAttempt.With(e.chasmMetricsHandler).Record(
+				int64(e.alertableAttempts), causeTag, metrics.StageTag("in_flight"))
+		}
+	}
 
 	if ok, rewrittenErr := e.isExpectedRetryableError(err); ok {
 		return rewrittenErr
@@ -695,6 +728,8 @@ func (e *executableImpl) Ack() {
 	}
 
 	metrics.TaskAttempt.With(e.chasmMetricsHandler).Record(e.attempt.Load())
+	metrics.TaskAlertableAttempt.With(e.chasmMetricsHandler).Record(
+		int64(e.alertableAttempts), e.alertableErrorCauseTag, metrics.StageTag("terminal"))
 
 	priorityTaggedProvider := e.chasmMetricsHandler.WithTags(metrics.TaskPriorityTag(e.priority.String()))
 	metrics.TaskLatency.With(priorityTaggedProvider).Record(e.inMemoryNoUserLatency)

--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -602,7 +602,7 @@ func (e *executableImpl) HandleErr(err error) (retErr error) {
 		e.alertableErrorCauseTag = causeTag
 		if e.attempt.Load() > taskCriticalLogMetricAttempts {
 			metrics.TaskAlertableAttempt.With(e.chasmMetricsHandler).Record(
-				int64(e.alertableAttempts), causeTag, metrics.StageTag("in_flight"))
+				int64(e.alertableAttempts), causeTag, metrics.AttemptStageInFlightTag)
 		}
 	}
 
@@ -730,7 +730,7 @@ func (e *executableImpl) Ack() {
 
 	metrics.TaskAttempt.With(e.chasmMetricsHandler).Record(e.attempt.Load())
 	metrics.TaskAlertableAttempt.With(e.chasmMetricsHandler).Record(
-		int64(e.alertableAttempts), e.alertableErrorCauseTag, metrics.StageTag("terminal"))
+		int64(e.alertableAttempts), e.alertableErrorCauseTag, metrics.AttemptStageTerminalTag)
 
 	priorityTaggedProvider := e.chasmMetricsHandler.WithTags(metrics.TaskPriorityTag(e.priority.String()))
 	metrics.TaskLatency.With(priorityTaggedProvider).Record(e.inMemoryNoUserLatency)

--- a/service/history/queues/executable_test.go
+++ b/service/history/queues/executable_test.go
@@ -721,7 +721,7 @@ func (s *executableSuite) TestAck_AlertableAttemptStageTag_Terminal() {
 	s.metricsHandler.StopCapture(capture)
 
 	recording := snapshot[metrics.TaskAlertableAttempt.Name()][0]
-	s.Equal("terminal", recording.Tags[metrics.StageTagName])
+	s.Equal(metrics.AttemptStageTerminal, recording.Tags[metrics.AttemptStageTagName])
 }
 
 // Guards against a zero-value (empty) cause tag when no alertable error ever occurred.
@@ -757,7 +757,7 @@ func (s *executableSuite) TestHandleErr_AlertableAttemptStageTag_InFlight() {
 
 	recordings := snapshot[metrics.TaskAlertableAttempt.Name()]
 	s.Len(recordings, 1)
-	s.Equal("in_flight", recordings[0].Tags[metrics.StageTagName])
+	s.Equal(metrics.AttemptStageInFlight, recordings[0].Tags[metrics.AttemptStageTagName])
 	s.Equal(enumspb.RESOURCE_EXHAUSTED_CAUSE_BUSY_WORKFLOW.String(), recordings[0].Tags[metrics.LastAttemptCauseTagName])
 }
 

--- a/service/history/queues/executable_test.go
+++ b/service/history/queues/executable_test.go
@@ -26,6 +26,7 @@ import (
 	"go.temporal.io/server/common/persistence/serialization"
 	ctasks "go.temporal.io/server/common/tasks"
 	"go.temporal.io/server/common/telemetry"
+	"go.temporal.io/server/common/util"
 	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/queues"
 	"go.temporal.io/server/service/history/queues/queuestest"
@@ -541,6 +542,209 @@ func (s *executableSuite) TestExecuteHandleErr_ResetAttempt() {
 			s.metricsHandler.StopCapture(capture)
 		})
 	}
+}
+
+// Expected-retryable errors skip the DLQ threshold entirely, but should still behave like any
+// other attempt otherwise.
+func (s *executableSuite) TestHandleErr_ExpectedRetryableError_AttemptAndMetricsUnaffected() {
+	testCases := []struct {
+		name    string
+		taskErr error
+	}{
+		{
+			name: "SystemScopedResourceExhausted",
+			taskErr: &serviceerror.ResourceExhausted{
+				Cause:   enumspb.RESOURCE_EXHAUSTED_CAUSE_SYSTEM_OVERLOADED,
+				Scope:   enumspb.RESOURCE_EXHAUSTED_SCOPE_SYSTEM,
+				Message: "test",
+			},
+		},
+		{
+			name:    "BusyWorkflow",
+			taskErr: consts.ErrResourceExhaustedBusyWorkflow,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			// attempt starts at 1, so 30 HandleErr calls land it at exactly 31 - one past
+			// taskCriticalLogMetricAttempts (30).
+			const numAttempts = 30
+			const finalAttempt = numAttempts + 1
+
+			queueWriter := &queuestest.FakeQueueWriter{}
+			executable := s.newTestExecutable(func(p *params) {
+				p.dlqWriter = queues.NewDLQWriter(queueWriter, metrics.NoopMetricsHandler, log.NewTestLogger(), s.mockNamespaceRegistry, s.chasmRegistry)
+				p.dlqEnabled = func() bool { return true }
+				p.maxUnexpectedErrorAttempts = func() int { return 1 }
+			})
+			s.mockExecutor.EXPECT().Execute(gomock.Any(), executable).Return(queues.ExecuteResponse{
+				ExecutionMetricTags: nil,
+				ExecutedAsActive:    true,
+				ExecutionErr:        tc.taskErr,
+			}).Times(numAttempts)
+
+			capture := s.metricsHandler.StartCapture()
+			for range numAttempts {
+				err := executable.Execute()
+				s.Error(err)
+				handledErr := executable.HandleErr(err)
+				s.Error(handledErr)
+				s.NotErrorIs(handledErr, queues.ErrTerminalTaskFailure)
+			}
+
+			// unexpectedErrorAttempts never climbed: no DLQ write despite maxUnexpectedErrorAttempts == 1.
+			s.Empty(queueWriter.EnqueueTaskRequests)
+
+			// attempt still climbs, and TaskAttempt still records once it crosses the floor.
+			inFlight := capture.Snapshot()[metrics.TaskAttempt.Name()]
+			s.Len(inFlight, 1)
+			s.EqualValues(finalAttempt, inFlight[0].Value)
+
+			executable.Ack()
+			snapshot := capture.Snapshot()
+			s.metricsHandler.StopCapture(capture)
+			terminal := snapshot[metrics.TaskAttempt.Name()]
+			s.Len(terminal, 2)
+			s.EqualValues(finalAttempt, terminal[1].Value)
+		})
+	}
+}
+
+func (s *executableSuite) TestHandleErr_IsAlertableError() {
+	testCases := []struct {
+		name                  string
+		taskErr               error
+		expectedAlertable     bool
+		expectedCauseTagValue string
+	}{
+		{
+			name:              "ResourceExhausted_NamespaceScoped_NotBusyWorkflow",
+			taskErr:           consts.ErrResourceExhaustedAPSLimit,
+			expectedAlertable: false,
+		},
+		{
+			name:                  "ResourceExhausted_BusyWorkflow",
+			taskErr:               consts.ErrResourceExhaustedBusyWorkflow,
+			expectedAlertable:     true,
+			expectedCauseTagValue: enumspb.RESOURCE_EXHAUSTED_CAUSE_BUSY_WORKFLOW.String(),
+		},
+		{
+			name: "ResourceExhausted_SystemScoped",
+			taskErr: &serviceerror.ResourceExhausted{
+				Cause:   enumspb.RESOURCE_EXHAUSTED_CAUSE_SYSTEM_OVERLOADED,
+				Scope:   enumspb.RESOURCE_EXHAUSTED_SCOPE_SYSTEM,
+				Message: "test",
+			},
+			expectedAlertable:     true,
+			expectedCauseTagValue: enumspb.RESOURCE_EXHAUSTED_CAUSE_SYSTEM_OVERLOADED.String(),
+		},
+		{
+			name: "ResourceExhausted_ScopeUnspecified",
+			taskErr: &serviceerror.ResourceExhausted{
+				Cause:   enumspb.RESOURCE_EXHAUSTED_CAUSE_CIRCUIT_BREAKER_OPEN,
+				Message: "test",
+			},
+			expectedAlertable:     true,
+			expectedCauseTagValue: enumspb.RESOURCE_EXHAUSTED_CAUSE_CIRCUIT_BREAKER_OPEN.String(),
+		},
+		{
+			name:                  "UnclassifiedCatchall",
+			taskErr:               errors.New("some random error"),
+			expectedAlertable:     true,
+			expectedCauseTagValue: util.ErrorType(errors.New("some random error")),
+		},
+		{
+			name:              "NamespaceNotActive",
+			taskErr:           serviceerror.NewNamespaceNotActive("", "", ""),
+			expectedAlertable: false,
+		},
+		{
+			name:              "ErrDependencyTaskNotCompleted",
+			taskErr:           consts.ErrDependencyTaskNotCompleted,
+			expectedAlertable: false,
+		},
+		{
+			name:              "ErrTaskRetry",
+			taskErr:           consts.ErrTaskRetry,
+			expectedAlertable: false,
+		},
+		{
+			name:              "ErrNamespaceHandover",
+			taskErr:           consts.ErrNamespaceHandover,
+			expectedAlertable: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			executable := s.newTestExecutable()
+			s.mockExecutor.EXPECT().Execute(gomock.Any(), executable).Return(queues.ExecuteResponse{
+				ExecutionMetricTags: nil,
+				ExecutedAsActive:    true,
+				ExecutionErr:        tc.taskErr,
+			})
+
+			err := executable.Execute()
+			s.Error(err)
+			s.Error(executable.HandleErr(err))
+
+			capture := s.metricsHandler.StartCapture()
+			executable.Ack()
+			snapshot := capture.Snapshot()
+			s.metricsHandler.StopCapture(capture)
+			recording := snapshot[metrics.TaskAlertableAttempt.Name()][0]
+			isAlertable := recording.Value == int64(1)
+			s.Equal(tc.expectedAlertable, isAlertable, "isAlertableError(%v)", tc.taskErr)
+			if tc.expectedAlertable {
+				s.Equal(tc.expectedCauseTagValue, recording.Tags[metrics.LastAttemptCauseTagName], "cause tag for %v", tc.taskErr)
+			}
+		})
+	}
+}
+
+func (s *executableSuite) TestAck_AlertableAttemptStageTag_Terminal() {
+	executable := s.newTestExecutable()
+	s.mockExecutor.EXPECT().Execute(gomock.Any(), executable).Return(queues.ExecuteResponse{
+		ExecutionMetricTags: nil,
+		ExecutedAsActive:    true,
+		ExecutionErr:        consts.ErrResourceExhaustedBusyWorkflow,
+	})
+
+	err := executable.Execute()
+	s.Error(err)
+	s.Error(executable.HandleErr(err))
+
+	capture := s.metricsHandler.StartCapture()
+	executable.Ack()
+	snapshot := capture.Snapshot()
+	s.metricsHandler.StopCapture(capture)
+
+	recording := snapshot[metrics.TaskAlertableAttempt.Name()][0]
+	s.Equal("terminal", recording.Tags[metrics.StageTagName])
+}
+
+func (s *executableSuite) TestHandleErr_AlertableAttemptStageTag_InFlight() {
+	executable := s.newTestExecutable()
+	s.mockExecutor.EXPECT().Execute(gomock.Any(), executable).Return(queues.ExecuteResponse{
+		ExecutionMetricTags: nil,
+		ExecutedAsActive:    true,
+		ExecutionErr:        consts.ErrResourceExhaustedBusyWorkflow,
+	}).Times(30) // attempt starts at 1; 30 HandleErr calls land it at 31, crossing the floor (30) once.
+
+	capture := s.metricsHandler.StartCapture()
+	for range 30 {
+		err := executable.Execute()
+		s.Error(err)
+		s.Error(executable.HandleErr(err))
+	}
+	snapshot := capture.Snapshot()
+	s.metricsHandler.StopCapture(capture)
+
+	recordings := snapshot[metrics.TaskAlertableAttempt.Name()]
+	s.Len(recordings, 1)
+	s.Equal("in_flight", recordings[0].Tags[metrics.StageTagName])
+	s.Equal(enumspb.RESOURCE_EXHAUSTED_CAUSE_BUSY_WORKFLOW.String(), recordings[0].Tags[metrics.LastAttemptCauseTagName])
 }
 
 func (s *executableSuite) TestExecuteHandleErr_Corrupted() {

--- a/service/history/queues/executable_test.go
+++ b/service/history/queues/executable_test.go
@@ -724,6 +724,20 @@ func (s *executableSuite) TestAck_AlertableAttemptStageTag_Terminal() {
 	s.Equal("terminal", recording.Tags[metrics.StageTagName])
 }
 
+// Guards against a zero-value (empty) cause tag when no alertable error ever occurred.
+func (s *executableSuite) TestAck_AlertableAttemptCauseTag_NoAlertableError() {
+	executable := s.newTestExecutable()
+
+	capture := s.metricsHandler.StartCapture()
+	executable.Ack()
+	snapshot := capture.Snapshot()
+	s.metricsHandler.StopCapture(capture)
+
+	recording := snapshot[metrics.TaskAlertableAttempt.Name()][0]
+	s.Contains(recording.Tags, metrics.LastAttemptCauseTagName)
+	s.NotEmpty(recording.Tags[metrics.LastAttemptCauseTagName])
+}
+
 func (s *executableSuite) TestHandleErr_AlertableAttemptStageTag_InFlight() {
 	executable := s.newTestExecutable()
 	s.mockExecutor.EXPECT().Execute(gomock.Any(), executable).Return(queues.ExecuteResponse{


### PR DESCRIPTION
## What changed?

Adds a new metric, `task_alertable_attempt`, alongside the existing `task_attempt` histogram in
`service/history/queues/executable.go`, to distinguish system-caused retry loops from
namespace/customer-caused ones.

- New predicate, counting: any `ResourceExhausted` error with `Scope != NAMESPACE` (system-caused
  throttling, including causes that never set `Scope` at all, e.g. `CIRCUIT_BREAKER_OPEN`), plus a
  deliberate `BUSY_WORKFLOW` carve-out; and everything else not explicitly excluded.
  Also excludes `NamespaceNotActive`, `ErrDependencyTaskNotCompleted`, `ErrTaskRetry`, `ErrNamespaceHandover`.
- Two emission sites, mirroring `task_attempt`'s: a terminal sample in `Ack()` (unconditional)
  and an in-flight sample gated by the `task_attempt` 30-attempt limit.
- Two tags on both sites: `last_attempt_cause` (the specific `ResourceExhausted` cause, or the Go
  error type for the catchall case) and `stage` (`terminal` vs. `in_flight`).

## Why?

`task_attempt` and its alert can't tell a system-caused retry storm apart from a
namespace/customer-caused one — e.g. a task throttled by its own namespace's APS limit climbs into
the same 100+ attempt range as a genuinely stuck task, firing the same cluster-wide stuck-task alert
and turning it into noise. Full investigation and design rationale in `task-attempt-metric-noise-v2.md`.

## How did you test it?

- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)
