### PR TITLE
Prevent Terminating an already Canceled SANO

### DIFF
--- a/chasm/lib/nexusoperation/operation.go
+++ b/chasm/lib/nexusoperation/operation.go
@@ -417,7 +417,7 @@ func (o *Operation) Terminate(
 		return chasm.TerminateComponentResponse{}, nil
 	}
 
-	if o.isClosed() {
+	if !TransitionTerminated.Possible(o) {
 		return chasm.TerminateComponentResponse{}, ErrOperationAlreadyCompleted
 	}
 

--- a/chasm/lib/nexusoperation/operation.go
+++ b/chasm/lib/nexusoperation/operation.go
@@ -417,6 +417,10 @@ func (o *Operation) Terminate(
 		return chasm.TerminateComponentResponse{}, nil
 	}
 
+	if o.isClosed() {
+		return chasm.TerminateComponentResponse{}, ErrOperationAlreadyCompleted
+	}
+
 	return chasm.TerminateComponentResponse{}, TransitionTerminated.Apply(o, ctx, EventTerminated{
 		TerminateComponentRequest: req,
 	})

--- a/chasm/lib/nexusoperation/operation_statemachine.go
+++ b/chasm/lib/nexusoperation/operation_statemachine.go
@@ -259,7 +259,6 @@ var TransitionTerminated = chasm.NewTransition(
 		nexusoperationpb.OPERATION_STATUS_SCHEDULED,
 		nexusoperationpb.OPERATION_STATUS_STARTED,
 		nexusoperationpb.OPERATION_STATUS_BACKING_OFF,
-		nexusoperationpb.OPERATION_STATUS_CANCELED,
 	},
 	nexusoperationpb.OPERATION_STATUS_TERMINATED,
 	func(o *Operation, ctx chasm.MutableContext, event EventTerminated) error {

--- a/chasm/lib/nexusoperation/operation_test.go
+++ b/chasm/lib/nexusoperation/operation_test.go
@@ -67,6 +67,63 @@ func TestRequestCancelDeduplicationAfterTerminalState(t *testing.T) {
 	})
 }
 
+func TestTerminate(t *testing.T) {
+	t.Parallel()
+
+	newOpWithStatus := func(status nexusoperationpb.OperationStatus) (*Operation, *chasm.MockMutableContext) {
+		ctx := &chasm.MockMutableContext{
+			MockContext: chasm.MockContext{
+				HandleNow: func(chasm.Component) time.Time { return defaultTime },
+				HandleNamespaceEntry: func() *namespace.Namespace {
+					return namespace.NewNamespaceForTest(
+						&persistencespb.NamespaceInfo{Name: "ns-name"}, nil, false, nil, 0,
+					)
+				},
+				GoCtx: context.WithValue(context.Background(), OperationContextKey, &OperationContext{
+					MetricTagConfig: dynamicconfig.GetTypedPropertyFn(NexusMetricTagConfig{}),
+				}),
+			},
+		}
+		op := newTestOperation()
+		op.Status = status
+		return op, ctx
+	}
+
+	t.Run("TerminatesARunningOperation", func(t *testing.T) {
+		op, ctx := newOpWithStatus(nexusoperationpb.OPERATION_STATUS_STARTED)
+
+		_, err := op.Terminate(ctx, chasm.TerminateComponentRequest{RequestID: "req-id"})
+		require.NoError(t, err)
+		require.Equal(t, nexusoperationpb.OPERATION_STATUS_TERMINATED, op.Status)
+	})
+
+	// Terminating an operation that already reached a terminal outcome is a FailedPrecondition,
+	// not a bare ErrInvalidTransition.
+	for _, status := range []nexusoperationpb.OperationStatus{
+		nexusoperationpb.OPERATION_STATUS_SUCCEEDED,
+		nexusoperationpb.OPERATION_STATUS_CANCELED,
+		nexusoperationpb.OPERATION_STATUS_FAILED,
+		nexusoperationpb.OPERATION_STATUS_TIMED_OUT,
+	} {
+		t.Run("Rejects"+status.String(), func(t *testing.T) {
+			op, ctx := newOpWithStatus(status)
+
+			_, err := op.Terminate(ctx, chasm.TerminateComponentRequest{RequestID: "req-id"})
+			require.ErrorIs(t, err, ErrOperationAlreadyCompleted)
+			require.Equal(t, status, op.Status)
+		})
+	}
+
+	t.Run("IsIdempotentForTheSameRequestID", func(t *testing.T) {
+		op, ctx := newOpWithStatus(nexusoperationpb.OPERATION_STATUS_STARTED)
+
+		_, err := op.Terminate(ctx, chasm.TerminateComponentRequest{RequestID: "req-id"})
+		require.NoError(t, err)
+		_, err = op.Terminate(ctx, chasm.TerminateComponentRequest{RequestID: "req-id"})
+		require.NoError(t, err)
+	})
+}
+
 func TestIsWaitStageReached(t *testing.T) {
 	t.Parallel()
 

--- a/chasm/lib/nexusoperation/operation_test.go
+++ b/chasm/lib/nexusoperation/operation_test.go
@@ -97,8 +97,7 @@ func TestTerminate(t *testing.T) {
 		require.Equal(t, nexusoperationpb.OPERATION_STATUS_TERMINATED, op.Status)
 	})
 
