### PR TITLE
Instrument the CHASM callback delivery and disposition paths

### DIFF
--- a/chasm/lib/callback/invocable_internal.go
+++ b/chasm/lib/callback/invocable_internal.go
@@ -3,6 +3,7 @@ package callback
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/nexus-rpc/sdk-go/nexus"
@@ -15,9 +16,11 @@ import (
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/nexus/nexusrpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -56,6 +59,17 @@ func (c invocableInternal) Invoke(
 	task *callbackspb.InvocationTask,
 	taskAttr chasm.TaskAttributes,
 ) invocationResult {
+	// nolint:forbidigo // Wall-clock RPC measurement, not component state; Invoke has no chasm.Context.
+	startTime := time.Now()
+	outcome := outcomeSuccess
+	defer func() {
+		namespaceTag := metrics.NamespaceTag(ns.Name().String())
+		destTag := metrics.DestinationTag(taskAttr.Destination)
+		outcomeTag := metrics.OutcomeTag(outcome)
+		h.metricsHandler.Counter(InternalRequestCounter.Name()).Record(1, namespaceTag, destTag, outcomeTag)
+		h.metricsHandler.Timer(InternalRequestLatencyHistogram.Name()).Record(time.Since(startTime), namespaceTag, destTag, outcomeTag)
+	}()
+
 	header := nexus.Header(c.callback.GetHeader())
 	if header == nil {
 		header = nexus.Header{}
@@ -64,11 +78,13 @@ func (c invocableInternal) Invoke(
 	// Get back the component ref and (optional) request ID from the callback token in the header.
 	encodedToken := header.Get(commonnexus.CallbackTokenHeader)
 	if encodedToken == "" {
+		outcome = outcomeMissingToken
 		return invocationResultFail{logInternalError(h.logger, "callback missing token", nil)}
 	}
 
 	decodedRef, requestID, err := chasm.UnpackNexusCallbackToken(encodedToken)
 	if err != nil {
+		outcome = outcomeTokenDecodeError
 		return invocationResultFail{logInternalError(h.logger, "failed to decode CHASM callback token", err)}
 	}
 
@@ -80,17 +96,29 @@ func (c invocableInternal) Invoke(
 	// Validate that the bytes are a valid ChasmComponentRef
 	ref := &persistencespb.ChasmComponentRef{}
 	if err := proto.Unmarshal(decodedRef, ref); err != nil {
+		outcome = outcomeInvalidRef
 		return invocationResultFail{logInternalError(h.logger, "failed to unmarshal CHASM ComponentRef", err)}
 	}
 
 	request, err := c.getHistoryRequest(decodedRef, requestID)
 	if err != nil {
+		outcome = outcomeRequestBuildError
 		return invocationResultFail{logInternalError(h.logger, "failed to build history request", err)}
 	}
 
 	// RPC to History for cross-shard completion delivery.
 	_, err = h.historyClient.CompleteNexusOperationChasm(ctx, request)
 	if err != nil {
+		// GetRPCStatus, not status.Code: the internode interceptor returns serviceerror
+		// types, which expose Status() rather than GRPCStatus(), so status.Code reports
+		// Unknown for all of them. IsRetryableRPCError below reads the code the same way.
+		outcome = "error:" + codes.Unknown.String()
+		if st, ok := common.GetRPCStatus(err); ok {
+			outcome = "error:" + st.Code().String()
+		}
+		if ctx.Err() != nil {
+			outcome = outcomeRequestTimeout
+		}
 		msg := logInternalError(h.logger, "failed to complete Nexus operation", err)
 		if common.IsRetryableRPCError(err) {
 			return invocationResultRetry{err: msg}

--- a/chasm/lib/callback/invocable_internal.go
+++ b/chasm/lib/callback/invocable_internal.go
@@ -67,7 +67,7 @@ func (c invocableInternal) Invoke(
 		destTag := metrics.DestinationTag(taskAttr.Destination)
 		outcomeTag := metrics.OutcomeTag(outcome)
 		h.metricsHandler.Counter(InternalRequestCounter.Name()).Record(1, namespaceTag, destTag, outcomeTag)
-		h.metricsHandler.Timer(InternalRequestLatencyHistogram.Name()).Record(time.Since(startTime), namespaceTag, destTag, outcomeTag)
+	outcome := outcomeUnknown
 	}()
 
 	header := nexus.Header(c.callback.GetHeader())

--- a/chasm/lib/callback/invocable_internal.go
+++ b/chasm/lib/callback/invocable_internal.go
@@ -61,13 +61,14 @@ func (c invocableInternal) Invoke(
 ) invocationResult {
 	// nolint:forbidigo // Wall-clock RPC measurement, not component state; Invoke has no chasm.Context.
 	startTime := time.Now()
-	outcome := outcomeSuccess
+	// Sentinel default: a return path that forgets to set outcome must not read as a success.
+	outcome := outcomeUnknown
 	defer func() {
 		namespaceTag := metrics.NamespaceTag(ns.Name().String())
 		destTag := metrics.DestinationTag(taskAttr.Destination)
 		outcomeTag := metrics.OutcomeTag(outcome)
 		h.metricsHandler.Counter(InternalRequestCounter.Name()).Record(1, namespaceTag, destTag, outcomeTag)
-	outcome := outcomeUnknown
+		h.metricsHandler.Timer(InternalRequestLatencyHistogram.Name()).Record(time.Since(startTime), namespaceTag, destTag, outcomeTag)
 	}()
 
 	header := nexus.Header(c.callback.GetHeader())
@@ -126,6 +127,7 @@ func (c invocableInternal) Invoke(
 		return invocationResultFail{msg}
 	}
 
+	outcome = outcomeSuccess
 	return invocationResultOK{}
 }
 

--- a/chasm/lib/callback/invocable_outbound.go
+++ b/chasm/lib/callback/invocable_outbound.go
@@ -97,12 +97,12 @@ func isRetryableCallError(err error) bool {
 func outcomeTag(callCtx context.Context, callErr error) string {
 	if callErr != nil {
 		if callCtx.Err() != nil {
-			return "request-timeout"
+			return outcomeRequestTimeout
 		}
 		if handlerErr, ok := errors.AsType[*nexus.HandlerError](callErr); ok {
 			return "handler-error:" + string(handlerErr.Type)
 		}
 		return "unknown-error"
 	}
-	return "success"
+	return outcomeSuccess
 }

--- a/chasm/lib/callback/metrics.go
+++ b/chasm/lib/callback/metrics.go
@@ -46,6 +46,9 @@ const (
 // Internal-path outcomes decided before the RPC is issued. Failures after it are tagged by
 // gRPC status code.
 const (
+	// outcomeUnknown is the sentinel Invoke starts from, so a path that returns without
+	// setting an outcome shows up as unknown rather than as a success.
+	outcomeUnknown           = "unknown"
 	outcomeSuccess           = "success"
 	outcomeMissingToken      = "missing-token"
 	outcomeTokenDecodeError  = "token-decode-error"

--- a/chasm/lib/callback/metrics.go
+++ b/chasm/lib/callback/metrics.go
@@ -13,4 +13,43 @@ var (
 		"callback_outbound_latency",
 		metrics.WithDescription("Latency histogram of outbound callback requests made by the history service."),
 	)
+
+	// Named separately from callback_outbound_* rather than sharing those names with a
+	// destination tag, so internal failures don't land in that metric's unscoped error alert.
+	InternalRequestCounter = metrics.NewCounterDef(
+		"callback_internal_requests",
+		metrics.WithDescription("The number of internal (cross-shard) callback deliveries made by the history service."),
+	)
+	InternalRequestLatencyHistogram = metrics.NewTimerDef(
+		"callback_internal_latency",
+		metrics.WithDescription("Latency histogram of internal (cross-shard) callback deliveries made by the history service."),
+	)
+
+	// Emitted for both the internal and outbound paths, once the transition has committed.
+	InvocationResultCounter = metrics.NewCounterDef(
+		"callback_invocation_results",
+		metrics.WithDescription("Committed callback invocation results, by disposition: succeeded, retrying, or failed. A failed result is terminal."),
+	)
+	InvocationAttemptsHistogram = metrics.NewDimensionlessHistogramDef(
+		"callback_invocation_attempts",
+		metrics.WithDescription("Attempts a callback had made on reaching a terminal disposition, by disposition."),
+	)
+)
+
+// Disposition tag values for InvocationResultCounter and InvocationAttemptsHistogram.
+const (
+	dispositionSucceeded = "succeeded"
+	dispositionRetrying  = "retrying"
+	dispositionFailed    = "failed"
+)
+
+// Internal-path outcomes decided before the RPC is issued. Failures after it are tagged by
+// gRPC status code.
+const (
+	outcomeSuccess           = "success"
+	outcomeMissingToken      = "missing-token"
+	outcomeTokenDecodeError  = "token-decode-error"
+	outcomeInvalidRef        = "invalid-ref"
+	outcomeRequestBuildError = "request-build-error"
+	outcomeRequestTimeout    = "request-timeout"
 )

--- a/chasm/lib/callback/tasks.go
+++ b/chasm/lib/callback/tasks.go
@@ -146,7 +146,45 @@ func (h *invocationTaskHandler) Execute(
 			retryPolicy: h.config.RetryPolicy(),
 		},
 	)
+	if saveErr == nil {
+		// Only after the transition commits; transitions can be rolled back.
+		h.recordDisposition(ns, taskAttr, task, result)
+	}
 	return invokable.WrapError(result, saveErr)
+}
+
+// recordDisposition emits the committed outcome of a single invocation.
+func (h *invocationTaskHandler) recordDisposition(
+	ns *namespace.Namespace,
+	taskAttr chasm.TaskAttributes,
+	task *callbackspb.InvocationTask,
+	result invocationResult,
+) {
+	var disposition string
+	switch result.(type) {
+	case invocationResultOK:
+		disposition = dispositionSucceeded
+	case invocationResultRetry:
+		disposition = dispositionRetrying
+	case invocationResultFail:
+		disposition = dispositionFailed
+	default:
+		// saveResult rejects anything else as an unprocessable task.
+		return
+	}
+
+	tags := []metrics.Tag{
+		metrics.NamespaceTag(ns.Name().String()),
+		metrics.DestinationTag(taskAttr.Destination),
+		metrics.OutcomeTag(disposition),
+	}
+	h.metricsHandler.Counter(InvocationResultCounter.Name()).Record(1, tags...)
+
+	if disposition != dispositionRetrying {
+		// Attempt is 0-based, so +1 is the count. Only terminal dispositions have a final total.
+		h.metricsHandler.Histogram(InvocationAttemptsHistogram.Name(), InvocationAttemptsHistogram.Unit()).
+			Record(int64(task.GetAttempt())+1, tags...)
+	}
 }
 
 type backoffTaskHandler struct {

--- a/chasm/lib/callback/tasks_test.go
+++ b/chasm/lib/callback/tasks_test.go
@@ -539,6 +539,48 @@ func TestExecuteInvocationTaskChasm_Outcomes(t *testing.T) {
 			wantAttemptSample:   true,
 		},
 		{
+			// The harness only sets CallbackTokenHeader when headerValue is non-empty.
+			name: "missing-token",
+			setupHistoryClient: func(t *testing.T, ctrl *gomock.Controller) resource.HistoryClient {
+				// No RPC call expected
+				return historyservicemock.NewMockHistoryServiceClient(ctrl)
+			},
+			completion: func() nexusrpc.CompleteOperationOptions {
+				return nexusrpc.CompleteOperationOptions{
+					Result: createPayloadBytes([]byte("result-data")),
+				}
+			}(),
+			headerValue: "",
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				require.ErrorContains(t, err, "internal error, reference-id:")
+				require.Equal(t, callbackspb.CALLBACK_STATUS_FAILED, cb.Status)
+			},
+			wantDeliveryOutcome: "missing-token",
+			wantDisposition:     "failed",
+			wantAttemptSample:   true,
+		},
+		{
+			// getHistoryRequest rejects a Result that isn't a *commonpb.Payload.
+			name: "request-build-error",
+			setupHistoryClient: func(t *testing.T, ctrl *gomock.Controller) resource.HistoryClient {
+				// No RPC call expected
+				return historyservicemock.NewMockHistoryServiceClient(ctrl)
+			},
+			completion: func() nexusrpc.CompleteOperationOptions {
+				return nexusrpc.CompleteOperationOptions{
+					Result: "not-a-payload",
+				}
+			}(),
+			headerValue: encodedRef,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				require.ErrorContains(t, err, "internal error, reference-id:")
+				require.Equal(t, callbackspb.CALLBACK_STATUS_FAILED, cb.Status)
+			},
+			wantDeliveryOutcome: "request-build-error",
+			wantDisposition:     "failed",
+			wantAttemptSample:   true,
+		},
+		{
 			name: "invalid-base64-header",
 			setupHistoryClient: func(t *testing.T, ctrl *gomock.Controller) resource.HistoryClient {
 				// No RPC call expected

--- a/chasm/lib/callback/tasks_test.go
+++ b/chasm/lib/callback/tasks_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nexus-rpc/sdk-go/nexus"
 	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/api/historyservicemock/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
@@ -22,6 +23,7 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/metrics/metricstest"
 	"go.temporal.io/server/common/namespace"
 	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/nexus/nexusrpc"
@@ -30,8 +32,6 @@ import (
 	queueserrors "go.temporal.io/server/service/history/queues/errors"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -86,7 +86,10 @@ func TestExecuteInvocationTaskNexus_Outcomes(t *testing.T) {
 		name                  string
 		caller                HTTPCaller
 		expectedMetricOutcome string
-		assertOutcome         func(*testing.T, *Callback, error)
+		// expectedDisposition is the outcome tag on callback_invocation_results, which is
+		// recorded for the outbound path as well as the internal one.
+		expectedDisposition string
+		assertOutcome       func(*testing.T, *Callback, error)
 	}{
 		{
 			name: "success",
@@ -94,6 +97,7 @@ func TestExecuteInvocationTaskNexus_Outcomes(t *testing.T) {
 				return &http.Response{StatusCode: 200, Body: http.NoBody}, nil
 			},
 			expectedMetricOutcome: "success",
+			expectedDisposition:   "succeeded",
 			assertOutcome: func(t *testing.T, cb *Callback, err error) {
 				require.NoError(t, err)
 				require.Equal(t, callbackspb.CALLBACK_STATUS_SUCCEEDED, cb.Status)
@@ -105,6 +109,7 @@ func TestExecuteInvocationTaskNexus_Outcomes(t *testing.T) {
 				return nil, errors.New("fake failure")
 			},
 			expectedMetricOutcome: "unknown-error",
+			expectedDisposition:   "retrying",
 			assertOutcome: func(t *testing.T, cb *Callback, err error) {
 				var destDownErr *queueserrors.DestinationDownError
 				require.ErrorAs(t, err, &destDownErr)
@@ -117,6 +122,7 @@ func TestExecuteInvocationTaskNexus_Outcomes(t *testing.T) {
 				return &http.Response{StatusCode: 500, Body: http.NoBody}, nil
 			},
 			expectedMetricOutcome: "handler-error:INTERNAL",
+			expectedDisposition:   "retrying",
 			assertOutcome: func(t *testing.T, cb *Callback, err error) {
 				var destDownErr *queueserrors.DestinationDownError
 				require.ErrorAs(t, err, &destDownErr)
@@ -129,6 +135,7 @@ func TestExecuteInvocationTaskNexus_Outcomes(t *testing.T) {
 				return &http.Response{StatusCode: 400, Body: http.NoBody}, nil
 			},
 			expectedMetricOutcome: "handler-error:BAD_REQUEST",
+			expectedDisposition:   "failed",
 			assertOutcome: func(t *testing.T, cb *Callback, err error) {
 				require.NoError(t, err)
 				require.Equal(t, callbackspb.CALLBACK_STATUS_FAILED, cb.Status)
@@ -168,6 +175,24 @@ func TestExecuteInvocationTaskNexus_Outcomes(t *testing.T) {
 				metrics.NamespaceTag("namespace-name"),
 				metrics.DestinationTag("http://localhost"),
 				metrics.OutcomeTag(tc.expectedMetricOutcome))
+
+			// The committed disposition is recorded for the outbound path too, not just the
+			// internal one, so a permanently dropped external callback is also visible.
+			dispositionTags := []metrics.Tag{
+				metrics.NamespaceTag("namespace-name"),
+				metrics.DestinationTag("http://localhost"),
+				metrics.OutcomeTag(tc.expectedDisposition),
+			}
+			dispositionCounter := metrics.NewMockCounterIface(ctrl)
+			metricsHandler.EXPECT().Counter(InvocationResultCounter.Name()).Return(dispositionCounter)
+			dispositionCounter.EXPECT().Record(int64(1), dispositionTags)
+			if tc.expectedDisposition != dispositionRetrying {
+				attemptHistogram := metrics.NewMockHistogramIface(ctrl)
+				metricsHandler.EXPECT().
+					Histogram(InvocationAttemptsHistogram.Name(), InvocationAttemptsHistogram.Unit()).
+					Return(attemptHistogram)
+				attemptHistogram.EXPECT().Record(int64(1), dispositionTags)
+			}
 
 			// Setup logger
 			logger := log.NewTestLogger()
@@ -357,6 +382,15 @@ func TestExecuteInvocationTaskChasm_Outcomes(t *testing.T) {
 		completion         nexusrpc.CompleteOperationOptions
 		headerValue        string
 		assertOutcome      func(*testing.T, *Callback, error)
+		// wantDeliveryOutcome is the outcome tag expected on callback_internal_requests.
+		// Every path through Invoke must record exactly one sample: this counter is the only
+		// evidence the delivery was attempted at all.
+		wantDeliveryOutcome string
+		// wantDisposition is the outcome tag expected on callback_invocation_results.
+		wantDisposition string
+		// wantAttemptSample is whether callback_invocation_attempts should be recorded, which
+		// happens only on a terminal disposition.
+		wantAttemptSample bool
 	}{
 		{
 			name: "success-with-successful-operation",
@@ -391,6 +425,9 @@ func TestExecuteInvocationTaskChasm_Outcomes(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, callbackspb.CALLBACK_STATUS_SUCCEEDED, cb.Status)
 			},
+			wantDeliveryOutcome: "success",
+			wantDisposition:     "succeeded",
+			wantAttemptSample:   true,
 		},
 		{
 			name: "success-with-failed-operation",
@@ -422,6 +459,9 @@ func TestExecuteInvocationTaskChasm_Outcomes(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, callbackspb.CALLBACK_STATUS_SUCCEEDED, cb.Status)
 			},
+			wantDeliveryOutcome: "success",
+			wantDisposition:     "succeeded",
+			wantAttemptSample:   true,
 		},
 		{
 			name: "retryable-rpc-error",
@@ -430,7 +470,7 @@ func TestExecuteInvocationTaskChasm_Outcomes(t *testing.T) {
 				client.EXPECT().CompleteNexusOperationChasm(
 					gomock.Any(),
 					gomock.Any(),
-				).Return(nil, status.Error(codes.Unavailable, "service unavailable"))
+				).Return(nil, serviceerror.NewUnavailable("service unavailable"))
 				return client
 			},
 			completion: func() nexusrpc.CompleteOperationOptions {
@@ -443,6 +483,9 @@ func TestExecuteInvocationTaskChasm_Outcomes(t *testing.T) {
 				require.ErrorContains(t, err, "internal error, reference-id:")
 				require.Equal(t, callbackspb.CALLBACK_STATUS_BACKING_OFF, cb.Status)
 			},
+			wantDeliveryOutcome: "error:Unavailable",
+			wantDisposition:     "retrying",
+			wantAttemptSample:   false,
 		},
 		{
 			name: "non-retryable-rpc-error",
@@ -451,7 +494,7 @@ func TestExecuteInvocationTaskChasm_Outcomes(t *testing.T) {
 				client.EXPECT().CompleteNexusOperationChasm(
 					gomock.Any(),
 					gomock.Any(),
-				).Return(nil, status.Error(codes.InvalidArgument, "invalid request"))
+				).Return(nil, serviceerror.NewInvalidArgument("invalid request"))
 				return client
 			},
 			completion: func() nexusrpc.CompleteOperationOptions {
@@ -464,6 +507,36 @@ func TestExecuteInvocationTaskChasm_Outcomes(t *testing.T) {
 				require.ErrorContains(t, err, "internal error, reference-id:")
 				require.Equal(t, callbackspb.CALLBACK_STATUS_FAILED, cb.Status)
 			},
+			wantDeliveryOutcome: "error:InvalidArgument",
+			wantDisposition:     "failed",
+			wantAttemptSample:   true,
+		},
+		{
+			// The failure mode this instrumentation exists for: the target component is gone
+			// (deleted scheduler, or a ref gone stale after a reset). NotFound is
+			// non-retryable, so the callback is dropped permanently here rather than retried.
+			name: "target-gone-not-found",
+			setupHistoryClient: func(t *testing.T, ctrl *gomock.Controller) resource.HistoryClient {
+				client := historyservicemock.NewMockHistoryServiceClient(ctrl)
+				client.EXPECT().CompleteNexusOperationChasm(
+					gomock.Any(),
+					gomock.Any(),
+				).Return(nil, serviceerror.NewNotFound("chasm component not found"))
+				return client
+			},
+			completion: func() nexusrpc.CompleteOperationOptions {
+				return nexusrpc.CompleteOperationOptions{
+					Result: createPayloadBytes([]byte("result-data")),
+				}
+			}(),
+			headerValue: encodedRef,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				require.ErrorContains(t, err, "internal error, reference-id:")
+				require.Equal(t, callbackspb.CALLBACK_STATUS_FAILED, cb.Status)
+			},
+			wantDeliveryOutcome: "error:NotFound",
+			wantDisposition:     "failed",
+			wantAttemptSample:   true,
 		},
 		{
 			name: "invalid-base64-header",
@@ -481,6 +554,9 @@ func TestExecuteInvocationTaskChasm_Outcomes(t *testing.T) {
 				require.ErrorContains(t, err, "internal error, reference-id:")
 				require.Equal(t, callbackspb.CALLBACK_STATUS_FAILED, cb.Status)
 			},
+			wantDeliveryOutcome: "token-decode-error",
+			wantDisposition:     "failed",
+			wantAttemptSample:   true,
 		},
 		{
 			name: "invalid-protobuf-in-ref",
@@ -498,6 +574,9 @@ func TestExecuteInvocationTaskChasm_Outcomes(t *testing.T) {
 				require.ErrorContains(t, err, "internal error, reference-id:")
 				require.Equal(t, callbackspb.CALLBACK_STATUS_FAILED, cb.Status)
 			},
+			wantDeliveryOutcome: "invalid-ref",
+			wantDisposition:     "failed",
+			wantAttemptSample:   true,
 		},
 	}
 
@@ -523,7 +602,10 @@ func TestExecuteInvocationTaskChasm_Outcomes(t *testing.T) {
 
 			// Setup logger, metricsHandler, and time source
 			logger := log.NewTestLogger()
-			metricsHandler := metrics.NoopMetricsHandler
+			capturingHandler := metricstest.NewCaptureHandler()
+			capture := capturingHandler.StartCapture()
+			defer capturingHandler.StopCapture(capture)
+			var metricsHandler metrics.Handler = capturingHandler
 			timeSource := clock.NewEventTimeSource()
 			timeSource.Update(time.Now())
 
@@ -661,6 +743,32 @@ func TestExecuteInvocationTaskChasm_Outcomes(t *testing.T) {
 			)
 
 			tc.assertOutcome(t, callback, err)
+
+			snapshot := capture.Snapshot()
+
+			delivery := snapshot[InternalRequestCounter.Name()]
+			require.Len(t, delivery, 1,
+				"every path through Invoke must record exactly one callback_internal_requests sample")
+			require.Equal(t, tc.wantDeliveryOutcome, delivery[0].Tags["outcome"])
+			require.Equal(t, "namespace-name", delivery[0].Tags["namespace"])
+			require.Len(t, snapshot[InternalRequestLatencyHistogram.Name()], 1,
+				"latency must be recorded alongside the request counter")
+
+			results := snapshot[InvocationResultCounter.Name()]
+			require.Len(t, results, 1)
+			require.Equal(t, tc.wantDisposition, results[0].Tags["outcome"])
+
+			attempts := snapshot[InvocationAttemptsHistogram.Name()]
+			if tc.wantAttemptSample {
+				require.Len(t, attempts, 1,
+					"a terminal disposition must record the attempt count")
+				require.Equal(t, tc.wantDisposition, attempts[0].Tags["outcome"])
+				// task.Attempt is 0-based, and the task below is built with Attempt: 1.
+				require.Equal(t, int64(2), attempts[0].Value)
+			} else {
+				require.Empty(t, attempts,
+					"a retrying disposition is not terminal, so the attempt count is not final")
+			}
 		})
 	}
 }

--- a/chasm/lib/scheduler/helper_test.go
+++ b/chasm/lib/scheduler/helper_test.go
@@ -110,7 +110,8 @@ func newTestLibrary(logger log.Logger, specProcessor scheduler.SpecProcessor) *s
 			BaseLogger:     logger,
 		}),
 		scheduler.NewSchedulerCallbacksTaskHandler(scheduler.SchedulerCallbacksTaskHandlerOptions{
-			Config: config,
+			Config:         config,
+			MetricsHandler: metrics.NoopMetricsHandler,
 		}),
 		scheduler.NewGeneratorTaskHandler(scheduler.GeneratorTaskHandlerOptions{
 			Config:         config,

--- a/chasm/lib/scheduler/scheduler_callbacks_reattach_internal_test.go
+++ b/chasm/lib/scheduler/scheduler_callbacks_reattach_internal_test.go
@@ -1,0 +1,208 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	schedulepb "go.temporal.io/api/schedule/v1"
+	"go.temporal.io/api/serviceerror"
+	workflowpb "go.temporal.io/api/workflow/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/api/historyservice/v1"
+	"go.temporal.io/server/api/historyservicemock/v1"
+	schedulespb "go.temporal.io/server/api/schedule/v1"
+	"go.temporal.io/server/chasm/lib/scheduler/gen/schedulerpb/v1"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/resource"
+	"go.temporal.io/server/common/testing/mockapi/workflowservicemock/v1"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// watchRunningStart decides, per buffered start, whether a completion callback was attached to
+// a still-running action or whether the action had already finished. Two of the "finished"
+// paths *synthesize* a result rather than reading one off the workflow -- a target that is
+// gone entirely is recorded TERMINATED, and one that closes mid-attach is recorded COMPLETED.
+// Those are the paths that were previously invisible, so the reason each result carries is
+// what ScheduleCallbackReattach is built on and is worth pinning down.
+func TestWatchRunningStart_ReattachClassification(t *testing.T) {
+	closeTime := timestamppb.New(time.Now().UTC())
+
+	cases := []struct {
+		name          string
+		setupHistory  func(*historyservicemock.MockHistoryServiceClient)
+		setupFrontend func(*workflowservicemock.MockWorkflowServiceClient)
+		wantReason    metrics.ReasonString
+		// wantStatus is zero when the callback was attached and the action is still running.
+		wantStatus enumspb.WorkflowExecutionStatus
+		wantErr    bool
+	}{
+		{
+			name: "attached to running workflow",
+			setupHistory: func(c *historyservicemock.MockHistoryServiceClient) {
+				c.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).Return(
+					&historyservice.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &workflowpb.WorkflowExecutionInfo{
+							Status: enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+						},
+					}, nil)
+			},
+			setupFrontend: func(c *workflowservicemock.MockWorkflowServiceClient) {
+				c.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).Return(
+					&workflowservice.StartWorkflowExecutionResponse{}, nil)
+			},
+			wantReason: reasonNone,
+		},
+		{
+			name: "paused workflow still counts as progressing",
+			setupHistory: func(c *historyservicemock.MockHistoryServiceClient) {
+				c.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).Return(
+					&historyservice.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &workflowpb.WorkflowExecutionInfo{
+							Status: enumspb.WORKFLOW_EXECUTION_STATUS_PAUSED,
+						},
+					}, nil)
+			},
+			setupFrontend: func(c *workflowservicemock.MockWorkflowServiceClient) {
+				c.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).Return(
+					&workflowservice.StartWorkflowExecutionResponse{}, nil)
+			},
+			wantReason: reasonNone,
+		},
+		{
+			name: "target gone entirely synthesizes TERMINATED",
+			setupHistory: func(c *historyservicemock.MockHistoryServiceClient) {
+				c.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).Return(
+					nil, serviceerror.NewNotFound("execution not found"))
+			},
+			setupFrontend: func(c *workflowservicemock.MockWorkflowServiceClient) {},
+			wantReason:    reasonReattachNotFound,
+			wantStatus:    enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED,
+		},
+		{
+			name: "already closed reports the observed status",
+			setupHistory: func(c *historyservicemock.MockHistoryServiceClient) {
+				c.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).Return(
+					&historyservice.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &workflowpb.WorkflowExecutionInfo{
+							Status:    enumspb.WORKFLOW_EXECUTION_STATUS_FAILED,
+							CloseTime: closeTime,
+						},
+					}, nil)
+			},
+			setupFrontend: func(c *workflowservicemock.MockWorkflowServiceClient) {},
+			wantReason:    reasonReattachAlreadyClosed,
+			wantStatus:    enumspb.WORKFLOW_EXECUTION_STATUS_FAILED,
+		},
+		{
+			name: "closed mid-attach synthesizes COMPLETED",
+			setupHistory: func(c *historyservicemock.MockHistoryServiceClient) {
+				c.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).Return(
+					&historyservice.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &workflowpb.WorkflowExecutionInfo{
+							Status: enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+						},
+					}, nil)
+			},
+			setupFrontend: func(c *workflowservicemock.MockWorkflowServiceClient) {
+				c.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).Return(
+					nil, serviceerror.NewWorkflowExecutionAlreadyStarted("already started", "req-id", "run-id"))
+			},
+			wantReason: reasonReattachRace,
+			wantStatus: enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+		},
+		{
+			name: "unexpected describe error is surfaced, not classified",
+			setupHistory: func(c *historyservicemock.MockHistoryServiceClient) {
+				c.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).Return(
+					nil, serviceerror.NewUnavailable("history unavailable"))
+			},
+			setupFrontend: func(c *workflowservicemock.MockWorkflowServiceClient) {},
+			wantErr:       true,
+		},
+		{
+			name: "unexpected attach error is surfaced, not classified",
+			setupHistory: func(c *historyservicemock.MockHistoryServiceClient) {
+				c.EXPECT().DescribeWorkflowExecution(gomock.Any(), gomock.Any()).Return(
+					&historyservice.DescribeWorkflowExecutionResponse{
+						WorkflowExecutionInfo: &workflowpb.WorkflowExecutionInfo{
+							Status: enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+						},
+					}, nil)
+			},
+			setupFrontend: func(c *workflowservicemock.MockWorkflowServiceClient) {
+				c.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).Return(
+					nil, errors.New("boom"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			historyClient := historyservicemock.NewMockHistoryServiceClient(ctrl)
+			frontendClient := workflowservicemock.NewMockWorkflowServiceClient(ctrl)
+			tc.setupHistory(historyClient)
+			tc.setupFrontend(frontendClient)
+
+			handler := &SchedulerCallbacksTaskHandler{
+				config: &Config{
+					EncodeInternalTokenWithEnvelope: func(string) bool { return true },
+				},
+				historyClient:  resource.HistoryClient(historyClient),
+				frontendClient: frontendClient,
+				metricsHandler: metrics.NoopMetricsHandler,
+			}
+
+			sched := &Scheduler{
+				SchedulerState: &schedulerpb.SchedulerState{
+					Namespace:   "ns",
+					NamespaceId: "ns-id",
+					ScheduleId:  "sched-id",
+					Schedule: &schedulepb.Schedule{
+						Action: &schedulepb.ScheduleAction{
+							Action: &schedulepb.ScheduleAction_StartWorkflow{
+								StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
+									WorkflowId:   "scheduled-wf",
+									WorkflowType: &commonpb.WorkflowType{Name: "scheduled-wf-type"},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			start := &schedulespb.BufferedStart{
+				RequestId:  "req-id",
+				WorkflowId: "scheduled-wf",
+				RunId:      "run-id",
+			}
+
+			result, err := handler.watchRunningStart(context.Background(), sched, start, []byte("ref"))
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Nil(t, result)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, tc.wantReason, result.reason)
+
+			if tc.wantStatus == enumspb.WORKFLOW_EXECUTION_STATUS_UNSPECIFIED {
+				require.Nil(t, result.completed,
+					"a successful attach must leave the start running so the callback reports its completion")
+				return
+			}
+			require.NotNil(t, result.completed)
+			require.Equal(t, tc.wantStatus, result.completed.Status)
+		})
+	}
+}

--- a/chasm/lib/scheduler/scheduler_tasks.go
+++ b/chasm/lib/scheduler/scheduler_tasks.go
@@ -127,6 +127,7 @@ type SchedulerCallbacksTaskHandlerOptions struct {
 	Config         *Config
 	HistoryClient  resource.HistoryClient
 	FrontendClient workflowservice.WorkflowServiceClient
+	MetricsHandler metrics.Handler
 }
 
 type SchedulerCallbacksTaskHandler struct {
@@ -134,6 +135,7 @@ type SchedulerCallbacksTaskHandler struct {
 	config         *Config
 	historyClient  resource.HistoryClient
 	frontendClient workflowservice.WorkflowServiceClient
+	metricsHandler metrics.Handler
 }
 
 func NewSchedulerCallbacksTaskHandler(opts SchedulerCallbacksTaskHandlerOptions) *SchedulerCallbacksTaskHandler {
@@ -141,6 +143,7 @@ func NewSchedulerCallbacksTaskHandler(opts SchedulerCallbacksTaskHandlerOptions)
 		config:         opts.Config,
 		historyClient:  opts.HistoryClient,
 		frontendClient: opts.FrontendClient,
+		metricsHandler: opts.MetricsHandler,
 	}
 }
 
@@ -149,6 +152,9 @@ func NewSchedulerCallbacksTaskHandler(opts SchedulerCallbacksTaskHandlerOptions)
 // workflow is still running.
 type watchResult struct {
 	completed *schedulespb.CompletedResult
+
+	// reason attributes how completed was arrived at, for ScheduleCallbackReattach.
+	reason metrics.ReasonString
 }
 
 func (r *SchedulerCallbacksTaskHandler) Execute(
@@ -237,6 +243,18 @@ func (r *SchedulerCallbacksTaskHandler) Execute(
 		return fmt.Errorf("failed to update component state: %w", err)
 	}
 
+	// Only after the update commits, so a rolled-back re-attach isn't counted.
+	metricsHandler := newTaggedMetricsHandler(r.metricsHandler, scheduler)
+	for _, result := range results {
+		outcome := outcomeReattachAttached
+		if result.completed != nil {
+			outcome = outcomeReattachCompleted
+		}
+		metrics.ScheduleCallbackReattach.With(metricsHandler).Record(1,
+			metrics.OutcomeTag(outcome),
+			metrics.ReasonTag(result.reason))
+	}
+
 	return nil
 }
 
@@ -267,6 +285,7 @@ func (r *SchedulerCallbacksTaskHandler) watchRunningStart(
 					Status:    enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED,
 					CloseTime: timestamppb.Now(),
 				},
+				reason: reasonReattachNotFound,
 			}, nil
 		}
 		return nil, err
@@ -282,6 +301,7 @@ func (r *SchedulerCallbacksTaskHandler) watchRunningStart(
 				Status:    wfInfo.GetStatus(),
 				CloseTime: wfInfo.GetCloseTime(),
 			},
+			reason: reasonReattachAlreadyClosed,
 		}, nil
 	}
 
