### PR TITLE
Fix MockContext dropping registered component context values

### DIFF
--- a/chasm/context_mock.go
+++ b/chasm/context_mock.go
@@ -46,6 +46,16 @@ type MockContext struct {
 	registeredContextValues map[any]any
 }
 
+// RegisterLibrary copies the context values that lib's components declare via
+// [WithContextValues] into the mock, mirroring what [Registry] does in production. Use this in
+// tests that reach into another library's component methods, so that library can keep its context
+// keys unexported.
+func (c *MockContext) RegisterLibrary(lib Library) {
+	for _, rc := range lib.Components() {
+		c.RegisterComponentContextValues(rc.contextValues)
+	}
+}
+
 func (c *MockContext) RegisterComponentContextValues(
 	keyValues map[any]any,
 ) {
@@ -138,7 +148,11 @@ func (c *MockContext) MetricsHandler() metrics.Handler {
 }
 
 func (c *MockContext) Value(key any) any {
-	return c.goContext().Value(key)
+	if v := c.goContext().Value(key); v != nil {
+		return v
+	}
+
+	return c.registeredContextValues[key]
 }
 
 func (c *MockContext) Links(component Component) []*commonpb.Link {
@@ -175,6 +189,8 @@ func (c *MockContext) withValue(key any, value any) Context {
 		HandleLinks:          c.HandleLinks,
 		HandleRequestLinks:   c.HandleRequestLinks,
 		HandleUserMetadata:   c.HandleUserMetadata,
+
+		registeredContextValues: c.registeredContextValues,
 	}
 }
 

--- a/chasm/context_mock_test.go
+++ b/chasm/context_mock_test.go
@@ -1,0 +1,68 @@
+package chasm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type mockCtxKeyType struct{}
+
+var mockCtxKey = mockCtxKeyType{}
+
+type mockCtxValuesComponent struct {
+	UnimplementedComponent
+}
+
+func (c *mockCtxValuesComponent) LifecycleState(_ Context) LifecycleState {
+	return LifecycleStateRunning
+}
+
+type mockCtxValuesLibrary struct {
+	UnimplementedLibrary
+}
+
+func (l *mockCtxValuesLibrary) Name() string { return "mockCtxValues" }
+
+func (l *mockCtxValuesLibrary) Components() []*RegistrableComponent {
+	return []*RegistrableComponent{
+		NewRegistrableComponent[*mockCtxValuesComponent](
+			"component",
+			WithContextValues(map[any]any{mockCtxKey: "from-library"}),
+		),
+	}
+}
+
+func TestMockContextValue(t *testing.T) {
+	t.Run("ReturnsRegisteredComponentValues", func(t *testing.T) {
+		c := &MockContext{}
+		c.RegisterComponentContextValues(map[any]any{mockCtxKey: "registered"})
+		require.Equal(t, "registered", c.Value(mockCtxKey))
+	})
+
+	t.Run("RegisterLibraryCopiesComponentValues", func(t *testing.T) {
+		c := &MockContext{}
+		c.RegisterLibrary(&mockCtxValuesLibrary{})
+		require.Equal(t, "from-library", c.Value(mockCtxKey))
+	})
+
+	t.Run("GoCtxTakesPrecedence", func(t *testing.T) {
+		c := &MockContext{GoCtx: context.WithValue(context.Background(), mockCtxKey, "from-goctx")}
+		c.RegisterComponentContextValues(map[any]any{mockCtxKey: "registered"})
+		require.Equal(t, "from-goctx", c.Value(mockCtxKey))
+	})
+
+	// withValue derives a new context; registered values must survive the copy.
+	t.Run("RegisteredValuesSurviveWithValue", func(t *testing.T) {
+		c := &MockContext{}
+		c.RegisterComponentContextValues(map[any]any{mockCtxKey: "registered"})
+		derived := c.withValue("other", "value")
+		require.Equal(t, "registered", derived.Value(mockCtxKey))
+	})
+
+	t.Run("UnknownKeyIsNil", func(t *testing.T) {
+		c := &MockContext{}
+		require.Nil(t, c.Value(mockCtxKey))
+	})
+}


### PR DESCRIPTION
## Problem

`MockContext.RegisterComponentContextValues` stored values that nothing ever read:

- `Value()` only consulted `GoCtx`, never the registered map.
- `withValue()` didn't copy the map, so a derived context lost them too.

A component that reads a value registered via `WithContextValues` therefore can't be tested with the mock — the value always comes back nil.

## Fix

`Value()` falls back to the registered map (`GoCtx` still wins), `withValue()` carries it over, and a new `RegisterLibrary(lib)` registers a whole library's values at once so libraries can keep their context keys unexported.

Adds `chasm/context_mock_test.go`; the three new cases fail without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)