-	// Terminating an operation that already reached a terminal outcome is a FailedPrecondition,
-	// not a bare ErrInvalidTransition.
+	// Terminating an operation that already reached a terminal outcome is a FailedPrecondition.
 	for _, status := range []nexusoperationpb.OperationStatus{
 		nexusoperationpb.OPERATION_STATUS_SUCCEEDED,
 		nexusoperationpb.OPERATION_STATUS_CANCELED,

--- a/tests/nexus_standalone_test.go
+++ b/tests/nexus_standalone_test.go
@@ -1194,7 +1194,9 @@ func (s *NexusStandaloneTestSuite) TestTerminateStandaloneNexusOperation() {
 		s.Contains(err.Error(), "already terminated")
 	})
 
-	s.Run("AlreadyCanceled", func(s *NexusStandaloneTestSuite) {
+	// A cancel request on a running operation only records the cancellation; the operation stays
+	// running, so terminate is still accepted and closes it as TERMINATED.
+	s.Run("CancelRequestedThenTerminated", func(s *NexusStandaloneTestSuite) {
 		env := s.newTestEnv()
 		endpointName := env.createRandomNexusEndpoint(s.Context(), s.T()).GetSpec().GetName()
 
@@ -1204,7 +1206,7 @@ func (s *NexusStandaloneTestSuite) TestTerminateStandaloneNexusOperation() {
 		})
 		s.NoError(err)
 
-		// Cancel the operation first.
+		// Request cancellation first.
 		_, err = env.FrontendClient().RequestCancelNexusOperationExecution(s.Context(), &workflowservice.RequestCancelNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "test-op",
@@ -1212,7 +1214,16 @@ func (s *NexusStandaloneTestSuite) TestTerminateStandaloneNexusOperation() {
 		})
 		s.NoError(err)
 
-		// Terminate a canceled operation — should succeed.
+		// No worker services this endpoint, so the operation is still running.
+		descResp, err := env.FrontendClient().DescribeNexusOperationExecution(s.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
+			Namespace:   env.Namespace().String(),
+			OperationId: "test-op",
+			RunId:       startResp.RunId,
+		})
+		s.NoError(err)
+		s.Equal(enumspb.NEXUS_OPERATION_EXECUTION_STATUS_RUNNING, descResp.GetInfo().GetStatus())
+		s.NotNil(descResp.GetInfo().GetCancellationInfo())
+
 		_, err = env.FrontendClient().TerminateNexusOperationExecution(s.Context(), &workflowservice.TerminateNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "test-op",
@@ -1222,14 +1233,70 @@ func (s *NexusStandaloneTestSuite) TestTerminateStandaloneNexusOperation() {
 		})
 		s.NoError(err)
 
-		// Verify state changed to terminated (terminate overrides cancel request).
-		descResp, err := env.FrontendClient().DescribeNexusOperationExecution(s.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
+		descResp, err = env.FrontendClient().DescribeNexusOperationExecution(s.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
 			Namespace:   env.Namespace().String(),
 			OperationId: "test-op",
 			RunId:       startResp.RunId,
 		})
 		s.NoError(err)
 		s.Equal(enumspb.NEXUS_OPERATION_EXECUTION_STATUS_TERMINATED, descResp.GetInfo().GetStatus())
+	})
+
+	s.Run("AlreadyCanceled", func(s *NexusStandaloneTestSuite) {
+		env := s.newTestEnv()
+		// The handler cancels on start, closing the operation as CANCELED.
+		endpointName := env.createRandomExternalNexusServer(s.Context(), s.T(), nexustest.Handler{
+			OnStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
+				return nil, &nexus.OperationError{
+					State: nexus.OperationStateCanceled,
+					Cause: &nexus.FailureError{Failure: nexus.Failure{Message: "canceled by handler"}},
+				}
+			},
+		})
+
+		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId: "test-op",
+			Endpoint:    endpointName,
+		})
+		s.NoError(err)
+
+		// Ensure the operation actually reached CANCELED before terminating.
+		_, err = env.FrontendClient().PollNexusOperationExecution(s.Context(), &workflowservice.PollNexusOperationExecutionRequest{
+			Namespace:   env.Namespace().String(),
+			OperationId: "test-op",
+			RunId:       startResp.RunId,
+			WaitStage:   enumspb.NEXUS_OPERATION_WAIT_STAGE_CLOSED,
+		})
+		s.NoError(err)
+
+		descResp, err := env.FrontendClient().DescribeNexusOperationExecution(s.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
+			Namespace:   env.Namespace().String(),
+			OperationId: "test-op",
+			RunId:       startResp.RunId,
+		})
+		s.NoError(err)
+		s.Equal(enumspb.NEXUS_OPERATION_EXECUTION_STATUS_CANCELED, descResp.GetInfo().GetStatus())
+
+		// Terminating a canceled operation is rejected.
+		_, err = env.FrontendClient().TerminateNexusOperationExecution(s.Context(), &workflowservice.TerminateNexusOperationExecutionRequest{
+			Namespace:   env.Namespace().String(),
+			OperationId: "test-op",
+			RunId:       startResp.RunId,
+			RequestId:   "terminate-request-id",
+			Reason:      "test termination",
+		})
+		var failedPrecondition *serviceerror.FailedPrecondition
+		s.ErrorAs(err, &failedPrecondition)
+		s.ErrorContains(err, "operation already completed")
+
+		// The rejected terminate left the outcome untouched.
+		descResp, err = env.FrontendClient().DescribeNexusOperationExecution(s.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
+			Namespace:   env.Namespace().String(),
+			OperationId: "test-op",
+			RunId:       startResp.RunId,
+		})
+		s.NoError(err)
+		s.Equal(enumspb.NEXUS_OPERATION_EXECUTION_STATUS_CANCELED, descResp.GetInfo().GetStatus())
 	})
 
 	s.Run("NotFound", func(s *NexusStandaloneTestSuite) {


### PR DESCRIPTION
## What changed?

Previously you could Terminate a standalone Nexus operation that was already in the Canceled state. This PR closes that gap.

## Why?

That behavior was never intended, and is a bug. Canceled is already a terminal state.

Not only does terminating an already canceled operation not make sense, it also opens up weird issues where we would mutate a resource that should be in a terminal state.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

This is a behavior change, and could break a test or something that was relying on this behavior earlier.