### PR TITLE
Dedupe the gRPC status unwrap behind common.GetRPCStatus

### DIFF
--- a/chasm/lib/callback/invocable_internal.go
+++ b/chasm/lib/callback/invocable_internal.go
@@ -12,13 +12,12 @@ import (
 	tokenspb "go.temporal.io/server/api/token/v1"
 	"go.temporal.io/server/chasm"
 	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/namespace"
 	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/nexus/nexusrpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -93,40 +92,13 @@ func (c invocableInternal) Invoke(
 	_, err = h.historyClient.CompleteNexusOperationChasm(ctx, request)
 	if err != nil {
 		msg := logInternalError(h.logger, "failed to complete Nexus operation", err)
-		if isRetryableRPCResponse(err) {
+		if common.IsRetryableRPCError(err) {
 			return invocationResultRetry{err: msg}
 		}
 		return invocationResultFail{msg}
 	}
 
 	return invocationResultOK{}
-}
-
-func isRetryableRPCResponse(err error) bool {
-	var st *status.Status
-	stGetter, ok := err.(interface{ Status() *status.Status })
-	if ok {
-		st = stGetter.Status()
-	} else {
-		st, ok = status.FromError(err)
-		if !ok {
-			// Not a gRPC induced error
-			return false
-		}
-	}
-	// nolint:exhaustive
-	switch st.Code() {
-	case codes.Canceled,
-		codes.Unknown,
-		codes.Unavailable,
-		codes.DeadlineExceeded,
-		codes.ResourceExhausted,
-		codes.Aborted,
-		codes.Internal:
-		return true
-	default:
-		return false
-	}
 }
 
 func (c invocableInternal) getHistoryRequest(

--- a/common/nexus/failure.go
+++ b/common/nexus/failure.go
@@ -14,8 +14,8 @@ import (
 	failurepb "go.temporal.io/api/failure/v1"
 	nexuspb "go.temporal.io/api/nexus/v1"
 	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/common"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
@@ -323,16 +323,10 @@ func nexusFailureMetadataToApplicationFailureInfo(failure nexus.Failure) (*failu
 // and
 // https://github.com/grpc-ecosystem/grpc-gateway/blob/a7cf811e6ffabeaddcfb4ff65602c12671ff326e/runtime/errors.go#L56.
 func ConvertGRPCError(err error, exposeDetails bool) error {
-	var st *status.Status
-	stGetter, ok := err.(interface{ Status() *status.Status })
-	if ok {
-		st = stGetter.Status()
-	} else {
-		st, ok = status.FromError(err)
-		if !ok {
-			// The Nexus SDK will translate this into an internal server error and will not expose the error details.
-			return err
-		}
+	st, ok := common.GetRPCStatus(err)
+	if !ok {
+		// The Nexus SDK will translate this into an internal server error and will not expose the error details.
+		return err
 	}
 
 	errMessage := err.Error()

--- a/common/util.go
+++ b/common/util.go
@@ -765,9 +765,15 @@ func getFieldNameFromStruct(structPtr any, fieldPtr any) (string, error) {
 // GetRPCStatus returns the gRPC status carried by err, or false if err is not a gRPC-induced
 // error.
 //
-// This does not unwrap err: If err may be wrapped (e.g. by an HTTP client, which wraps
-// RoundTripper errors in *url.Error), unwrap it yourself and pass the unwrapped error here.
+// Wrapped gRPC status errors are supported, but wrapped errors implementing
+// Status() must be unwrapped before calling GetRPCStatus.
 func GetRPCStatus(err error) (*status.Status, bool) {
+	// This isn't correct, but is to maintain existing behavior.
+	//
+	// Exposing gRPC errors via `Status()` was a convention that existed for several years,
+	// but the canonical way to expose error status (from google.golang.org/grpc/status) is
+	// by an `GRPCStatus() *status.Status` method. [status.FromError] below does unwrapping
+	// and checks for that.
 	if stGetter, ok := err.(interface{ Status() *status.Status }); ok {
 		return stGetter.Status(), true
 	}

--- a/common/util.go
+++ b/common/util.go
@@ -762,21 +762,26 @@ func getFieldNameFromStruct(structPtr any, fieldPtr any) (string, error) {
 	return "", serviceerror.NewInternal("field not found in the struct")
 }
 
-// IsRetryableRPCError checks if the error is a retryable gRPC error.
+// GetRPCStatus returns the gRPC status carried by err, or false if err is not a gRPC-induced
+// error.
 //
 // This does not unwrap err: If err may be wrapped (e.g. by an HTTP client, which wraps
 // RoundTripper errors in *url.Error), unwrap it yourself and pass the unwrapped error here.
+func GetRPCStatus(err error) (*status.Status, bool) {
+	if stGetter, ok := err.(interface{ Status() *status.Status }); ok {
+		return stGetter.Status(), true
+	}
+	return status.FromError(err)
+}
+
+// IsRetryableRPCError checks if the error is a retryable gRPC error.
+//
+// This does not unwrap err, see [GetRPCStatus].
 func IsRetryableRPCError(err error) bool {
-	var st *status.Status
-	stGetter, ok := err.(interface{ Status() *status.Status })
-	if ok {
-		st = stGetter.Status()
-	} else {
-		st, ok = status.FromError(err)
-		if !ok {
-			// Not a gRPC induced error
-			return false
-		}
+	st, ok := GetRPCStatus(err)
+	if !ok {
+		// Not a gRPC induced error
+		return false
 	}
 	// nolint:exhaustive
 	switch st.Code() {

--- a/service/history/hsm/callbacks/chasm_invocation.go
+++ b/service/history/hsm/callbacks/chasm_invocation.go
@@ -11,13 +11,12 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	tokenspb "go.temporal.io/server/api/token/v1"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/namespace"
 	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/nexus/nexusrpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -71,7 +70,7 @@ func (c chasmInvocation) Invoke(ctx context.Context, ns *namespace.Namespace, e 
 	_, err = e.HistoryClient.CompleteNexusOperationChasm(ctx, request)
 	if err != nil {
 		redactedErr := logInternalError(e.Logger, "failed to complete Nexus operation", err)
-		if isRetryableRPCResponse(err) {
+		if common.IsRetryableRPCError(err) {
 			return invocationResultRetry{redactedErr}
 		}
 		return invocationResultFail{redactedErr}
@@ -132,31 +131,4 @@ func (c chasmInvocation) getHistoryRequest(
 	}
 
 	return req, nil
-}
-
-func isRetryableRPCResponse(err error) bool {
-	var st *status.Status
-	stGetter, ok := err.(interface{ Status() *status.Status })
-	if ok {
-		st = stGetter.Status()
-	} else {
-		st, ok = status.FromError(err)
-		if !ok {
-			// Not a gRPC induced error
-			return false
-		}
-	}
-	// nolint:exhaustive
-	switch st.Code() {
-	case codes.Canceled,
-		codes.Unknown,
-		codes.Unavailable,
-		codes.DeadlineExceeded,
-		codes.ResourceExhausted,
-		codes.Aborted,
-		codes.Internal:
-		return true
-	default:
-		return false
-	}
 }


### PR DESCRIPTION
I'm trying to reduce the size of a monstrous PR I'm working on, this was one of the changes that could be teased out independently.

## Problem

Four places independently unwrapped a `*status.Status` from an error with the same 12-line dance: `common.IsRetryableRPCError`, `commonnexus.ConvertGRPCError`, and a private `isRetryableRPCResponse` in both `chasm/lib/callback` and `service/history/hsm/callbacks`.

## Fix

Extract it as `common.GetRPCStatus(err) (*status.Status, bool)` and delete the copies.

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)