### PR TITLE
Share one operation-error-to-failure conversion

### DIFF
--- a/chasm/lib/callback/invocable_internal.go
+++ b/chasm/lib/callback/invocable_internal.go
@@ -158,17 +158,9 @@ func (c invocableInternal) getHistoryRequest(
 			Completion: completion,
 		}
 	} else {
-		failure, err := nexusrpc.DefaultFailureConverter().ErrorToFailure(c.completion.Error)
+		apiFailure, err := commonnexus.OperationErrorToTemporalFailure(c.completion.Error)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert error to failure: %w", err)
-		}
-		// Unwrap the operation error, the handler on the other side is expecting to receive the underlying cause.
-		if failure.Cause != nil {
-			failure = *failure.Cause
-		}
-		apiFailure, err := commonnexus.NexusFailureToTemporalFailure(failure)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert failure type: %w", err)
 		}
 
 		req = &historyservice.CompleteNexusOperationChasmRequest{

--- a/chasm/lib/nexusoperation/task_handler_helpers.go
+++ b/chasm/lib/nexusoperation/task_handler_helpers.go
@@ -270,7 +270,7 @@ func newInvocationResult(
 	}
 
 	if opErr, ok := errors.AsType[*nexus.OperationError](callErr); ok {
-		failure, err := operationErrorToFailure(opErr)
+		failure, err := commonnexus.OperationErrorToTemporalFailure(opErr)
 		if err != nil {
 			return nil, err
 		}
@@ -307,20 +307,6 @@ func newInvocationResult(
 		return invocationResultFail{failure: failure}, nil
 	}
 	return invocationResultRetry{failure: failure}, nil
-}
-
-func operationErrorToFailure(opErr *nexus.OperationError) (*failurepb.Failure, error) {
-	var nf nexus.Failure
-	if opErr.OriginalFailure != nil {
-		nf = *opErr.OriginalFailure
-	} else {
-		var err error
-		nf, err = nexusrpc.DefaultFailureConverter().ErrorToFailure(opErr)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return commonnexus.NexusFailureToTemporalFailure(*nexusrpc.UnwrapFailure(&nf))
 }
 
 func buildCallbackURL(

--- a/common/nexus/failure.go
+++ b/common/nexus/failure.go
@@ -14,6 +14,7 @@ import (
 	failurepb "go.temporal.io/api/failure/v1"
 	nexuspb "go.temporal.io/api/nexus/v1"
 	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/common/nexus/nexusrpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -431,6 +432,27 @@ func ConvertGRPCError(err error, exposeDetails bool) error {
 	}
 	// Let the nexus SDK handle this for us (log and convert to an internal error).
 	return err
+}
+
+// OperationErrorToTemporalFailure converts a Nexus operation error into the Temporal failure that
+// gets reported to the caller of the operation.
+func OperationErrorToTemporalFailure(opErr *nexus.OperationError) (*failurepb.Failure, error) {
+	var nf nexus.Failure
+	if opErr.OriginalFailure != nil {
+		// Prefer the failure as it came off the wire, rather than round-tripping it through the
+		// converter and losing whatever the converter cannot represent.
+		nf = *opErr.OriginalFailure
+	} else {
+		var err error
+		nf, err = nexusrpc.DefaultFailureConverter().ErrorToFailure(opErr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// The failure may be a wrapper whose metadata asks that its cause be reported instead, to avoid
+	// an unnecessary layer of indirection.
+	return NexusFailureToTemporalFailure(*nexusrpc.UnwrapFailure(&nf))
 }
 
 func AdaptAuthorizeError(permissionDeniedError *serviceerror.PermissionDenied) error {


### PR DESCRIPTION
## Problem

Two paths convert a `*nexus.OperationError` into a `failurepb.Failure`, and they disagree. `nexusoperation`'s version is the correct one; the CHASM callback internal-completion path (`invocable_internal.go`):

- ignored `opErr.OriginalFailure` and always re-derived the failure through the converter, losing whatever the converter can't represent; and
- unconditionally replaced the failure with its `.Cause`, discarding the outer failure even when it wasn't a wrapper. `nexusrpc.UnwrapFailure` only does that when the failure's metadata marks it as one.

## Fix

Hoist `nexusoperation`'s version to `commonnexus.OperationErrorToTemporalFailure` and use it in both. This changes what the internal-completion path delivers, per the two bullets above.

**Not fixed here:** `service/history/hsm/callbacks/chasm_invocation.go` still does the unconditional `.Cause` unwrap. Left alone since the HSM path is on its way out — say the word if you'd rather it move too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)