@@ -322,13 +342,14 @@ func (r *SchedulerCallbacksTaskHandler) watchRunningStart(
 					Status:    enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
 					CloseTime: timestamppb.Now(),
 				},
+				reason: reasonReattachRace,
 			}, nil
 		}
 		return nil, err
 	}
 
 	// Callback attached successfully.
-	return &watchResult{}, nil
+	return &watchResult{reason: reasonNone}, nil
 }
 
 func (r *SchedulerCallbacksTaskHandler) Validate(

--- a/chasm/lib/scheduler/util.go
+++ b/chasm/lib/scheduler/util.go
@@ -66,6 +66,17 @@ const (
 // identical.
 const reasonNone metrics.ReasonString = "none"
 
+// Outcomes and reasons for ScheduleCallbackReattach. not_found and attach_race synthesize a
+// completion rather than observing one, so they are recorded distinctly from already_closed.
+const (
+	outcomeReattachAttached  = "attached"
+	outcomeReattachCompleted = "completed"
+
+	reasonReattachNotFound      metrics.ReasonString = "not_found"
+	reasonReattachAlreadyClosed metrics.ReasonString = "already_closed"
+	reasonReattachRace          metrics.ReasonString = "attach_race"
+)
+
 // validateTaskHighWaterMark validates a component's lastProcessedTime against a
 // task timestamp. A task is valid if its scheduled time is after the high water mark.
 // Immediate tasks (zero scheduled time) are always valid since they execute inline.

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1654,6 +1654,10 @@ var (
 		"schedule_callback_ignored",
 		WithDescription("Scheduler received a completion callback unassociated with any known running actions"),
 	)
+	ScheduleCallbackReattach = NewCounterDef(
+		"schedule_callback_reattach",
+		WithDescription("Outcomes of re-attaching a completion callback to an already-running action, used for migration and anti-entropy. The reason tag distinguishes a genuine attach from the paths that synthesize an action result: not_found (target gone, recorded TERMINATED) and attach_race (target closed mid-attach, recorded COMPLETED)."),
+	)
 
 	// Worker Versioning
 	WorkerDeploymentCreated                           = NewCounterDef("worker_deployment_created")

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -32,6 +32,7 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/metrics/metricstest"
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/primitives"
@@ -258,6 +259,18 @@ func registerGatedWorkflow(env *testcore.TestEnv, wt string, runs *atomic.Int32)
 	}, workflow.RegisterOptions{Name: wt})
 }
 
