### PR TITLE
Add CHASM force termination metric and archetype tag

### DIFF
--- a/chasm/tree.go
+++ b/chasm/tree.go
@@ -3104,6 +3104,15 @@ func (n *Node) Terminate(
 	}
 
 	n.terminated = true
+	archetypeID := n.ArchetypeID()
+	archetype := strconv.FormatUint(uint64(archetypeID), 10)
+	if archetypeFQN, ok := n.registry.ComponentFqnByID(archetypeID); ok {
+		archetype = archetypeFQN
+	}
+	metrics.ExecutionTerminate.With(n.metricsHandler).Record(
+		1,
+		metrics.ArchetypeTag(archetype),
+	)
 	return nil
 }
 

--- a/chasm/tree_test.go
+++ b/chasm/tree_test.go
@@ -25,6 +25,7 @@ import (
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/metrics/metricstest"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/testing/protoassert"
 	"go.temporal.io/server/common/testing/protorequire"
@@ -3626,6 +3627,11 @@ func (s *nodeSuite) TestCloseTransaction_ApplyMutation_PureTasks() {
 }
 
 func (s *nodeSuite) TestTerminate() {
+	metricsHandler := metricstest.NewCaptureHandler()
+	capture := metricsHandler.StartCapture()
+	defer metricsHandler.StopCapture(capture)
+	s.metricsHandler = metricsHandler
+
 	node := s.testComponentTree()
 
 	// First closeTransaction once to make the tree clean.
@@ -3639,6 +3645,10 @@ func (s *nodeSuite) TestTerminate() {
 	err = node.Terminate(TerminateComponentRequest{})
 	s.NoError(err)
 	s.True(node.terminated)
+	recordings := capture.Snapshot()[metrics.ExecutionTerminate.Name()]
+	s.Len(recordings, 1)
+	s.Equal(int64(1), recordings[0].Value)
+	s.Equal(testComponentFQN, recordings[0].Tags[metrics.ArchetypeTagName])
 
 	mutations, err := node.CloseTransaction()
 	s.NoError(err)

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -933,6 +933,10 @@ var (
 		"chasm_pure_task_errors",
 		WithDescription("The number of errors during CHASM pure task execution."),
 	)
+	ExecutionTerminate = NewCounterDef(
+		"execution_terminate",
+		WithDescription("The number of CHASM executions that were terminated."),
+	)
 	ChasmIncomingSignalWritten = NewCounterDef(
 		"chasm_incoming_signal_written",
 		WithDescription("The number of signal backlinks written to the CHASM IncomingSignals map."),


### PR DESCRIPTION
## What changed?
Add CHASM force termination metric and archetype tag

## Why?
`workflow_terminated` exists as a metric to show when any workflow is terminated, but no such metric is published when CHASM executions are force terminated due to exceeding mutable state size etc.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)
