### PR TITLE
Add context to archival URI validation errors

### DIFF
--- a/service/frontend/namespace_handler.go
+++ b/service/frontend/namespace_handler.go
@@ -1110,10 +1110,13 @@ func (d *namespaceHandler) validateHistoryArchivalURI(URIString string) error {
 
 	a, err := d.archiverProvider.GetHistoryArchiver(URI.Scheme())
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get history archiver for scheme %q: %w", URI.Scheme(), err)
 	}
 
-	return a.ValidateURI(URI)
+	if err := a.ValidateURI(URI); err != nil {
+		return fmt.Errorf("failed to validate history archival URI %q: %w", URIString, err)
+	}
+	return nil
 }
 
 func (d *namespaceHandler) validateVisibilityArchivalURI(URIString string) error {
@@ -1124,10 +1127,13 @@ func (d *namespaceHandler) validateVisibilityArchivalURI(URIString string) error
 
 	a, err := d.archiverProvider.GetVisibilityArchiver(URI.Scheme())
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get visibility archiver for scheme %q: %w", URI.Scheme(), err)
 	}
 
-	return a.ValidateURI(URI)
+	if err := a.ValidateURI(URI); err != nil {
+		return fmt.Errorf("failed to validate visibility archival URI %q: %w", URIString, err)
+	}
+	return nil
 }
 
 // maybeUpdateFailoverHistory adds an entry if the Namespace is becoming active in a new cluster.

--- a/service/frontend/namespace_handler_test.go
+++ b/service/frontend/namespace_handler_test.go
@@ -3,6 +3,7 @@ package frontend
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"slices"
 	"testing"
 	"time"
@@ -656,6 +657,48 @@ func (s *namespaceHandlerCommonSuite) TestRegisterNamespace_InvalidRetentionPeri
 		s.Equal(errInvalidRetentionPeriod, err)
 		s.Nil(resp)
 	}
+}
+
+func (s *namespaceHandlerCommonSuite) TestRegisterNamespace_InvalidHistoryArchivalURIIncludesUnderlyingError() {
+	retention := durationpb.New(24 * time.Hour)
+	underlyingErr := errors.New("Forbidden: Forbidden\n\tstatus code: 403")
+
+	s.archivalMetadata = archiver.NewArchivalMetadata(
+		dc.NewNoopCollection(),
+		"enabled",
+		true,
+		"disabled",
+		false,
+		&config.ArchivalNamespaceDefaults{
+			History: config.HistoryArchivalNamespaceDefaults{
+				State: "disabled",
+				URI:   "s3://default",
+			},
+		},
+	)
+	s.handler.archivalMetadata = s.archivalMetadata
+
+	s.mockClusterMetadata.EXPECT().IsGlobalNamespaceEnabled().Return(false).AnyTimes()
+	s.mockClusterMetadata.EXPECT().IsMasterCluster().Return(false).AnyTimes()
+	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
+	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
+	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(nil, &serviceerror.NamespaceNotFound{})
+
+	mockHistoryArchiver := archiver.NewMockHistoryArchiver(s.controller)
+	s.mockArchiverProvider.EXPECT().GetHistoryArchiver("s3").Return(mockHistoryArchiver, nil)
+	mockHistoryArchiver.EXPECT().ValidateURI(gomock.Any()).Return(underlyingErr)
+
+	resp, err := s.handler.RegisterNamespace(context.Background(), &workflowservice.RegisterNamespaceRequest{
+		Namespace:                        "namespace-to-register",
+		WorkflowExecutionRetentionPeriod: retention,
+		HistoryArchivalState:             enumspb.ARCHIVAL_STATE_ENABLED,
+		HistoryArchivalUri:               "s3://bucket/prefix",
+	})
+
+	s.Nil(resp)
+	s.ErrorIs(err, underlyingErr)
+	s.ErrorContains(err, `failed to validate history archival URI "s3://bucket/prefix"`)
+	s.ErrorContains(err, "status code: 403")
 }
 
 func (s *namespaceHandlerCommonSuite) TestUpdateNamespace_InvalidRetentionPeriod() {


### PR DESCRIPTION
## What changed
- Wrap history and visibility archival URI validation errors with archival-specific context.
- Preserve the underlying archiver/provider error in the error chain.
- Add a regression test for namespace registration returning an underlying archival validation error.

Fixes #983

## Validation
- go test ./service/frontend -run TestNamespaceHandlerCommonSuite/TestRegisterNamespace_InvalidHistoryArchivalURIIncludesUnderlyingError -count=1
- go test ./service/frontend -run TestNamespaceHandlerCommonSuite -count=1
- git diff --check