+// countMetric returns how many captured samples of metricName carry every tag in want.
+func countMetric(capture *testcore.NamespaceMetricCapture, metricName string, want map[string]string) int {
+	return len(capture.CollectMetric(metricName, func(rec *metricstest.CapturedRecording) bool {
+		for key, value := range want {
+			if rec.Tags[key] != value {
+				return false
+			}
+		}
+		return true
+	}))
+}
+
 // scheduleClosed reports whether the schedule has closed, i.e. DescribeSchedule
 // returns NotFound specifically (not just any error).
 func scheduleClosed(ctx context.Context, env *testcore.TestEnv, sid string) bool {
@@ -414,6 +427,11 @@ func TestScheduleCHASM(t *testing.T) {
 	t.Run("TestResetWithAdditionalCallback_HSMCallbacks", func(t *testing.T) { t.Parallel(); testResetWithAdditionalCallback(t, newContext, false) })
 	t.Run("TestResetWithAdditionalCallback_ChasmCallbacks", func(t *testing.T) { t.Parallel(); testResetWithAdditionalCallback(t, newContext, true) })
 	t.Run("TestMigrationCallbackAttach", func(t *testing.T) { t.Parallel(); testMigrationCallbackAttach(t, newContext) })
+	t.Run("TestMigrationCallbackReattachSynthesized", func(t *testing.T) {
+		t.Parallel()
+		testMigrationCallbackReattachSynthesized(t, newContext)
+	})
+	t.Run("TestCallbackCompletionMetrics", func(t *testing.T) { t.Parallel(); testCallbackCompletionMetrics(t, newContext) })
 	t.Run("TestCreatesWorkflowSentinel", func(t *testing.T) { t.Parallel(); testCreatesWorkflowSentinel(t, newContext) })
 	t.Run("TestSkipsWorkflowSentinelWhenDisabled", func(t *testing.T) { t.Parallel(); testSkipsWorkflowSentinelWhenDisabled(t, newContext) })
 	t.Run("TestLargeScheduleID", func(t *testing.T) { t.Parallel(); testLargeScheduleID(t, newContext) })
@@ -3561,32 +3579,18 @@ func testPatchRejectsExcessBackfillers(t *testing.T, newContext contextFactory) 
 	s.Contains(err.Error(), "too many concurrent backfillers")
 }
 
-func testMigrationCallbackAttach(t *testing.T, newContext contextFactory) {
-	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
-
-	sid := testcore.RandomizeStr("sid")
-	wid := testcore.RandomizeStr("wid")
-	wt := testcore.RandomizeStr("wt")
-
-	resumeSignal := "resume"
-	s.SdkWorker().RegisterWorkflowWithOptions(
-		func(ctx workflow.Context) error {
-			workflow.GetSignalChannel(ctx, resumeSignal).Receive(ctx, nil)
-			return nil
-		},
-		workflow.RegisterOptions{Name: wt},
-	)
-
-	ctx := newContext(s.Context())
-	startResp, err := s.FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
-		Namespace:    s.Namespace().String(),
-		WorkflowId:   wid,
-		WorkflowType: &commonpb.WorkflowType{Name: wt},
-		TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
-		Identity:     testcore.RandomizeStr("identity"),
-		RequestId:    testcore.RandomizeStr("request-id"),
-	})
-	s.NoError(err)
+// createSchedulerFromMigrationState creates a V2 scheduler directly from a migration
+// state carrying a single BufferedStart pointing at (wid, runID). That start is what
+// arms the callback re-attach task: it is the only path that produces a start with a
+// RunId but no callback attached, so it is the only way to reach
+// SchedulerCallbacksTaskHandler in a running server.
+func createSchedulerFromMigrationState(
+	ctx context.Context,
+	t *testing.T,
+	s *testcore.TestEnv,
+	sid, wid, wt, runID string,
+) {
+	t.Helper()
 
 	schedule := &schedulepb.Schedule{
 		Spec: &schedulepb.ScheduleSpec{
@@ -3625,7 +3629,7 @@ func testMigrationCallbackAttach(t *testing.T, newContext contextFactory) {
 					ActualTime:  timestamppb.New(now),
 					StartTime:   timestamppb.New(now),
 					WorkflowId:  wid,
-					RunId:       startResp.RunId,
+					RunId:       runID,
 					RequestId:   uuid.NewString(),
 					Attempt:     1,
 					HasCallback: false,
@@ -3633,14 +3637,57 @@ func testMigrationCallbackAttach(t *testing.T, newContext contextFactory) {
 			},
 		},
 	}
-	_, err = s.GetTestCluster().SchedulerClient().CreateFromMigrationState(
+	_, err := s.GetTestCluster().SchedulerClient().CreateFromMigrationState(
 		ctx,
 		&schedulerpb.CreateFromMigrationStateRequest{
 			NamespaceId: nsID,
 			State:       migrationState,
 		},
 	)
+	require.NoError(t, err)
+}
+
+// awaitReattachMetric waits for a schedule_callback_reattach sample with the given
+// outcome and reason. The counter is recorded only after the re-attach's component
+// update commits, so it lags the state it describes.
+func awaitReattachMetric(t *testing.T, capture *testcore.NamespaceMetricCapture, outcome, reason string) {
+	t.Helper()
+	want := map[string]string{"outcome": outcome, "reason": reason}
+	await.RequireTruef(t, func() bool {
+		return countMetric(capture, metrics.ScheduleCallbackReattach.Name(), want) >= 1
+	}, awaitTimeout, pollInterval, "re-attach should record outcome=%s reason=%s", outcome, reason)
+}
+
+func testMigrationCallbackAttach(t *testing.T, newContext contextFactory) {
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+
+	sid := testcore.RandomizeStr("sid")
+	wid := testcore.RandomizeStr("wid")
+	wt := testcore.RandomizeStr("wt")
+
+	resumeSignal := "resume"
+	s.SdkWorker().RegisterWorkflowWithOptions(
+		func(ctx workflow.Context) error {
+			workflow.GetSignalChannel(ctx, resumeSignal).Receive(ctx, nil)
+			return nil
+		},
+		workflow.RegisterOptions{Name: wt},
+	)
+
+	ctx := newContext(testcontext.For(t))
+	metricCapture := s.StartNamespaceMetricCapture()
+	startResp, err := s.FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
+		Namespace:    s.Namespace().String(),
+		WorkflowId:   wid,
+		WorkflowType: &commonpb.WorkflowType{Name: wt},
+		TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		Identity:     testcore.RandomizeStr("identity"),
+		RequestId:    testcore.RandomizeStr("request-id"),
+	})
 	s.NoError(err)
+
+	nsID := s.NamespaceID().String()
+	createSchedulerFromMigrationState(ctx, t, s, sid, wid, wt, startResp.RunId)
 
 	s.Eventually(func() bool {
 		descResp, err := s.GetTestCluster().SchedulerClient().DescribeSchedule(
@@ -3656,6 +3703,17 @@ func testMigrationCallbackAttach(t *testing.T, newContext contextFactory) {
 		running := descResp.GetFrontendResponse().GetInfo().GetRunningWorkflows()
 		return len(running) > 0 && running[0].WorkflowId == wid
 	}, 15*time.Second, 500*time.Millisecond, "CHASM scheduler should show running workflow")
+
+	// A genuine attach: the target was running when the re-attach task ran, so the
+	// completion below is observed over a callback rather than synthesized from a
+	// describe. reason=none is what separates it from the two synthesizing paths covered
+	// by testMigrationCallbackReattachSynthesized.
+	//
+	// This must be waited on before signaling: RunningWorkflows is populated straight
+	// from the migration state and says nothing about whether the callback was attached
+	// yet, so completing the target first would let the re-attach describe an
+	// already-closed workflow and take the already_closed path instead.
+	awaitReattachMetric(t, metricCapture, "attached", "none")
 
 	_, err = s.FrontendClient().SignalWorkflowExecution(ctx, &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace: s.Namespace().String(),
@@ -3687,6 +3745,194 @@ func testMigrationCallbackAttach(t *testing.T, newContext contextFactory) {
 		}
 		return false
 	}, 15*time.Second, 500*time.Millisecond, "CHASM scheduler should reflect workflow completion")
+
+	// The re-attached callback delivers over the same internal path as a natively
+	// started action, so the delivery must be instrumented here too.
+	requireInternalCallbackDelivered(t, metricCapture)
+}
+
+// requireInternalCallbackDelivered asserts that at least one completion callback was
+// delivered over the internal (cross-shard) path and that the delivery is fully
+// instrumented: a successful delivery sample, a committed disposition, an attempt
+// count, and no sample left at the "unknown" sentinel -- an outcome that would mean a
+// return path recorded no outcome at all, which is indistinguishable from never having
+// run.
+func requireInternalCallbackDelivered(t *testing.T, capture *testcore.NamespaceMetricCapture) {
+	t.Helper()
+
+	// The disposition is recorded after the callback's own state transition commits,
+	// which is strictly after the scheduler observed the completion, so poll.
+	await.RequireTruef(t, func() bool {
+		return countMetric(capture, callback.InvocationResultCounter.Name(),
+			map[string]string{"outcome": "succeeded", "destination": chasm.NexusCompletionHandlerURL}) >= 1
+	}, awaitTimeout, pollInterval, "a committed callback disposition should be recorded")
+
+	deliveries := capture.Metric(callback.InternalRequestCounter.Name())
+	require.NotEmpty(t, deliveries, "internal callback delivery should be counted")
+	for _, delivery := range deliveries {
+		require.NotEqual(t, "unknown", delivery.Tags["outcome"],
+			"a delivery returned without recording an outcome")
+		require.Equal(t, chasm.NexusCompletionHandlerURL, delivery.Tags["destination"])
+	}
+	require.GreaterOrEqual(t,
+		countMetric(capture, callback.InternalRequestCounter.Name(), map[string]string{"outcome": "success"}), 1,
+		"a successful internal delivery should be counted")
+
+	// Counter and latency are recorded together on every exit path, so a latency sample
+	// missing against a counted request means a path skipped the deferred record.
+	await.RequireTruef(t, func() bool {
+		return len(capture.Metric(callback.InternalRequestLatencyHistogram.Name())) ==
+			len(capture.Metric(callback.InternalRequestCounter.Name()))
+	}, awaitTimeout, pollInterval, "every counted delivery should also record a latency sample")
+
+	// Attempts are recorded only on a terminal disposition, where the total is final.
+	attempts := capture.CollectMetric(callback.InvocationAttemptsHistogram.Name(),
+		func(rec *metricstest.CapturedRecording) bool { return rec.Tags["outcome"] == "succeeded" })
+	require.NotEmpty(t, attempts, "a terminal disposition should record an attempt count")
+	require.GreaterOrEqual(t, attempts[0].Value, int64(1))
+
+	require.Zero(t, countMetric(capture, callback.InvocationResultCounter.Name(),
+		map[string]string{"outcome": "failed"}), "no callback should have been dropped permanently")
+}
+
+// testCallbackCompletionMetrics pins the instrumentation on the V2 completion-callback
+// delivery path for a natively started action. The schedule learns its action finished
+// only through that callback, so a delivery that is dropped leaves the schedule
+// believing the action is still running -- and before this instrumentation that drop
+// left no trace beyond a log line.
+func testCallbackCompletionMetrics(t *testing.T, newContext contextFactory) {
+	s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+	// The instrumented delivery path is the CHASM callback implementation. It is the
+	// default, but pin it: under the HSM implementation these metrics never fire.
+	s.OverrideDynamicConfig(dynamicconfig.EnableCHASMCallbacks, true)
+
+	sid := testcore.RandomizeStr("sched-callback-metrics")
+	wid := testcore.RandomizeStr("sched-callback-metrics-wf")
+	wt := testcore.RandomizeStr("sched-callback-metrics-wt")
+
+	var runs atomic.Int32
+	registerCountingWorkflow(s, wt, &runs)
+
+	ctx := newContext(testcontext.For(t))
+	metricCapture := s.StartNamespaceMetricCapture()
+
+	createSchedule(ctx, t, s, sid, &schedulepb.Schedule{
+		Spec:   intervalSpec(noOpInterval),
+		Action: startWorkflowAction(s, wid, wt),
+	})
+	patchSchedule(ctx, t, s, sid, triggerPatch(enumspb.SCHEDULE_OVERLAP_POLICY_UNSPECIFIED))
+
+	// A COMPLETED recent action is proof the callback landed: nothing else tells the
+	// schedule the workflow finished.
+	await.RequireTruef(t, func() bool {
+		desc, err := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+			Namespace:  s.Namespace().String(),
+			ScheduleId: sid,
+		})
+		if err != nil {
+			return false
+		}
+		actions := desc.GetInfo().GetRecentActions()
+		return len(actions) == 1 &&
+			actions[0].GetStartWorkflowStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED
+	}, awaitTimeout, pollInterval, "the triggered action should be observed as completed")
+	require.Equal(t, int32(1), runs.Load())
+
+	requireInternalCallbackDelivered(t, metricCapture)
+
+	// A natively started action attaches its callback at start time, so the re-attach
+	// path -- and its counter -- must not be involved.
+	require.Empty(t, metricCapture.Metric(metrics.ScheduleCallbackReattach.Name()))
+}
+
+// testMigrationCallbackReattachSynthesized covers the two re-attach classifications
+// that synthesize an action result instead of observing one. Both fabricate a
+// completion for the schedule from a describe rather than from a callback, so they are
+// the paths where a migrated schedule can silently record an outcome the workflow never
+// had.
+func testMigrationCallbackReattachSynthesized(t *testing.T, newContext contextFactory) {
+	cases := []struct {
+		name string
+		// targetMissing points the buffered start at a workflow that never existed,
+		// standing in for a target deleted before the migration's re-attach ran.
+		targetMissing bool
+		wantReason    string
+		wantStatus    enumspb.WorkflowExecutionStatus
+	}{
+		{
+			name:       "AlreadyClosed",
+			wantReason: "already_closed",
+			wantStatus: enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+		},
+		{
+			// Target gone: recorded TERMINATED, because the real outcome is unknowable.
+			name:          "TargetGone",
+			targetMissing: true,
+			wantReason:    "not_found",
+			wantStatus:    enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := newScheduleEnv(t, scheduleCommonOpts(t)...)
+
+			sid := testcore.RandomizeStr("sched-reattach")
+			wid := testcore.RandomizeStr("sched-reattach-wf")
+			wt := testcore.RandomizeStr("sched-reattach-wt")
+
+			ctx := newContext(testcontext.For(t))
+			metricCapture := s.StartNamespaceMetricCapture()
+
+			runID := uuid.NewString()
+			if !tc.targetMissing {
+				var runs atomic.Int32
+				registerCountingWorkflow(s, wt, &runs)
+				startResp, err := s.FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
+					Namespace:    s.Namespace().String(),
+					WorkflowId:   wid,
+					WorkflowType: &commonpb.WorkflowType{Name: wt},
+					TaskQueue:    &taskqueuepb.TaskQueue{Name: s.WorkerTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+					Identity:     testcore.RandomizeStr("identity"),
+					RequestId:    testcore.RandomizeStr("request-id"),
+				})
+				require.NoError(t, err)
+				runID = startResp.RunId
+
+				// Close it before migrating, so the re-attach describes a workflow that is
+				// already finished rather than racing one that is still running.
+				await.RequireTruef(t, func() bool {
+					desc, err := s.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+						Namespace: s.Namespace().String(),
+						Execution: &commonpb.WorkflowExecution{WorkflowId: wid, RunId: runID},
+					})
+					return err == nil &&
+						desc.GetWorkflowExecutionInfo().GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED
+				}, awaitTimeout, pollInterval, "target workflow should close before migration")
+			}
+
+			createSchedulerFromMigrationState(ctx, t, s, sid, wid, wt, runID)
+
+			awaitReattachMetric(t, metricCapture, "completed", tc.wantReason)
+
+			// The synthesized result must also reach the schedule's own view, not just
+			// the counter.
+			desc, err := s.FrontendClient().DescribeSchedule(ctx, &workflowservice.DescribeScheduleRequest{
+				Namespace:  s.Namespace().String(),
+				ScheduleId: sid,
+			})
+			require.NoError(t, err)
+			require.Empty(t, desc.GetInfo().GetRunningWorkflows())
+			actions := desc.GetInfo().GetRecentActions()
+			require.Len(t, actions, 1)
+			require.Equal(t, wid, actions[0].GetStartWorkflowResult().GetWorkflowId())
+			require.Equal(t, tc.wantStatus, actions[0].GetStartWorkflowStatus())
+
+			// Nothing was actually attached, so no delivery should have been attempted.
+			require.Empty(t, metricCapture.Metric(callback.InternalRequestCounter.Name()))
+		})
+	}
 }
 
 // testCHASMCanListV1Schedules tests that a schedule created in the V1 stack


