### PR TITLE
Guard that ValidatorConfig.Validate checks every field

### DIFF
--- a/common/callbacks/validator_test.go
+++ b/common/callbacks/validator_test.go
@@ -2,6 +2,7 @@ package callbacks
 
 import (
 	"context"
+	"reflect"
 	"regexp"
 	"testing"
 
@@ -25,6 +26,18 @@ func TestValidatorConfigValidate(t *testing.T) {
 
 	_, err := NewValidator(cfg)
 	require.EqualError(t, err, "missing required fields: [URLMaxLength EndpointRules]")
+}
+
+// ValidatorConfig.Validate names each missing field explicitly, so a field added to the struct but
+// not to Validate silently defaults to nil and nil-panics at request time instead of at startup.
+func TestValidatorConfigValidateNamesEveryField(t *testing.T) {
+	_, err := NewValidator(ValidatorConfig{})
+	require.Error(t, err)
+
+	for field := range reflect.TypeFor[ValidatorConfig]().Fields() {
+		require.Containsf(t, err.Error(), field.Name,
+			"ValidatorConfig.%s is not checked by Validate", field.Name)
+	}
 }
 
 func TestValidateCallbacks(t *testing.T) {

--- a/common/callbacks/validator_test.go
+++ b/common/callbacks/validator_test.go
@@ -32,13 +32,13 @@ func TestValidatorConfigValidate(t *testing.T) {
 // field added to the struct but not to Validate stays nil and panics at request time instead of
 // failing at startup. Optional or non-nilable fields would need a different check.
 func TestValidatorConfigValidateNamesEveryField(t *testing.T) {
-	_, err := NewValidator(ValidatorConfig{})
-	require.Error(t, err)
-
+	var fields []string
 	for field := range reflect.TypeFor[ValidatorConfig]().Fields() {
-		require.Containsf(t, err.Error(), field.Name,
-			"ValidatorConfig.%s is not checked by Validate", field.Name)
+		fields = append(fields, field.Name)
 	}
+
+	_, err := NewValidator(ValidatorConfig{})
+	require.EqualError(t, err, fmt.Sprintf("missing required fields: %v", fields))
 }
 
 func TestValidateCallbacks(t *testing.T) {

--- a/common/callbacks/validator_test.go
+++ b/common/callbacks/validator_test.go
@@ -28,8 +28,9 @@ func TestValidatorConfigValidate(t *testing.T) {
 	require.EqualError(t, err, "missing required fields: [URLMaxLength EndpointRules]")
 }
 
-// ValidatorConfig.Validate names each missing field explicitly, so a field added to the struct but
-// not to Validate silently defaults to nil and nil-panics at request time instead of at startup.
+// Every field of ValidatorConfig is required, and Validate names each missing one explicitly. A
+// field added to the struct but not to Validate stays nil and panics at request time instead of
+// failing at startup. Optional or non-nilable fields would need a different check.
 func TestValidatorConfigValidateNamesEveryField(t *testing.T) {
 	_, err := NewValidator(ValidatorConfig{})
 	require.Error(t, err)

--- a/common/callbacks/validator_test.go
+++ b/common/callbacks/validator_test.go
@@ -2,6 +2,7 @@ package callbacks
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"regexp"
 	"testing"


### PR DESCRIPTION
## What changed?

Add a new unit test for `common/callbacks.ValidatorConfig`.

## Why?

While working on a PR that extended `ValidatorConfig` and adding new fields, some bugs crept in because the new fields weren't checked in the `Validate` function. This unit test will now catch those automatically, by running `Validate` on an empty `ValidatorConfig`, and then confirming that every field of the type is found in the error message. (Reporting that it is uninitialized.)

This PR also allows me to remove this tiny change from an otherwise monstrous PR I am trying to slim down.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks

None