### PR TITLE
Add HTTP fault injection to server functional tests

### DIFF
--- a/chasm/lib/callback/fx.go
+++ b/chasm/lib/callback/fx.go
@@ -11,7 +11,10 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/namespace"
 	commonnexus "go.temporal.io/server/common/nexus"
+	"go.temporal.io/server/common/rpc/httpfaults"
 	"go.temporal.io/server/common/telemetry"
+	"go.temporal.io/server/common/testing/httpfaultstest"
+	"go.temporal.io/server/common/testing/testhooks"
 	queuescommon "go.temporal.io/server/service/history/queues/common"
 	"go.uber.org/fx"
 )
@@ -31,6 +34,7 @@ func httpCallerProviderProvider(
 	httpClientCache *cluster.FrontendHTTPClientCache,
 	logger log.Logger,
 	httpClientTransportInstrumenter telemetry.HTTPClientTransportInstrumenter,
+	testHooks testhooks.TestHooks,
 ) (HTTPCallerProvider, error) {
 	localClient, err := rpcFactory.CreateLocalFrontendHTTPClient()
 	if err != nil {
@@ -44,9 +48,11 @@ func httpCallerProviderProvider(
 		Transport: httpClientTransportInstrumenter.Instrument(externalTransport),
 	}
 	callbackTokenGenerator := commonnexus.NewCallbackTokenGenerator()
+	httpFaultGenerator := httpfaultstest.NewGenerator(testHooks)
 
-	m := collection.NewOnceMap(func(queuescommon.NamespaceIDAndDestination) HTTPCaller {
-		return func(r *http.Request) (*http.Response, error) {
+	m := collection.NewOnceMap(func(key queuescommon.NamespaceIDAndDestination) HTTPCaller {
+		scope := httpfaults.Scope{NamespaceID: namespace.ID(key.NamespaceID)}
+		caller := func(r *http.Request) (*http.Response, error) {
 			return routeRequest(r,
 				clusterMetadata,
 				namespaceRegistry,
@@ -57,6 +63,7 @@ func httpCallerProviderProvider(
 				logger,
 			)
 		}
+		return httpfaults.Wrap(httpFaultGenerator, scope, caller)
 	})
 	return m.Get, nil
 }

--- a/chasm/lib/nexusoperation/fx.go
+++ b/chasm/lib/nexusoperation/fx.go
@@ -21,7 +21,10 @@ import (
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/resource"
 	"go.temporal.io/server/common/rpc"
+	"go.temporal.io/server/common/rpc/httpfaults"
 	"go.temporal.io/server/common/telemetry"
+	"go.temporal.io/server/common/testing/httpfaultstest"
+	"go.temporal.io/server/common/testing/testhooks"
 	"go.uber.org/fx"
 )
 
@@ -126,6 +129,7 @@ func clientProviderFactory(
 	namespaceRegistry namespace.Registry,
 	rpcFactory common.RPCFactory,
 	httpClientTransportInstrumenter telemetry.HTTPClientTransportInstrumenter,
+	testHooks testhooks.TestHooks,
 ) (ClientProvider, error) {
 	cl, err := rpcFactory.CreateLocalFrontendHTTPClient()
 	if err != nil {
@@ -136,6 +140,7 @@ func clientProviderFactory(
 	if clusterInfo, ok := clusterMetadata.GetAllClusterInfo()[clusterMetadata.GetCurrentClusterName()]; ok {
 		clusterID = clusterInfo.ClusterID
 	}
+	httpFaultGenerator := httpfaultstest.NewGenerator(testHooks)
 	m := collection.NewFallibleOnceMap(func(key clientProviderCacheKey) (*http.Client, error) {
 		transport := httpTransportProvider(key.namespaceID, key.endpointID)
 		return &http.Client{
@@ -194,6 +199,11 @@ func clientProviderFactory(
 				return baseHTTPCaller(r)
 			}
 		}
+		httpCaller = httpfaults.Wrap(
+			httpFaultGenerator,
+			httpfaults.Scope{NamespaceID: namespace.ID(namespaceID)},
+			httpCaller,
+		)
 
 		return nexusrpc.NewHTTPClient(nexusrpc.HTTPClientOptions{
 			BaseURL:    url,

--- a/chasm/lib/nexusoperation/fx_test.go
+++ b/chasm/lib/nexusoperation/fx_test.go
@@ -11,6 +11,7 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/cluster"
+	"go.temporal.io/server/common/testing/testhooks"
 	"go.uber.org/mock/gomock"
 )
 
@@ -108,6 +109,7 @@ func TestClientProviderFactoryUsesSelectedHTTPClient(t *testing.T) {
 				nil,
 				rpcFactory,
 				nil,
+				testhooks.NewTestHooks(),
 			)
 			require.NoError(t, err)
 

--- a/common/rpc/faultinjection/generator.go
+++ b/common/rpc/faultinjection/generator.go
@@ -1,0 +1,266 @@
+// Package faultinjection registers request and response faults for multiple transports.
+package faultinjection
+
+import (
+	"context"
+	"sync"
+
+	"go.temporal.io/server/common/namespace"
+)
+
+type (
+	faultScopeGetter interface {
+		FaultScope() Scope
+	}
+
+	namespaceNameGetter interface {
+		GetNamespace() string
+	}
+
+	namespaceIDGetter interface {
+		GetNamespaceId() string
+	}
+)
+
+type faultStage int
+
+const (
+	faultStageRequest faultStage = iota
+	faultStageResponse
+)
+
+// Outcome defines the result of a matched fault.
+type Outcome[Resp any] struct {
+	Response Resp
+	Error    error
+}
+
+// RequestCallback checks a request before the handler runs.
+type RequestCallback[Req, Resp any] func(ctx context.Context, operation string, req Req) *Outcome[Resp]
+
+// ResponseCallback checks a result after the handler runs.
+type ResponseCallback[Req, Resp any] func(ctx context.Context, operation string, req Req, resp Resp, err error) *Outcome[Resp]
+
+// Generator checks for faults before and after a handler runs.
+type Generator[Req, Resp any] interface {
+	GenerateRequest(ctx context.Context, operation string, req Req) *Outcome[Resp]
+	GenerateResponse(ctx context.Context, operation string, req Req, resp Resp, err error) *Outcome[Resp]
+}
+
+// Hooks installs callbacks outside the generator.
+type Hooks[Req, Resp any] interface {
+	InstallRequestCallback(Scope, RequestCallback[Req, Resp]) func()
+	InstallResponseCallback(Scope, ResponseCallback[Req, Resp]) func()
+}
+
+type callback[Req, Resp any] func(ctx context.Context, operation string, req Req, resp Resp, err error) *Outcome[Resp]
+
+// callbackEntry represents a registered callback with its ID.
+type callbackEntry[Req, Resp any] struct {
+	id       uint64
+	callback callback[Req, Resp]
+}
+
+// Scope identifies a namespace by ID, name, or both. An empty scope applies globally.
+type Scope struct {
+	NamespaceID   namespace.ID
+	NamespaceName namespace.Name
+}
+
+type callbackScope struct {
+	Scope
+	stage faultStage
+}
+
+type callbackBucket[Req, Resp any] struct {
+	callbacks  []callbackEntry[Req, Resp]
+	unregister func()
+}
+
+// CallbackGenerator stores request and response fault callbacks.
+type CallbackGenerator[Req, Resp any] struct {
+	mu        sync.RWMutex
+	callbacks map[callbackScope]*callbackBucket[Req, Resp]
+	nextID    uint64
+	hooks     Hooks[Req, Resp]
+}
+
+// NewCallbackGenerator returns a callback generator.
+func NewCallbackGenerator[Req, Resp any]() *CallbackGenerator[Req, Resp] {
+	return NewCallbackGeneratorWithHooks[Req, Resp](nil)
+}
+
+// NewCallbackGeneratorWithHooks returns a callback generator that uses hooks.
+func NewCallbackGeneratorWithHooks[Req, Resp any](hooks Hooks[Req, Resp]) *CallbackGenerator[Req, Resp] {
+	return &CallbackGenerator[Req, Resp]{
+		callbacks: make(map[callbackScope]*callbackBucket[Req, Resp]),
+		hooks:     hooks,
+	}
+}
+
+// RegisterRequestCallback registers a request callback and returns its cleanup function.
+func (r *CallbackGenerator[Req, Resp]) RegisterRequestCallback(scope Scope, cb RequestCallback[Req, Resp]) func() {
+	return r.registerCallback(scope, faultStageRequest, func(ctx context.Context, operation string, req Req, _ Resp, _ error) *Outcome[Resp] {
+		return cb(ctx, operation, req)
+	})
+}
+
+// RegisterResponseCallback registers a response callback and returns its cleanup function.
+func (r *CallbackGenerator[Req, Resp]) RegisterResponseCallback(scope Scope, cb ResponseCallback[Req, Resp]) func() {
+	return r.registerCallback(scope, faultStageResponse, func(ctx context.Context, operation string, req Req, resp Resp, err error) *Outcome[Resp] {
+		return cb(ctx, operation, req, resp, err)
+	})
+}
+
+func (r *CallbackGenerator[Req, Resp]) registerCallback(faultScope Scope, stage faultStage, cb callback[Req, Resp]) func() {
+	if r == nil {
+		return func() {}
+	}
+
+	var callbackScopes []callbackScope
+	if faultScope.NamespaceID != "" {
+		callbackScopes = append(callbackScopes, callbackScope{Scope: Scope{NamespaceID: faultScope.NamespaceID}, stage: stage})
+	}
+	if faultScope.NamespaceName != "" {
+		callbackScopes = append(callbackScopes, callbackScope{Scope: Scope{NamespaceName: faultScope.NamespaceName}, stage: stage})
+	}
+	if len(callbackScopes) == 0 {
+		callbackScopes = append(callbackScopes, callbackScope{stage: stage})
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.nextID++
+	entry := callbackEntry[Req, Resp]{id: r.nextID, callback: cb}
+	for _, callbackScope := range callbackScopes {
+		bucket := r.callbacks[callbackScope]
+		if bucket == nil {
+			bucket = &callbackBucket[Req, Resp]{}
+			if r.hooks != nil {
+				bucket.unregister = r.installHooks(callbackScope)
+			}
+			r.callbacks[callbackScope] = bucket
+		}
+		bucket.callbacks = append(bucket.callbacks, entry)
+	}
+	return func() {
+		r.unregisterCallback(callbackScopes, entry.id)
+	}
+}
+
+func (r *CallbackGenerator[Req, Resp]) unregisterCallback(callbackScopes []callbackScope, id uint64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, callbackScope := range callbackScopes {
+		bucket := r.callbacks[callbackScope]
+		if bucket == nil {
+			continue
+		}
+		for i, existing := range bucket.callbacks {
+			if existing.id == id {
+				bucket.callbacks = append(bucket.callbacks[:i], bucket.callbacks[i+1:]...)
+				break
+			}
+		}
+		if len(bucket.callbacks) == 0 {
+			if bucket.unregister != nil {
+				bucket.unregister()
+			}
+			delete(r.callbacks, callbackScope)
+		}
+	}
+}
+
+func (r *CallbackGenerator[Req, Resp]) installHooks(scope callbackScope) func() {
+	if scope.stage == faultStageRequest {
+		return r.hooks.InstallRequestCallback(scope.Scope, func(ctx context.Context, operation string, req Req) *Outcome[Resp] {
+			var zero Resp
+			return r.generate(ctx, operation, scope, req, zero, nil)
+		})
+	}
+	return r.hooks.InstallResponseCallback(scope.Scope, func(ctx context.Context, operation string, req Req, resp Resp, err error) *Outcome[Resp] {
+		return r.generate(ctx, operation, scope, req, resp, err)
+	})
+}
+
+// GenerateRequest checks registered callbacks before the handler runs.
+func (r *CallbackGenerator[Req, Resp]) GenerateRequest(ctx context.Context, operation string, req Req) *Outcome[Resp] {
+	var zero Resp
+	return r.generateFaultForStage(ctx, operation, faultStageRequest, req, zero, nil)
+}
+
+// GenerateResponse checks registered callbacks after the handler runs.
+func (r *CallbackGenerator[Req, Resp]) GenerateResponse(ctx context.Context, operation string, req Req, resp Resp, err error) *Outcome[Resp] {
+	return r.generateFaultForStage(ctx, operation, faultStageResponse, req, resp, err)
+}
+
+func (r *CallbackGenerator[Req, Resp]) generateFaultForStage(ctx context.Context, operation string, stage faultStage, req Req, resp Resp, err error) *Outcome[Resp] {
+	scope := ScopeFromRequest(req)
+	if scope.NamespaceID != "" {
+		if outcome := r.generate(ctx, operation, callbackScope{
+			Scope: Scope{NamespaceID: scope.NamespaceID},
+			stage: stage,
+		}, req, resp, err); outcome != nil {
+			return outcome
+		}
+	}
+	if scope.NamespaceName != "" {
+		if outcome := r.generate(ctx, operation, callbackScope{
+			Scope: Scope{NamespaceName: scope.NamespaceName},
+			stage: stage,
+		}, req, resp, err); outcome != nil {
+			return outcome
+		}
+	}
+	return r.generate(ctx, operation, callbackScope{stage: stage}, req, resp, err)
+}
+
+func (r *CallbackGenerator[Req, Resp]) generate(ctx context.Context, operation string, scope callbackScope, req Req, resp Resp, err error) *Outcome[Resp] {
+	if r == nil {
+		return nil
+	}
+	r.mu.RLock()
+	bucket := r.callbacks[scope]
+	if bucket == nil || len(bucket.callbacks) == 0 {
+		r.mu.RUnlock()
+		return nil
+	}
+	callbacks := make([]callbackEntry[Req, Resp], len(bucket.callbacks))
+	copy(callbacks, bucket.callbacks)
+	r.mu.RUnlock()
+
+	for _, entry := range callbacks {
+		if outcome := entry.callback(ctx, operation, req, resp, err); outcome != nil {
+			return outcome
+		}
+	}
+	return nil
+}
+
+// ScopeFromRequest returns the namespace scope from req.
+func ScopeFromRequest(req any) Scope {
+	if request, ok := req.(faultScopeGetter); ok {
+		return request.FaultScope()
+	}
+	if namespaceID := namespaceIDFromRequest(req); namespaceID != "" {
+		return Scope{NamespaceID: namespace.ID(namespaceID)}
+	}
+	if namespaceName := namespaceNameFromRequest(req); namespaceName != "" {
+		return Scope{NamespaceName: namespace.Name(namespaceName)}
+	}
+	return Scope{}
+}
+
+func namespaceIDFromRequest(req any) string {
+	if request, ok := req.(namespaceIDGetter); ok {
+		return request.GetNamespaceId()
+	}
+	return ""
+}
+
+func namespaceNameFromRequest(req any) string {
+	if request, ok := req.(namespaceNameGetter); ok {
+		return request.GetNamespace()
+	}
+	return ""
+}

--- a/common/rpc/faultinjection/generator_test.go
+++ b/common/rpc/faultinjection/generator_test.go
@@ -1,6 +1,6 @@
 //go:build test_dep
 
-package grpcfaults_test
+package faultinjection_test
 
 import (
 	"context"
@@ -10,23 +10,29 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
-	"go.temporal.io/server/common/rpc/grpcfaults"
+	"go.temporal.io/server/common/rpc/faultinjection"
 	"go.temporal.io/server/common/testing/await"
 )
+
+type scopedRequest struct {
+	scope faultinjection.Scope
+}
+
+func (r scopedRequest) FaultScope() faultinjection.Scope { return r.scope }
 
 func TestCallbackGenerator_Generate(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	fullMethod := "/test.Service/Method"
+	operation := "/test.Service/Method"
 	handlerResponse := &struct{}{}
 	handlerErr := errors.New("handler")
 	injectedErr := errors.New("injected")
-	bothNamespaces := grpcfaults.Scope{NamespaceID: "namespace-id", NamespaceName: "namespace-name"}
+	bothNamespaces := faultinjection.Scope{NamespaceID: "namespace-id", NamespaceName: "namespace-name"}
 
 	type callback struct {
 		name     string
-		scope    grpcfaults.Scope
+		scope    faultinjection.Scope
 		miss     bool
 		response any
 		err      error
@@ -63,7 +69,7 @@ func TestCallbackGenerator_Generate(t *testing.T) {
 				name:    "namespace before global",
 				request: &matchingservice.AddWorkflowTaskRequest{NamespaceId: "namespace-id"},
 				callbacks: []callback{
-					{name: "namespace", scope: grpcfaults.Scope{NamespaceID: "namespace-id"}, response: "namespace response"},
+					{name: "namespace", scope: faultinjection.Scope{NamespaceID: "namespace-id"}, response: "namespace response"},
 					{name: "global", response: "global response"},
 				},
 				expectedResp:  "namespace response",
@@ -73,7 +79,7 @@ func TestCallbackGenerator_Generate(t *testing.T) {
 				name:    "global after namespace miss",
 				request: &matchingservice.AddWorkflowTaskRequest{NamespaceId: "namespace-id"},
 				callbacks: []callback{
-					{name: "namespace", scope: grpcfaults.Scope{NamespaceID: "namespace-id"}, miss: true},
+					{name: "namespace", scope: faultinjection.Scope{NamespaceID: "namespace-id"}, miss: true},
 					{name: "global", response: "response"},
 				},
 				expectedResp:  "response",
@@ -83,7 +89,7 @@ func TestCallbackGenerator_Generate(t *testing.T) {
 				name:    "namespace mismatch",
 				request: &matchingservice.AddWorkflowTaskRequest{NamespaceId: "other-namespace-id"},
 				callbacks: []callback{
-					{name: "namespace", scope: grpcfaults.Scope{NamespaceID: "namespace-id"}, err: injectedErr},
+					{name: "namespace", scope: faultinjection.Scope{NamespaceID: "namespace-id"}, err: injectedErr},
 				},
 				expectedMiss: true,
 			},
@@ -91,7 +97,7 @@ func TestCallbackGenerator_Generate(t *testing.T) {
 				name:    "matched error",
 				request: &matchingservice.AddWorkflowTaskRequest{NamespaceId: "namespace-id"},
 				callbacks: []callback{
-					{name: "namespace", scope: grpcfaults.Scope{NamespaceID: "namespace-id"}, err: injectedErr},
+					{name: "namespace", scope: faultinjection.Scope{NamespaceID: "namespace-id"}, err: injectedErr},
 				},
 				expectedErr:   injectedErr,
 				expectedCalls: []string{"namespace"},
@@ -100,9 +106,9 @@ func TestCallbackGenerator_Generate(t *testing.T) {
 				name:    "first match wins",
 				request: &matchingservice.AddWorkflowTaskRequest{NamespaceId: "namespace-id"},
 				callbacks: []callback{
-					{name: "first", scope: grpcfaults.Scope{NamespaceID: "namespace-id"}, miss: true}, // no match!
-					{name: "second", scope: grpcfaults.Scope{NamespaceID: "namespace-id"}, response: "response"},
-					{name: "third", scope: grpcfaults.Scope{NamespaceID: "namespace-id"}, response: "other response"}, // never reached!
+					{name: "first", scope: faultinjection.Scope{NamespaceID: "namespace-id"}, miss: true},
+					{name: "second", scope: faultinjection.Scope{NamespaceID: "namespace-id"}, response: "response"},
+					{name: "third", scope: faultinjection.Scope{NamespaceID: "namespace-id"}, response: "other response"},
 				},
 				expectedResp:  "response",
 				expectedCalls: []string{"first", "second"},
@@ -125,17 +131,26 @@ func TestCallbackGenerator_Generate(t *testing.T) {
 				expectedResp:  "response",
 				expectedCalls: []string{"namespace"},
 			},
+			{
+				name:    "explicit fault scope",
+				request: scopedRequest{scope: bothNamespaces},
+				callbacks: []callback{
+					{name: "namespace", scope: bothNamespaces, response: "response"},
+				},
+				expectedResp:  "response",
+				expectedCalls: []string{"namespace"},
+			},
 		} {
 			test := test
 			t.Run(stage.name+"/"+test.name, func(t *testing.T) {
 				t.Parallel()
 
-				generator := grpcfaults.NewCallbackGenerator()
+				generator := faultinjection.NewCallbackGenerator[any, any]()
 				var calls []string
-				invoke := func(callback callback, actualCtx context.Context, actualMethod string, actualRequest, actualResponse any, actualErr error) *grpcfaults.Outcome {
+				invoke := func(callback callback, actualCtx context.Context, actualOperation string, actualRequest, actualResponse any, actualErr error) *faultinjection.Outcome[any] {
 					calls = append(calls, callback.name)
 					require.Equal(t, ctx, actualCtx)
-					require.Equal(t, fullMethod, actualMethod)
+					require.Equal(t, operation, actualOperation)
 					require.Equal(t, test.request, actualRequest)
 					if stage.response {
 						require.Equal(t, handlerResponse, actualResponse)
@@ -144,27 +159,27 @@ func TestCallbackGenerator_Generate(t *testing.T) {
 					if callback.miss {
 						return nil
 					}
-					return &grpcfaults.Outcome{Response: callback.response, Error: callback.err}
+					return &faultinjection.Outcome[any]{Response: callback.response, Error: callback.err}
 				}
 
 				for _, callback := range test.callbacks {
 					callback := callback
 					if stage.response {
-						generator.RegisterResponseCallback(callback.scope, func(actualCtx context.Context, actualMethod string, actualRequest, actualResponse any, actualErr error) *grpcfaults.Outcome {
-							return invoke(callback, actualCtx, actualMethod, actualRequest, actualResponse, actualErr)
+						generator.RegisterResponseCallback(callback.scope, func(actualCtx context.Context, actualOperation string, actualRequest, actualResponse any, actualErr error) *faultinjection.Outcome[any] {
+							return invoke(callback, actualCtx, actualOperation, actualRequest, actualResponse, actualErr)
 						})
 					} else {
-						generator.RegisterRequestCallback(callback.scope, func(actualCtx context.Context, actualMethod string, actualRequest any) *grpcfaults.Outcome {
-							return invoke(callback, actualCtx, actualMethod, actualRequest, nil, nil)
+						generator.RegisterRequestCallback(callback.scope, func(actualCtx context.Context, actualOperation string, actualRequest any) *faultinjection.Outcome[any] {
+							return invoke(callback, actualCtx, actualOperation, actualRequest, nil, nil)
 						})
 					}
 				}
 
-				var outcome *grpcfaults.Outcome
+				var outcome *faultinjection.Outcome[any]
 				if stage.response {
-					outcome = generator.GenerateResponse(ctx, fullMethod, test.request, handlerResponse, handlerErr)
+					outcome = generator.GenerateResponse(ctx, operation, test.request, handlerResponse, handlerErr)
 				} else {
-					outcome = generator.GenerateRequest(ctx, fullMethod, test.request)
+					outcome = generator.GenerateRequest(ctx, operation, test.request)
 				}
 
 				if test.expectedMiss {
@@ -191,9 +206,9 @@ func TestCallbackGenerator_Unregister(t *testing.T) {
 	t.Run("idempotent", func(t *testing.T) {
 		t.Parallel()
 
-		generator := grpcfaults.NewCallbackGenerator()
-		unregister := generator.RegisterRequestCallback(grpcfaults.Scope{NamespaceID: "namespace-id"}, func(context.Context, string, any) *grpcfaults.Outcome {
-			return &grpcfaults.Outcome{Response: "response"}
+		generator := faultinjection.NewCallbackGenerator[any, any]()
+		unregister := generator.RegisterRequestCallback(faultinjection.Scope{NamespaceID: "namespace-id"}, func(context.Context, string, any) *faultinjection.Outcome[any] {
+			return &faultinjection.Outcome[any]{Response: "response"}
 		})
 
 		unregister()
@@ -210,9 +225,9 @@ func TestCallbackGenerator_Unregister(t *testing.T) {
 	t.Run("removes namespace ID and name registrations", func(t *testing.T) {
 		t.Parallel()
 
-		generator := grpcfaults.NewCallbackGenerator()
-		unregister := generator.RegisterRequestCallback(grpcfaults.Scope{NamespaceID: "namespace-id", NamespaceName: "namespace-name"}, func(context.Context, string, any) *grpcfaults.Outcome {
-			return &grpcfaults.Outcome{Response: "response"}
+		generator := faultinjection.NewCallbackGenerator[any, any]()
+		unregister := generator.RegisterRequestCallback(faultinjection.Scope{NamespaceID: "namespace-id", NamespaceName: "namespace-name"}, func(context.Context, string, any) *faultinjection.Outcome[any] {
+			return &faultinjection.Outcome[any]{Response: "response"}
 		})
 		unregister()
 
@@ -240,16 +255,16 @@ func TestCallbackGenerator_Unregister(t *testing.T) {
 	t.Run("during generate", func(t *testing.T) {
 		t.Parallel()
 
-		generator := grpcfaults.NewCallbackGenerator()
+		generator := faultinjection.NewCallbackGenerator[any, any]()
 		callbackStarted := make(chan struct{})
 		continueCallback := make(chan struct{})
-		unregister := generator.RegisterRequestCallback(grpcfaults.Scope{NamespaceID: "namespace-id"}, func(context.Context, string, any) *grpcfaults.Outcome {
+		unregister := generator.RegisterRequestCallback(faultinjection.Scope{NamespaceID: "namespace-id"}, func(context.Context, string, any) *faultinjection.Outcome[any] {
 			await.Snd(t, callbackStarted, struct{}{})
 			await.Rcv(t, continueCallback)
-			return &grpcfaults.Outcome{Response: "response"}
+			return &faultinjection.Outcome[any]{Response: "response"}
 		})
 		type result struct {
-			outcome *grpcfaults.Outcome
+			outcome *faultinjection.Outcome[any]
 		}
 		resultCh := make(chan result, 1)
 		go func() {

--- a/common/rpc/grpcfaults/generator.go
+++ b/common/rpc/grpcfaults/generator.go
@@ -1,242 +1,30 @@
 package grpcfaults
 
-import (
-	"context"
-	"sync"
-
-	"go.temporal.io/server/common/namespace"
-)
+import "go.temporal.io/server/common/rpc/faultinjection"
 
 type (
-	namespaceNameGetter interface {
-		GetNamespace() string
-	}
-
-	namespaceIDGetter interface {
-		GetNamespaceId() string
-	}
+	// Outcome contains the result returned when a gRPC fault matches.
+	Outcome = faultinjection.Outcome[any]
+	// RequestCallback is a callback function for pre-handler gRPC fault injection.
+	RequestCallback = faultinjection.RequestCallback[any, any]
+	// ResponseCallback is a callback function for post-handler gRPC fault injection.
+	ResponseCallback = faultinjection.ResponseCallback[any, any]
+	// Generator checks for gRPC faults before and after a handler runs.
+	Generator = faultinjection.Generator[any, any]
+	// Hooks connects a CallbackGenerator to externally managed fault callbacks.
+	Hooks = faultinjection.Hooks[any, any]
+	// Scope identifies a namespace by ID, name, or both. An empty scope applies globally.
+	Scope = faultinjection.Scope
+	// CallbackGenerator handles fault injection for gRPC requests and responses.
+	CallbackGenerator = faultinjection.CallbackGenerator[any, any]
 )
-
-type faultStage int
-
-const (
-	faultStageRequest faultStage = iota
-	faultStageResponse
-)
-
-// Outcome contains the response and error returned when a gRPC fault matches.
-type Outcome struct {
-	Response any
-	Error    error
-}
-
-// RequestCallback is a callback function for pre-handler gRPC fault injection.
-type RequestCallback func(ctx context.Context, fullMethod string, req any) *Outcome
-
-// ResponseCallback is a callback function for post-handler gRPC fault injection.
-type ResponseCallback func(ctx context.Context, fullMethod string, req, resp any, err error) *Outcome
-
-// Hooks connects a CallbackGenerator to externally managed fault callbacks.
-type Hooks interface {
-	InstallRequestCallback(Scope, RequestCallback) func()
-	InstallResponseCallback(Scope, ResponseCallback) func()
-}
-
-type callback func(ctx context.Context, fullMethod string, req, resp any, err error) *Outcome
-
-// callbackEntry represents a registered gRPC callback with its ID.
-type callbackEntry struct {
-	id       uint64
-	callback callback
-}
-
-// Scope identifies a namespace by ID, name, or both. An empty scope applies globally.
-type Scope struct {
-	NamespaceID   namespace.ID
-	NamespaceName namespace.Name
-}
-
-type callbackScope struct {
-	Scope
-	stage faultStage
-}
-
-type callbackBucket struct {
-	callbacks  []callbackEntry
-	unregister func()
-}
-
-// CallbackGenerator handles fault injection for gRPC requests and responses.
-type CallbackGenerator struct {
-	mu        sync.RWMutex
-	callbacks map[callbackScope]*callbackBucket
-	nextID    uint64
-	hooks     Hooks
-}
 
 // NewCallbackGenerator creates a new CallbackGenerator instance.
 func NewCallbackGenerator() *CallbackGenerator {
-	return NewCallbackGeneratorWithHooks(nil)
+	return faultinjection.NewCallbackGenerator[any, any]()
 }
 
 // NewCallbackGeneratorWithHooks creates a CallbackGenerator connected to external fault hooks.
 func NewCallbackGeneratorWithHooks(hooks Hooks) *CallbackGenerator {
-	return &CallbackGenerator{
-		callbacks: make(map[callbackScope]*callbackBucket),
-		hooks:     hooks,
-	}
-}
-
-// RegisterRequestCallback registers a pre-handler gRPC fault injection callback and returns a
-// cleanup function that removes the callback when called.
-func (r *CallbackGenerator) RegisterRequestCallback(scope Scope, cb RequestCallback) func() {
-	return r.registerCallback(scope, faultStageRequest, func(ctx context.Context, fullMethod string, req, _ any, _ error) *Outcome {
-		return cb(ctx, fullMethod, req)
-	})
-}
-
-// RegisterResponseCallback registers a post-handler gRPC fault injection callback and returns a
-// cleanup function that removes the callback when called.
-func (r *CallbackGenerator) RegisterResponseCallback(scope Scope, cb ResponseCallback) func() {
-	return r.registerCallback(scope, faultStageResponse, func(ctx context.Context, fullMethod string, req, resp any, err error) *Outcome {
-		return cb(ctx, fullMethod, req, resp, err)
-	})
-}
-
-func (r *CallbackGenerator) registerCallback(faultScope Scope, stage faultStage, cb callback) func() {
-	if r == nil {
-		return func() {}
-	}
-
-	var callbackScopes []callbackScope
-	if faultScope.NamespaceID != "" {
-		callbackScopes = append(callbackScopes, callbackScope{Scope: Scope{NamespaceID: faultScope.NamespaceID}, stage: stage})
-	}
-	if faultScope.NamespaceName != "" {
-		callbackScopes = append(callbackScopes, callbackScope{Scope: Scope{NamespaceName: faultScope.NamespaceName}, stage: stage})
-	}
-	if len(callbackScopes) == 0 {
-		callbackScopes = append(callbackScopes, callbackScope{stage: stage})
-	}
-
-	r.mu.Lock()
-	r.nextID++
-	entry := callbackEntry{id: r.nextID, callback: cb}
-	for _, callbackScope := range callbackScopes {
-		bucket := r.callbacks[callbackScope]
-		if bucket == nil {
-			bucket = &callbackBucket{}
-			if r.hooks != nil {
-				bucket.unregister = r.installHooks(callbackScope)
-			}
-			r.callbacks[callbackScope] = bucket
-		}
-		bucket.callbacks = append(bucket.callbacks, entry)
-	}
-	r.mu.Unlock()
-
-	return func() {
-		r.unregisterCallback(callbackScopes, entry.id)
-	}
-}
-
-func (r *CallbackGenerator) unregisterCallback(callbackScopes []callbackScope, id uint64) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	for _, callbackScope := range callbackScopes {
-		bucket := r.callbacks[callbackScope]
-		if bucket == nil {
-			continue
-		}
-		for i, existing := range bucket.callbacks {
-			if existing.id == id {
-				bucket.callbacks = append(bucket.callbacks[:i], bucket.callbacks[i+1:]...)
-				break
-			}
-		}
-		if len(bucket.callbacks) == 0 {
-			if bucket.unregister != nil {
-				bucket.unregister()
-			}
-			delete(r.callbacks, callbackScope)
-		}
-	}
-}
-
-func (r *CallbackGenerator) installHooks(scope callbackScope) func() {
-	if scope.stage == faultStageRequest {
-		return r.hooks.InstallRequestCallback(scope.Scope, func(ctx context.Context, fullMethod string, req any) *Outcome {
-			return r.generate(ctx, fullMethod, scope, req, nil, nil)
-		})
-	}
-	return r.hooks.InstallResponseCallback(scope.Scope, func(ctx context.Context, fullMethod string, req, resp any, err error) *Outcome {
-		return r.generate(ctx, fullMethod, scope, req, resp, err)
-	})
-}
-
-// GenerateRequest checks registered gRPC callbacks before the handler runs.
-func (r *CallbackGenerator) GenerateRequest(ctx context.Context, fullMethod string, req any) *Outcome {
-	return r.generateFaultForStage(ctx, fullMethod, faultStageRequest, req, nil, nil)
-}
-
-// GenerateResponse checks registered gRPC callbacks after the handler runs.
-func (r *CallbackGenerator) GenerateResponse(ctx context.Context, fullMethod string, req, resp any, err error) *Outcome {
-	return r.generateFaultForStage(ctx, fullMethod, faultStageResponse, req, resp, err)
-}
-
-func (r *CallbackGenerator) generateFaultForStage(ctx context.Context, fullMethod string, stage faultStage, req, resp any, err error) *Outcome {
-	if namespaceID, ok := namespaceIDFromRequest(req); ok {
-		if outcome := r.generate(ctx, fullMethod, callbackScope{
-			Scope: Scope{NamespaceID: namespaceID},
-			stage: stage,
-		}, req, resp, err); outcome != nil {
-			return outcome
-		}
-	} else if namespaceName, ok := namespaceNameFromRequest(req); ok {
-		if outcome := r.generate(ctx, fullMethod, callbackScope{
-			Scope: Scope{NamespaceName: namespaceName},
-			stage: stage,
-		}, req, resp, err); outcome != nil {
-			return outcome
-		}
-	}
-	return r.generate(ctx, fullMethod, callbackScope{stage: stage}, req, resp, err)
-}
-
-func (r *CallbackGenerator) generate(ctx context.Context, fullMethod string, scope callbackScope, req, resp any, err error) *Outcome {
-	if r == nil {
-		return nil
-	}
-	r.mu.RLock()
-	bucket := r.callbacks[scope]
-	if bucket == nil || len(bucket.callbacks) == 0 {
-		r.mu.RUnlock()
-		return nil
-	}
-	callbacks := make([]callbackEntry, len(bucket.callbacks))
-	copy(callbacks, bucket.callbacks)
-	r.mu.RUnlock()
-
-	for _, entry := range callbacks {
-		if outcome := entry.callback(ctx, fullMethod, req, resp, err); outcome != nil {
-			return outcome
-		}
-	}
-	return nil
-}
-
-func namespaceIDFromRequest(req any) (namespace.ID, bool) {
-	request, ok := req.(namespaceIDGetter)
-	if !ok || request.GetNamespaceId() == "" {
-		return "", false
-	}
-	return namespace.ID(request.GetNamespaceId()), true
-}
-
-func namespaceNameFromRequest(req any) (namespace.Name, bool) {
-	request, ok := req.(namespaceNameGetter)
-	if !ok || request.GetNamespace() == "" {
-		return "", false
-	}
-	return namespace.Name(request.GetNamespace()), true
+	return faultinjection.NewCallbackGeneratorWithHooks[any, any](hooks)
 }

--- a/common/rpc/grpcfaults/interceptor.go
+++ b/common/rpc/grpcfaults/interceptor.go
@@ -6,12 +6,6 @@ import (
 	"google.golang.org/grpc"
 )
 
-// Generator checks for gRPC faults before and after a handler runs.
-type Generator interface {
-	GenerateRequest(ctx context.Context, fullMethod string, req any) *Outcome
-	GenerateResponse(ctx context.Context, fullMethod string, req, resp any, err error) *Outcome
-}
-
 // UnaryServerInterceptor returns a unary server interceptor that checks for
 // dynamically registered fault injection callbacks before and after the handler.
 //
@@ -20,23 +14,23 @@ type Generator interface {
 //
 // Behavior:
 // - If no request generator is registered, the handler proceeds normally.
-// - Request callbacks are checked before the handler. If matched, the handler is skipped.
-// - Response callbacks are checked after the handler with actual resp/err. If matched, returned values are used.
-// - If no callbacks match, the handler's response/error is returned.
+// - Request callbacks are checked before the handler. A matched fault can skip the handler.
+// - Response callbacks are checked after the handler with its response and error. A matched fault can replace them.
+// - If no callbacks match, the handler's response and error are returned.
 func UnaryServerInterceptor(generator Generator) grpc.UnaryServerInterceptor {
 	if generator == nil {
 		return nil
 	}
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-		// Check before handler (can short-circuit)
+		// Check before the handler. A fault can short-circuit the call.
 		if outcome := generator.GenerateRequest(ctx, info.FullMethod, req); outcome != nil {
 			return outcome.Response, outcome.Error
 		}
 
-		// Call handler
+		// Call the handler.
 		resp, err := handler(ctx, req)
 
-		// Check after handler (can modify response/error)
+		// Check after the handler. A fault can replace the response or error.
 		if outcome := generator.GenerateResponse(ctx, info.FullMethod, req, resp, err); outcome != nil {
 			return outcome.Response, outcome.Error
 		}

--- a/common/rpc/httpfaults/httpfaults.go
+++ b/common/rpc/httpfaults/httpfaults.go
@@ -1,0 +1,98 @@
+// Package httpfaults injects faults into HTTP client calls.
+package httpfaults
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"go.temporal.io/server/common/rpc/faultinjection"
+)
+
+// Scope identifies a namespace for fault matching.
+type Scope = faultinjection.Scope
+
+// Request contains an HTTP request and its namespace scope.
+type Request struct {
+	Raw *http.Request
+	Scope
+}
+
+func (r *Request) FaultScope() Scope { return r.Scope }
+
+type (
+	// Outcome defines the result of a matched HTTP fault.
+	Outcome = faultinjection.Outcome[*http.Response]
+	// RequestCallback checks a request before the HTTP call.
+	RequestCallback = faultinjection.RequestCallback[*Request, *http.Response]
+	// ResponseCallback checks a result after the HTTP call.
+	ResponseCallback = faultinjection.ResponseCallback[*Request, *http.Response]
+	// Generator checks for faults before and after an HTTP call.
+	Generator = faultinjection.Generator[*Request, *http.Response]
+	// Hooks installs callbacks outside the generator.
+	Hooks = faultinjection.Hooks[*Request, *http.Response]
+	// CallbackGenerator stores HTTP callbacks in the shared fault registry.
+	CallbackGenerator = faultinjection.CallbackGenerator[*Request, *http.Response]
+)
+
+// NewCallbackGenerator returns a callback generator.
+func NewCallbackGenerator() *CallbackGenerator {
+	return faultinjection.NewCallbackGenerator[*Request, *http.Response]()
+}
+
+// NewCallbackGeneratorWithHooks returns a callback generator that uses hooks.
+func NewCallbackGeneratorWithHooks(hooks Hooks) *CallbackGenerator {
+	return faultinjection.NewCallbackGeneratorWithHooks[*Request, *http.Response](hooks)
+}
+
+// Wrap applies faults before and after an HTTP call. A nil generator returns inner as is.
+func Wrap(
+	generator Generator,
+	scope Scope,
+	inner func(*http.Request) (*http.Response, error),
+) func(*http.Request) (*http.Response, error) {
+	if generator == nil {
+		return inner
+	}
+	return func(req *http.Request) (*http.Response, error) {
+		wrapped := &Request{Raw: req, Scope: scope}
+		operation := req.Method + " " + req.URL.Path
+
+		if outcome := generator.GenerateRequest(req.Context(), operation, wrapped); outcome != nil {
+			return outcome.Response, outcome.Error
+		}
+
+		resp, err := inner(req)
+		if outcome := generator.GenerateResponse(req.Context(), operation, wrapped, resp, err); outcome != nil {
+			return applyOutcome(resp, outcome)
+		}
+		return resp, err
+	}
+}
+
+func applyOutcome(original *http.Response, outcome *Outcome) (*http.Response, error) {
+	if original == outcome.Response {
+		return outcome.Response, outcome.Error
+	}
+	return outcome.Response, errors.Join(outcome.Error, closeResponse(original))
+}
+
+func closeResponse(resp *http.Response) error {
+	if resp == nil || resp.Body == nil {
+		return nil
+	}
+	return resp.Body.Close()
+}
+
+// NewResponse returns a synthetic HTTP response.
+func NewResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode:    status,
+		Status:        fmt.Sprintf("%d %s", status, http.StatusText(status)),
+		Header:        make(http.Header),
+		Body:          io.NopCloser(strings.NewReader(body)),
+		ContentLength: int64(len(body)),
+	}
+}

--- a/common/rpc/httpfaults/httpfaults_test.go
+++ b/common/rpc/httpfaults/httpfaults_test.go
@@ -1,0 +1,177 @@
+package httpfaults_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/rpc/httpfaults"
+)
+
+func newRequest(t *testing.T) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, "http://example.com/cb1", nil)
+	require.NoError(t, err)
+	return req
+}
+
+type trackingBody struct {
+	io.Reader
+	closed   bool
+	closeErr error
+}
+
+func (b *trackingBody) Close() error {
+	b.closed = true
+	return b.closeErr
+}
+
+func TestWrap_NilGeneratorReturnsNext(t *testing.T) {
+	t.Parallel()
+
+	next := func(*http.Request) (*http.Response, error) { return nil, nil }
+	requireSameFunction(t, next, httpfaults.Wrap(nil, httpfaults.Scope{}, next))
+}
+
+func TestWrap_RequestFault(t *testing.T) {
+	t.Parallel()
+
+	injectedErr := errors.New("injected")
+	generator := httpfaults.NewCallbackGenerator()
+	generator.RegisterRequestCallback(httpfaults.Scope{}, func(_ context.Context, operation string, req *httpfaults.Request) *httpfaults.Outcome {
+		require.Equal(t, "POST /cb1", operation)
+		require.Equal(t, "/cb1", req.Raw.URL.Path)
+		return &httpfaults.Outcome{Error: injectedErr}
+	})
+
+	called := false
+	wrapped := httpfaults.Wrap(generator, httpfaults.Scope{}, func(*http.Request) (*http.Response, error) {
+		called = true
+		return nil, nil
+	})
+	resp, err := wrapped(newRequest(t))
+
+	require.Nil(t, resp)
+	require.ErrorIs(t, err, injectedErr)
+	require.False(t, called)
+}
+
+func TestWrap_RequestFaultResponse(t *testing.T) {
+	t.Parallel()
+
+	injected := httpfaults.NewResponse(http.StatusServiceUnavailable, "injected")
+	generator := httpfaults.NewCallbackGenerator()
+	generator.RegisterRequestCallback(httpfaults.Scope{}, func(context.Context, string, *httpfaults.Request) *httpfaults.Outcome {
+		return &httpfaults.Outcome{Response: injected}
+	})
+
+	wrapped := httpfaults.Wrap(generator, httpfaults.Scope{}, func(*http.Request) (*http.Response, error) {
+		require.FailNow(t, "HTTP call should not run")
+		return nil, nil
+	})
+	resp, err := wrapped(newRequest(t))
+
+	require.NoError(t, err)
+	require.Same(t, injected, resp)
+}
+
+func TestWrap_ResponseFault(t *testing.T) {
+	t.Parallel()
+
+	body := &trackingBody{Reader: strings.NewReader("original")}
+	original := &http.Response{StatusCode: http.StatusOK, Body: body}
+	injected := httpfaults.NewResponse(http.StatusServiceUnavailable, "injected")
+	generator := httpfaults.NewCallbackGenerator()
+	generator.RegisterResponseCallback(httpfaults.Scope{}, func(
+		_ context.Context,
+		_ string,
+		_ *httpfaults.Request,
+		resp *http.Response,
+		callErr error,
+	) *httpfaults.Outcome {
+		require.Same(t, original, resp)
+		require.NoError(t, callErr)
+		return &httpfaults.Outcome{Response: injected}
+	})
+
+	wrapper := httpfaults.Wrap(generator, httpfaults.Scope{}, func(*http.Request) (*http.Response, error) {
+		return original, nil
+	})
+	resp, err := wrapper(newRequest(t))
+
+	require.NoError(t, err)
+	require.Same(t, injected, resp)
+	require.True(t, body.closed)
+	require.NoError(t, resp.Body.Close())
+}
+
+func TestWrap_ResponseFaultIncludesCloseError(t *testing.T) {
+	t.Parallel()
+
+	injectedErr := errors.New("injected")
+	closeErr := errors.New("close")
+	body := &trackingBody{closeErr: closeErr}
+	generator := httpfaults.NewCallbackGenerator()
+	generator.RegisterResponseCallback(httpfaults.Scope{}, func(context.Context, string, *httpfaults.Request, *http.Response, error) *httpfaults.Outcome {
+		return &httpfaults.Outcome{Error: injectedErr}
+	})
+	wrapper := httpfaults.Wrap(generator, httpfaults.Scope{}, func(*http.Request) (*http.Response, error) {
+		return &http.Response{Body: body}, nil
+	})
+
+	resp, err := wrapper(newRequest(t))
+
+	require.Nil(t, resp)
+	require.ErrorIs(t, err, injectedErr)
+	require.ErrorIs(t, err, closeErr)
+	require.True(t, body.closed)
+}
+
+func TestWrap_ScopedByNamespace(t *testing.T) {
+	t.Parallel()
+
+	injectedErr := errors.New("injected")
+	generator := httpfaults.NewCallbackGenerator()
+	generator.RegisterRequestCallback(httpfaults.Scope{NamespaceID: "target-ns"}, func(context.Context, string, *httpfaults.Request) *httpfaults.Outcome {
+		return &httpfaults.Outcome{Error: injectedErr}
+	})
+	next := func(*http.Request) (*http.Response, error) {
+		return httpfaults.NewResponse(http.StatusOK, "ok"), nil
+	}
+
+	_, err := httpfaults.Wrap(generator, httpfaults.Scope{NamespaceID: "target-ns"}, next)(newRequest(t))
+	require.ErrorIs(t, err, injectedErr)
+
+	resp, err := httpfaults.Wrap(generator, httpfaults.Scope{NamespaceID: "other-ns"}, next)(newRequest(t))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+}
+
+func TestNewResponse(t *testing.T) {
+	t.Parallel()
+
+	resp := httpfaults.NewResponse(http.StatusServiceUnavailable, "injected")
+	defer func() { require.NoError(t, resp.Body.Close()) }()
+
+	require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	require.Equal(t, "503 Service Unavailable", resp.Status)
+	require.Equal(t, int64(len("injected")), resp.ContentLength)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "injected", string(body))
+}
+
+func requireSameFunction(
+	t *testing.T,
+	expected func(*http.Request) (*http.Response, error),
+	actual func(*http.Request) (*http.Response, error),
+) {
+	t.Helper()
+	require.Equal(t, reflect.ValueOf(expected).Pointer(), reflect.ValueOf(actual).Pointer())
+}

--- a/common/rpc/httpfaults/httpfaults_test.go
+++ b/common/rpc/httpfaults/httpfaults_test.go
@@ -35,7 +35,11 @@ func TestWrap_NilGeneratorReturnsNext(t *testing.T) {
 	t.Parallel()
 
 	next := func(*http.Request) (*http.Response, error) { return nil, nil }
-	requireSameFunction(t, next, httpfaults.Wrap(nil, httpfaults.Scope{}, next))
+	require.Equal(
+		t,
+		reflect.ValueOf(next).Pointer(),
+		reflect.ValueOf(httpfaults.Wrap(nil, httpfaults.Scope{}, next)).Pointer(),
+	)
 }
 
 func TestWrap_RequestFault(t *testing.T) {
@@ -165,13 +169,4 @@ func TestNewResponse(t *testing.T) {
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	require.Equal(t, "injected", string(body))
-}
-
-func requireSameFunction(
-	t *testing.T,
-	expected func(*http.Request) (*http.Response, error),
-	actual func(*http.Request) (*http.Response, error),
-) {
-	t.Helper()
-	require.Equal(t, reflect.ValueOf(expected).Pointer(), reflect.ValueOf(actual).Pointer())
 }

--- a/common/testing/faultinjectiontest/hooks_testdep.go
+++ b/common/testing/faultinjectiontest/hooks_testdep.go
@@ -1,0 +1,108 @@
+//go:build test_dep
+
+package faultinjectiontest
+
+import (
+	"context"
+
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/rpc/faultinjection"
+	"go.temporal.io/server/common/testing/testhooks"
+)
+
+// Keys identifies namespace-scoped hooks.
+type Keys[Callback any] struct {
+	ByNamespaceID   testhooks.Key[Callback, namespace.ID]
+	ByNamespaceName testhooks.Key[Callback, namespace.Name]
+}
+
+// HookKeys identifies request and response hooks.
+type HookKeys[Req, Resp any] struct {
+	Request  Keys[faultinjection.RequestCallback[Req, Resp]]
+	Response Keys[faultinjection.ResponseCallback[Req, Resp]]
+}
+
+// Adapter connects a request and response generator to test hooks.
+type Adapter[Req, Resp any] struct {
+	testHooks    testhooks.TestHooks
+	requestKeys  Keys[faultinjection.RequestCallback[Req, Resp]]
+	responseKeys Keys[faultinjection.ResponseCallback[Req, Resp]]
+}
+
+// NewAdapter returns a request and response adapter.
+func NewAdapter[Req, Resp any](testHooks testhooks.TestHooks, keys HookKeys[Req, Resp]) Adapter[Req, Resp] {
+	return Adapter[Req, Resp]{
+		testHooks:    testHooks,
+		requestKeys:  keys.Request,
+		responseKeys: keys.Response,
+	}
+}
+
+func (a Adapter[Req, Resp]) InstallRequestCallback(
+	scope faultinjection.Scope,
+	callback faultinjection.RequestCallback[Req, Resp],
+) func() {
+	return install(a.testHooks, a.requestKeys, scope, callback)
+}
+
+func (a Adapter[Req, Resp]) GenerateRequest(
+	ctx context.Context,
+	operation string,
+	req Req,
+) *faultinjection.Outcome[Resp] {
+	if generate, ok := get(a.testHooks, a.requestKeys, faultinjection.ScopeFromRequest(req)); ok {
+		return generate(ctx, operation, req)
+	}
+	return nil
+}
+
+func (a Adapter[Req, Resp]) InstallResponseCallback(
+	scope faultinjection.Scope,
+	callback faultinjection.ResponseCallback[Req, Resp],
+) func() {
+	return install(a.testHooks, a.responseKeys, scope, callback)
+}
+
+func (a Adapter[Req, Resp]) GenerateResponse(
+	ctx context.Context,
+	operation string,
+	req Req,
+	resp Resp,
+	err error,
+) *faultinjection.Outcome[Resp] {
+	if generate, ok := get(a.testHooks, a.responseKeys, faultinjection.ScopeFromRequest(req)); ok {
+		return generate(ctx, operation, req, resp, err)
+	}
+	return nil
+}
+
+func install[Callback any](
+	testHooks testhooks.TestHooks,
+	keys Keys[Callback],
+	scope faultinjection.Scope,
+	callback Callback,
+) func() {
+	switch {
+	case scope.NamespaceID != "":
+		return testhooks.Set(testHooks, keys.ByNamespaceID, callback, scope.NamespaceID)
+	case scope.NamespaceName != "":
+		return testhooks.Set(testHooks, keys.ByNamespaceName, callback, scope.NamespaceName)
+	default:
+		panic("fault injection test hooks require a namespace scope")
+	}
+}
+
+func get[Callback any](
+	testHooks testhooks.TestHooks,
+	keys Keys[Callback],
+	scope faultinjection.Scope,
+) (Callback, bool) {
+	if scope.NamespaceID != "" {
+		return testhooks.Get(testHooks, keys.ByNamespaceID, scope.NamespaceID)
+	}
+	if scope.NamespaceName != "" {
+		return testhooks.Get(testHooks, keys.ByNamespaceName, scope.NamespaceName)
+	}
+	var zero Callback
+	return zero, false
+}

--- a/common/testing/grpcfaultstest/hooks_testdep.go
+++ b/common/testing/grpcfaultstest/hooks_testdep.go
@@ -3,96 +3,30 @@
 package grpcfaultstest
 
 import (
-	"context"
-
-	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/rpc/grpcfaults"
-	rpcinterceptor "go.temporal.io/server/common/rpc/interceptor"
+	"go.temporal.io/server/common/testing/faultinjectiontest"
 	commontesthooks "go.temporal.io/server/common/testing/testhooks"
 )
 
-type adapter struct {
-	testHooks commontesthooks.TestHooks
-}
-
 // NewCallbackGenerator creates a CallbackGenerator connected to namespace-scoped test hooks.
 func NewCallbackGenerator(testHooks commontesthooks.TestHooks) *grpcfaults.CallbackGenerator {
-	return grpcfaults.NewCallbackGeneratorWithHooks(adapter{testHooks: testHooks})
-}
-
-func (a adapter) InstallRequestCallback(scope grpcfaults.Scope, callback grpcfaults.RequestCallback) func() {
-	switch {
-	case scope.NamespaceID != "":
-		return commontesthooks.Set(a.testHooks, commontesthooks.GRPCRequestFaultGeneratorByNamespaceID, callback, scope.NamespaceID)
-	case scope.NamespaceName != "":
-		return commontesthooks.Set(a.testHooks, commontesthooks.GRPCRequestFaultGeneratorByNamespaceName, callback, scope.NamespaceName)
-	default:
-		return func() {}
-	}
-}
-
-func (a adapter) InstallResponseCallback(scope grpcfaults.Scope, callback grpcfaults.ResponseCallback) func() {
-	switch {
-	case scope.NamespaceID != "":
-		return commontesthooks.Set(a.testHooks, commontesthooks.GRPCResponseFaultGeneratorByNamespaceID, callback, scope.NamespaceID)
-	case scope.NamespaceName != "":
-		return commontesthooks.Set(a.testHooks, commontesthooks.GRPCResponseFaultGeneratorByNamespaceName, callback, scope.NamespaceName)
-	default:
-		return func() {}
-	}
+	return grpcfaults.NewCallbackGeneratorWithHooks(newAdapter(testHooks))
 }
 
 // NewGenerator creates a Generator backed by namespace-scoped test hooks.
 func NewGenerator(testHooks commontesthooks.TestHooks) grpcfaults.Generator {
-	return adapter{testHooks: testHooks}
+	return newAdapter(testHooks)
 }
 
-func (a adapter) GenerateRequest(ctx context.Context, fullMethod string, req any) *grpcfaults.Outcome {
-	if generate, ok := getRequestFaultGenerator(a.testHooks, req); ok {
-		return generate(ctx, fullMethod, req)
-	}
-	return nil
-}
-
-func (a adapter) GenerateResponse(ctx context.Context, fullMethod string, req, resp any, err error) *grpcfaults.Outcome {
-	if generate, ok := getResponseFaultGenerator(a.testHooks, req); ok {
-		return generate(ctx, fullMethod, req, resp, err)
-	}
-	return nil
-}
-
-func getRequestFaultGenerator(testHooks commontesthooks.TestHooks, req any) (grpcfaults.RequestCallback, bool) {
-	if namespaceID, ok := namespaceIDFromRequest(req); ok {
-		return commontesthooks.Get(testHooks, commontesthooks.GRPCRequestFaultGeneratorByNamespaceID, namespaceID)
-	}
-	if namespaceName, ok := namespaceNameFromRequest(req); ok {
-		return commontesthooks.Get(testHooks, commontesthooks.GRPCRequestFaultGeneratorByNamespaceName, namespaceName)
-	}
-	return nil, false
-}
-
-func getResponseFaultGenerator(testHooks commontesthooks.TestHooks, req any) (grpcfaults.ResponseCallback, bool) {
-	if namespaceID, ok := namespaceIDFromRequest(req); ok {
-		return commontesthooks.Get(testHooks, commontesthooks.GRPCResponseFaultGeneratorByNamespaceID, namespaceID)
-	}
-	if namespaceName, ok := namespaceNameFromRequest(req); ok {
-		return commontesthooks.Get(testHooks, commontesthooks.GRPCResponseFaultGeneratorByNamespaceName, namespaceName)
-	}
-	return nil, false
-}
-
-func namespaceIDFromRequest(req any) (namespace.ID, bool) {
-	request, ok := req.(rpcinterceptor.NamespaceIDGetter)
-	if !ok || request.GetNamespaceId() == "" {
-		return "", false
-	}
-	return namespace.ID(request.GetNamespaceId()), true
-}
-
-func namespaceNameFromRequest(req any) (namespace.Name, bool) {
-	request, ok := req.(rpcinterceptor.NamespaceNameGetter)
-	if !ok || request.GetNamespace() == "" {
-		return "", false
-	}
-	return namespace.Name(request.GetNamespace()), true
+func newAdapter(testHooks commontesthooks.TestHooks) faultinjectiontest.Adapter[any, any] {
+	return faultinjectiontest.NewAdapter(testHooks, faultinjectiontest.HookKeys[any, any]{
+		Request: faultinjectiontest.Keys[grpcfaults.RequestCallback]{
+			ByNamespaceID:   commontesthooks.GRPCRequestFaultGeneratorByNamespaceID,
+			ByNamespaceName: commontesthooks.GRPCRequestFaultGeneratorByNamespaceName,
+		},
+		Response: faultinjectiontest.Keys[grpcfaults.ResponseCallback]{
+			ByNamespaceID:   commontesthooks.GRPCResponseFaultGeneratorByNamespaceID,
+			ByNamespaceName: commontesthooks.GRPCResponseFaultGeneratorByNamespaceName,
+		},
+	})
 }

--- a/common/testing/httpfaultstest/hooks_noop.go
+++ b/common/testing/httpfaultstest/hooks_noop.go
@@ -1,0 +1,18 @@
+//go:build !test_dep
+
+package httpfaultstest
+
+import (
+	"go.temporal.io/server/common/rpc/httpfaults"
+	commontesthooks "go.temporal.io/server/common/testing/testhooks"
+)
+
+// NewCallbackGenerator returns a callback generator without test hooks.
+func NewCallbackGenerator(commontesthooks.TestHooks) *httpfaults.CallbackGenerator {
+	return httpfaults.NewCallbackGenerator()
+}
+
+// NewGenerator returns nil without the test_dep build tag.
+func NewGenerator(commontesthooks.TestHooks) httpfaults.Generator {
+	return nil
+}

--- a/common/testing/httpfaultstest/hooks_testdep.go
+++ b/common/testing/httpfaultstest/hooks_testdep.go
@@ -1,0 +1,34 @@
+//go:build test_dep
+
+package httpfaultstest
+
+import (
+	"net/http"
+
+	"go.temporal.io/server/common/rpc/httpfaults"
+	"go.temporal.io/server/common/testing/faultinjectiontest"
+	commontesthooks "go.temporal.io/server/common/testing/testhooks"
+)
+
+// NewCallbackGenerator returns a generator that uses namespace-scoped test hooks.
+func NewCallbackGenerator(testHooks commontesthooks.TestHooks) *httpfaults.CallbackGenerator {
+	return httpfaults.NewCallbackGeneratorWithHooks(newAdapter(testHooks))
+}
+
+// NewGenerator returns a generator that uses namespace-scoped test hooks.
+func NewGenerator(testHooks commontesthooks.TestHooks) httpfaults.Generator {
+	return newAdapter(testHooks)
+}
+
+func newAdapter(testHooks commontesthooks.TestHooks) faultinjectiontest.Adapter[*httpfaults.Request, *http.Response] {
+	return faultinjectiontest.NewAdapter(testHooks, faultinjectiontest.HookKeys[*httpfaults.Request, *http.Response]{
+		Request: faultinjectiontest.Keys[httpfaults.RequestCallback]{
+			ByNamespaceID:   commontesthooks.HTTPRequestFaultGeneratorByNamespaceID,
+			ByNamespaceName: commontesthooks.HTTPRequestFaultGeneratorByNamespaceName,
+		},
+		Response: faultinjectiontest.Keys[httpfaults.ResponseCallback]{
+			ByNamespaceID:   commontesthooks.HTTPResponseFaultGeneratorByNamespaceID,
+			ByNamespaceName: commontesthooks.HTTPResponseFaultGeneratorByNamespaceName,
+		},
+	})
+}

--- a/common/testing/httpfaultstest/hooks_testdep_test.go
+++ b/common/testing/httpfaultstest/hooks_testdep_test.go
@@ -1,0 +1,111 @@
+//go:build test_dep
+
+package httpfaultstest_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/rpc/httpfaults"
+	"go.temporal.io/server/common/testing/httpfaultstest"
+	"go.temporal.io/server/common/testing/testhooks"
+)
+
+func newRequest(t *testing.T) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, "http://example.com/cb1", nil)
+	require.NoError(t, err)
+	return req
+}
+
+func TestWrap_NoGenerator(t *testing.T) {
+	t.Parallel()
+
+	handlerCalled := false
+	next := func(*http.Request) (*http.Response, error) {
+		handlerCalled = true
+		return &http.Response{StatusCode: http.StatusOK}, nil
+	}
+	wrapped := httpfaults.Wrap(httpfaultstest.NewGenerator(testhooks.NewTestHooks()), httpfaults.Scope{NamespaceID: "namespace-id"}, next)
+
+	resp, err := wrapped(newRequest(t))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.True(t, handlerCalled)
+}
+
+func TestWrap_BeforeHandler(t *testing.T) {
+	t.Parallel()
+
+	testHooks := testhooks.NewTestHooks()
+	injectedErr := errors.New("injected")
+	generator := httpfaultstest.NewCallbackGenerator(testHooks)
+	generator.RegisterRequestCallback(httpfaults.Scope{NamespaceID: "namespace-id"}, func(context.Context, string, *httpfaults.Request) *httpfaults.Outcome {
+		return &httpfaults.Outcome{Error: injectedErr}
+	})
+	handlerCalled := false
+	next := func(*http.Request) (*http.Response, error) {
+		handlerCalled = true
+		return &http.Response{StatusCode: http.StatusOK}, nil
+	}
+	wrapped := httpfaults.Wrap(httpfaultstest.NewGenerator(testHooks), httpfaults.Scope{NamespaceID: "namespace-id"}, next)
+
+	_, err := wrapped(newRequest(t))
+
+	require.ErrorIs(t, err, injectedErr)
+	require.False(t, handlerCalled)
+}
+
+func TestWrap_AfterHandler(t *testing.T) {
+	t.Parallel()
+
+	testHooks := testhooks.NewTestHooks()
+	generator := httpfaultstest.NewCallbackGenerator(testHooks)
+	generator.RegisterResponseCallback(httpfaults.Scope{NamespaceName: "namespace-name"}, func(context.Context, string, *httpfaults.Request, *http.Response, error) *httpfaults.Outcome {
+		return &httpfaults.Outcome{Response: httpfaults.NewResponse(http.StatusServiceUnavailable, "injected")}
+	})
+	wrapper := httpfaults.Wrap(
+		httpfaultstest.NewGenerator(testHooks),
+		httpfaults.Scope{NamespaceName: "namespace-name"},
+		func(*http.Request) (*http.Response, error) {
+			return httpfaults.NewResponse(http.StatusOK, "original"), nil
+		},
+	)
+
+	resp, err := wrapper(newRequest(t))
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+}
+
+func TestNewCallbackGenerator_UnregisterRemovesHook(t *testing.T) {
+	t.Parallel()
+
+	testHooks := testhooks.NewTestHooks()
+	generator := httpfaultstest.NewCallbackGenerator(testHooks)
+	unregister := generator.RegisterRequestCallback(httpfaults.Scope{NamespaceID: "namespace-id"}, func(context.Context, string, *httpfaults.Request) *httpfaults.Outcome {
+		return nil
+	})
+	_, ok := testhooks.Get(testHooks, testhooks.HTTPRequestFaultGeneratorByNamespaceID, namespace.ID("namespace-id"))
+	require.True(t, ok)
+
+	unregister()
+	_, ok = testhooks.Get(testHooks, testhooks.HTTPRequestFaultGeneratorByNamespaceID, namespace.ID("namespace-id"))
+	require.False(t, ok)
+}
+
+func TestNewCallbackGenerator_RequiresNamespaceScope(t *testing.T) {
+	t.Parallel()
+
+	generator := httpfaultstest.NewCallbackGenerator(testhooks.NewTestHooks())
+	require.PanicsWithValue(t, "fault injection test hooks require a namespace scope", func() {
+		generator.RegisterRequestCallback(httpfaults.Scope{}, func(context.Context, string, *httpfaults.Request) *httpfaults.Outcome {
+			return nil
+		})
+	})
+}

--- a/common/testing/testhooks/hooks.go
+++ b/common/testing/testhooks/hooks.go
@@ -10,6 +10,7 @@ import (
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/rpc/grpcfaults"
+	"go.temporal.io/server/common/rpc/httpfaults"
 	historytasks "go.temporal.io/server/service/history/tasks"
 )
 
@@ -49,6 +50,10 @@ var (
 	GRPCRequestFaultGeneratorByNamespaceName  = newKey[grpcfaults.RequestCallback, namespace.Name]()
 	GRPCResponseFaultGeneratorByNamespaceID   = newKey[grpcfaults.ResponseCallback, namespace.ID]()
 	GRPCResponseFaultGeneratorByNamespaceName = newKey[grpcfaults.ResponseCallback, namespace.Name]()
+	HTTPRequestFaultGeneratorByNamespaceID    = newKey[httpfaults.RequestCallback, namespace.ID]()
+	HTTPRequestFaultGeneratorByNamespaceName  = newKey[httpfaults.RequestCallback, namespace.Name]()
+	HTTPResponseFaultGeneratorByNamespaceID   = newKey[httpfaults.ResponseCallback, namespace.ID]()
+	HTTPResponseFaultGeneratorByNamespaceName = newKey[httpfaults.ResponseCallback, namespace.Name]()
 )
 
 // keyID is a unique identifier for a key, used as a map key.

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -224,6 +224,28 @@ Only unary RPCs are intercepted; streaming RPCs are unaffected.
 
 The `env` methods scope faults to the test's namespace.
 
+### HTTP fault injection
+
+`InjectHTTPRequestFault` and `InjectHTTPResponseFault` inject faults into HTTP clients that install
+the test fault generator. Callback delivery and Nexus operation clients support these faults. The
+faults are scoped to the test namespace and are unavailable in builds without `test_dep`.
+
+Return an `httpfaults.Outcome` with one action:
+
+- `Response` returns a synthetic HTTP response.
+- `Error` returns a transport error.
+
+```go
+env.InjectHTTPRequestFault(func(ctx context.Context, req *http.Request) *httpfaults.Outcome {
+    if req.URL.Path != "/callback" {
+        return nil
+    }
+    return &httpfaults.Outcome{
+        Response: httpfaults.NewResponse(http.StatusServiceUnavailable, "injected"),
+    }
+})
+```
+
 ### testhooks package
 
 The `testhooks` package injects test-specific behavior into production code paths that are otherwise

--- a/service/history/hsm/callbacks/fx.go
+++ b/service/history/hsm/callbacks/fx.go
@@ -10,6 +10,9 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/namespace"
 	commonnexus "go.temporal.io/server/common/nexus"
+	"go.temporal.io/server/common/rpc/httpfaults"
+	"go.temporal.io/server/common/testing/httpfaultstest"
+	"go.temporal.io/server/common/testing/testhooks"
 	queuescommon "go.temporal.io/server/service/history/queues/common"
 	"go.uber.org/fx"
 )
@@ -29,6 +32,7 @@ func HTTPCallerProviderProvider(
 	rpcFactory common.RPCFactory,
 	httpClientCache *cluster.FrontendHTTPClientCache,
 	logger log.Logger,
+	testHooks testhooks.TestHooks,
 ) (HTTPCallerProvider, error) {
 	localClient, err := rpcFactory.CreateLocalFrontendHTTPClient()
 	if err != nil {
@@ -40,9 +44,10 @@ func HTTPCallerProviderProvider(
 	}
 	defaultClient := &http.Client{Transport: defaultTransport}
 	callbackTokenGenerator := commonnexus.NewCallbackTokenGenerator()
+	httpFaultGenerator := httpfaultstest.NewGenerator(testHooks)
 
-	m := collection.NewOnceMap(func(queuescommon.NamespaceIDAndDestination) HTTPCaller {
-		return func(r *http.Request) (*http.Response, error) {
+	m := collection.NewOnceMap(func(key queuescommon.NamespaceIDAndDestination) HTTPCaller {
+		caller := func(r *http.Request) (*http.Response, error) {
 			return routeRequest(r,
 				clusterMetadata,
 				namespaceRegistry,
@@ -53,6 +58,7 @@ func HTTPCallerProviderProvider(
 				logger,
 			)
 		}
+		return httpfaults.Wrap(httpFaultGenerator, httpfaults.Scope{NamespaceID: namespace.ID(key.NamespaceID)}, caller)
 	})
 	return m.Get, nil
 }

--- a/tests/callbacks_test.go
+++ b/tests/callbacks_test.go
@@ -1,7 +1,11 @@
 package tests
 
 import (
+	"context"
 	"errors"
+	"net/http"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -20,6 +24,7 @@ import (
 	"go.temporal.io/server/chasm/lib/callback"
 	"go.temporal.io/server/common/dynamicconfig"
 	commonnexus "go.temporal.io/server/common/nexus"
+	"go.temporal.io/server/common/rpc/httpfaults"
 	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/common/testing/protoassert"
@@ -34,7 +39,9 @@ type CallbacksSuite struct {
 }
 
 func TestCallbacksSuiteHSM(t *testing.T) {
-	parallelsuite.Run(t, &CallbacksSuite{}, []testcore.TestOption{})
+	parallelsuite.Run(t, &CallbacksSuite{}, []testcore.TestOption{
+		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMCallbacks, false),
+	})
 }
 
 func TestCallbacksSuiteCHASM(t *testing.T) {
@@ -51,6 +58,73 @@ func (s *CallbacksSuite) newTestEnv(opts ...testcore.TestOption) *testcore.TestE
 		[]any{map[string]any{"Pattern": "*", "AllowInsecure": true}},
 	)
 	return env
+}
+
+func (s *CallbacksSuite) TestHTTPFaultInjection_NexusCallbackRetriesAfterResponseFault(opts []testcore.TestOption) {
+	testOpts := append([]testcore.TestOption{}, opts...)
+	testOpts = append(testOpts, testcore.WithDynamicConfig(callback.RetryPolicyInitialInterval, 50*time.Millisecond))
+	env := s.newTestEnv(testOpts...)
+	ctx := s.Context()
+
+	workflowType := "test-http-fault-injection"
+	workflowID := env.Tv().WorkflowID()
+	env.SdkWorker().RegisterWorkflowWithOptions(
+		func(workflow.Context) (int, error) { return 666, nil },
+		workflow.RegisterOptions{Name: workflowType},
+	)
+
+	ch, callbackAddress := newNexusCompletionHandler(s.T())
+
+	var attempts atomic.Int32
+	env.InjectHTTPResponseFault(func(_ context.Context, req *http.Request, _ *http.Response, _ error) *httpfaults.Outcome {
+		if !strings.HasSuffix(req.URL.Path, "/cb1") {
+			return nil
+		}
+		if attempts.Add(1) == 1 {
+			return &httpfaults.Outcome{
+				Response: httpfaults.NewResponse(http.StatusServiceUnavailable, "injected"),
+			}
+		}
+		return nil
+	})
+
+	cb := &commonpb.Callback{
+		Variant: &commonpb.Callback_Nexus_{
+			Nexus: &commonpb.Callback_Nexus{Url: callbackAddress + "/cb1"},
+		},
+	}
+	request := &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:           uuid.NewString(),
+		Namespace:           env.Namespace().String(),
+		WorkflowId:          workflowID,
+		WorkflowType:        &commonpb.WorkflowType{Name: workflowType},
+		TaskQueue:           &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		WorkflowRunTimeout:  durationpb.New(100 * time.Second),
+		Identity:            s.T().Name(),
+		CompletionCallbacks: []*commonpb.Callback{cb},
+	}
+
+	_, err := env.FrontendClient().StartWorkflowExecution(ctx, request)
+	s.NoError(err)
+
+	await.Rcv(s.T(), ch.requestCh)
+	await.Snd(s.T(), ch.requestCompleteCh, nil)
+	await.Rcv(s.T(), ch.requestCh)
+	await.Snd(s.T(), ch.requestCompleteCh, nil)
+
+	sdkClient := env.SdkClient()
+	await.Require(ctx, s.T(), func(col *await.T) {
+		description, err := sdkClient.DescribeWorkflowExecution(ctx, workflowID, "")
+		require.NoError(col, err)
+		require.Len(col, description.Callbacks, 1)
+		callbackInfo := description.Callbacks[0]
+		require.Equal(col, enumspb.CALLBACK_STATE_SUCCEEDED, callbackInfo.State)
+		require.Nil(col, callbackInfo.LastAttemptFailure)
+		require.GreaterOrEqual(col, callbackInfo.Attempt, int32(2))
+		protorequire.ProtoEqual(col, cb, callbackInfo.Callback)
+	}, 5*time.Second, 100*time.Millisecond)
+
+	s.GreaterOrEqual(attempts.Load(), int32(2))
 }
 
 func (s *CallbacksSuite) TestScheduledCallbackTokenMigration_LegacyWriteEnvelopeRead(opts []testcore.TestOption) {

--- a/tests/callbacks_test.go
+++ b/tests/callbacks_test.go
@@ -66,11 +66,10 @@ func (s *CallbacksSuite) TestHTTPFaultInjection_NexusCallbackRetriesAfterRespons
 	env := s.newTestEnv(testOpts...)
 	ctx := s.Context()
 
-	workflowType := "test-http-fault-injection"
 	workflowID := env.Tv().WorkflowID()
 	env.SdkWorker().RegisterWorkflowWithOptions(
-		func(workflow.Context) (int, error) { return 666, nil },
-		workflow.RegisterOptions{Name: workflowType},
+		func(workflow.Context) (int, error) { return 42, nil },
+		workflow.RegisterOptions{Name: env.Tv().WorkflowType().GetName()},
 	)
 
 	ch, callbackAddress := newNexusCompletionHandler(s.T())
@@ -97,7 +96,7 @@ func (s *CallbacksSuite) TestHTTPFaultInjection_NexusCallbackRetriesAfterRespons
 		RequestId:           uuid.NewString(),
 		Namespace:           env.Namespace().String(),
 		WorkflowId:          workflowID,
-		WorkflowType:        &commonpb.WorkflowType{Name: workflowType},
+		WorkflowType:        env.Tv().WorkflowType(),
 		TaskQueue:           &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
 		WorkflowRunTimeout:  durationpb.New(100 * time.Second),
 		Identity:            s.T().Name(),
@@ -113,15 +112,15 @@ func (s *CallbacksSuite) TestHTTPFaultInjection_NexusCallbackRetriesAfterRespons
 	await.Snd(s.T(), ch.requestCompleteCh, nil)
 
 	sdkClient := env.SdkClient()
-	await.Require(ctx, s.T(), func(col *await.T) {
-		description, err := sdkClient.DescribeWorkflowExecution(ctx, workflowID, "")
-		require.NoError(col, err)
-		require.Len(col, description.Callbacks, 1)
+	s.Await(func(s *CallbacksSuite) {
+		description, err := sdkClient.DescribeWorkflowExecution(s.Context(), workflowID, "")
+		s.NoError(err)
+		s.Len(description.Callbacks, 1)
 		callbackInfo := description.Callbacks[0]
-		require.Equal(col, enumspb.CALLBACK_STATE_SUCCEEDED, callbackInfo.State)
-		require.Nil(col, callbackInfo.LastAttemptFailure)
-		require.GreaterOrEqual(col, callbackInfo.Attempt, int32(2))
-		protorequire.ProtoEqual(col, cb, callbackInfo.Callback)
+		s.Equal(enumspb.CALLBACK_STATE_SUCCEEDED, callbackInfo.State)
+		s.Nil(callbackInfo.LastAttemptFailure)
+		s.GreaterOrEqual(callbackInfo.Attempt, int32(2))
+		protorequire.ProtoEqual(s.T(), cb, callbackInfo.Callback)
 	}, 5*time.Second, 100*time.Millisecond)
 
 	s.GreaterOrEqual(attempts.Load(), int32(2))

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"slices"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -44,6 +46,7 @@ import (
 	"go.temporal.io/server/common/nexus/nexusrpc"
 	"go.temporal.io/server/common/nexus/nexustest"
 	"go.temporal.io/server/common/payloads"
+	"go.temporal.io/server/common/rpc/httpfaults"
 	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/common/testing/historyrequire"
 	"go.temporal.io/server/common/testing/parallelsuite"
@@ -573,6 +576,62 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationSyncCompletion(chasmEnabled b
 	})
 	s.NoError(err)
 	s.Empty(desc.DatabaseMutableState.GetExecutionInfo().SubStateMachinesByType)
+}
+
+func (s *NexusWorkflowTestSuite) TestNexusOperationRetriesAfterHTTPFault(chasmEnabled bool) {
+	const retryInterval = 50 * time.Millisecond
+	env := s.newTestEnv(
+		chasmEnabled,
+		testcore.WithDynamicConfig(nexusoperations.RetryPolicyInitialInterval, retryInterval),
+		testcore.WithDynamicConfig(chasmnexus.RetryPolicy, chasmnexus.RetryPolicyConfig{
+			InitialInterval: retryInterval,
+			MaxInterval:     retryInterval,
+		}),
+	)
+	ctx := s.Context()
+	taskQueue := testcore.RandomizeStr(s.T().Name())
+
+	var handlerCalls atomic.Int32
+	h := nexustest.Handler{
+		OnStartOperation: func(context.Context, string, string, *nexus.LazyValue, nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
+			handlerCalls.Add(1)
+			return &nexus.HandlerStartOperationResultSync[any]{Value: "result"}, nil
+		},
+	}
+	endpointName := env.createRandomExternalNexusServer(ctx, s.T(), h)
+
+	// The first request fails before it reaches the handler. The retry succeeds.
+	injectedErr := errors.New("simulated transport failure")
+	var attempts atomic.Int32
+	env.InjectHTTPRequestFault(func(_ context.Context, req *http.Request) *httpfaults.Outcome {
+		if !strings.HasSuffix(req.URL.Path, "/operation") {
+			return nil
+		}
+		if attempts.Add(1) == 1 {
+			return &httpfaults.Outcome{Error: injectedErr}
+		}
+		return nil
+	})
+
+	callerWF := func(ctx workflow.Context) (string, error) {
+		c := workflow.NewNexusClient(endpointName, "service")
+		var result string
+		err := c.ExecuteOperation(ctx, "operation", "input", workflow.NexusOperationOptions{}).Get(ctx, &result)
+		return result, err
+	}
+
+	w := worker.New(env.SdkClient(), taskQueue, worker.Options{})
+	w.RegisterWorkflow(callerWF)
+	s.NoError(w.Start())
+	defer w.Stop()
+
+	run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{TaskQueue: taskQueue}, callerWF)
+	s.NoError(err)
+	var result string
+	s.NoError(run.Get(ctx, &result))
+	s.Equal("result", result)
+	s.EqualValues(2, attempts.Load())
+	s.EqualValues(1, handlerCalls.Load())
 }
 
 // TestNexusOperationCallerMetrics verifies that an in-workflow Nexus operation emits the

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -601,14 +601,13 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationRetriesAfterHTTPFault(chasmEn
 	endpointName := env.createRandomExternalNexusServer(ctx, s.T(), h)
 
 	// The first request fails before it reaches the handler. The retry succeeds.
-	injectedErr := errors.New("simulated transport failure")
 	var attempts atomic.Int32
 	env.InjectHTTPRequestFault(func(_ context.Context, req *http.Request) *httpfaults.Outcome {
 		if !strings.HasSuffix(req.URL.Path, "/operation") {
 			return nil
 		}
 		if attempts.Add(1) == 1 {
-			return &httpfaults.Outcome{Error: injectedErr}
+			return &httpfaults.Outcome{Error: errors.New("simulated transport failure")}
 		}
 		return nil
 	})

--- a/tests/testcore/fault_injection.go
+++ b/tests/testcore/fault_injection.go
@@ -1,9 +1,13 @@
 package testcore
 
 import (
+	"context"
+	"net/http"
 	"sync"
 	"sync/atomic"
 	"testing"
+
+	"go.temporal.io/server/common/rpc/httpfaults"
 )
 
 // RequestFault determines whether a fault should be injected before a gRPC handler runs.
@@ -13,6 +17,12 @@ type RequestFault func(req any) error
 // ResponseFault determines whether a fault should be injected after a gRPC handler runs.
 // Return the error to inject, or nil to preserve the handler response and error.
 type ResponseFault func(req, resp any, handlerErr error) error
+
+// HTTPRequestFault checks a request before the HTTP call.
+type HTTPRequestFault func(context.Context, *http.Request) *httpfaults.Outcome
+
+// HTTPResponseFault checks a result after the HTTP call.
+type HTTPResponseFault func(context.Context, *http.Request, *http.Response, error) *httpfaults.Outcome
 
 type faultTracker struct {
 	t     testing.TB

--- a/tests/testcore/onebox.go
+++ b/tests/testcore/onebox.go
@@ -33,7 +33,9 @@ import (
 	"go.temporal.io/server/common/rpc/auth"
 	"go.temporal.io/server/common/rpc/encryption"
 	"go.temporal.io/server/common/rpc/grpcfaults"
+	"go.temporal.io/server/common/rpc/httpfaults"
 	"go.temporal.io/server/common/testing/grpcfaultstest"
+	"go.temporal.io/server/common/testing/httpfaultstest"
 	"go.temporal.io/server/common/testing/testhooks"
 	"go.temporal.io/server/service/history/hsm/nexusoperations"
 	"go.temporal.io/server/temporal"
@@ -67,6 +69,7 @@ type (
 		replicationStreamRecorder *ReplicationStreamRecorder
 		historyTaskRecorder       *HistoryTaskRecorder
 		grpcFaultGenerator        *grpcfaults.CallbackGenerator
+		httpFaultGenerator        *httpfaults.CallbackGenerator
 
 		callbackLock sync.RWMutex
 		onGetClaims  func(*authorization.AuthInfo) (*authorization.Claims, error)
@@ -133,6 +136,7 @@ func newTemporal(t *testing.T, params *temporalParams) *temporalImpl {
 		replicationStreamRecorder: NewReplicationStreamRecorder(),
 	}
 	impl.grpcFaultGenerator = grpcfaultstest.NewCallbackGenerator(impl.testHooks)
+	impl.httpFaultGenerator = httpfaultstest.NewCallbackGenerator(impl.testHooks)
 
 	// Base options are independent of which services this test cluster starts.
 	// [Start] adds the per-service config and static host map.
@@ -357,6 +361,10 @@ func (c *temporalImpl) GetHistoryTaskRecorder() *HistoryTaskRecorder {
 
 func (c *temporalImpl) GetGRPCFaultGenerator() *grpcfaults.CallbackGenerator {
 	return c.grpcFaultGenerator
+}
+
+func (c *temporalImpl) GetHTTPFaultGenerator() *httpfaults.CallbackGenerator {
+	return c.httpFaultGenerator
 }
 
 func (c *temporalImpl) TLSConfigProvider() *encryption.FixedTLSConfigProvider {

--- a/tests/testcore/test_env.go
+++ b/tests/testcore/test_env.go
@@ -5,6 +5,7 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -29,6 +30,7 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/rpc/grpcfaults"
+	"go.temporal.io/server/common/rpc/httpfaults"
 	"go.temporal.io/server/common/testing/taskpoller"
 	"go.temporal.io/server/common/testing/testcontext"
 	"go.temporal.io/server/common/testing/testhooks"
@@ -494,6 +496,40 @@ func (e *TestEnv) InjectResponseFault(fault ResponseFault) func() {
 		if injectedErr := fault(req, resp, err); injectedErr != nil {
 			tracker.markFired(req)
 			return &grpcfaults.Outcome{Error: injectedErr}
+		}
+		return nil
+	})
+	return tracker.attach(unregister)
+}
+
+// InjectHTTPRequestFault registers a fault for HTTP requests in this namespace.
+func (e *TestEnv) InjectHTTPRequestFault(fault HTTPRequestFault) func() {
+	scope := httpfaults.Scope{
+		NamespaceID:   e.nsID,
+		NamespaceName: e.nsName,
+	}
+	tracker := newFaultTracker(e.t)
+	unregister := e.GetTestCluster().Host().GetHTTPFaultGenerator().RegisterRequestCallback(scope, func(ctx context.Context, _ string, req *httpfaults.Request) *httpfaults.Outcome {
+		if outcome := fault(ctx, req.Raw); outcome != nil {
+			tracker.markFired(req.Raw)
+			return outcome
+		}
+		return nil
+	})
+	return tracker.attach(unregister)
+}
+
+// InjectHTTPResponseFault registers a fault for HTTP results in this namespace.
+func (e *TestEnv) InjectHTTPResponseFault(fault HTTPResponseFault) func() {
+	scope := httpfaults.Scope{
+		NamespaceID:   e.nsID,
+		NamespaceName: e.nsName,
+	}
+	tracker := newFaultTracker(e.t)
+	unregister := e.GetTestCluster().Host().GetHTTPFaultGenerator().RegisterResponseCallback(scope, func(ctx context.Context, _ string, req *httpfaults.Request, resp *http.Response, callErr error) *httpfaults.Outcome {
+		if outcome := fault(ctx, req.Raw, resp, callErr); outcome != nil {
+			tracker.markFired(req.Raw)
+			return outcome
 		}
 		return nil
 	})


### PR DESCRIPTION
## What changed?

As titled. This follows a similar path as the prior gRPC fault injection flow (https://github.com/temporalio/temporal/pull/9076):
1. We wire in a `Wrap(...)` function in the fx.go that we wanna wire fault injection into -- for now I did it for callbacks (HSM, CHASM) and nexusoperation
2. In prod build, the fault generator is always `nil`
3. In test build, this provides a generator that allows us to wire in callbacks that carries the injected fault(s)
4. Then in test_env.go, we export utils that allow user to programmatically inject a fault that gets propagated all the way into the HTTP requests that we wired the generator into in step 1.

See tests/callbacks_test.go and tests/nexus_workflow_test.go in this PR for newly added tests where we are able to programmatically inject faults with the utils added.

## Why?

This will allow us to build {deterministic, random} functional tests driven by configs, with this + other fault injection hooks as foundation.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)