### PR DESCRIPTION
Adds some instrumentation around the callback path. 

## LLM Summary

The callback delivery path needs more instrumentation. Nothing currently covers it:

- `callback_outbound_requests` / `callback_outbound_latency` are recorded only in `invocable_outbound.go`, i.e. for external HTTP callbacks. That's why the `CallbackOutboundErrors` alert does not cover Schedules despite the name.
- The generic queue metrics can't substitute: `task_errors` carries no `destination` tag, and the callback task's `archetype` is the *target workflow's*, so `OutboundActive.callback.invoke` mixes internal scheduler callbacks with customer-facing Nexus ones and cannot be split.
- The state machine has no counter on any transition, so a callback reaching `CALLBACK_STATUS_FAILED` — dropped permanently, never retried — leaves no trace but an error log.

## What this adds

**1. `callback_internal_requests` / `callback_internal_latency`** — recorded on every exit path of `invocableInternal.Invoke` via `defer`, tagged `namespace` / `destination` / `outcome`. The four pre-flight failures that were previously log-only each get a distinct outcome (`missing-token`, `token-decode-error`, `invalid-ref`, `request-build-error`).

RPC failures are tagged by **gRPC status code** rather than a coarse retryable bool, deliberately: `NotFound` is the code that means the target component is gone — a deleted scheduler, or a ref gone stale after a reset — and it is non-retryable, so the callback is dropped permanently at that point. That's the failure mode with no detection today, and it deserves its own label value rather than being lumped into "error".

