### PR TITLE
[Visibility] Fix legacy visibility query converter

### DIFF
--- a/common/persistence/visibility/store/elasticsearch/query_interceptors.go
+++ b/common/persistence/visibility/store/elasticsearch/query_interceptors.go
@@ -78,8 +78,14 @@ func (ni *nameInterceptor) Name(name string, usage query.FieldNameUsage) (string
 	if err != nil {
 		return "", err
 	}
-	fieldName, fieldType, err := query.ResolveSearchAttributeAlias(name, ni.namespace, mapper,
-		ni.searchAttributesTypeMap, ni.chasmMapper)
+	fieldName, fieldType, err := query.ResolveSearchAttributeAlias(
+		name,
+		ni.namespace,
+		mapper,
+		ni.searchAttributesTypeMap,
+		ni.chasmMapper,
+		ni.archetypeID,
+	)
 	if err != nil {
 		// Check for special aliases that require archetypeID context.
 		if ni.archetypeID != chasm.SchedulerArchetypeID || name != "TemporalSystemExecutionStatus" {
@@ -127,7 +133,7 @@ func (vi *valuesInterceptor) Values(name string, fieldName string, values ...any
 
 	fieldType, err = vi.saTypeMap.GetType(fieldName)
 	if err != nil {
-		return nil, query.NewConverterError("invalid search attribute: %s", name)
+		return nil, query.NewConverterError("%s: %s", query.InvalidSearchAttribute, name)
 	}
 
 	var result []any

--- a/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
@@ -411,6 +411,82 @@ func (s *ESVisibilitySuite) Test_convertQueryLegacy() {
 	s.Equal(`{"bool":{"filter":[{"term":{"NamespaceId":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}},{"bool":{"should":[{"range":{"ExecutionTime":{"from":null,"include_lower":true,"include_upper":false,"to":"1970-01-01T00:00:00.001Z"}}},{"range":{"ExecutionTime":{"from":"1970-01-01T00:00:00.002Z","include_lower":false,"include_upper":true,"to":null}}}]}}],"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`, s.queryToJSON(queryParams.Query))
 	s.Nil(queryParams.Sorter)
 
+	// The SQL parser folds the sign into integer values, but represents signed floats as an
+	// unary expression.
+	query = `CustomIntField = -10`
+	queryParams, err = s.visibilityStore.convertQueryLegacy(testNamespace, testNamespaceID, query, nil, chasm.UnspecifiedArchetypeID)
+	s.NoError(err)
+	s.JSONEq(`{"bool":{"filter":[{"term":{"NamespaceId":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}},{"bool":{"filter":{"match":{"CustomIntField":{"query":-10}}}}}],"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`, s.queryToJSON(queryParams.Query))
+	s.Nil(queryParams.Sorter)
+
+	query = `CustomDoubleField = -1.5`
+	queryParams, err = s.visibilityStore.convertQueryLegacy(testNamespace, testNamespaceID, query, nil, chasm.UnspecifiedArchetypeID)
+	s.NoError(err)
+	s.JSONEq(`{"bool":{"filter":[{"term":{"NamespaceId":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}},{"bool":{"filter":{"match":{"CustomDoubleField":{"query":-1.5}}}}}],"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`, s.queryToJSON(queryParams.Query))
+	s.Nil(queryParams.Sorter)
+
+	query = `CustomDoubleField = +1.5`
+	queryParams, err = s.visibilityStore.convertQueryLegacy(testNamespace, testNamespaceID, query, nil, chasm.UnspecifiedArchetypeID)
+	s.NoError(err)
+	s.JSONEq(`{"bool":{"filter":[{"term":{"NamespaceId":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}},{"bool":{"filter":{"match":{"CustomDoubleField":{"query":1.5}}}}}],"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`, s.queryToJSON(queryParams.Query))
+	s.Nil(queryParams.Sorter)
+
+	query = `CustomDoubleField > -1.5`
+	queryParams, err = s.visibilityStore.convertQueryLegacy(testNamespace, testNamespaceID, query, nil, chasm.UnspecifiedArchetypeID)
+	s.NoError(err)
+	s.JSONEq(`{"bool":{"filter":[{"term":{"NamespaceId":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}},{"bool":{"filter":{"range":{"CustomDoubleField":{"from":-1.5,"include_lower":false,"include_upper":true,"to":null}}}}}],"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`, s.queryToJSON(queryParams.Query))
+	s.Nil(queryParams.Sorter)
+
+	query = `CustomDoubleField between -2.5 and -1.5`
+	queryParams, err = s.visibilityStore.convertQueryLegacy(testNamespace, testNamespaceID, query, nil, chasm.UnspecifiedArchetypeID)
+	s.NoError(err)
+	s.JSONEq(`{"bool":{"filter":[{"term":{"NamespaceId":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}},{"bool":{"filter":{"range":{"CustomDoubleField":{"from":-2.5,"include_lower":true,"include_upper":true,"to":-1.5}}}}}],"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`, s.queryToJSON(queryParams.Query))
+	s.Nil(queryParams.Sorter)
+
+	query = `CustomDoubleField in (-1.5, 2.5)`
+	queryParams, err = s.visibilityStore.convertQueryLegacy(testNamespace, testNamespaceID, query, nil, chasm.UnspecifiedArchetypeID)
+	s.NoError(err)
+	s.JSONEq(`{"bool":{"filter":[{"term":{"NamespaceId":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}},{"bool":{"filter":{"terms":{"CustomDoubleField":[-1.5,2.5]}}}}],"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`, s.queryToJSON(queryParams.Query))
+	s.Nil(queryParams.Sorter)
+
+	// Only a literal value can be signed, not another unary expression.
+	query = `CustomDoubleField = - -1.5`
+	queryParams, err = s.visibilityStore.convertQueryLegacy(testNamespace, testNamespaceID, query, nil, chasm.UnspecifiedArchetypeID)
+	s.Error(err)
+	var invalidArgumentErr *serviceerror.InvalidArgument
+	s.ErrorAs(err, &invalidArgumentErr)
+	s.Equal(
+		`invalid query: unable to convert filter expression: `+
+			`unable to convert right side of "CustomDoubleField = - -1.5": `+
+			`invalid expression: unary operator not supported in "- -1.5"`,
+		err.Error(),
+	)
+	s.Nil(queryParams)
+
+	query = `CustomKeywordField = -'foo'`
+	queryParams, err = s.visibilityStore.convertQueryLegacy(testNamespace, testNamespaceID, query, nil, chasm.UnspecifiedArchetypeID)
+	s.Error(err)
+	s.ErrorAs(err, &invalidArgumentErr)
+	s.Equal(
+		`invalid query: unable to convert filter expression: `+
+			`unable to convert right side of "CustomKeywordField = -'foo'": `+
+			`invalid expression: unary operator not supported in "-'foo'"`,
+		err.Error(),
+	)
+	s.Nil(queryParams)
+
+	query = `CustomIntField = ~1`
+	queryParams, err = s.visibilityStore.convertQueryLegacy(testNamespace, testNamespaceID, query, nil, chasm.UnspecifiedArchetypeID)
+	s.Error(err)
+	s.ErrorAs(err, &invalidArgumentErr)
+	s.Equal(
+		`invalid query: unable to convert filter expression: `+
+			`unable to convert right side of "CustomIntField = ~1": `+
+			`operation is not supported: unary operator "~"`,
+		err.Error(),
+	)
+	s.Nil(queryParams)
+
 	query = `order by ExecutionTime`
 	queryParams, err = s.visibilityStore.convertQueryLegacy(testNamespace, testNamespaceID, query, nil, chasm.UnspecifiedArchetypeID)
 	s.NoError(err)
@@ -625,7 +701,7 @@ func (s *ESVisibilitySuite) Test_convertQuery() {
 		{
 			name:  "invalid custom search attributes",
 			query: "WorkflowId = 'wid' AND InvalidField = 'foo'",
-			err:   query.InvalidExpressionErrMessage,
+			err:   query.InvalidSearchAttribute,
 		},
 	}
 
@@ -2088,7 +2164,7 @@ func (s *ESVisibilitySuite) Test_convertQuery_ChasmMapper() {
 		{
 			name:  "invalid chasm attribute",
 			query: "UnknownChasmField = 'value'",
-			err:   query.InvalidExpressionErrMessage,
+			err:   query.InvalidSearchAttribute,
 		},
 	}
 

--- a/common/persistence/visibility/store/query/converter.go
+++ b/common/persistence/visibility/store/query/converter.go
@@ -492,7 +492,14 @@ func (c *QueryConverter[ExprT]) convertColName(in sqlparser.Expr) (*SAColumn, er
 		)
 	}
 	saAlias := strings.ReplaceAll(sqlparser.String(expr), "`", "")
-	saFieldName, saType, err := c.resolveSearchAttributeAlias(saAlias)
+	saFieldName, saType, err := ResolveSearchAttributeAlias(
+		saAlias,
+		c.namespaceName,
+		c.saMapper,
+		c.saTypeMap,
+		c.chasmMapper,
+		c.archetypeID,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -506,79 +513,6 @@ func (c *QueryConverter[ExprT]) convertColName(in sqlparser.Expr) (*SAColumn, er
 		return nil, err
 	}
 	return colName, nil
-}
-
-func (c *QueryConverter[ExprT]) resolveSearchAttributeAlias(
-	alias string,
-) (fieldName string, fieldType enumspb.IndexedValueType, retErr error) {
-	// resolveCSA only returns true if `alias` is a custom search attribute.
-	resolveCSA := func(alias string) bool {
-		fn, err := c.saMapper.GetFieldName(alias, c.namespaceName.String())
-		if err != nil {
-			return false
-		}
-		ft, err := c.saTypeMap.GetType(fn)
-		if err != nil {
-			return false
-		}
-		fieldName, fieldType = fn, ft
-		return true
-	}
-	// resolveChasmSA only returns true if `alias` is a CHASM search attribute.
-	resolveChasmSA := func(alias string) bool {
-		if c.chasmMapper == nil {
-			return false
-		}
-		fn, err := c.chasmMapper.Field(alias)
-		if err != nil {
-			return false
-		}
-		ft, err := c.chasmMapper.ValueType(fn)
-		if err != nil {
-			return false
-		}
-		fieldName, fieldType = fn, ft
-		return true
-	}
-
-	var err error
-	fieldName = alias
-	// First, check if it's a custom search attribute.
-	if sadefs.IsMappable(alias) && resolveCSA(alias) {
-		return
-	}
-	// Second, check if it's a CHASM search attribute.
-	if resolveChasmSA(alias) {
-		return
-	}
-	// Third, check if it's a system/reserved search attribute.
-	fieldType, err = c.saTypeMap.GetType(fieldName)
-	if err == nil {
-		return
-	}
-	// Fourth, check for special aliases or adding/removing the `Temporal` prefix.
-	if strings.TrimPrefix(alias, sadefs.ReservedPrefix) == sadefs.ScheduleID {
-		fieldName = sadefs.WorkflowID
-	} else if c.archetypeID == chasm.SchedulerArchetypeID && alias == "TemporalSystemExecutionStatus" {
-		// To support querying Workflow based schedulers and CHASM based schedulers, we need to translate
-		// TemporalSystemExecutionStatus as an alias to the system search attribute ExecutionStatus.
-		fieldName = "ExecutionStatus"
-	} else if strings.HasPrefix(fieldName, sadefs.ReservedPrefix) {
-		fieldName = fieldName[len(sadefs.ReservedPrefix):]
-	} else {
-		fieldName = sadefs.ReservedPrefix + fieldName
-	}
-	fieldType, err = c.saTypeMap.GetType(fieldName)
-	if err == nil {
-		return
-	}
-
-	retErr = NewConverterError(
-		"%s: column name '%s' is not a valid search attribute",
-		InvalidExpressionErrMessage,
-		alias,
-	)
-	return
 }
 
 func (c *QueryConverter[ExprT]) parseValueExpr(

--- a/common/persistence/visibility/store/query/converter_legacy.go
+++ b/common/persistence/visibility/store/query/converter_legacy.go
@@ -534,6 +534,44 @@ func convertComparisonExprValue(expr sqlparser.Expr) (any, error) {
 			result = append(result, v)
 		}
 		return result, nil
+	case *sqlparser.UnaryExpr:
+		// Negative value may be parsed as UnaryExpr
+		if e.Operator != sqlparser.UPlusStr && e.Operator != sqlparser.UMinusStr {
+			return nil, NewConverterError(
+				"%s: unary operator %q",
+				NotSupportedErrMessage,
+				e.Operator,
+			)
+		}
+		if value, ok := e.Expr.(*sqlparser.SQLVal); !ok || value.Type == sqlparser.StrVal {
+			return nil, NewConverterError(
+				"%s: unary operator not supported in %q",
+				InvalidExpressionErrMessage,
+				sqlparser.String(expr),
+			)
+		}
+		value, err := convertComparisonExprValue(e.Expr)
+		if err != nil {
+			return nil, err
+		}
+		switch v := value.(type) {
+		case int64:
+			if e.Operator == sqlparser.UMinusStr {
+				value = -v
+			}
+		case float64:
+			if e.Operator == sqlparser.UMinusStr {
+				value = -v
+			}
+		default:
+			// This should never happen, but here to catch any unexpected case.
+			return nil, NewConverterError(
+				"%s: unary expression %q",
+				InvalidExpressionErrMessage,
+				sqlparser.String(expr),
+			)
+		}
+		return value, nil
 	case *sqlparser.GroupConcatExpr:
 		return nil, NewConverterError("%s: 'group_concat'", NotSupportedErrMessage)
 	case *sqlparser.FuncExpr:

--- a/common/persistence/visibility/store/query/converter_test.go
+++ b/common/persistence/visibility/store/query/converter_test.go
@@ -508,13 +508,13 @@ func TestQueryConverter_ConvertSelectStmt(t *testing.T) {
 		{
 			name: "fail invalid group by field",
 			in:   "select * from t group by InvalidField",
-			err:  InvalidExpressionErrMessage,
+			err:  InvalidSearchAttribute,
 		},
 
 		{
 			name: "fail invalid order by field",
 			in:   "select * from t order by InvalidField",
-			err:  InvalidExpressionErrMessage,
+			err:  InvalidSearchAttribute,
 		},
 
 		{
@@ -1319,7 +1319,7 @@ func TestQueryConverter_ConvertComparisonExprFail(t *testing.T) {
 		{
 			name: "invalid col name",
 			in:   "InvalidField = 'foo'",
-			err:  InvalidExpressionErrMessage,
+			err:  InvalidSearchAttribute,
 		},
 
 		{
@@ -1430,7 +1430,7 @@ func TestQueryConverter_ConvertRangeCond(t *testing.T) {
 		{
 			name: "fail invalid col name",
 			in:   "InvalidField BETWEEN '123' AND '456'",
-			err:  InvalidExpressionErrMessage,
+			err:  InvalidSearchAttribute,
 		},
 
 		{
@@ -1537,7 +1537,7 @@ func TestQueryConverter_ConvertIsExpr(t *testing.T) {
 		{
 			name: "fail invalid col name",
 			in:   "InvalidField IS NOT NULL",
-			err:  InvalidExpressionErrMessage,
+			err:  InvalidSearchAttribute,
 		},
 
 		{
@@ -1680,10 +1680,7 @@ func TestQueryConverter_ConvertColName(t *testing.T) {
 			in: &sqlparser.ColName{
 				Name: sqlparser.NewColIdent("InvalidField"),
 			},
-			err: fmt.Sprintf(
-				"%s: column name 'InvalidField' is not a valid search attribute",
-				InvalidExpressionErrMessage,
-			),
+			err: fmt.Sprintf("%s: InvalidField", InvalidSearchAttribute),
 		},
 	}
 
@@ -1708,166 +1705,6 @@ func TestQueryConverter_ConvertColName(t *testing.T) {
 				} else {
 					r.False(queryConverter.seenNamespaceDivision)
 				}
-			}
-		})
-	}
-}
-
-func TestQueryConverter_ResolveSearchAttributeAlias(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		name                 string
-		in                   string
-		withCustomScheduleID bool
-		useNoopMapper        bool
-		outFn                string
-		outFt                enumspb.IndexedValueType
-		err                  string
-	}{
-		{
-			name:  "success system StartTime",
-			in:    "StartTime",
-			outFn: "StartTime",
-			outFt: enumspb.INDEXED_VALUE_TYPE_DATETIME,
-		},
-
-		{
-			name:  "success system WorkflowId",
-			in:    "WorkflowId",
-			outFn: "WorkflowId",
-			outFt: enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-		},
-
-		{
-			name:  "success reserved BuildIds",
-			in:    "BuildIds",
-			outFn: "BuildIds",
-			outFt: enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST,
-		},
-
-		{
-			name:  "success reserved TemporalBuildIds",
-			in:    "TemporalBuildIds",
-			outFn: "BuildIds",
-			outFt: enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST,
-		},
-
-		{
-			name:  "success reserved TemporalWorkerDeployment",
-			in:    "TemporalWorkerDeployment",
-			outFn: "TemporalWorkerDeployment",
-			outFt: enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-		},
-
-		{
-			name:  "success reserved WorkerDeployment",
-			in:    "WorkerDeployment",
-			outFn: "TemporalWorkerDeployment",
-			outFt: enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-		},
-
-		{
-			name:  "success custom AliasForInt01",
-			in:    "AliasForInt01",
-			outFn: "Int01",
-			outFt: enumspb.INDEXED_VALUE_TYPE_INT,
-		},
-
-		{
-			name:          "success custom noop mapper Int01",
-			in:            "Int01",
-			useNoopMapper: true,
-			outFn:         "Int01",
-			outFt:         enumspb.INDEXED_VALUE_TYPE_INT,
-		},
-
-		{
-			name:  "success special ScheduleId",
-			in:    "ScheduleId",
-			outFn: "WorkflowId",
-			outFt: enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-		},
-
-		{
-			name:  "success special TemporalScheduleId",
-			in:    "TemporalScheduleId",
-			outFn: "WorkflowId",
-			outFt: enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-		},
-
-		{
-			name:                 "success custom ScheduleId",
-			in:                   "ScheduleId",
-			withCustomScheduleID: true,
-			outFn:                searchattribute.TestScheduleIDFieldName,
-			outFt:                enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-		},
-
-		{
-			name:                 "success custom ScheduleId reserved TemporalScheduleId",
-			in:                   "TemporalScheduleId",
-			withCustomScheduleID: true,
-			outFn:                "WorkflowId",
-			outFt:                enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-		},
-
-		{
-			name:                 "success noop mapper ScheduleId",
-			in:                   "ScheduleId",
-			withCustomScheduleID: false,
-			outFn:                "WorkflowId",
-			outFt:                enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-		},
-
-		{
-			name:                 "success noop mapper TemporalScheduleId",
-			in:                   "TemporalScheduleId",
-			withCustomScheduleID: false,
-			outFn:                "WorkflowId",
-			outFt:                enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-		},
-
-		{
-			name: "invalid search attribute",
-			in:   "Foo",
-			err: fmt.Sprintf(
-				"%s: column name 'Foo' is not a valid search attribute",
-				InvalidExpressionErrMessage,
-			),
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			r := require.New(t)
-			ctrl := gomock.NewController(t)
-			storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-			queryConverter := NewQueryConverter(
-				storeQCMock,
-				testNamespaceName,
-				searchattribute.TestNameTypeMap(),
-				&searchattribute.TestMapper{
-					WithCustomScheduleID: tc.withCustomScheduleID,
-				},
-				metrics.NewMockHandler(ctrl),
-				log.NewNoopLogger(),
-			)
-
-			if tc.useNoopMapper {
-				queryConverter.saMapper = &searchattribute.NoopMapper{}
-			}
-
-			fn, ft, err := queryConverter.resolveSearchAttributeAlias(tc.in)
-			if tc.err != "" {
-				r.Error(err)
-				r.ErrorContains(err, tc.err)
-				var expectedErr *ConverterError
-				r.ErrorAs(err, &expectedErr)
-			} else {
-				r.NoError(err)
-				r.Equal(tc.outFn, fn)
-				r.Equal(tc.outFt, ft)
 			}
 		})
 	}
@@ -2534,82 +2371,8 @@ func TestQueryConverter_TemporalSystemExecutionStatus(t *testing.T) {
 		}
 		_, err := queryConverter.convertColName(in)
 		r.Error(err)
-		r.ErrorContains(err, "not a valid search attribute")
+		r.ErrorContains(err, InvalidSearchAttribute)
 	})
-}
-
-func TestQueryConverter_ResolveSearchAttributeAlias_WithChasmMapper(t *testing.T) {
-	t.Parallel()
-	ctrl := gomock.NewController(t)
-	storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-
-	chasmMapper := chasm.NewTestVisibilitySearchAttributesMapper(
-		map[string]string{
-			"TemporalBool01":    "ChasmCompleted",
-			"TemporalKeyword01": "ChasmStatus",
-		},
-		map[string]enumspb.IndexedValueType{
-			"TemporalBool01":    enumspb.INDEXED_VALUE_TYPE_BOOL,
-			"TemporalKeyword01": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-		},
-	)
-
-	queryConverter := newTestQueryConverter(storeQCMock).
-		WithChasmMapper(chasmMapper)
-
-	testCases := []struct {
-		name                    string
-		expectedFieldName       string
-		expectedFieldType       enumspb.IndexedValueType
-		expectedErr             bool
-		expectNamespaceDivision bool
-	}{
-		{
-			name:                    "ChasmCompleted",
-			expectedFieldName:       "TemporalBool01",
-			expectedFieldType:       enumspb.INDEXED_VALUE_TYPE_BOOL,
-			expectedErr:             false,
-			expectNamespaceDivision: false,
-		},
-		{
-			name:                    "ChasmStatus",
-			expectedFieldName:       "TemporalKeyword01",
-			expectedFieldType:       enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-			expectedErr:             false,
-			expectNamespaceDivision: false,
-		},
-		{
-			name:                    "TemporalNamespaceDivision",
-			expectedFieldName:       "TemporalNamespaceDivision",
-			expectedFieldType:       enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-			expectedErr:             false,
-			expectNamespaceDivision: true,
-		},
-		{
-			name:                    "NonExistentChasmAlias",
-			expectedFieldName:       "",
-			expectedFieldType:       enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED,
-			expectedErr:             true,
-			expectNamespaceDivision: false,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			r := require.New(t)
-			fieldName, fieldType, err := queryConverter.resolveSearchAttributeAlias(tc.name)
-			if tc.expectedErr {
-				r.Error(err)
-				// Note: fieldName may have been set during resolution attempts
-				r.Equal(enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, fieldType)
-			} else {
-				r.NoError(err)
-				r.Equal(tc.expectedFieldName, fieldName)
-				r.Equal(tc.expectedFieldType, fieldType)
-				// Note: seenNamespaceDivision is only set in convertColName, not resolveSearchAttributeAlias
-			}
-		})
-	}
 }
 
 func TestQueryConverter_CapturePanic(t *testing.T) {

--- a/common/persistence/visibility/store/query/errors.go
+++ b/common/persistence/visibility/store/query/errors.go
@@ -19,6 +19,7 @@ var (
 	MalformedSqlQueryErrMessage = "malformed SQL query"
 	NotSupportedErrMessage      = "operation is not supported"
 	InvalidExpressionErrMessage = "invalid expression"
+	InvalidSearchAttribute      = "invalid search attribute"
 )
 
 func NewConverterError(format string, a ...any) error {

--- a/common/persistence/visibility/store/query/resolve.go
+++ b/common/persistence/visibility/store/query/resolve.go
@@ -10,109 +10,76 @@ import (
 	"go.temporal.io/server/common/searchattribute/sadefs"
 )
 
-// ResolveSearchAttributeAlias resolves the search attribute alias for the given name. The process is:
-//  1. If the name has the "Temporal", skip mapping to a custom search attribute.
-//  2. If the search attribute exists in the visibility mapper, pass it through.
-//  3. If the search attribute exists in the CHASM mapper, pass it through.
-//  4. If it exists as a system / predefined attribute, map it.
-//     4.1 Some pre-defined attributes are already defined with the Temporal prefix, so both options need to be checked.
 func ResolveSearchAttributeAlias(
-	name string,
-	ns namespace.Name,
-	mapper searchattribute.Mapper,
+	alias string,
+	namespaceName namespace.Name,
+	saMapper searchattribute.Mapper,
 	saTypeMap searchattribute.NameTypeMap,
 	chasmMapper *chasm.VisibilitySearchAttributesMapper,
-) (string, enumspb.IndexedValueType, error) {
-	if sadefs.IsMappable(name) {
-		// First check if the visibility mapper can handle this field (e.g., custom search attributes)
-		fieldName, fieldType := tryVisibilityMapper(name, ns, mapper, saTypeMap)
-		if fieldName != "" {
-			return fieldName, fieldType, nil
+	archetypeID chasm.ArchetypeID,
+) (fieldName string, fieldType enumspb.IndexedValueType, retErr error) {
+	// resolveCSA only returns true if `alias` is a custom search attribute.
+	resolveCSA := func(alias string) bool {
+		fn, err := saMapper.GetFieldName(alias, namespaceName.String())
+		if err != nil {
+			return false
 		}
-
-		// Handle ScheduleID → WorkflowID transformation, but only if ScheduleID is not defined as a custom search attribute
-		// This fallback only applies when the visibility mapper doesn't handle the field
-		if name == sadefs.ScheduleID {
-			// ScheduleID is not defined, transform to WorkflowID
-			saType, _ := saTypeMap.GetType(sadefs.WorkflowID)
-			return sadefs.WorkflowID, saType, nil
+		ft, err := saTypeMap.GetType(fn)
+		if err != nil {
+			return false
 		}
+		fieldName, fieldType = fn, ft
+		return true
+	}
+	// resolveChasmSA only returns true if `alias` is a CHASM search attribute.
+	resolveChasmSA := func(alias string) bool {
+		if chasmMapper == nil {
+			return false
+		}
+		fn, err := chasmMapper.Field(alias)
+		if err != nil {
+			return false
+		}
+		ft, err := chasmMapper.ValueType(fn)
+		if err != nil {
+			return false
+		}
+		fieldName, fieldType = fn, ft
+		return true
 	}
 
-	fieldName, fieldType := tryChasmMapper(name, chasmMapper)
-	if fieldName != "" {
-		return fieldName, fieldType, nil
+	var err error
+	fieldName = alias
+	// First, check if it's a custom search attribute.
+	if sadefs.IsMappable(alias) && resolveCSA(alias) {
+		return
+	}
+	// Second, check if it's a CHASM search attribute.
+	if resolveChasmSA(alias) {
+		return
+	}
+	// Third, check if it's a system/reserved search attribute.
+	fieldType, err = saTypeMap.GetType(fieldName)
+	if err == nil {
+		return
+	}
+	// Fourth, check for special aliases or adding/removing the `Temporal` prefix.
+	if strings.TrimPrefix(alias, sadefs.ReservedPrefix) == sadefs.ScheduleID {
+		fieldName = sadefs.WorkflowID
+	} else if archetypeID == chasm.SchedulerArchetypeID && alias == "TemporalSystemExecutionStatus" {
+		// To support querying Workflow based schedulers and CHASM based schedulers, we need to translate
+		// TemporalSystemExecutionStatus as an alias to the system search attribute ExecutionStatus.
+		fieldName = sadefs.ExecutionStatus
+	} else if strings.HasPrefix(fieldName, sadefs.ReservedPrefix) {
+		fieldName = fieldName[len(sadefs.ReservedPrefix):]
+	} else {
+		fieldName = sadefs.ReservedPrefix + fieldName
+	}
+	fieldType, err = saTypeMap.GetType(fieldName)
+	if err == nil {
+		return
 	}
 
-	fieldName, fieldType, found := tryDirectAndPrefixedLookup(name, saTypeMap)
-	if found {
-		return fieldName, fieldType, nil
-	}
-
-	return "", enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, NewConverterError("invalid search attribute: %s", name)
-}
-
-// tryVisibilityMapper might find a successful match in which case we return it
-// otherwise we continue with the fallback logic.
-func tryVisibilityMapper(
-	name string,
-	ns namespace.Name,
-	mapper searchattribute.Mapper,
-	saTypeMap searchattribute.NameTypeMap,
-) (string, enumspb.IndexedValueType) {
-	if mapper == nil {
-		return "", enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED
-	}
-
-	fieldName, err := mapper.GetFieldName(name, ns.String())
-	if err != nil {
-		// If there is an error, we need to continue with the fallback logic
-		// because this search attribute is not defined in the mapper, but might
-		// exist with a different name in the namespace.
-		return "", enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED
-	}
-
-	// Mapper successfully resolved the field name, now check if it exists in the type map
-	fieldType, err := saTypeMap.GetType(fieldName)
-	if err != nil {
-		// If the mapped field doesn't exist in type map, allow fallback to direct/prefixed lookup.
-		return "", enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED
-	}
-
-	return fieldName, fieldType
-}
-
-func tryChasmMapper(name string, chasmMapper *chasm.VisibilitySearchAttributesMapper) (string, enumspb.IndexedValueType) {
-	if chasmMapper == nil {
-		return "", enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED
-	}
-
-	fieldName, err := chasmMapper.Field(name)
-	if err != nil {
-		return "", enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED
-	}
-
-	fieldType, err := chasmMapper.ValueType(fieldName)
-	if err != nil {
-		return "", enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED
-	}
-	return fieldName, fieldType
-}
-
-func tryDirectAndPrefixedLookup(name string, saTypeMap searchattribute.NameTypeMap) (string, enumspb.IndexedValueType, bool) {
-	if saType, err := saTypeMap.GetType(name); err == nil {
-		return name, saType, true
-	}
-
-	prefixedName := sadefs.ReservedPrefix + name
-	if saType, err := saTypeMap.GetType(prefixedName); err == nil {
-		return prefixedName, saType, true
-	}
-
-	strippedName := strings.TrimPrefix(name, sadefs.ReservedPrefix)
-	if saType, err := saTypeMap.GetType(strippedName); err == nil {
-		return strippedName, saType, true
-	}
-
-	return "", enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, false
+	return "", enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED,
+		NewConverterError("%s: %s", InvalidSearchAttribute, alias)
 }

--- a/common/persistence/visibility/store/query/resolve_test.go
+++ b/common/persistence/visibility/store/query/resolve_test.go
@@ -1,314 +1,350 @@
 package query
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	enumspb "go.temporal.io/api/enums/v1"
-	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/chasm"
-	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/searchattribute"
-	"go.temporal.io/server/common/searchattribute/sadefs"
 )
 
+// mapAllMapper is a mapper that resolves every alias to the same field name, to assert that
+// search attributes that are not mappable are not resolved through the namespace mapper.
+type mapAllMapper string
+
+var _ searchattribute.Mapper = mapAllMapper("")
+
+func (m mapAllMapper) GetAlias(fieldName string, _ string) (string, error) {
+	return fieldName, nil
+}
+
+func (m mapAllMapper) GetFieldName(_ string, _ string) (string, error) {
+	return string(m), nil
+}
+
 func TestResolveSearchAttributeAlias(t *testing.T) {
-	cases := []struct {
-		name              string
-		expectedFieldName string
-		expectedFieldType enumspb.IndexedValueType
-		expectedErr       bool
-	}{
-		{name: "MyCustomField", expectedFieldName: "MyCustomField", expectedFieldType: enumspb.INDEXED_VALUE_TYPE_KEYWORD, expectedErr: false},
-		{name: "ExecutionStatus", expectedFieldName: "ExecutionStatus", expectedFieldType: enumspb.INDEXED_VALUE_TYPE_KEYWORD, expectedErr: false},
-		{name: "ScheduledStartTime", expectedFieldName: "TemporalScheduledStartTime", expectedFieldType: enumspb.INDEXED_VALUE_TYPE_DATETIME, expectedErr: false},
-		{name: "SchedulePaused", expectedFieldName: "TemporalSchedulePaused", expectedFieldType: enumspb.INDEXED_VALUE_TYPE_BOOL, expectedErr: false},
-		{name: "BuildIds", expectedFieldName: "BuildIds", expectedFieldType: enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST, expectedErr: false},
-		{name: "TemporalBuildIds", expectedFieldName: "BuildIds", expectedFieldType: enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST, expectedErr: false},
-		{name: "TemporalPauseInfo", expectedFieldName: "TemporalPauseInfo", expectedFieldType: enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST, expectedErr: false},
-		{name: "NonExistentField", expectedFieldName: "", expectedFieldType: enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, expectedErr: true},
-		{name: sadefs.ScheduleID, expectedFieldName: sadefs.WorkflowID, expectedFieldType: enumspb.INDEXED_VALUE_TYPE_KEYWORD, expectedErr: false},
-	}
-
-	ns := namespace.Name("test-namespace")
-	saTypeMap := searchattribute.NewNameTypeMapStub(map[string]enumspb.IndexedValueType{
-		"MyCustomField":   enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-		"ExecutionStatus": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-	})
-	mapper := customMapper{
-		fieldToAlias: map[string]string{
-			"MyCustomField":   "some-alias",
-			"ExecutionStatus": "some-alias2",
-		},
-		aliasToField: map[string]string{
-			"some-alias":  "MyCustomField",
-			"some-alias2": "ExecutionStatus",
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			fieldName, fieldType, err := ResolveSearchAttributeAlias(tc.name, ns, mapper, saTypeMap, nil)
-			require.Equal(t, tc.expectedFieldName, fieldName)
-			require.Equal(t, tc.expectedFieldType, fieldType)
-			require.Equal(t, tc.expectedErr, err != nil)
-		})
-	}
-}
-
-func TestResolveSearchAttributeAlias_CustomScheduleID(t *testing.T) {
-	ns := namespace.Name("test-namespace")
-
-	// Test case where ScheduleID is defined as a custom search attribute
-	saTypeMapWithCustomScheduleID := searchattribute.NewNameTypeMapStub(map[string]enumspb.IndexedValueType{
-		sadefs.ScheduleID: enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST,
-	})
-
-	mapper := customMapper{
-		fieldToAlias: map[string]string{
-			sadefs.ScheduleID: sadefs.ScheduleID,
-		},
-		aliasToField: map[string]string{
-			sadefs.ScheduleID: sadefs.ScheduleID,
-		},
-	}
-
-	// When ScheduleID is a custom search attribute, it should use the custom attribute, not transform to WorkflowID
-	fieldName, fieldType, err := ResolveSearchAttributeAlias(sadefs.ScheduleID, ns, mapper, saTypeMapWithCustomScheduleID, nil)
-	require.NoError(t, err)
-	require.Equal(t, sadefs.ScheduleID, fieldName)
-	require.Equal(t, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST, fieldType)
-}
-
-type customMapper struct {
-	fieldToAlias map[string]string
-	aliasToField map[string]string
-}
-
-func (m customMapper) GetAlias(fieldName string, ns string) (string, error) {
-	if fn, ok := m.fieldToAlias[fieldName]; ok {
-		return fn, nil
-	}
-	return "", serviceerror.NewInvalidArgument(
-		fmt.Sprintf("Namespace %s has no mapping defined for field name %s", ns, fieldName),
-	)
-}
-
-func (m customMapper) GetFieldName(alias string, ns string) (string, error) {
-	if fn, ok := m.aliasToField[alias]; ok {
-		return fn, nil
-	}
-	return "", serviceerror.NewInvalidArgument(
-		fmt.Sprintf("Namespace %s has no mapping defined for search attribute %s", ns, alias),
-	)
-}
-
-func TestResolveSearchAttributeAlias_WithChasmMapper(t *testing.T) {
-	ns := namespace.Name("test-namespace")
-	saTypeMap := searchattribute.NewNameTypeMapStub(map[string]enumspb.IndexedValueType{
-		"ExecutionStatus": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-		"StartTime":       enumspb.INDEXED_VALUE_TYPE_DATETIME,
-	})
-	mapper := customMapper{
-		fieldToAlias: map[string]string{},
-		aliasToField: map[string]string{},
-	}
-
-	chasmMapper := chasm.NewTestVisibilitySearchAttributesMapper(
-		map[string]string{
-			"TemporalBool01":    "ChasmCompleted",
-			"TemporalKeyword01": "ChasmStatus",
-		},
-		map[string]enumspb.IndexedValueType{
-			"TemporalBool01":    enumspb.INDEXED_VALUE_TYPE_BOOL,
-			"TemporalKeyword01": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-		},
-	)
+	t.Parallel()
 
 	testCases := []struct {
-		name              string
-		chasmMapper       *chasm.VisibilitySearchAttributesMapper
-		expectedFieldName string
-		expectedFieldType enumspb.IndexedValueType
-		expectedErr       bool
+		name                 string
+		in                   string
+		withCustomScheduleID bool
+		// saMapper overrides the default searchattribute.TestMapper.
+		saMapper    searchattribute.Mapper
+		archetypeID chasm.ArchetypeID
+		outFn       string
+		outFt       enumspb.IndexedValueType
+		err         string
 	}{
 		{
-			name:              "ChasmCompleted",
-			chasmMapper:       chasmMapper,
-			expectedFieldName: "TemporalBool01",
-			expectedFieldType: enumspb.INDEXED_VALUE_TYPE_BOOL,
-			expectedErr:       false,
+			name:  "success system StartTime",
+			in:    "StartTime",
+			outFn: "StartTime",
+			outFt: enumspb.INDEXED_VALUE_TYPE_DATETIME,
 		},
+
 		{
-			name:              "ChasmStatus",
-			chasmMapper:       chasmMapper,
-			expectedFieldName: "TemporalKeyword01",
-			expectedFieldType: enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-			expectedErr:       false,
+			name:  "success system WorkflowId",
+			in:    "WorkflowId",
+			outFn: "WorkflowId",
+			outFt: enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 		},
+
 		{
-			name:              "ExecutionStatus",
-			chasmMapper:       chasmMapper,
-			expectedFieldName: "ExecutionStatus",
-			expectedFieldType: enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-			expectedErr:       false,
+			name:  "success reserved BuildIds",
+			in:    "BuildIds",
+			outFn: "BuildIds",
+			outFt: enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST,
 		},
+
 		{
-			name:              "NonExistentChasmAlias",
-			chasmMapper:       chasmMapper,
-			expectedFieldName: "",
-			expectedFieldType: enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED,
-			expectedErr:       true,
+			name:  "success reserved TemporalBuildIds",
+			in:    "TemporalBuildIds",
+			outFn: "BuildIds",
+			outFt: enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST,
 		},
+
 		{
-			name:              "ChasmCompleted",
-			chasmMapper:       nil,
-			expectedFieldName: "",
-			expectedFieldType: enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED,
-			expectedErr:       true,
+			name:  "success reserved TemporalWorkerDeployment",
+			in:    "TemporalWorkerDeployment",
+			outFn: "TemporalWorkerDeployment",
+			outFt: enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		},
+
+		{
+			name:  "success reserved WorkerDeployment",
+			in:    "WorkerDeployment",
+			outFn: "TemporalWorkerDeployment",
+			outFt: enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		},
+
+		{
+			name:  "success custom AliasForInt01",
+			in:    "AliasForInt01",
+			outFn: "Int01",
+			outFt: enumspb.INDEXED_VALUE_TYPE_INT,
+		},
+
+		{
+			name:     "success custom noop mapper Int01",
+			in:       "Int01",
+			saMapper: &searchattribute.NoopMapper{},
+			outFn:    "Int01",
+			outFt:    enumspb.INDEXED_VALUE_TYPE_INT,
+		},
+
+		{
+			// System search attributes are not mappable, so the namespace mapper must not
+			// be able to resolve them to another field.
+			name:     "success system not resolved by mapper",
+			in:       "WorkflowId",
+			saMapper: mapAllMapper("Int01"),
+			outFn:    "WorkflowId",
+			outFt:    enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		},
+
+		{
+			// Predefined search attributes are not mappable either.
+			name:     "success predefined not resolved by mapper",
+			in:       "TemporalSchedulePaused",
+			saMapper: mapAllMapper("Int01"),
+			outFn:    "TemporalSchedulePaused",
+			outFt:    enumspb.INDEXED_VALUE_TYPE_BOOL,
+		},
+
+		{
+			name:  "success special ScheduleId",
+			in:    "ScheduleId",
+			outFn: "WorkflowId",
+			outFt: enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		},
+
+		{
+			name:  "success special TemporalScheduleId",
+			in:    "TemporalScheduleId",
+			outFn: "WorkflowId",
+			outFt: enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		},
+
+		{
+			name:                 "success custom ScheduleId",
+			in:                   "ScheduleId",
+			withCustomScheduleID: true,
+			outFn:                searchattribute.TestScheduleIDFieldName,
+			outFt:                enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		},
+
+		{
+			name:                 "success custom ScheduleId reserved TemporalScheduleId",
+			in:                   "TemporalScheduleId",
+			withCustomScheduleID: true,
+			outFn:                "WorkflowId",
+			outFt:                enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		},
+
+		{
+			name:     "success noop mapper ScheduleId",
+			in:       "ScheduleId",
+			saMapper: &searchattribute.NoopMapper{},
+			outFn:    "WorkflowId",
+			outFt:    enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		},
+
+		{
+			name:     "success noop mapper TemporalScheduleId",
+			in:       "TemporalScheduleId",
+			saMapper: &searchattribute.NoopMapper{},
+			outFn:    "WorkflowId",
+			outFt:    enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		},
+
+		{
+			// The ScheduleId alias is resolved before the scheduler archetype aliases.
+			name:        "success scheduler archetype ScheduleId",
+			in:          "ScheduleId",
+			archetypeID: chasm.SchedulerArchetypeID,
+			outFn:       "WorkflowId",
+			outFt:       enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		},
+
+		{
+			// TemporalSystemExecutionStatus allows querying Workflow based and CHASM based
+			// schedulers with the same alias.
+			name:        "success scheduler archetype TemporalSystemExecutionStatus",
+			in:          "TemporalSystemExecutionStatus",
+			archetypeID: chasm.SchedulerArchetypeID,
+			outFn:       "ExecutionStatus",
+			outFt:       enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		},
+
+		{
+			name: "invalid TemporalSystemExecutionStatus without archetype",
+			in:   "TemporalSystemExecutionStatus",
+			err:  "invalid search attribute: TemporalSystemExecutionStatus",
+		},
+
+		{
+			name:        "invalid TemporalSystemExecutionStatus with other archetype",
+			in:          "TemporalSystemExecutionStatus",
+			archetypeID: chasm.SchedulerArchetypeID + 1,
+			err:         "invalid search attribute: TemporalSystemExecutionStatus",
+		},
+
+		{
+			name: "invalid search attribute",
+			in:   "Foo",
+			err:  "invalid search attribute: Foo",
+		},
+
+		{
+			// The mapper resolves the alias, but the field is not in the type map.
+			name: "invalid custom search attribute unknown field",
+			in:   "AliasForFoo",
+			err:  "invalid search attribute: AliasForFoo",
+		},
+
+		{
+			name: "invalid search attribute with reserved prefix",
+			in:   "TemporalFoo",
+			err:  "invalid search attribute: TemporalFoo",
+		},
+
+		{
+			name: "invalid empty search attribute",
+			in:   "",
+			err:  "invalid search attribute: ",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			fieldName, fieldType, err := ResolveSearchAttributeAlias(tc.name, ns, mapper, saTypeMap, tc.chasmMapper)
-			require.Equal(t, tc.expectedFieldName, fieldName)
-			require.Equal(t, tc.expectedFieldType, fieldType)
-			require.Equal(t, tc.expectedErr, err != nil)
+			r := require.New(t)
+			saMapper := tc.saMapper
+			if saMapper == nil {
+				saMapper = &searchattribute.TestMapper{
+					WithCustomScheduleID: tc.withCustomScheduleID,
+				}
+			}
+
+			fn, ft, err := ResolveSearchAttributeAlias(
+				tc.in,
+				testNamespaceName,
+				saMapper,
+				searchattribute.TestNameTypeMap(),
+				nil, // chasmMapper
+				tc.archetypeID,
+			)
+			if tc.err != "" {
+				r.Error(err)
+				r.ErrorContains(err, tc.err)
+				var expectedErr *ConverterError
+				r.ErrorAs(err, &expectedErr)
+				r.Empty(fn)
+				r.Equal(enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, ft)
+			} else {
+				r.NoError(err)
+				r.Equal(tc.outFn, fn)
+				r.Equal(tc.outFt, ft)
+			}
 		})
 	}
 }
 
-func TestResolveSearchAttributeAlias_ChasmOverridesSystemAttribute(t *testing.T) {
-	ns := namespace.Name("test-namespace")
-	saTypeMap := searchattribute.NewNameTypeMapStub(map[string]enumspb.IndexedValueType{
-		"ExecutionStatus": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-	})
-	mapper := customMapper{
-		fieldToAlias: map[string]string{},
-		aliasToField: map[string]string{},
-	}
+func TestResolveSearchAttributeAlias_WithChasmMapper(t *testing.T) {
+	t.Parallel()
 
 	chasmMapper := chasm.NewTestVisibilitySearchAttributesMapper(
 		map[string]string{
-			"TemporalLowCardinalityKeyword01": "ExecutionStatus",
+			"TemporalBool01":    "ChasmCompleted",
+			"TemporalKeyword01": "ChasmStatus",
+			// Shadows the ExecutionStatus system search attribute.
+			"TemporalKeyword02": "ExecutionStatus",
+			// Shadows the alias of the Keyword01 custom search attribute.
+			"TemporalKeyword03": "AliasForKeyword01",
 		},
 		map[string]enumspb.IndexedValueType{
-			"TemporalLowCardinalityKeyword01": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-		},
-	)
-
-	fieldName, fieldType, err := ResolveSearchAttributeAlias("ExecutionStatus", ns, mapper, saTypeMap, chasmMapper)
-	require.NoError(t, err)
-	require.Equal(t, "TemporalLowCardinalityKeyword01", fieldName)
-	require.Equal(t, enumspb.INDEXED_VALUE_TYPE_KEYWORD, fieldType)
-}
-
-func TestResolveSearchAttributeAlias_ChasmPriority(t *testing.T) {
-	ns := namespace.Name("test-namespace")
-	saTypeMap := searchattribute.NewNameTypeMapStub(map[string]enumspb.IndexedValueType{
-		"MyCustomField": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-		"StartTime":     enumspb.INDEXED_VALUE_TYPE_DATETIME,
-	})
-	mapper := customMapper{
-		fieldToAlias: map[string]string{
-			"MyCustomField": "MyCustomField",
-		},
-		aliasToField: map[string]string{
-			"MyCustomField": "MyCustomField",
-		},
-	}
-
-	chasmMapper := chasm.NewTestVisibilitySearchAttributesMapper(
-		map[string]string{
-			"TemporalKeyword01": "MyCustomField",
-		},
-		map[string]enumspb.IndexedValueType{
+			"TemporalBool01":    enumspb.INDEXED_VALUE_TYPE_BOOL,
 			"TemporalKeyword01": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+			"TemporalKeyword02": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+			"TemporalKeyword03": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 		},
 	)
 
-	// Custom SA should take precedence over CHASM SA
-	fieldName, fieldType, err := ResolveSearchAttributeAlias("MyCustomField", ns, mapper, saTypeMap, chasmMapper)
-	require.NoError(t, err)
-	require.Equal(t, "MyCustomField", fieldName)
-	require.Equal(t, enumspb.INDEXED_VALUE_TYPE_KEYWORD, fieldType)
-
-	// CHASM SA should be used when custom SA doesn't exist
-	chasmMapper2 := chasm.NewTestVisibilitySearchAttributesMapper(
-		map[string]string{
-			"TemporalKeyword01": "ChasmOnlyField",
-		},
-		map[string]enumspb.IndexedValueType{
-			"TemporalKeyword01": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-		},
-	)
-	fieldName2, fieldType2, err2 := ResolveSearchAttributeAlias("ChasmOnlyField", ns, mapper, saTypeMap, chasmMapper2)
-	require.NoError(t, err2)
-	require.Equal(t, "TemporalKeyword01", fieldName2)
-	require.Equal(t, enumspb.INDEXED_VALUE_TYPE_KEYWORD, fieldType2)
-}
-
-func TestResolveSearchAttributeAlias_OverridableSystemResolvesViaSystemColumn(t *testing.T) {
-	ns := namespace.Name("test-namespace")
-	mapper := customMapper{
-		fieldToAlias: map[string]string{},
-		aliasToField: map[string]string{},
-	}
-
-	// System search attribute overrides are recorded only in the mapper's overriddenSystemFields
-	// and are NOT added to the CHASM alias/field maps. On the query path they resolve via the
-	// system type map (which always includes system search attributes), preserving the column name.
-	chasmMapper := chasm.NewTestVisibilitySearchAttributesMapper(
-		map[string]string{},
-		map[string]enumspb.IndexedValueType{},
-	)
-	saTypeMap := searchattribute.NewNameTypeMapStub(map[string]enumspb.IndexedValueType{
-		sadefs.ExecutionTime: enumspb.INDEXED_VALUE_TYPE_DATETIME,
-		sadefs.TaskQueue:     enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-	})
-
-	cases := []struct {
-		name string
-		typ  enumspb.IndexedValueType
+	testCases := []struct {
+		name                    string
+		expectedFieldName       string
+		expectedFieldType       enumspb.IndexedValueType
+		expectedErr             bool
+		expectNamespaceDivision bool
 	}{
-		{sadefs.ExecutionTime, enumspb.INDEXED_VALUE_TYPE_DATETIME},
-		{sadefs.TaskQueue, enumspb.INDEXED_VALUE_TYPE_KEYWORD},
+		{
+			name:                    "ChasmCompleted",
+			expectedFieldName:       "TemporalBool01",
+			expectedFieldType:       enumspb.INDEXED_VALUE_TYPE_BOOL,
+			expectedErr:             false,
+			expectNamespaceDivision: false,
+		},
+		{
+			name:                    "ChasmStatus",
+			expectedFieldName:       "TemporalKeyword01",
+			expectedFieldType:       enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+			expectedErr:             false,
+			expectNamespaceDivision: false,
+		},
+		{
+			name:                    "TemporalNamespaceDivision",
+			expectedFieldName:       "TemporalNamespaceDivision",
+			expectedFieldType:       enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+			expectedErr:             false,
+			expectNamespaceDivision: true,
+		},
+		{
+			// A CHASM search attribute takes precedence over a system search attribute,
+			// which is not mappable.
+			name:                    "ExecutionStatus",
+			expectedFieldName:       "TemporalKeyword02",
+			expectedFieldType:       enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+			expectedErr:             false,
+			expectNamespaceDivision: false,
+		},
+		{
+			// A custom search attribute takes precedence over a CHASM search attribute.
+			name:                    "AliasForKeyword01",
+			expectedFieldName:       "Keyword01",
+			expectedFieldType:       enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+			expectedErr:             false,
+			expectNamespaceDivision: false,
+		},
+		{
+			name:                    "NonExistentChasmAlias",
+			expectedFieldName:       "",
+			expectedFieldType:       enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED,
+			expectedErr:             true,
+			expectNamespaceDivision: false,
+		},
 	}
-	for _, tc := range cases {
+
+	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			fieldName, fieldType, err := ResolveSearchAttributeAlias(tc.name, ns, mapper, saTypeMap, chasmMapper)
-			require.NoError(t, err)
-			require.Equal(t, tc.name, fieldName)
-			require.Equal(t, tc.typ, fieldType)
+			r := require.New(t)
+			fieldName, fieldType, err := ResolveSearchAttributeAlias(
+				tc.name,
+				testNamespaceName,
+				&searchattribute.TestMapper{},
+				searchattribute.TestNameTypeMap(),
+				chasmMapper,
+				chasm.UnspecifiedArchetypeID,
+			)
+			if tc.expectedErr {
+				r.Error(err)
+				r.Empty(fieldName)
+				r.Equal(enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, fieldType)
+			} else {
+				r.NoError(err)
+				r.Equal(tc.expectedFieldName, fieldName)
+				r.Equal(tc.expectedFieldType, fieldType)
+			}
 		})
 	}
-}
-
-func TestResolveSearchAttributeAlias_ChasmMissingType(t *testing.T) {
-	ns := namespace.Name("test-namespace")
-	saTypeMap := searchattribute.NewNameTypeMapStub(map[string]enumspb.IndexedValueType{
-		"StartTime": enumspb.INDEXED_VALUE_TYPE_DATETIME,
-	})
-	mapper := customMapper{
-		fieldToAlias: map[string]string{},
-		aliasToField: map[string]string{},
-	}
-
-	// CHASM mapper with field that doesn't exist in type map
-	chasmMapper := chasm.NewTestVisibilitySearchAttributesMapper(
-		map[string]string{
-			"TemporalKeyword01": "ChasmField",
-		},
-		map[string]enumspb.IndexedValueType{
-			// Missing TemporalKeyword01 in type map
-		},
-	)
-
-	// Should fall back to system SA resolution
-	fieldName, fieldType, err := ResolveSearchAttributeAlias("ChasmField", ns, mapper, saTypeMap, chasmMapper)
-	require.Error(t, err)
-	require.Empty(t, fieldName)
-	require.Equal(t, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, fieldType)
 }

--- a/common/persistence/visibility/store/sql/query_converter_legacy.go
+++ b/common/persistence/visibility/store/sql/query_converter_legacy.go
@@ -450,19 +450,16 @@ func (c *QueryConverterLegacy) convertColName(exprRef *sqlparser.Expr) (*saColNa
 	}
 	saAlias := strings.ReplaceAll(sqlparser.String(expr), "`", "")
 
-	saFieldName, saType, err := query.ResolveSearchAttributeAlias(saAlias, c.namespaceName, c.saMapper, c.saTypeMap, c.chasmMapper)
+	saFieldName, saType, err := query.ResolveSearchAttributeAlias(
+		saAlias,
+		c.namespaceName,
+		c.saMapper,
+		c.saTypeMap,
+		c.chasmMapper,
+		c.archetypeID,
+	)
 	if err != nil {
-		if c.archetypeID != chasm.SchedulerArchetypeID || saAlias != "TemporalSystemExecutionStatus" {
-			return nil, query.NewConverterError(
-				"%s: column name '%s' is not a valid search attribute",
-				query.InvalidExpressionErrMessage,
-				saAlias,
-			)
-		}
-		// To support querying Workflow based schedulers and CHASM based schedulers, we need to translate
-		// TemporalSystemExecutionStatus as an alias to the system search attribute ExecutionStatus.
-		saFieldName = sadefs.ExecutionStatus
-		saType, _ = c.saTypeMap.GetType(saFieldName)
+		return nil, err
 	}
 	if saFieldName == sadefs.TemporalNamespaceDivision {
 		c.seenNamespaceDivision = true
@@ -526,6 +523,43 @@ func (c *QueryConverterLegacy) convertValueExpr(
 			}
 		}
 		return nil
+	case *sqlparser.UnaryExpr:
+		// Negative value may be parsed as UnaryExpr
+		if e.Operator != sqlparser.UPlusStr && e.Operator != sqlparser.UMinusStr {
+			return query.NewConverterError(
+				"%s: unary operator %q",
+				query.NotSupportedErrMessage,
+				e.Operator,
+			)
+		}
+		if value, ok := e.Expr.(*sqlparser.SQLVal); !ok || value.Type == sqlparser.StrVal {
+			return query.NewConverterError(
+				"%s: unary operator not supported in %q",
+				query.InvalidExpressionErrMessage,
+				sqlparser.String(expr),
+			)
+		}
+		err := c.convertValueExpr(&e.Expr, name, saFieldName, saType)
+		if err != nil {
+			return err
+		}
+		if value, ok := e.Expr.(*sqlparser.SQLVal); ok && (value.Type == sqlparser.IntVal || value.Type == sqlparser.FloatVal) {
+			if e.Operator == sqlparser.UMinusStr && len(value.Val) > 0 {
+				if value.Val[0] == '-' {
+					value.Val = value.Val[1:]
+				} else {
+					value.Val = append([]byte{'-'}, value.Val...)
+				}
+			}
+			*exprRef = e.Expr
+			return nil
+		}
+		// This should never happen, but here to catch any unexpected case.
+		return query.NewConverterError(
+			"%s: unary expression %q",
+			query.InvalidExpressionErrMessage,
+			sqlparser.String(expr),
+		)
 	case *sqlparser.GroupConcatExpr:
 		return query.NewConverterError("%s: 'group_concat'", query.NotSupportedErrMessage)
 	case *sqlparser.FuncExpr:

--- a/common/persistence/visibility/store/sql/query_converter_legacy_test.go
+++ b/common/persistence/visibility/store/sql/query_converter_legacy_test.go
@@ -523,11 +523,7 @@ func (s *queryConverterSuite) TestConvertColName() {
 			input:    "InvalidName",
 			output:   "",
 			retValue: nil,
-			err: query.NewConverterError(
-				"%s: column name '%s' is not a valid search attribute",
-				query.InvalidExpressionErrMessage,
-				"InvalidName",
-			),
+			err:      query.NewConverterError("%s: %s", query.InvalidSearchAttribute, "InvalidName"),
 		},
 		{
 			name:   "valid system search attribute: ExecutionStatus",
@@ -784,6 +780,206 @@ func (s *queryConverterSuite) TestConvertValueExpr() {
 			},
 			output: "('foo', 'bar')",
 			err:    nil,
+		},
+		// The SQL parser folds the sign into integer values, but represents signed floats
+		// as an unary expression.
+		{
+			name:  "valid negative integer",
+			input: "-123",
+			args: map[string]any{
+				"saName":      "AliasForInt01",
+				"saFieldName": "Int01",
+				"saType":      enumspb.INDEXED_VALUE_TYPE_INT,
+			},
+			output: "-123",
+			err:    nil,
+		},
+		{
+			// The parser folds both signs into the value, so this is not an unary expression.
+			name:  "valid double negative integer",
+			input: "- -123",
+			args: map[string]any{
+				"saName":      "AliasForInt01",
+				"saFieldName": "Int01",
+				"saType":      enumspb.INDEXED_VALUE_TYPE_INT,
+			},
+			output: "123",
+			err:    nil,
+		},
+		{
+			name:  "valid positive negative integer",
+			input: "+ -123",
+			args: map[string]any{
+				"saName":      "AliasForInt01",
+				"saFieldName": "Int01",
+				"saType":      enumspb.INDEXED_VALUE_TYPE_INT,
+			},
+			output: "-123",
+			err:    nil,
+		},
+		{
+			name:  "valid negative positive integer",
+			input: "- +123",
+			args: map[string]any{
+				"saName":      "AliasForInt01",
+				"saFieldName": "Int01",
+				"saType":      enumspb.INDEXED_VALUE_TYPE_INT,
+			},
+			output: "-123",
+			err:    nil,
+		},
+		{
+			name:  "valid negative float",
+			input: "-1.5",
+			args: map[string]any{
+				"saName":      "AliasForDouble01",
+				"saFieldName": "Double01",
+				"saType":      enumspb.INDEXED_VALUE_TYPE_DOUBLE,
+			},
+			output: "-1.5",
+			err:    nil,
+		},
+		{
+			name:  "valid positive sign float",
+			input: "+1.5",
+			args: map[string]any{
+				"saName":      "AliasForDouble01",
+				"saFieldName": "Double01",
+				"saType":      enumspb.INDEXED_VALUE_TYPE_DOUBLE,
+			},
+			output: "1.5",
+			err:    nil,
+		},
+		{
+			name:  "valid negative float with trailing zeros",
+			input: "-1.500",
+			args: map[string]any{
+				"saName":      "AliasForDouble01",
+				"saFieldName": "Double01",
+				"saType":      enumspb.INDEXED_VALUE_TYPE_DOUBLE,
+			},
+			output: "-1.5",
+			err:    nil,
+		},
+		{
+			name:  "valid negative float in tuple",
+			input: "(-1.5, 2.5)",
+			args: map[string]any{
+				"saName":      "AliasForDouble01",
+				"saFieldName": "Double01",
+				"saType":      enumspb.INDEXED_VALUE_TYPE_DOUBLE,
+			},
+			output: "(-1.5, 2.5)",
+			err:    nil,
+		},
+		{
+			// Only a literal value can be signed, not another unary expression.
+			name:  "nested unary expression",
+			input: "- -1.5",
+			args: map[string]any{
+				"saName":      "AliasForDouble01",
+				"saFieldName": "Double01",
+				"saType":      enumspb.INDEXED_VALUE_TYPE_DOUBLE,
+			},
+			output: "",
+			err: query.NewConverterError(
+				"%s: unary operator not supported in %q",
+				query.InvalidExpressionErrMessage,
+				"- -1.5",
+			),
+		},
+		{
+			name:  "unary expression with string value",
+			input: "-'foo'",
+			args: map[string]any{
+				"saName":      "AliasForKeyword01",
+				"saFieldName": "Keyword01",
+				"saType":      enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+			},
+			output: "",
+			err: query.NewConverterError(
+				"%s: unary operator not supported in %q",
+				query.InvalidExpressionErrMessage,
+				"-'foo'",
+			),
+		},
+		{
+			name:  "unary expression with bool value",
+			input: "-true",
+			args: map[string]any{
+				"saName":      "AliasForBool01",
+				"saFieldName": "Bool01",
+				"saType":      enumspb.INDEXED_VALUE_TYPE_BOOL,
+			},
+			output: "",
+			err: query.NewConverterError(
+				"%s: unary operator not supported in %q",
+				query.InvalidExpressionErrMessage,
+				"-true",
+			),
+		},
+		{
+			name:  "unary expression with parenthesized value",
+			input: "-(10)",
+			args: map[string]any{
+				"saName":      "AliasForInt01",
+				"saFieldName": "Int01",
+				"saType":      enumspb.INDEXED_VALUE_TYPE_INT,
+			},
+			output: "",
+			err: query.NewConverterError(
+				"%s: unary operator not supported in %q",
+				query.InvalidExpressionErrMessage,
+				"-(10)",
+			),
+		},
+		{
+			name:  "unsupported unary operator: bitwise not",
+			input: "~1",
+			args: map[string]any{
+				"saName":      "AliasForInt01",
+				"saFieldName": "Int01",
+				"saType":      enumspb.INDEXED_VALUE_TYPE_INT,
+			},
+			output: "",
+			err: query.NewConverterError(
+				"%s: unary operator %q",
+				query.NotSupportedErrMessage,
+				sqlparser.TildaStr,
+			),
+		},
+		{
+			name:  "unsupported unary operator: logical not",
+			input: "!1",
+			args: map[string]any{
+				"saName":      "AliasForInt01",
+				"saFieldName": "Int01",
+				"saType":      enumspb.INDEXED_VALUE_TYPE_INT,
+			},
+			output: "",
+			err: query.NewConverterError(
+				"%s: unary operator %q",
+				query.NotSupportedErrMessage,
+				sqlparser.BangStr,
+			),
+		},
+		{
+			// The value is converted before the sign is applied, so the errors of the
+			// underlying value are returned as is.
+			name:  "unary expression with invalid value type",
+			input: "-1.5",
+			args: map[string]any{
+				"saName":      "StartTime",
+				"saFieldName": "StartTime",
+				"saType":      enumspb.INDEXED_VALUE_TYPE_DATETIME,
+			},
+			output: "",
+			err: query.NewConverterError(
+				"%s: unexpected value type %T for search attribute %s",
+				query.InvalidExpressionErrMessage,
+				float64(1.5),
+				"StartTime",
+			),
 		},
 	}
 

--- a/common/persistence/visibility/store/sql/visibility_store_test.go
+++ b/common/persistence/visibility/store/sql/visibility_store_test.go
@@ -54,7 +54,7 @@ func TestBuildQueryParams(t *testing.T) {
 		{
 			name:  "fail invalid custom search attribute",
 			query: "AliasForFoo = 'foo'",
-			err:   "invalid expression: column name 'AliasForFoo' is not a valid search attribute",
+			err:   "invalid search attribute: AliasForFoo",
 		},
 		{
 			name:  "fail order by not supported",

--- a/common/persistence/visibility/store/tests/query_converter_legacy_test.go
+++ b/common/persistence/visibility/store/tests/query_converter_legacy_test.go
@@ -1,0 +1,424 @@
+package tests
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
+	"go.temporal.io/server/common/persistence/visibility/store/elasticsearch"
+	"go.temporal.io/server/common/persistence/visibility/store/query"
+	vissql "go.temporal.io/server/common/persistence/visibility/store/sql"
+	"go.temporal.io/server/common/searchattribute"
+)
+
+const (
+	testNamespaceID = namespace.ID("test-namespace-id")
+	testPageSize    = 10
+)
+
+// legacyDivergence describes a query from queryConverterTestCases that the legacy query
+// converter accepts or rejects differently from the unified one. The legacy converters build
+// the whole statement (SQL) or leave the namespace filters to the store (Elasticsearch), so
+// their output can't be compared against the expectations in queryConverterTestCases; only
+// whether the query is accepted is.
+type legacyDivergence struct {
+	// accepted is whether the legacy query converter accepts the query, and plugins
+	// overrides it for the SQL plugins that behave differently.
+	accepted bool
+	plugins  map[string]bool
+	// why documents why the legacy query converter behaves differently.
+	why string
+}
+
+func (d legacyDivergence) isAccepted(store string) bool {
+	if accepted, ok := d.plugins[store]; ok {
+		return accepted
+	}
+	return d.accepted
+}
+
+// legacySQLDivergences maps a test case name from queryConverterTestCases to how the legacy
+// SQL query converter handles it. Every entry is a behavior change intentionally introduced
+// by the unified query converter: queries that used to be silently accepted are now validated,
+// and queries that used to be rejected are now supported.
+var legacySQLDivergences = map[string]legacyDivergence{
+	// The legacy query converter doesn't validate the value against the search attribute type.
+	"Keyword invalid value type": {
+		accepted: true,
+		why:      "legacy doesn't validate the value type of Keyword search attributes",
+	},
+	"Keyword with bool value": {
+		accepted: true,
+		why:      "legacy doesn't validate the value type of Keyword search attributes",
+	},
+	"KeywordList invalid value type": {
+		accepted: true,
+		// SQLite requires a string to build the full text search query.
+		plugins: map[string]bool{sqliteStore: false},
+		why:     "legacy doesn't validate the value type of KeywordList search attributes",
+	},
+	"Int invalid value type": {
+		accepted: true,
+		why:      "legacy doesn't validate the value type of Int search attributes",
+	},
+	"Int mixed types in list": {
+		accepted: true,
+		why:      "legacy doesn't validate the value type of the items of a list",
+	},
+	"Double invalid value type": {
+		accepted: true,
+		why:      "legacy doesn't validate the value type of Double search attributes",
+	},
+	"Bool invalid value type": {
+		accepted: true,
+		why:      "legacy doesn't validate the value type of Bool search attributes",
+	},
+	"Datetime with bool value": {
+		accepted: true,
+		why:      "legacy doesn't validate the value type of Datetime search attributes",
+	},
+	"ExecutionStatus invalid code": {
+		accepted: true,
+		why:      "legacy doesn't validate that the ExecutionStatus code is a valid enum value",
+	},
+	"ExecutionDuration with bool value": {
+		accepted: true,
+		why:      "legacy doesn't validate the value type of ExecutionDuration",
+	},
+	"Text invalid value type": {
+		accepted: true,
+		// PostgreSQL and SQLite require a string to build the full text search query.
+		plugins: map[string]bool{postgresStore: false, sqliteStore: false},
+		why:     "legacy doesn't validate the value type of Text search attributes",
+	},
+	"Text empty value": {
+		accepted: true,
+		// PostgreSQL and SQLite tokenize the value to build the full text search query.
+		plugins: map[string]bool{postgresStore: false, sqliteStore: false},
+		why:     "legacy only rejects a blank Text value on the stores that tokenize it",
+	},
+	"Text blank value": {
+		accepted: true,
+		plugins:  map[string]bool{postgresStore: false, sqliteStore: false},
+		why:      "legacy only rejects a blank Text value on the stores that tokenize it",
+	},
+
+	// The legacy query converter rejects ORDER BY for every SQL plugin. The unified query
+	// converter parses it, and the SQL visibility store rejects it instead.
+	"order by": {
+		why: "legacy rejects 'ORDER BY' in the query converter instead of the store",
+	},
+	"order by desc": {
+		why: "legacy rejects 'ORDER BY' in the query converter instead of the store",
+	},
+	"order by multiple search attributes": {
+		why: "legacy rejects 'ORDER BY' in the query converter instead of the store",
+	},
+	"order by with where clause": {
+		why: "legacy rejects 'ORDER BY' in the query converter instead of the store",
+	},
+	"order by custom search attribute": {
+		why: "legacy rejects 'ORDER BY' in the query converter instead of the store",
+	},
+}
+
+func newLegacyQueryConverter(plugin string, queryString string) *vissql.QueryConverterLegacy {
+	return vissql.NewQueryConverterLegacy(
+		plugin,
+		testNamespaceName,
+		testNamespaceID,
+		searchattribute.TestNameTypeMap(),
+		&searchattribute.TestMapper{},
+		queryString,
+		nil, // chasmMapper
+		chasm.UnspecifiedArchetypeID,
+	)
+}
+
+func TestSQLQueryConverterLegacy(t *testing.T) {
+	t.Parallel()
+	for _, plugin := range sqlPlugins {
+		t.Run(plugin, func(t *testing.T) {
+			t.Parallel()
+			for _, tc := range queryConverterTestCases {
+				t.Run(tc.name, func(t *testing.T) {
+					r := require.New(t)
+
+					// The legacy query converter output can't be compared against the
+					// expectations in queryConverterTestCases, so the test only asserts that
+					// both query converters accept the same queries, except for the
+					// differences listed in legacySQLDivergences.
+					_, unifiedErr := tc.expected(plugin)
+					accepted := unifiedErr == ""
+					reason := "unified query converter and legacy query converter must agree"
+					if divergence, ok := legacySQLDivergences[tc.name]; ok {
+						accepted = divergence.isAccepted(plugin)
+						reason = divergence.why
+					}
+
+					// Count queries support the GROUP BY clause.
+					countFilter, err := newLegacyQueryConverter(plugin, tc.in).BuildCountStmt()
+					assertLegacyOutcome(r, countFilter, err, accepted, reason)
+					if accepted {
+						r.Equal(tc.groupBy, countFilter.GroupBy)
+					}
+
+					// List queries don't support the GROUP BY clause.
+					selectFilter, err := newLegacyQueryConverter(plugin, tc.in).
+						BuildSelectStmt(testPageSize, nil)
+					if accepted && len(tc.groupBy) > 0 {
+						r.Error(err)
+						r.EqualError(err, "operation is not supported: 'GROUP BY' clause")
+						r.Nil(selectFilter)
+						return
+					}
+					assertLegacyOutcome(r, selectFilter, err, accepted, reason)
+				})
+			}
+		})
+	}
+}
+
+// TestSQLQueryConverterLegacyDivergences keeps legacySQLDivergences honest: an entry that
+// names a test case that no longer exists, or that no longer differs from the unified query
+// converter, silently weakens TestSQLQueryConverterLegacy.
+func TestSQLQueryConverterLegacyDivergences(t *testing.T) {
+	t.Parallel()
+	assertDivergencesAreCurrent(t, "legacySQLDivergences", legacySQLDivergences, sqlPlugins)
+}
+
+func assertDivergencesAreCurrent(
+	t *testing.T,
+	varName string,
+	divergences map[string]legacyDivergence,
+	stores []string,
+) {
+	t.Helper()
+	r := require.New(t)
+
+	testCases := make(map[string]queryConverterTestCase, len(queryConverterTestCases))
+	for _, tc := range queryConverterTestCases {
+		testCases[tc.name] = tc
+	}
+
+	for name, divergence := range divergences {
+		tc, ok := testCases[name]
+		r.True(ok, "%s has an entry for unknown test case %q", varName, name)
+		r.NotEmpty(divergence.why, "%s entry %q must document why", varName, name)
+
+		diverges := false
+		for _, store := range stores {
+			_, unifiedErr := tc.expected(store)
+			diverges = diverges || divergence.isAccepted(store) != (unifiedErr == "")
+		}
+		r.True(
+			diverges,
+			"%s entry %q agrees with the unified query converter for every store: remove it",
+			varName,
+			name,
+		)
+	}
+}
+
+// legacyESDivergences maps a test case name from queryConverterTestCases to how the legacy
+// Elasticsearch query converter handles it. Every entry is a behavior change intentionally
+// introduced by the unified query converter: queries that used to be silently accepted are
+// now validated, and queries that used to be rejected are now supported.
+var legacyESDivergences = map[string]legacyDivergence{
+	// The legacy query converter doesn't validate the value against the search attribute type.
+	"Keyword invalid value type": {
+		accepted: true,
+		why:      "legacy doesn't validate the value type of Keyword search attributes",
+	},
+	"Keyword with bool value": {
+		accepted: true,
+		why:      "legacy doesn't validate the value type of Keyword search attributes",
+	},
+	"KeywordList invalid value type": {
+		accepted: true,
+		why:      "legacy doesn't validate the value type of KeywordList search attributes",
+	},
+	"Text invalid value type": {
+		accepted: true,
+		why:      "legacy doesn't validate the value type of Text search attributes",
+	},
+	"Text empty value": {
+		accepted: true,
+		why:      "legacy doesn't reject a blank Text value",
+	},
+	"Text blank value": {
+		accepted: true,
+		why:      "legacy doesn't reject a blank Text value",
+	},
+	"ExecutionStatus invalid name": {
+		accepted: true,
+		why:      "legacy doesn't validate that the ExecutionStatus name is a valid enum value",
+	},
+	"ExecutionStatus invalid value in list": {
+		accepted: true,
+		why:      "legacy doesn't validate that the ExecutionStatus name is a valid enum value",
+	},
+	"ExecutionStatus invalid value type": {
+		accepted: true,
+		why:      "legacy doesn't validate the value type of ExecutionStatus",
+	},
+
+	// The legacy query converter doesn't validate the operator against the search attribute
+	// type, and relies on Elasticsearch to reject the query instead.
+	"KeywordList unsupported operator": {
+		accepted: true,
+		why:      "legacy doesn't validate the operator of KeywordList search attributes",
+	},
+	"KeywordList starts with not supported": {
+		accepted: true,
+		why:      "legacy doesn't validate the operator of KeywordList search attributes",
+	},
+	"Text unsupported operator": {
+		accepted: true,
+		why:      "legacy doesn't validate the operator of Text search attributes",
+	},
+	"Text in not supported": {
+		accepted: true,
+		why:      "legacy doesn't validate the operator of Text search attributes",
+	},
+	"Text range condition not supported": {
+		accepted: true,
+		why:      "legacy doesn't validate the type of a range condition",
+	},
+
+	// The legacy query converter doesn't support the NOT operator.
+	"not expression": {
+		why: "legacy doesn't support the 'NOT' operator",
+	},
+	"not parenthesized and expression": {
+		why: "legacy doesn't support the 'NOT' operator",
+	},
+	"not parenthesized or expression": {
+		why: "legacy doesn't support the 'NOT' operator",
+	},
+	"not is null expression": {
+		why: "legacy doesn't support the 'NOT' operator",
+	},
+	"complex query": {
+		why: "legacy doesn't support the 'NOT' operator",
+	},
+}
+
+func newLegacyESQueryConverter() *query.ConverterLegacy {
+	saTypeMap := searchattribute.TestNameTypeMap()
+	return elasticsearch.NewQueryConverterLegacy(
+		elasticsearch.NewNameInterceptor(
+			testNamespaceName,
+			saTypeMap,
+			searchattribute.NewTestMapperProvider(&searchattribute.TestMapper{}),
+			nil, // chasmMapper
+			chasm.UnspecifiedArchetypeID,
+		),
+		elasticsearch.NewValuesInterceptor(
+			testNamespaceName,
+			saTypeMap,
+			nil, // chasmMapper
+			metrics.NoopMetricsHandler,
+			log.NewNoopLogger(),
+		),
+		saTypeMap,
+		nil, // chasmMapper
+	)
+}
+
+func TestElasticsearchQueryConverterLegacy(t *testing.T) {
+	t.Parallel()
+	for _, tc := range queryConverterTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := require.New(t)
+
+			// The legacy query converter doesn't add the namespace and namespace division
+			// filters, which the visibility store adds instead, so its output can't be
+			// compared against the expectations in queryConverterTestCases. The test only
+			// asserts that both query converters accept the same queries, except for the
+			// differences listed in legacyESDivergences.
+			_, unifiedErr := tc.expected(esStore)
+			accepted := unifiedErr == ""
+			reason := "unified query converter and legacy query converter must agree"
+			if divergence, ok := legacyESDivergences[tc.name]; ok {
+				accepted = divergence.isAccepted(esStore)
+				reason = divergence.why
+			}
+
+			queryParams, err := newLegacyESQueryConverter().ConvertWhereOrderBy(tc.in)
+			if !accepted {
+				r.Error(err, reason)
+				// The visibility store converts a ConverterError into an InvalidArgument
+				// and returns any other error as is, so a rejected query must fail with
+				// one of the two to reach the caller as an invalid argument.
+				var converterErr *query.ConverterError
+				var invalidArgumentErr *serviceerror.InvalidArgument
+				r.True(
+					errors.As(err, &converterErr) || errors.As(err, &invalidArgumentErr),
+					"expected a ConverterError or an InvalidArgument, got %T: %v",
+					err,
+					err,
+				)
+				r.Nil(queryParams)
+				return
+			}
+			r.NoError(err, reason)
+
+			// Unlike the SQL stores, Elasticsearch supports both clauses.
+			r.Equal(tc.groupBy, queryParams.GroupBy)
+			if tc.orderBy == "" {
+				r.Empty(queryParams.Sorter)
+			} else {
+				r.NotEmpty(queryParams.Sorter)
+			}
+
+			if hasFilter(tc.in) {
+				r.NotNil(queryParams.Query)
+			} else {
+				r.Nil(queryParams.Query)
+			}
+		})
+	}
+}
+
+// TestElasticsearchQueryConverterLegacyDivergences keeps legacyESDivergences honest: an entry
+// that names a test case that no longer exists, or that no longer differs from the unified
+// query converter, silently weakens TestElasticsearchQueryConverterLegacy.
+func TestElasticsearchQueryConverterLegacyDivergences(t *testing.T) {
+	t.Parallel()
+	assertDivergencesAreCurrent(t, "legacyESDivergences", legacyESDivergences, []string{esStore})
+}
+
+// hasFilter returns whether the query has a filtering clause, following the same rule the
+// query converters use to tell a filter from a standalone GROUP BY or ORDER BY clause.
+func hasFilter(queryString string) bool {
+	queryString = strings.ToLower(strings.TrimSpace(queryString))
+	return queryString != "" &&
+		!strings.HasPrefix(queryString, "group by") &&
+		!strings.HasPrefix(queryString, "order by")
+}
+
+func assertLegacyOutcome(
+	r *require.Assertions,
+	filter *sqlplugin.VisibilitySelectFilter,
+	err error,
+	accepted bool,
+	reason string,
+) {
+	if !accepted {
+		r.Error(err, reason)
+		var converterErr *query.ConverterError
+		r.ErrorAs(err, &converterErr)
+		r.Nil(filter)
+		return
+	}
+	r.NoError(err, reason)
+	r.NotEmpty(filter.Query)
+}

--- a/common/persistence/visibility/store/tests/query_converter_test.go
+++ b/common/persistence/visibility/store/tests/query_converter_test.go
@@ -235,7 +235,7 @@ var queryConverterTestCases = []queryConverterTestCase{
 	{
 		name: "search attribute name is case sensitive",
 		in:   "workflowid = 'wid'",
-		err:  "invalid expression: column name 'workflowid' is not a valid search attribute",
+		err:  "invalid search attribute: workflowid",
 	},
 
 	// Int type search attributes.
@@ -908,12 +908,12 @@ var queryConverterTestCases = []queryConverterTestCase{
 	{
 		name: "unknown search attribute",
 		in:   "Foo = 'bar'",
-		err:  "invalid expression: column name 'Foo' is not a valid search attribute",
+		err:  "invalid search attribute: Foo",
 	},
 	{
 		name: "reserved field name is not a search attribute",
 		in:   "NamespaceId = 'foo'",
-		err:  "invalid expression: column name 'NamespaceId' is not a valid search attribute",
+		err:  "invalid search attribute: NamespaceId",
 	},
 
 	// Namespace division.
@@ -1036,17 +1036,17 @@ var queryConverterTestCases = []queryConverterTestCase{
 	{
 		name: "error inside and expression",
 		in:   "WorkflowId = 'wid' AND Foo = 'bar'",
-		err:  "invalid expression: column name 'Foo' is not a valid search attribute",
+		err:  "invalid search attribute: Foo",
 	},
 	{
 		name: "error inside or expression",
 		in:   "Foo = 'bar' OR WorkflowId = 'wid'",
-		err:  "invalid expression: column name 'Foo' is not a valid search attribute",
+		err:  "invalid search attribute: Foo",
 	},
 	{
 		name: "error inside not expression",
 		in:   "NOT Foo = 'bar'",
-		err:  "invalid expression: column name 'Foo' is not a valid search attribute",
+		err:  "invalid search attribute: Foo",
 	},
 
 	// GROUP BY clause.
@@ -1082,7 +1082,7 @@ var queryConverterTestCases = []queryConverterTestCase{
 	{
 		name: "group by unknown search attribute",
 		in:   "GROUP BY Foo",
-		err:  "invalid expression: column name 'Foo' is not a valid search attribute",
+		err:  "invalid search attribute: Foo",
 	},
 
 	// ORDER BY clause.
@@ -1129,7 +1129,7 @@ var queryConverterTestCases = []queryConverterTestCase{
 	{
 		name: "order by unknown search attribute",
 		in:   "ORDER BY Foo",
-		err:  "invalid expression: column name 'Foo' is not a valid search attribute",
+		err:  "invalid search attribute: Foo",
 	},
 
 	// Malformed and unsupported queries.

--- a/service/worker/scheduler/query_test.go
+++ b/service/worker/scheduler/query_test.go
@@ -250,7 +250,7 @@ func TestGetQueryFields(t *testing.T) {
 			name:           "invalid custom search attribute",
 			input:          "Foo = 'bar'",
 			expectedFields: nil,
-			expectedErrMsg: "'Foo' is not a valid search attribute",
+			expectedErrMsg: "invalid search attribute: Foo",
 		},
 	}
 
@@ -334,7 +334,7 @@ func TestValidateVisibilityQuery(t *testing.T) {
 		{
 			name:           "invalid custom search attribute",
 			input:          "Foo = foo",
-			expectedErrMsg: "'Foo' is not a valid search attribute",
+			expectedErrMsg: "invalid search attribute: Foo",
 		},
 	}
 


### PR DESCRIPTION
## What changed?
- Fix parsing negative double values.
- Consolidated the function to resolve alias (there were two, and not behaving the same way, the legacy was missing some cases).
- Added more unit tests to verify the legacy query converter behaves the same as in the new one except for the expected differences.

## Why?
Fixes to legacy visibility query converter for SQL and Elasticsearch.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