Named separately from `callback_outbound_*` rather than sharing those names with a `destination` tag, because the alert on `callback_outbound_requests` is an **unscoped error ratio**: folding internal deliveries into it would attribute internal failures to the outbound callback owners and page the wrong team. Happy to revisit if @temporalio/nexus would rather share the name and scope their alert instead.

**2. `callback_invocation_results` / `callback_invocation_attempts`** — emitted for **both** the internal and outbound paths from `invocationTaskHandler.Execute`, once the transition has committed.

Not from the transition functions themselves: those run inside the CHASM transaction and can be rolled back, so emitting there would count dispositions that never took effect. The attempt histogram is recorded only on a terminal disposition, where the total is final — so attempts burned by a permanently dropped callback are distinguishable from those of one that eventually succeeded.

**3. `schedule_callback_reattach`** — the scheduler's callback re-attach task had **no `MetricsHandler` injected at all**. Its `reason` tag separates a genuine attach from the two paths that *synthesize* an action result rather than observing one: `not_found` (target gone, recorded `TERMINATED`) and `attach_race` (target closed between the describe and the attach, recorded `COMPLETED`). Both fabricate a completion for the schedule, and both were silent.

## Tests

- The existing internal- and outbound-path outcome tables now assert the recorded samples, including that **every path through `Invoke` records exactly one delivery sample** — a path that returns without one is indistinguishable from a path that never ran, which is the bug class this PR exists to fix.
- `TestWatchRunningStart_ReattachClassification` — the first coverage of the re-attach path at all. Pins the four classifications and confirms unexpected errors are surfaced rather than misclassified as a completion.
- Both new assertion sets were negative-controlled (deliberately broken to confirm they fail).

`make lint-code-fast` clean, `go build ./...` clean, `./chasm/...` and `./service/history/hsm/...` green.

## Reviewer notes

- **One `nolint:forbidigo`** for `time.Now` in `invocable_internal.go`, with justification: the `ctx.Now` rule exists to keep component state transitions deterministic under replay, and this is a wall-clock measurement of an RPC, not state — `Invoke` receives a plain `context.Context` with no component to call `ctx.Now` on. Note `invocable_outbound.go:68` already does the same thing unannotated; I left it alone rather than widening the diff, but it's the same call.
- `helper_test.go` needed `MetricsHandler` added where it constructs `SchedulerCallbacksTaskHandler`, otherwise the newly-injected handler is nil and the lifecycle harness panics.