### PR TITLE
Backport release/1.32.0 labeled fixes

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1714,6 +1714,20 @@ leaves the membership ring, giving in-flight long-polls time to drain before the
 
 	// keys for history
 
+	EnablePaginationTokenBranchValidation = NewGlobalBoolSetting(
+		"history.enablePaginationTokenBranchValidation",
+		true,
+		`EnablePaginationTokenBranchValidation enables checking that the branch token in a
+GetWorkflowExecutionHistory(Reverse) page token is the current branch token of the requested
+execution.`,
+	)
+	EnablePaginationTokenBranchValidationShadowMode = NewGlobalBoolSetting(
+		"history.enablePaginationTokenBranchValidationShadowMode",
+		false,
+		`EnablePaginationTokenBranchValidationShadowMode logs and emits metrics for a page token whose
+branch token is not the execution's current one, but still serves the read.`,
+	)
+
 	EnableReplicationStream = NewGlobalBoolSetting(
 		"history.enableReplicationStream",
 		true,

--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -259,6 +259,11 @@ func WorkflowBranchToken(branchToken []byte) ZapTag {
 	return NewBinaryTag("wf-branch-token", branchToken)
 }
 
+// WorkflowRequestBranchToken returns tag for a branch token supplied by the caller
+func WorkflowRequestBranchToken(branchToken []byte) ZapTag {
+	return NewBinaryTag("wf-request-branch-token", branchToken)
+}
+
 // WorkflowTreeID returns tag for WorkflowTreeID
 func WorkflowTreeID(treeID string) ZapTag {
 	return NewStringTag("wf-tree-id", treeID)

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1012,6 +1012,7 @@ var (
 	FailedWorkflowTasksCounter                    = NewCounterDef("failed_workflow_tasks")
 	WorkflowTaskAttempt                           = NewDimensionlessHistogramDef("workflow_task_attempt")
 	StaleMutableStateCounter                      = NewCounterDef("stale_mutable_state")
+	PaginationTokenBranchMismatchCounter          = NewCounterDef("pagination_token_branch_mismatch")
 	AutoResetPointsLimitExceededCounter           = NewCounterDef("auto_reset_points_exceed_limit")
 	AutoResetPointCorruptionCounter               = NewCounterDef("auto_reset_point_corruption")
 	BatchableTaskBatchCount                       = NewGaugeDef("batchable_task_batch_count")

--- a/common/persistence/visibility/store/elasticsearch/query_converter.go
+++ b/common/persistence/visibility/store/elasticsearch/query_converter.go
@@ -6,25 +6,29 @@ import (
 
 	"github.com/olivere/elastic/v7"
 	"github.com/temporalio/sqlparser"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence/visibility/store/query"
+	"go.temporal.io/server/common/searchattribute"
 )
 
-type queryConverter struct{}
+type esQueryConverter struct{}
 
-var _ query.StoreQueryConverter[elastic.Query] = (*queryConverter)(nil)
+var _ query.StoreQueryConverter[elastic.Query] = (*esQueryConverter)(nil)
 
-func (c *queryConverter) GetDatetimeFormat() string {
+func (c *esQueryConverter) GetDatetimeFormat() string {
 	return time.RFC3339Nano
 }
 
-func (c *queryConverter) BuildParenExpr(expr elastic.Query) (elastic.Query, error) {
+func (c *esQueryConverter) BuildParenExpr(expr elastic.Query) (elastic.Query, error) {
 	if expr == nil {
 		return nil, nil
 	}
 	return expr, nil
 }
 
-func (c *queryConverter) BuildNotExpr(expr elastic.Query) (elastic.Query, error) {
+func (c *esQueryConverter) BuildNotExpr(expr elastic.Query) (elastic.Query, error) {
 	if expr == nil {
 		return nil, nil
 	}
@@ -37,7 +41,7 @@ func (c *queryConverter) BuildNotExpr(expr elastic.Query) (elastic.Query, error)
 	return newBoolQuery().MustNot(expr), nil
 }
 
-func (c *queryConverter) BuildAndExpr(exprs ...elastic.Query) (elastic.Query, error) {
+func (c *esQueryConverter) BuildAndExpr(exprs ...elastic.Query) (elastic.Query, error) {
 	var reusableBoolQuery *boolQuery
 	validExprs := make([]elastic.Query, 0, len(exprs))
 	for _, e := range exprs {
@@ -65,7 +69,7 @@ func (c *queryConverter) BuildAndExpr(exprs ...elastic.Query) (elastic.Query, er
 	return newBoolQuery().Filter(validExprs...), nil
 }
 
-func (c *queryConverter) BuildOrExpr(exprs ...elastic.Query) (elastic.Query, error) {
+func (c *esQueryConverter) BuildOrExpr(exprs ...elastic.Query) (elastic.Query, error) {
 	var reusableBoolQuery *boolQuery
 	validExprs := make([]elastic.Query, 0, len(exprs))
 	for _, e := range exprs {
@@ -93,7 +97,7 @@ func (c *queryConverter) BuildOrExpr(exprs ...elastic.Query) (elastic.Query, err
 	return newBoolQuery().Should(validExprs...).MinimumNumberShouldMatch(1), nil
 }
 
-func (c *queryConverter) ConvertComparisonExpr(
+func (c *esQueryConverter) ConvertComparisonExpr(
 	operator string,
 	col *query.SAColumn,
 	value any,
@@ -126,7 +130,7 @@ func (c *queryConverter) ConvertComparisonExpr(
 	return res, nil
 }
 
-func (c *queryConverter) ConvertKeywordComparisonExpr(
+func (c *esQueryConverter) ConvertKeywordComparisonExpr(
 	operator string,
 	col *query.SAColumn,
 	value any,
@@ -152,7 +156,7 @@ func (c *queryConverter) ConvertKeywordComparisonExpr(
 	}
 }
 
-func (c *queryConverter) ConvertKeywordListComparisonExpr(
+func (c *esQueryConverter) ConvertKeywordListComparisonExpr(
 	operator string,
 	col *query.SAColumn,
 	value any,
@@ -160,7 +164,7 @@ func (c *queryConverter) ConvertKeywordListComparisonExpr(
 	return c.ConvertKeywordComparisonExpr(operator, col, value)
 }
 
-func (c *queryConverter) ConvertTextComparisonExpr(
+func (c *esQueryConverter) ConvertTextComparisonExpr(
 	operator string,
 	col *query.SAColumn,
 	value any,
@@ -176,7 +180,7 @@ func (c *queryConverter) ConvertTextComparisonExpr(
 	}
 }
 
-func (c *queryConverter) ConvertRangeExpr(
+func (c *esQueryConverter) ConvertRangeExpr(
 	operator string,
 	col *query.SAColumn,
 	from, to any,
@@ -198,7 +202,7 @@ func (c *queryConverter) ConvertRangeExpr(
 	}
 }
 
-func (c *queryConverter) ConvertIsExpr(
+func (c *esQueryConverter) ConvertIsExpr(
 	operator string,
 	col *query.SAColumn,
 ) (elastic.Query, error) {
@@ -216,4 +220,21 @@ func (c *queryConverter) ConvertIsExpr(
 			query.InvalidExpressionErrMessage,
 		)
 	}
+}
+
+func NewQueryConverter(
+	namespaceName namespace.Name,
+	saTypeMap searchattribute.NameTypeMap,
+	saMapper searchattribute.Mapper,
+	metricsHandler metrics.Handler,
+	logger log.Logger,
+) *query.QueryConverter[elastic.Query] {
+	return query.NewQueryConverter(
+		&esQueryConverter{},
+		namespaceName,
+		saTypeMap,
+		saMapper,
+		metricsHandler,
+		logger,
+	)
 }

--- a/common/persistence/visibility/store/elasticsearch/query_converter_test.go
+++ b/common/persistence/visibility/store/elasticsearch/query_converter_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestQueryConverter_GetDatetimeFormat(t *testing.T) {
-	qc := &queryConverter{}
+	qc := &esQueryConverter{}
 	require.Equal(t, time.RFC3339Nano, qc.GetDatetimeFormat())
 }
 
@@ -43,7 +43,7 @@ func TestQueryConverter_BuildParenExpr(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := require.New(t)
-			qc := &queryConverter{}
+			qc := &esQueryConverter{}
 			out, err := qc.BuildParenExpr(tc.in)
 			r.NoError(err)
 			r.Equal(tc.out, out)
@@ -88,7 +88,7 @@ func TestQueryConverter_BuildNotExpr(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := require.New(t)
-			qc := &queryConverter{}
+			qc := &esQueryConverter{}
 			out, err := qc.BuildNotExpr(tc.in)
 			r.NoError(err)
 			r.Equal(tc.out, out)
@@ -169,7 +169,7 @@ func TestQueryConverter_BuildAndExpr(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := require.New(t)
-			qc := &queryConverter{}
+			qc := &esQueryConverter{}
 			out, err := qc.BuildAndExpr(tc.in...)
 			r.NoError(err)
 			r.Equal(tc.out, out)
@@ -250,7 +250,7 @@ func TestQueryConverter_BuildOrExpr(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := require.New(t)
-			qc := &queryConverter{}
+			qc := &esQueryConverter{}
 			out, err := qc.BuildOrExpr(tc.in...)
 			r.NoError(err)
 			r.Equal(tc.out, out)
@@ -346,7 +346,7 @@ func TestQueryConverter_ConvertComparisonExpr(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := require.New(t)
-			qc := &queryConverter{}
+			qc := &esQueryConverter{}
 			out, err := qc.ConvertComparisonExpr(tc.operator, tc.col, tc.value)
 			if tc.err != "" {
 				r.Error(err)
@@ -483,7 +483,7 @@ func TestQueryConverter_ConvertKeywordComparisonExpr(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := require.New(t)
-			qc := &queryConverter{}
+			qc := &esQueryConverter{}
 			out, err := qc.ConvertKeywordComparisonExpr(tc.operator, tc.col, tc.value)
 			if tc.err != "" {
 				r.Error(err)
@@ -558,7 +558,7 @@ func TestQueryConverter_ConvertKeywordListComparisonExpr(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := require.New(t)
-			qc := &queryConverter{}
+			qc := &esQueryConverter{}
 			out, err := qc.ConvertKeywordListComparisonExpr(tc.operator, tc.col, tc.value)
 			if tc.err != "" {
 				r.Error(err)
@@ -617,7 +617,7 @@ func TestQueryConverter_ConvertTextComparisonExpr(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := require.New(t)
-			qc := &queryConverter{}
+			qc := &esQueryConverter{}
 			out, err := qc.ConvertTextComparisonExpr(tc.operator, tc.col, tc.value)
 			if tc.err != "" {
 				r.Error(err)
@@ -681,7 +681,7 @@ func TestQueryConverter_ConvertRangeExpr(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := require.New(t)
-			qc := &queryConverter{}
+			qc := &esQueryConverter{}
 			out, err := qc.ConvertRangeExpr(tc.operator, tc.col, tc.from, tc.to)
 			if tc.err != "" {
 				r.Error(err)
@@ -736,7 +736,7 @@ func TestQueryConverter_ConvertIsExpr(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := require.New(t)
-			qc := &queryConverter{}
+			qc := &esQueryConverter{}
 			out, err := qc.ConvertIsExpr(tc.operator, tc.col)
 			if tc.err != "" {
 				r.Error(err)

--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -908,7 +908,7 @@ func (s *VisibilityStore) GetListWorkflowExecutionsResponse(
 		lastHitSort = hit.Sort
 	}
 
-	if len(searchResult.Hits.Hits) > 0 { // this means the response might not the last page
+	if len(searchResult.Hits.Hits) == pageSize { // this means the response might not the last page
 		response.NextPageToken, err = s.serializePageToken(&visibilityPageToken{
 			SearchAfter: lastHitSort,
 		})

--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -763,14 +763,8 @@ func (s *VisibilityStore) convertQuery(
 		return nil, err
 	}
 
-	c := query.NewQueryConverter(
-		&queryConverter{},
-		namespaceName,
-		saTypeMap,
-		saMapper,
-		s.metricsHandler,
-		s.logger,
-	).WithChasmMapper(chasmMapper).
+	c := NewQueryConverter(namespaceName, saTypeMap, saMapper, s.metricsHandler, s.logger).
+		WithChasmMapper(chasmMapper).
 		WithArchetypeID(archetypeID)
 
 	queryParams, err := c.Convert(queryString)

--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -763,8 +763,14 @@ func (s *VisibilityStore) convertQuery(
 		return nil, err
 	}
 
-	c := query.NewQueryConverter(&queryConverter{}, namespaceName, saTypeMap, saMapper).
-		WithChasmMapper(chasmMapper).
+	c := query.NewQueryConverter(
+		&queryConverter{},
+		namespaceName,
+		saTypeMap,
+		saMapper,
+		s.metricsHandler,
+		s.logger,
+	).WithChasmMapper(chasmMapper).
 		WithArchetypeID(archetypeID)
 
 	queryParams, err := c.Convert(queryString)

--- a/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
@@ -683,7 +683,7 @@ func (s *ESVisibilitySuite) TestGetListWorkflowExecutionsResponse() {
 	// test page size > number of results
 	resp, err = s.visibilityStore.GetListWorkflowExecutionsResponse(searchResult, testNamespace, 2, nil)
 	s.NoError(err)
-	s.Equal(serializedToken, resp.NextPageToken)
+	s.Empty(resp.NextPageToken)
 	s.Equal(1, len(resp.Executions))
 
 	// test for search after
@@ -704,7 +704,7 @@ func (s *ESVisibilitySuite) TestGetListWorkflowExecutionsResponse() {
 	// test page size > number of results
 	resp, err = s.visibilityStore.GetListWorkflowExecutionsResponse(searchResult, testNamespace, numOfHits+1, nil)
 	s.NoError(err)
-	s.Equal(serializedToken, resp.NextPageToken)
+	s.Empty(resp.NextPageToken)
 	s.Equal(numOfHits, len(resp.Executions))
 }
 

--- a/common/persistence/visibility/store/query/converter.go
+++ b/common/persistence/visibility/store/query/converter.go
@@ -595,8 +595,7 @@ func (c *QueryConverter[ExprT]) parseValueExpr(
 		}
 		return value, nil
 	case sqlparser.BoolVal:
-		// no-op: no validation needed
-		return bool(e), nil
+		return c.validateValueType(saName, saType, bool(e))
 	case sqlparser.ValTuple:
 		// This is "in (1,2,3)" case.
 		values := make([]any, 0, len(e))
@@ -608,6 +607,44 @@ func (c *QueryConverter[ExprT]) parseValueExpr(
 			values = append(values, item)
 		}
 		return values, nil
+	case *sqlparser.UnaryExpr:
+		// Negative value may be parsed as UnaryExpr
+		if e.Operator != sqlparser.UPlusStr && e.Operator != sqlparser.UMinusStr {
+			return nil, NewConverterError(
+				"%s: unary operator %q",
+				NotSupportedErrMessage,
+				e.Operator,
+			)
+		}
+		if value, ok := e.Expr.(*sqlparser.SQLVal); !ok || value.Type == sqlparser.StrVal {
+			return nil, NewConverterError(
+				"%s: unary operator not supported in %q",
+				InvalidExpressionErrMessage,
+				sqlparser.String(expr),
+			)
+		}
+		value, err := c.parseValueExpr(e.Expr, saName, saFieldName, saType)
+		if err != nil {
+			return nil, err
+		}
+		switch v := value.(type) {
+		case int64:
+			if e.Operator == sqlparser.UMinusStr {
+				value = -v
+			}
+		case float64:
+			if e.Operator == sqlparser.UMinusStr {
+				value = -v
+			}
+		default:
+			// This should never happen, but here to catch any unexpected case.
+			return nil, NewConverterError(
+				"%s: unary expression %q",
+				InvalidExpressionErrMessage,
+				sqlparser.String(expr),
+			)
+		}
+		return value, nil
 	case *sqlparser.GroupConcatExpr:
 		return nil, NewConverterError("%s: 'group_concat'", NotSupportedErrMessage)
 	case *sqlparser.FuncExpr:
@@ -666,6 +703,16 @@ func (c *QueryConverter[ExprT]) parseSQLVal(
 	}
 }
 
+// validateValueType validates a single value type against the search attribute type,
+// and returns the value formatted if needed.
+// If search attribute type is:
+//   - Int, Double: value type must be int64 or float64 and returns the input value;
+//   - Bool: value type must be bool and returns the input value;
+//   - Keyword, KeywordList: value type must be string and returns the input value;
+//   - Text: value type must be string with a valid token (empty string or string
+//     with only spaces are not valid) and returns the input value;
+//   - Datetime: value type must be int64 (Unix nanos) or string and returns datetime
+//     formated based on storeQC.GetDatetimeFormat() value.
 func (c *QueryConverter[ExprT]) validateValueType(
 	saName string,
 	saType enumspb.IndexedValueType,
@@ -713,10 +760,20 @@ func (c *QueryConverter[ExprT]) validateValueType(
 		}
 		return tm.UTC().Format(c.storeQC.GetDatetimeFormat()), nil
 	case enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-		enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST,
-		enumspb.INDEXED_VALUE_TYPE_TEXT:
+		enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST:
 		if _, ok := value.(string); !ok {
 			return nil, valueTypeErr
+		}
+		return value, nil
+	case enumspb.INDEXED_VALUE_TYPE_TEXT:
+		if v, ok := value.(string); !ok {
+			return nil, valueTypeErr
+		} else if strings.TrimSpace(v) == "" {
+			return nil, NewConverterError(
+				"%s: no tokens found filtering on Text type search attribute %s",
+				InvalidExpressionErrMessage,
+				saName,
+			)
 		}
 		return value, nil
 	default:

--- a/common/persistence/visibility/store/query/converter.go
+++ b/common/persistence/visibility/store/query/converter.go
@@ -13,6 +13,8 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/searchattribute/sadefs"
@@ -63,6 +65,9 @@ type (
 		archetypeID   chasm.ArchetypeID
 
 		seenNamespaceDivision bool
+
+		metricsHandler metrics.Handler
+		logger         log.Logger
 	}
 
 	QueryConverterOptionFunc[ExprT any] func(*QueryConverter[ExprT])
@@ -134,6 +139,8 @@ func NewQueryConverter[ExprT any](
 	namespaceName namespace.Name,
 	saTypeMap searchattribute.NameTypeMap,
 	saMapper searchattribute.Mapper,
+	metricsHandler metrics.Handler,
+	logger log.Logger,
 ) *QueryConverter[ExprT] {
 	c := &QueryConverter[ExprT]{
 		storeQC:       storeQC,
@@ -144,6 +151,9 @@ func NewQueryConverter[ExprT any](
 		saMapper:      saMapper,
 
 		seenNamespaceDivision: false,
+
+		metricsHandler: metricsHandler,
+		logger:         logger,
 	}
 	return c
 }
@@ -178,7 +188,11 @@ func (c *QueryConverter[ExprT]) SeenNamespaceDivision() bool {
 
 func (c *QueryConverter[ExprT]) Convert(
 	queryString string,
-) (*QueryParams[ExprT], error) {
+) (_ *QueryParams[ExprT], retError error) {
+	// Convert function may throw unexpected panics (eg: bugs).
+	// Capture them here to replace with an error.
+	defer metrics.CapturePanic(c.logger, c.metricsHandler, &retError)
+
 	queryParams, err := c.convertWhereString(queryString)
 	if err != nil {
 		return nil, err

--- a/common/persistence/visibility/store/query/converter_test.go
+++ b/common/persistence/visibility/store/query/converter_test.go
@@ -11,6 +11,8 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/searchattribute/sadefs"
@@ -19,7 +21,6 @@ import (
 
 const (
 	testNamespaceName = namespace.Name("test-namespace")
-	testNamespaceID   = namespace.ID("test-namespace-id")
 )
 
 func TestWithSearchAttributeInterceptor(t *testing.T) {
@@ -29,31 +30,18 @@ func TestWithSearchAttributeInterceptor(t *testing.T) {
 	storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
 
 	// QueryConverter without explicit SearchAttributeInterceptor sets the nop interceptor.
-	c := NewQueryConverter(
-		storeQCMock,
-		testNamespaceName,
-		searchattribute.TestNameTypeMap(),
-		&searchattribute.TestMapper{},
-	)
+	c := newTestQueryConverter(storeQCMock)
 	r.Equal(nopSearchAttributeInterceptor, c.saInterceptor)
 
 	// Setting nil interceptor sets the nop interceptor.
-	c = NewQueryConverter(
-		storeQCMock,
-		testNamespaceName,
-		searchattribute.TestNameTypeMap(),
-		&searchattribute.TestMapper{},
-	).WithSearchAttributeInterceptor(nil)
+	c = newTestQueryConverter(storeQCMock).
+		WithSearchAttributeInterceptor(nil)
 	r.Equal(nopSearchAttributeInterceptor, c.saInterceptor)
 
 	// Setting non-nil interceptor
 	i := &testSearchAttributeInterceptor{}
-	c = NewQueryConverter(
-		storeQCMock,
-		testNamespaceName,
-		searchattribute.TestNameTypeMap(),
-		&searchattribute.TestMapper{},
-	).WithSearchAttributeInterceptor(i)
+	c = newTestQueryConverter(storeQCMock).
+		WithSearchAttributeInterceptor(i)
 	r.Equal(i, c.saInterceptor)
 }
 
@@ -247,12 +235,7 @@ func TestQueryConverter_Convert(t *testing.T) {
 			r := require.New(t)
 			ctrl := gomock.NewController(t)
 			storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-			queryConverter := NewQueryConverter(
-				storeQCMock,
-				testNamespaceName,
-				searchattribute.TestNameTypeMap(),
-				&searchattribute.TestMapper{},
-			)
+			queryConverter := newTestQueryConverter(storeQCMock)
 
 			if tc.setupMocks != nil {
 				tc.setupMocks(storeQCMock)
@@ -381,12 +364,7 @@ func TestQueryConverter_ConvertWhereString(t *testing.T) {
 			r := require.New(t)
 			ctrl := gomock.NewController(t)
 			storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-			queryConverter := NewQueryConverter(
-				storeQCMock,
-				testNamespaceName,
-				searchattribute.TestNameTypeMap(),
-				&searchattribute.TestMapper{},
-			)
+			queryConverter := newTestQueryConverter(storeQCMock)
 
 			if tc.setupMocks != nil {
 				tc.setupMocks(storeQCMock)
@@ -554,12 +532,7 @@ func TestQueryConverter_ConvertSelectStmt(t *testing.T) {
 			r := require.New(t)
 			ctrl := gomock.NewController(t)
 			storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-			queryConverter := NewQueryConverter(
-				storeQCMock,
-				testNamespaceName,
-				searchattribute.TestNameTypeMap(),
-				&searchattribute.TestMapper{},
-			)
+			queryConverter := newTestQueryConverter(storeQCMock)
 
 			if tc.setupMocks != nil {
 				tc.setupMocks(storeQCMock)
@@ -824,12 +797,7 @@ func TestQueryConverter_ConvertWhereExpr(t *testing.T) {
 			r := require.New(t)
 			ctrl := gomock.NewController(t)
 			storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-			queryConverter := NewQueryConverter(
-				storeQCMock,
-				testNamespaceName,
-				searchattribute.TestNameTypeMap(),
-				&searchattribute.TestMapper{},
-			)
+			queryConverter := newTestQueryConverter(storeQCMock)
 
 			if tc.setupMocks != nil {
 				tc.setupMocks(storeQCMock)
@@ -914,12 +882,7 @@ func TestQueryConverter_ConvertParenExpr(t *testing.T) {
 			r := require.New(t)
 			ctrl := gomock.NewController(t)
 			storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-			queryConverter := NewQueryConverter(
-				storeQCMock,
-				testNamespaceName,
-				searchattribute.TestNameTypeMap(),
-				&searchattribute.TestMapper{},
-			)
+			queryConverter := newTestQueryConverter(storeQCMock)
 
 			if tc.setupMocks != nil {
 				tc.setupMocks(storeQCMock)
@@ -994,12 +957,7 @@ func TestQueryConverter_ConvertNotExpr(t *testing.T) {
 			r := require.New(t)
 			ctrl := gomock.NewController(t)
 			storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-			queryConverter := NewQueryConverter(
-				storeQCMock,
-				testNamespaceName,
-				searchattribute.TestNameTypeMap(),
-				&searchattribute.TestMapper{},
-			)
+			queryConverter := newTestQueryConverter(storeQCMock)
 
 			if tc.setupMocks != nil {
 				tc.setupMocks(storeQCMock)
@@ -1103,12 +1061,7 @@ func TestQueryConverter_ConvertAndExpr(t *testing.T) {
 			r := require.New(t)
 			ctrl := gomock.NewController(t)
 			storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-			queryConverter := NewQueryConverter(
-				storeQCMock,
-				testNamespaceName,
-				searchattribute.TestNameTypeMap(),
-				&searchattribute.TestMapper{},
-			)
+			queryConverter := newTestQueryConverter(storeQCMock)
 
 			if tc.setupMocks != nil {
 				tc.setupMocks(storeQCMock)
@@ -1212,12 +1165,7 @@ func TestQueryConverter_ConvertOrExpr(t *testing.T) {
 			r := require.New(t)
 			ctrl := gomock.NewController(t)
 			storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-			queryConverter := NewQueryConverter(
-				storeQCMock,
-				testNamespaceName,
-				searchattribute.TestNameTypeMap(),
-				&searchattribute.TestMapper{},
-			)
+			queryConverter := newTestQueryConverter(storeQCMock)
 
 			if tc.setupMocks != nil {
 				tc.setupMocks(storeQCMock)
@@ -1334,12 +1282,7 @@ func TestQueryConverter_ConvertComparisonExprStoreQueryConverterCalled(t *testin
 			r := require.New(t)
 			ctrl := gomock.NewController(t)
 			storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-			queryConverter := NewQueryConverter(
-				storeQCMock,
-				testNamespaceName,
-				searchattribute.TestNameTypeMap(),
-				&searchattribute.TestMapper{},
-			)
+			queryConverter := newTestQueryConverter(storeQCMock)
 			storeQCMock.EXPECT().GetDatetimeFormat().Return(time.RFC3339Nano).AnyTimes()
 
 			input := &sqlparser.ComparisonExpr{
@@ -1427,12 +1370,7 @@ func TestQueryConverter_ConvertComparisonExprFail(t *testing.T) {
 			r := require.New(t)
 			ctrl := gomock.NewController(t)
 			storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-			queryConverter := NewQueryConverter(
-				storeQCMock,
-				testNamespaceName,
-				searchattribute.TestNameTypeMap(),
-				&searchattribute.TestMapper{},
-			)
+			queryConverter := newTestQueryConverter(storeQCMock)
 
 			inExpr := parseWhereString(tc.in).(*sqlparser.ComparisonExpr)
 			_, err := queryConverter.convertComparisonExpr(inExpr)
@@ -1522,12 +1460,7 @@ func TestQueryConverter_ConvertRangeCond(t *testing.T) {
 			r := require.New(t)
 			ctrl := gomock.NewController(t)
 			storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-			queryConverter := NewQueryConverter(
-				storeQCMock,
-				testNamespaceName,
-				searchattribute.TestNameTypeMap(),
-				&searchattribute.TestMapper{},
-			)
+			queryConverter := newTestQueryConverter(storeQCMock)
 
 			if tc.setupMocks != nil {
 				tc.setupMocks(storeQCMock)
@@ -1659,12 +1592,7 @@ func TestQueryConverter_ConvertIsExpr(t *testing.T) {
 			r := require.New(t)
 			ctrl := gomock.NewController(t)
 			storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-			queryConverter := NewQueryConverter(
-				storeQCMock,
-				testNamespaceName,
-				searchattribute.TestNameTypeMap(),
-				&searchattribute.TestMapper{},
-			)
+			queryConverter := newTestQueryConverter(storeQCMock)
 
 			if tc.setupMocks != nil {
 				tc.setupMocks(storeQCMock)
@@ -1764,12 +1692,7 @@ func TestQueryConverter_ConvertColName(t *testing.T) {
 			r := require.New(t)
 			ctrl := gomock.NewController(t)
 			storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-			queryConverter := NewQueryConverter(
-				storeQCMock,
-				testNamespaceName,
-				searchattribute.TestNameTypeMap(),
-				&searchattribute.TestMapper{},
-			)
+			queryConverter := newTestQueryConverter(storeQCMock)
 
 			out, err := queryConverter.convertColName(tc.in)
 			if tc.err != "" {
@@ -1927,6 +1850,8 @@ func TestQueryConverter_ResolveSearchAttributeAlias(t *testing.T) {
 				&searchattribute.TestMapper{
 					WithCustomScheduleID: tc.withCustomScheduleID,
 				},
+				metrics.NewMockHandler(ctrl),
+				log.NewNoopLogger(),
 			)
 
 			if tc.useNoopMapper {
@@ -2065,12 +1990,7 @@ func TestQueryConverter_ParseValueExpr(t *testing.T) {
 			r := require.New(t)
 			ctrl := gomock.NewController(t)
 			storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-			queryConverter := NewQueryConverter(
-				storeQCMock,
-				testNamespaceName,
-				searchattribute.TestNameTypeMap(),
-				&searchattribute.TestMapper{},
-			)
+			queryConverter := newTestQueryConverter(storeQCMock)
 
 			out, err := queryConverter.parseValueExpr(tc.expr, tc.alias, tc.field, tc.saType)
 			if tc.err != "" {
@@ -2188,12 +2108,7 @@ func TestQueryConverter_ParseSQLVal(t *testing.T) {
 			r := require.New(t)
 			ctrl := gomock.NewController(t)
 			storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-			queryConverter := NewQueryConverter(
-				storeQCMock,
-				testNamespaceName,
-				searchattribute.TestNameTypeMap(),
-				&searchattribute.TestMapper{},
-			)
+			queryConverter := newTestQueryConverter(storeQCMock)
 			storeQCMock.EXPECT().GetDatetimeFormat().Return(time.RFC3339Nano).AnyTimes()
 
 			out, err := queryConverter.parseSQLVal(tc.expr, tc.saName, tc.saFieldName, tc.saType)
@@ -2405,12 +2320,7 @@ func TestQueryConverter_ValidateValueType(t *testing.T) {
 			r := require.New(t)
 			ctrl := gomock.NewController(t)
 			storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
-			queryConverter := NewQueryConverter(
-				storeQCMock,
-				testNamespaceName,
-				searchattribute.TestNameTypeMap(),
-				&searchattribute.TestMapper{},
-			)
+			queryConverter := newTestQueryConverter(storeQCMock)
 			storeQCMock.EXPECT().GetDatetimeFormat().Return(time.RFC3339Nano).AnyTimes()
 
 			out, err := queryConverter.validateValueType(tc.saName, tc.saType, tc.value)
@@ -2566,12 +2476,7 @@ func TestQueryConverter_WithChasmMapper(t *testing.T) {
 		},
 	)
 
-	c := NewQueryConverter(
-		storeQCMock,
-		testNamespaceName,
-		searchattribute.TestNameTypeMap(),
-		&searchattribute.TestMapper{},
-	)
+	c := newTestQueryConverter(storeQCMock)
 	r.Nil(c.chasmMapper)
 
 	c = c.WithChasmMapper(chasmMapper)
@@ -2587,12 +2492,7 @@ func TestQueryConverter_WithArchetypeID(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
 
-	c := NewQueryConverter(
-		storeQCMock,
-		testNamespaceName,
-		searchattribute.TestNameTypeMap(),
-		&searchattribute.TestMapper{},
-	)
+	c := newTestQueryConverter(storeQCMock)
 	r.Equal(chasm.UnspecifiedArchetypeID, c.archetypeID)
 
 	c = c.WithArchetypeID(123)
@@ -2610,12 +2510,8 @@ func TestQueryConverter_TemporalSystemExecutionStatus(t *testing.T) {
 	// Test that TemporalSystemExecutionStatus maps to ExecutionStatus only for SchedulerArchetypeID
 	t.Run("with SchedulerArchetypeID", func(t *testing.T) {
 		r := require.New(t)
-		queryConverter := NewQueryConverter(
-			storeQCMock,
-			testNamespaceName,
-			searchattribute.TestNameTypeMap(),
-			&searchattribute.TestMapper{},
-		).WithArchetypeID(chasm.SchedulerArchetypeID)
+		queryConverter := newTestQueryConverter(storeQCMock).
+			WithArchetypeID(chasm.SchedulerArchetypeID)
 
 		in := &sqlparser.ColName{
 			Name: sqlparser.NewColIdent("TemporalSystemExecutionStatus"),
@@ -2631,12 +2527,7 @@ func TestQueryConverter_TemporalSystemExecutionStatus(t *testing.T) {
 
 	t.Run("without SchedulerArchetypeID", func(t *testing.T) {
 		r := require.New(t)
-		queryConverter := NewQueryConverter(
-			storeQCMock,
-			testNamespaceName,
-			searchattribute.TestNameTypeMap(),
-			&searchattribute.TestMapper{},
-		)
+		queryConverter := newTestQueryConverter(storeQCMock)
 
 		in := &sqlparser.ColName{
 			Name: sqlparser.NewColIdent("TemporalSystemExecutionStatus"),
@@ -2663,12 +2554,8 @@ func TestQueryConverter_ResolveSearchAttributeAlias_WithChasmMapper(t *testing.T
 		},
 	)
 
-	queryConverter := NewQueryConverter(
-		storeQCMock,
-		testNamespaceName,
-		searchattribute.TestNameTypeMap(),
-		&searchattribute.TestMapper{},
-	).WithChasmMapper(chasmMapper)
+	queryConverter := newTestQueryConverter(storeQCMock).
+		WithChasmMapper(chasmMapper)
 
 	testCases := []struct {
 		name                    string
@@ -2723,4 +2610,49 @@ func TestQueryConverter_ResolveSearchAttributeAlias_WithChasmMapper(t *testing.T
 			}
 		})
 	}
+}
+
+func TestQueryConverter_CapturePanic(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+	ctrl := gomock.NewController(t)
+	metricsHandlerMock := metrics.NewMockHandler(ctrl)
+	loggerMock := log.NewMockLogger(ctrl)
+	storeQCMock := NewMockStoreQueryConverter[sqlparser.Expr](ctrl)
+	queryConverter := newTestQueryConverter(storeQCMock)
+	queryConverter.metricsHandler = metricsHandlerMock
+	queryConverter.logger = loggerMock
+
+	keywordCol := NewSAColumn(
+		"AliasForKeyword01",
+		"Keyword01",
+		enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+	)
+
+	counterMock := metrics.NewMockCounterIface(ctrl)
+	counterMock.EXPECT().Record(int64(1))
+	metricsHandlerMock.EXPECT().Counter(metrics.ServicePanic.Name()).Return(counterMock)
+	loggerMock.EXPECT().Error("Panic is captured", gomock.Any(), gomock.Any()).Return()
+	storeQCMock.EXPECT().ConvertKeywordComparisonExpr(sqlparser.EqualStr, keywordCol, "foo").
+		DoAndReturn(
+			func(operator string, col *SAColumn, value any) (sqlparser.Expr, error) {
+				panic("random")
+			},
+		)
+	out, err := queryConverter.Convert("AliasForKeyword01 = 'foo'")
+	r.ErrorContains(err, "panic: random")
+	r.Nil(out)
+}
+
+func newTestQueryConverter(
+	storeQC StoreQueryConverter[sqlparser.Expr],
+) *QueryConverter[sqlparser.Expr] {
+	return NewQueryConverter(
+		storeQC,
+		testNamespaceName,
+		searchattribute.TestNameTypeMap(),
+		&searchattribute.TestMapper{},
+		nil, // metricsHandler
+		log.NewNoopLogger(),
+	)
 }

--- a/common/persistence/visibility/store/query/interceptors_test.go
+++ b/common/persistence/visibility/store/query/interceptors_test.go
@@ -5,7 +5,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/searchattribute"
+	"go.uber.org/mock/gomock"
 )
 
 type testSearchAttributeInterceptor struct {
@@ -24,12 +27,15 @@ func (t *testSearchAttributeInterceptor) Intercept(col *SAColumn) error {
 
 func TestSearchAttributeInterceptor(t *testing.T) {
 	t.Parallel()
+	ctrl := gomock.NewController(t)
 
 	interceptor := &testSearchAttributeInterceptor{}
 	c := NewNilQueryConverter(
 		"",
 		searchattribute.TestNameTypeMap(),
 		&searchattribute.TestMapper{},
+		metrics.NewMockHandler(ctrl),
+		log.NewNoopLogger(),
 	).WithSearchAttributeInterceptor(interceptor)
 
 	_, err := c.Convert("ExecutionStatus='Running' order by StartTime")

--- a/common/persistence/visibility/store/query/nil_converter.go
+++ b/common/persistence/visibility/store/query/nil_converter.go
@@ -1,6 +1,8 @@
 package query
 
 import (
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/searchattribute"
 )
@@ -83,11 +85,15 @@ func NewNilQueryConverter(
 	namespaceName namespace.Name,
 	saTypeMap searchattribute.NameTypeMap,
 	saMapper searchattribute.Mapper,
+	metricsHandler metrics.Handler,
+	logger log.Logger,
 ) NilQueryConverter {
 	return NewQueryConverter(
 		&nilStoreQueryConverter{},
 		namespaceName,
 		saTypeMap,
 		saMapper,
+		metricsHandler,
+		logger,
 	)
 }

--- a/common/persistence/visibility/store/query/nil_converter_test.go
+++ b/common/persistence/visibility/store/query/nil_converter_test.go
@@ -4,7 +4,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/searchattribute"
+	"go.uber.org/mock/gomock"
 )
 
 func TestNilStoreQueryConverter_GetDatetimeFormat(t *testing.T) {
@@ -95,6 +98,13 @@ func TestNilStoreQueryConverter_ConvertIsExpr(t *testing.T) {
 
 func TestNewNilQueryConverter(t *testing.T) {
 	t.Parallel()
-	c := NewNilQueryConverter("", searchattribute.TestNameTypeMap(), nil)
+	ctrl := gomock.NewController(t)
+	c := NewNilQueryConverter(
+		"",
+		searchattribute.TestNameTypeMap(),
+		nil, // saMapper
+		metrics.NewMockHandler(ctrl),
+		log.NewNoopLogger(),
+	)
 	require.Equal(t, &nilStoreQueryConverter{}, c.storeQC)
 }

--- a/common/persistence/visibility/store/sql/query_converter.go
+++ b/common/persistence/visibility/store/sql/query_converter.go
@@ -263,15 +263,15 @@ func (c *SQLQueryConverter) ConvertIsExpr(
 }
 
 func (c *SQLQueryConverter) buildValueExpr(name string, value any) (sqlparser.Expr, error) {
-	// ExecutionStatus is stored as an integer in SQL database.
-	if name == sadefs.ExecutionStatus {
-		// Query converter already validates the value, so there should not be any errors here.
-		status, _ := enumspb.WorkflowExecutionStatusFromString(value.(string))
-		return sqlparser.NewIntVal([]byte(strconv.FormatInt(int64(status), 10))), nil
-	}
-
 	switch v := value.(type) {
 	case string:
+		// ExecutionStatus is stored as an integer in SQL database.
+		if name == sadefs.ExecutionStatus {
+			// Query converter already validates the value, so there should not be any errors here.
+			status, _ := enumspb.WorkflowExecutionStatusFromString(value.(string))
+			return sqlparser.NewIntVal([]byte(strconv.FormatInt(int64(status), 10))), nil
+		}
+
 		// escape strings for safety
 		replacer := strings.NewReplacer(escapeCharMap...)
 		return query.NewUnsafeSQLString(replacer.Replace(v)), nil

--- a/common/persistence/visibility/store/sql/visibility_store.go
+++ b/common/persistence/visibility/store/sql/visibility_store.go
@@ -275,6 +275,8 @@ func (s *VisibilityStore) countChasmExecutions(
 		saMapper,
 		mapper,
 		request.ArchetypeId,
+		s.metricsHandler,
+		s.logger,
 	)
 	if err != nil {
 		var converterErr *query.ConverterError
@@ -387,6 +389,8 @@ func (s *VisibilityStore) listExecutionsInternal(
 		saMapper,
 		request.ChasmMapper,
 		request.ArchetypeID,
+		s.metricsHandler,
+		s.logger,
 	)
 	if err != nil {
 		// Convert ConverterError to InvalidArgument and pass through all other errors (which should be
@@ -622,6 +626,8 @@ func (s *VisibilityStore) countWorkflowExecutions(
 		saMapper,
 		nil,
 		chasm.UnspecifiedArchetypeID,
+		s.metricsHandler,
+		s.logger,
 	)
 	if err != nil {
 		// Convert ConverterError to InvalidArgument and pass through all other errors (which should be
@@ -935,8 +941,10 @@ func buildQueryParams(
 	saMapper searchattribute.Mapper,
 	chasmMapper *chasm.VisibilitySearchAttributesMapper,
 	archetypeID chasm.ArchetypeID,
+	metricsHandler metrics.Handler,
+	logger log.Logger,
 ) (*query.QueryParams[sqlparser.Expr], error) {
-	c := query.NewQueryConverter(sqlQC, namespaceName, saTypeMap, saMapper).
+	c := query.NewQueryConverter(sqlQC, namespaceName, saTypeMap, saMapper, metricsHandler, logger).
 		WithChasmMapper(chasmMapper).
 		WithArchetypeID(archetypeID)
 

--- a/common/persistence/visibility/store/sql/visibility_store_test.go
+++ b/common/persistence/visibility/store/sql/visibility_store_test.go
@@ -7,10 +7,13 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/temporalio/sqlparser"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin/mysql"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin/postgresql"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin/sqlite"
 	"go.temporal.io/server/common/searchattribute"
+	"go.uber.org/mock/gomock"
 )
 
 var pluginNames = []string{
@@ -65,6 +68,7 @@ func TestBuildQueryParams(t *testing.T) {
 			tcName := fmt.Sprintf("%s/%s", pluginName, tc.name)
 			t.Run(tcName, func(t *testing.T) {
 				r := require.New(t)
+				ctrl := gomock.NewController(t)
 				sqlQC, err := NewSQLQueryConverter(pluginName)
 				r.NoError(err)
 
@@ -75,8 +79,10 @@ func TestBuildQueryParams(t *testing.T) {
 					sqlQC,
 					searchattribute.TestNameTypeMap(),
 					&searchattribute.TestMapper{},
-					nil,
+					nil, // chasmMapper
 					chasm.UnspecifiedArchetypeID,
+					metrics.NewMockHandler(ctrl),
+					log.NewNoopLogger(),
 				)
 				if tc.err != "" {
 					r.Error(err)

--- a/common/persistence/visibility/store/tests/query_converter_test.go
+++ b/common/persistence/visibility/store/tests/query_converter_test.go
@@ -1,0 +1,1293 @@
+package tests
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/olivere/elastic/v7"
+	"github.com/stretchr/testify/require"
+	"github.com/temporalio/sqlparser"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/persistence/sql"
+	"go.temporal.io/server/common/persistence/visibility/store/elasticsearch"
+	"go.temporal.io/server/common/persistence/visibility/store/query"
+	vissql "go.temporal.io/server/common/persistence/visibility/store/sql"
+	"go.temporal.io/server/common/searchattribute"
+)
+
+const (
+	testNamespaceName = namespace.Name("test-namespace")
+
+	mysqlStore    = "mysql8"
+	postgresStore = "postgres12"
+	sqliteStore   = "sqlite"
+	esStore       = "elasticsearch"
+)
+
+var sqlPlugins = []string{mysqlStore, postgresStore, sqliteStore}
+
+type queryConverterTestCase struct {
+	name string
+	in   string
+
+	// out is the expected converted query: `sql` is the WHERE clause expected for every SQL
+	// plugin, and `mysql`, `postgres` and `sqlite` override it for the plugins whose output
+	// differs (mostly Text and KeywordList types); `es` is the expected Elasticsearch query.
+	sql      string
+	mysql    string
+	postgres string
+	sqlite   string
+	es       string
+
+	// err is the expected error message for every store: most errors come from the shared
+	// front-end converter. When only some stores fail, use the store specific fields
+	// instead: sqlErr for every SQL plugin, and mysqlErr, postgresErr, sqliteErr and esErr
+	// for a single store.
+	err         string
+	sqlErr      string
+	mysqlErr    string
+	postgresErr string
+	sqliteErr   string
+	esErr       string
+
+	// groupBy is the expected list of GROUP BY search attribute field names.
+	groupBy []string
+	// orderBy is the expected ORDER BY clause.
+	orderBy string
+}
+
+func (tc *queryConverterTestCase) expected(store string) (out string, errMsg string) {
+	if tc.err != "" {
+		return "", tc.err
+	}
+	if store == esStore {
+		return tc.es, tc.esErr
+	}
+
+	var outOverride, errOverride string
+	switch store {
+	case mysqlStore:
+		outOverride, errOverride = tc.mysql, tc.mysqlErr
+	case postgresStore:
+		outOverride, errOverride = tc.postgres, tc.postgresErr
+	case sqliteStore:
+		outOverride, errOverride = tc.sqlite, tc.sqliteErr
+	default:
+		// no-op
+	}
+
+	if errOverride != "" {
+		return "", errOverride
+	}
+	if outOverride != "" {
+		return outOverride, ""
+	}
+	return tc.sql, tc.sqlErr
+}
+
+var queryConverterTestCases = []queryConverterTestCase{
+	{
+		name: "empty query",
+		in:   "",
+		sql:  "TemporalNamespaceDivision is null",
+		es:   `{"bool":{"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "blank query",
+		in:   "   ",
+		sql:  "TemporalNamespaceDivision is null",
+		es:   `{"bool":{"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	// Keyword type search attributes.
+	{
+		name: "Keyword equal",
+		in:   "WorkflowId = 'wid'",
+		sql:  "TemporalNamespaceDivision is null and workflow_id = 'wid'",
+		es:   `{"bool":{"filter":{"term":{"WorkflowId":"wid"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Keyword not equal",
+		in:   "WorkflowId != 'wid'",
+		sql:  "TemporalNamespaceDivision is null and workflow_id != 'wid'",
+		es:   `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"term":{"WorkflowId":"wid"}}]}}`,
+	},
+	{
+		name: "Keyword in",
+		in:   "WorkflowType IN ('foo', 'bar')",
+		sql:  "TemporalNamespaceDivision is null and workflow_type_name in ('foo', 'bar')",
+		es:   `{"bool":{"filter":{"terms":{"WorkflowType":["foo","bar"]}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Keyword not in",
+		in:   "WorkflowType NOT IN ('foo', 'bar')",
+		sql:  "TemporalNamespaceDivision is null and workflow_type_name not in ('foo', 'bar')",
+		es:   `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"terms":{"WorkflowType":["foo","bar"]}}]}}`,
+	},
+	{
+		name: "Keyword starts with",
+		in:   "TaskQueue STARTS_WITH 'foo'",
+		sql:  "TemporalNamespaceDivision is null and task_queue like 'foo%' escape '!'",
+		es:   `{"bool":{"filter":{"prefix":{"TaskQueue":"foo"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Keyword not starts with",
+		in:   "TaskQueue NOT STARTS_WITH 'foo'",
+		sql:  "TemporalNamespaceDivision is null and task_queue not like 'foo%' escape '!'",
+		es:   `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"prefix":{"TaskQueue":"foo"}}]}}`,
+	},
+	{
+		name: "Keyword starts with special chars",
+		in:   "AliasForKeyword01 STARTS_WITH 'a%b_c!d'",
+		sql:  "TemporalNamespaceDivision is null and Keyword01 like 'a!%b!_c!!d%' escape '!'",
+		es:   `{"bool":{"filter":{"prefix":{"Keyword01":"a%b_c!d"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Keyword starts with non string value",
+		in:   "AliasForKeyword01 STARTS_WITH 123",
+		err:  "invalid expression: invalid value type for search attribute AliasForKeyword01 of type Keyword: 123 (type: int64)",
+	},
+	{
+		name: "Keyword greater than",
+		in:   "AliasForKeyword01 > 'foo'",
+		sql:  "TemporalNamespaceDivision is null and Keyword01 > 'foo'",
+		es:   `{"bool":{"filter":{"range":{"Keyword01":{"from":"foo","include_lower":false,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Keyword between",
+		in:   "AliasForKeyword01 BETWEEN 'a' AND 'b'",
+		sql:  "TemporalNamespaceDivision is null and Keyword01 between 'a' and 'b'",
+		es:   `{"bool":{"filter":{"range":{"Keyword01":{"from":"a","include_lower":true,"include_upper":true,"to":"b"}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Keyword is null",
+		in:   "AliasForKeyword01 IS NULL",
+		sql:  "TemporalNamespaceDivision is null and Keyword01 is null",
+		es:   `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"exists":{"field":"Keyword01"}}]}}`,
+	},
+	{
+		name: "Keyword is not null",
+		in:   "AliasForKeyword01 IS NOT NULL",
+		sql:  "TemporalNamespaceDivision is null and Keyword01 is not null",
+		es:   `{"bool":{"filter":{"exists":{"field":"Keyword01"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Keyword empty string",
+		in:   "AliasForKeyword01 = ''",
+		sql:  "TemporalNamespaceDivision is null and Keyword01 = ''",
+		es:   `{"bool":{"filter":{"term":{"Keyword01":""}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Keyword value with quote",
+		in:   "AliasForKeyword01 = 'foo''s bar'",
+		sql:  "TemporalNamespaceDivision is null and Keyword01 = 'foo''s bar'",
+		es:   `{"bool":{"filter":{"term":{"Keyword01":"foo's bar"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Keyword value with backslash",
+		in:   "AliasForKeyword01 = 'foo\\\\bar'",
+		sql:  "TemporalNamespaceDivision is null and Keyword01 = 'foo\\\\bar'",
+		es:   `{"bool":{"filter":{"term":{"Keyword01":"foo\\bar"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Keyword invalid value type",
+		in:   "AliasForKeyword01 = 123",
+		err:  "invalid expression: invalid value type for search attribute AliasForKeyword01 of type Keyword: 123 (type: int64)",
+	},
+	{
+		name: "Keyword with bool value",
+		in:   "AliasForKeyword01 = true",
+		err:  "invalid expression: invalid value type for search attribute AliasForKeyword01 of type Keyword: true (type: bool)",
+	},
+	{
+		name: "Keyword with negative value",
+		in:   "AliasForKeyword01 = -'foo'",
+		err:  `invalid expression: unary operator not supported in "-'foo'"`,
+	},
+	{
+		name: "Keyword with positive value",
+		in:   "AliasForKeyword01 = +'foo'",
+		err:  `invalid expression: unary operator not supported in "+'foo'"`,
+	},
+	{
+		name: "Keyword unsupported operator",
+		in:   "AliasForKeyword01 LIKE 'foo%'",
+		err:  "operation is not supported: operator 'LIKE' not supported for Keyword type search attribute 'AliasForKeyword01'",
+	},
+	{
+		name: "Keyword value with escaped chars",
+		in:   "AliasForKeyword01 = 'foo\\nbar\\ttail'",
+		sql:  "TemporalNamespaceDivision is null and Keyword01 = 'foo\\nbar\\ttail'",
+		es:   `{"bool":{"filter":{"term":{"Keyword01":"foo\nbar\ttail"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Keyword single value in list",
+		in:   "WorkflowId IN ('wid')",
+		sql:  "TemporalNamespaceDivision is null and workflow_id in ('wid')",
+		es:   `{"bool":{"filter":{"terms":{"WorkflowId":["wid"]}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Keyword empty list",
+		in:   "WorkflowId IN ()",
+		err:  "malformed SQL query: syntax error at position 44",
+	},
+	{
+		name: "search attribute name is case sensitive",
+		in:   "workflowid = 'wid'",
+		err:  "invalid expression: column name 'workflowid' is not a valid search attribute",
+	},
+
+	// Int type search attributes.
+	{
+		name: "Int equal",
+		in:   "HistoryLength = 10",
+		sql:  "TemporalNamespaceDivision is null and history_length = 10",
+		es:   `{"bool":{"filter":{"term":{"HistoryLength":10}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Int negative value",
+		in:   "AliasForInt01 = -10",
+		sql:  "TemporalNamespaceDivision is null and Int01 = -10",
+		es:   `{"bool":{"filter":{"term":{"Int01":-10}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Int positive sign value",
+		in:   "AliasForInt01 = +10",
+		sql:  "TemporalNamespaceDivision is null and Int01 = 10",
+		es:   `{"bool":{"filter":{"term":{"Int01":10}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		// Only a literal value can be negated, not an arbitrary expression.
+		name: "Int negative parenthesized value",
+		in:   "AliasForInt01 = -(10)",
+		err:  `invalid expression: unary operator not supported in "-(10)"`,
+	},
+	{
+		name: "Int greater than",
+		in:   "HistoryLength > 10",
+		sql:  "TemporalNamespaceDivision is null and history_length > 10",
+		es:   `{"bool":{"filter":{"range":{"HistoryLength":{"from":10,"include_lower":false,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Int greater equal",
+		in:   "HistoryLength >= 10",
+		sql:  "TemporalNamespaceDivision is null and history_length >= 10",
+		es:   `{"bool":{"filter":{"range":{"HistoryLength":{"from":10,"include_lower":true,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Int less than",
+		in:   "StateTransitionCount < 10",
+		sql:  "TemporalNamespaceDivision is null and state_transition_count < 10",
+		es:   `{"bool":{"filter":{"range":{"StateTransitionCount":{"from":null,"include_lower":true,"include_upper":false,"to":10}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Int less equal",
+		in:   "StateTransitionCount <= 10",
+		sql:  "TemporalNamespaceDivision is null and state_transition_count <= 10",
+		es:   `{"bool":{"filter":{"range":{"StateTransitionCount":{"from":null,"include_lower":true,"include_upper":true,"to":10}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Int in",
+		in:   "HistorySizeBytes IN (1, 2, 3)",
+		sql:  "TemporalNamespaceDivision is null and history_size_bytes in (1, 2, 3)",
+		es:   `{"bool":{"filter":{"terms":{"HistorySizeBytes":[1,2,3]}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Int between",
+		in:   "HistoryLength BETWEEN 1 AND 10",
+		sql:  "TemporalNamespaceDivision is null and history_length between 1 and 10",
+		es:   `{"bool":{"filter":{"range":{"HistoryLength":{"from":1,"include_lower":true,"include_upper":true,"to":10}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Int not between",
+		in:   "HistoryLength NOT BETWEEN 1 AND 10",
+		sql:  "TemporalNamespaceDivision is null and history_length not between 1 and 10",
+		es:   `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"range":{"HistoryLength":{"from":1,"include_lower":true,"include_upper":true,"to":10}}}]}}`,
+	},
+	{
+		name: "Int with float value",
+		in:   "AliasForInt01 = 1.5",
+		sql:  "TemporalNamespaceDivision is null and Int01 = 1.5",
+		es:   `{"bool":{"filter":{"term":{"Int01":1.5}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Int with negative float value",
+		in:   "AliasForInt01 = -1.5",
+		sql:  "TemporalNamespaceDivision is null and Int01 = -1.5",
+		es:   `{"bool":{"filter":{"term":{"Int01":-1.5}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Int with positive sign float value",
+		in:   "AliasForInt01 = +1.5",
+		sql:  "TemporalNamespaceDivision is null and Int01 = 1.5",
+		es:   `{"bool":{"filter":{"term":{"Int01":1.5}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		// negative int is parsed as SQLVal, and sqlparser reduces inline
+		name: "Int negative negative int value",
+		in:   "AliasForInt01 = - -10",
+		sql:  "TemporalNamespaceDivision is null and Int01 = 10",
+		es:   `{"bool":{"filter":{"term":{"Int01":10}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		// negative float is parsed as UnaryExpr, and nested unary expressions is not allowed
+		name: "Int negative negative float value",
+		in:   "AliasForInt01 = - -1.0",
+		err:  `invalid expression: unary operator not supported in "- -1.0"`,
+	},
+	{
+		name: "Int invalid value type",
+		in:   "HistoryLength = 'foo'",
+		err:  `invalid expression: invalid value type for search attribute HistoryLength of type Int: "foo" (type: string)`,
+	},
+	{
+		name: "Int unsupported operator",
+		in:   "HistoryLength STARTS_WITH 1",
+		err:  "operation is not supported: operator 'STARTS_WITH' not supported for Int type search attribute 'HistoryLength'",
+	},
+	{
+		name: "Int mixed types in list",
+		in:   "AliasForInt01 IN (1, 'foo')",
+		err:  `invalid expression: invalid value type for search attribute AliasForInt01 of type Int: "foo" (type: string)`,
+	},
+
+	// Double type search attributes.
+	{
+		name: "Double equal",
+		in:   "AliasForDouble01 = 1.5",
+		sql:  "TemporalNamespaceDivision is null and Double01 = 1.5",
+		es:   `{"bool":{"filter":{"term":{"Double01":1.5}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		// Unlike negative integers, negative floats are parsed as an unary expression.
+		name: "Double negative value",
+		in:   "AliasForDouble01 >= -1.5",
+		sql:  "TemporalNamespaceDivision is null and Double01 >= -1.5",
+		es:   `{"bool":{"filter":{"range":{"Double01":{"from":-1.5,"include_lower":true,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Double positive sign value",
+		in:   "AliasForDouble01 = +1.5",
+		sql:  "TemporalNamespaceDivision is null and Double01 = 1.5",
+		es:   `{"bool":{"filter":{"term":{"Double01":1.5}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Double with int value",
+		in:   "AliasForDouble01 = 1",
+		sql:  "TemporalNamespaceDivision is null and Double01 = 1",
+		es:   `{"bool":{"filter":{"term":{"Double01":1}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Double with negative int value",
+		in:   "AliasForDouble01 = -1",
+		sql:  "TemporalNamespaceDivision is null and Double01 = -1",
+		es:   `{"bool":{"filter":{"term":{"Double01":-1}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Double with positive sign int value",
+		in:   "AliasForDouble01 = +1",
+		sql:  "TemporalNamespaceDivision is null and Double01 = 1",
+		es:   `{"bool":{"filter":{"term":{"Double01":1}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		// negative int is parsed as SQLVal, and sqlparser reduces inline
+		name: "Double negative negative int value",
+		in:   "AliasForDouble01 = - -10",
+		sql:  "TemporalNamespaceDivision is null and Double01 = 10",
+		es:   `{"bool":{"filter":{"term":{"Double01":10}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		// negative float is parsed as UnaryExpr, and nested unary expressions is not allowed
+		name: "Double negative negative float value",
+		in:   "AliasForDouble01 = - -1.0",
+		err:  `invalid expression: unary operator not supported in "- -1.0"`,
+	},
+	{
+		name: "Double invalid value type",
+		in:   "AliasForDouble01 = 'foo'",
+		err:  `invalid expression: invalid value type for search attribute AliasForDouble01 of type Double: "foo" (type: string)`,
+	},
+
+	// Bool type search attributes.
+	{
+		name: "Bool true",
+		in:   "AliasForBool01 = true",
+		sql:  "TemporalNamespaceDivision is null and Bool01 = true",
+		es:   `{"bool":{"filter":{"term":{"Bool01":true}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Bool false",
+		in:   "TemporalSchedulePaused = false",
+		sql:  "TemporalNamespaceDivision is null and TemporalSchedulePaused = false",
+		es:   `{"bool":{"filter":{"term":{"TemporalSchedulePaused":false}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Bool not equal",
+		in:   "AliasForBool01 != true",
+		sql:  "TemporalNamespaceDivision is null and Bool01 != true",
+		es:   `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"term":{"Bool01":true}}]}}`,
+	},
+	{
+		name: "Bool invalid value type",
+		in:   "AliasForBool01 = 'true'",
+		err:  `invalid expression: invalid value type for search attribute AliasForBool01 of type Bool: "true" (type: string)`,
+	},
+	{
+		name: "Bool range condition not supported",
+		in:   "AliasForBool01 BETWEEN false AND true",
+		err:  "invalid expression: cannot do range condition on search attribute 'AliasForBool01' of type Bool",
+	},
+	{
+		name: "Bool invalid unary negative value type",
+		in:   "AliasForBool01 = -true",
+		err:  `invalid expression: unary operator not supported in "-true"`,
+	},
+	{
+		name: "Bool invalid unary positive value type",
+		in:   "AliasForBool01 = +true",
+		err:  `invalid expression: unary operator not supported in "+true"`,
+	},
+
+	// Datetime type search attributes.
+	{
+		name:     "Datetime equal",
+		in:       "StartTime = '2020-01-02T15:04:05Z'",
+		mysql:    "TemporalNamespaceDivision is null and start_time = '2020-01-02 15:04:05'",
+		postgres: "TemporalNamespaceDivision is null and start_time = '2020-01-02 15:04:05'",
+		sqlite:   "TemporalNamespaceDivision is null and start_time = '2020-01-02 15:04:05+00:00'",
+		es:       `{"bool":{"filter":{"term":{"StartTime":"2020-01-02T15:04:05Z"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name:     "Datetime with nanoseconds and offset",
+		in:       "StartTime > '2020-01-02T15:04:05.123456789-07:00'",
+		mysql:    "TemporalNamespaceDivision is null and start_time > '2020-01-02 22:04:05.123456'",
+		postgres: "TemporalNamespaceDivision is null and start_time > '2020-01-02 22:04:05.123456'",
+		sqlite:   "TemporalNamespaceDivision is null and start_time > '2020-01-02 22:04:05.123456+00:00'",
+		es:       `{"bool":{"filter":{"range":{"StartTime":{"from":"2020-01-02T22:04:05.123456789Z","include_lower":false,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name:     "Datetime with unix nanoseconds",
+		in:       "StartTime > 1577977445000000000",
+		mysql:    "TemporalNamespaceDivision is null and start_time > '2020-01-02 15:04:05'",
+		postgres: "TemporalNamespaceDivision is null and start_time > '2020-01-02 15:04:05'",
+		sqlite:   "TemporalNamespaceDivision is null and start_time > '2020-01-02 15:04:05+00:00'",
+		es:       `{"bool":{"filter":{"range":{"StartTime":{"from":"2020-01-02T15:04:05Z","include_lower":false,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name:     "Datetime between",
+		in:       "CloseTime BETWEEN '2020-01-02T15:04:05Z' AND '2020-01-03T15:04:05Z'",
+		mysql:    "TemporalNamespaceDivision is null and close_time between '2020-01-02 15:04:05' and '2020-01-03 15:04:05'",
+		postgres: "TemporalNamespaceDivision is null and close_time between '2020-01-02 15:04:05' and '2020-01-03 15:04:05'",
+		sqlite:   "TemporalNamespaceDivision is null and close_time between '2020-01-02 15:04:05+00:00' and '2020-01-03 15:04:05+00:00'",
+		es:       `{"bool":{"filter":{"range":{"CloseTime":{"from":"2020-01-02T15:04:05Z","include_lower":true,"include_upper":true,"to":"2020-01-03T15:04:05Z"}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Datetime is null",
+		in:   "CloseTime IS NULL",
+		sql:  "TemporalNamespaceDivision is null and close_time is null",
+		es:   `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"exists":{"field":"CloseTime"}}]}}`,
+	},
+	{
+		name: "Datetime is not null",
+		in:   "CloseTime IS NOT NULL",
+		sql:  "TemporalNamespaceDivision is null and close_time is not null",
+		es:   `{"bool":{"filter":{"exists":{"field":"CloseTime"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name:     "Datetime custom search attribute",
+		in:       "AliasForDatetime01 <= '2020-01-02T15:04:05Z'",
+		mysql:    "TemporalNamespaceDivision is null and Datetime01 <= '2020-01-02 15:04:05'",
+		postgres: "TemporalNamespaceDivision is null and Datetime01 <= '2020-01-02 15:04:05'",
+		sqlite:   "TemporalNamespaceDivision is null and Datetime01 <= '2020-01-02 15:04:05+00:00'",
+		es:       `{"bool":{"filter":{"range":{"Datetime01":{"from":null,"include_lower":true,"include_upper":true,"to":"2020-01-02T15:04:05Z"}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Datetime invalid value",
+		in:   "StartTime = 'foo'",
+		err:  "invalid expression: unable to parse datetime 'foo'",
+	},
+	{
+		name: "Datetime with bool value",
+		in:   "StartTime = true",
+		err:  "invalid expression: invalid value type for search attribute StartTime of type Datetime: true (type: bool)",
+	},
+	{
+		name: "Datetime invalid unary negative value type",
+		in:   "StartTime = -'2020-01-02T15:04:05Z'",
+		err:  `invalid expression: unary operator not supported in "-'2020-01-02T15:04:05Z'"`,
+	},
+	{
+		name: "Datetime invalid unary positive value type",
+		in:   "StartTime = +'2020-01-02T15:04:05Z'",
+		err:  `invalid expression: unary operator not supported in "+'2020-01-02T15:04:05Z'"`,
+	},
+
+	// ExecutionStatus search attribute.
+	{
+		name: "ExecutionStatus equal",
+		in:   "ExecutionStatus = 'Running'",
+		sql:  "TemporalNamespaceDivision is null and status = 1",
+		es:   `{"bool":{"filter":{"term":{"ExecutionStatus":"Running"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "ExecutionStatus equal code",
+		in:   "ExecutionStatus = 1",
+		sql:  "TemporalNamespaceDivision is null and status = 1",
+		es:   `{"bool":{"filter":{"term":{"ExecutionStatus":"Running"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "ExecutionStatus not equal",
+		in:   "ExecutionStatus != 'Completed'",
+		sql:  "TemporalNamespaceDivision is null and status != 2",
+		es:   `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"term":{"ExecutionStatus":"Completed"}}]}}`,
+	},
+	{
+		name: "ExecutionStatus in",
+		in:   "ExecutionStatus IN ('Running', 'Completed')",
+		sql:  "TemporalNamespaceDivision is null and status in (1, 2)",
+		es:   `{"bool":{"filter":{"terms":{"ExecutionStatus":["Running","Completed"]}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "ExecutionStatus in code",
+		in:   "ExecutionStatus IN (1, 2)",
+		sql:  "TemporalNamespaceDivision is null and status in (1, 2)",
+		es:   `{"bool":{"filter":{"terms":{"ExecutionStatus":["Running","Completed"]}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "ExecutionStatus not in",
+		in:   "ExecutionStatus NOT IN ('Running', 'Completed')",
+		sql:  "TemporalNamespaceDivision is null and status not in (1, 2)",
+		es:   `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"terms":{"ExecutionStatus":["Running","Completed"]}}]}}`,
+	},
+	{
+		name: "ExecutionStatus unspecified",
+		in:   "ExecutionStatus = 'Unspecified'",
+		sql:  "TemporalNamespaceDivision is null and status = 0",
+		es:   `{"bool":{"filter":{"term":{"ExecutionStatus":"Unspecified"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "ExecutionStatus invalid name",
+		in:   "ExecutionStatus = 'Foo'",
+		err:  "invalid expression: invalid ExecutionStatus value 'Foo'",
+	},
+	{
+		name: "ExecutionStatus invalid code",
+		in:   "ExecutionStatus = 42",
+		err:  "invalid expression: invalid ExecutionStatus value 42",
+	},
+	{
+		name: "ExecutionStatus invalid value type",
+		in:   "ExecutionStatus = 1.5",
+		err:  "invalid expression: unexpected value type float64 for search attribute ExecutionStatus",
+	},
+	{
+		name: "ExecutionStatus invalid value in list",
+		in:   "ExecutionStatus IN ('Running', 'Foo')",
+		err:  "invalid expression: invalid ExecutionStatus value 'Foo'",
+	},
+	{
+		name: "ExecutionStatus is null",
+		in:   "ExecutionStatus IS NULL",
+		sql:  "TemporalNamespaceDivision is null and status is null",
+		es:   `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"exists":{"field":"ExecutionStatus"}}]}}`,
+	},
+	{
+		// ExecutionStatus is stored as an integer in SQL databases, thus a prefix search
+		// is only possible in Elasticsearch.
+		name:   "ExecutionStatus starts with",
+		in:     "ExecutionStatus STARTS_WITH 'Running'",
+		sqlErr: `invalid expression: right-hand side of "starts_with" operator must be a literal string (got: Running)`,
+		es:     `{"bool":{"filter":{"prefix":{"ExecutionStatus":"Running"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+
+	// ExecutionDuration search attribute.
+	{
+		name: "ExecutionDuration nanoseconds",
+		in:   "ExecutionDuration > 1000000",
+		sql:  "TemporalNamespaceDivision is null and execution_duration > 1000000",
+		es:   `{"bool":{"filter":{"range":{"ExecutionDuration":{"from":1000000,"include_lower":false,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "ExecutionDuration golang duration",
+		in:   "ExecutionDuration > '10s'",
+		sql:  "TemporalNamespaceDivision is null and execution_duration > 10000000000",
+		es:   `{"bool":{"filter":{"range":{"ExecutionDuration":{"from":10000000000,"include_lower":false,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "ExecutionDuration days",
+		in:   "ExecutionDuration > '2d'",
+		sql:  "TemporalNamespaceDivision is null and execution_duration > 172800000000000",
+		es:   `{"bool":{"filter":{"range":{"ExecutionDuration":{"from":172800000000000,"include_lower":false,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "ExecutionDuration hh:mm:ss",
+		in:   "ExecutionDuration > '00:10:30'",
+		sql:  "TemporalNamespaceDivision is null and execution_duration > 630000000000",
+		es:   `{"bool":{"filter":{"range":{"ExecutionDuration":{"from":630000000000,"include_lower":false,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		// negative zero hours works because -0 = 0, it does not negate the duration (bug?)
+		name: "ExecutionDuration negative 00:mm:ss",
+		in:   "ExecutionDuration > '-00:10:30'",
+		sql:  "TemporalNamespaceDivision is null and execution_duration > 630000000000",
+		es:   `{"bool":{"filter":{"range":{"ExecutionDuration":{"from":630000000000,"include_lower":false,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "ExecutionDuration between",
+		in:   "ExecutionDuration BETWEEN '1s' AND '1m'",
+		sql:  "TemporalNamespaceDivision is null and execution_duration between 1000000000 and 60000000000",
+		es:   `{"bool":{"filter":{"range":{"ExecutionDuration":{"from":1000000000,"include_lower":true,"include_upper":true,"to":60000000000}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "ExecutionDuration invalid value",
+		in:   "ExecutionDuration > 'foo'",
+		err:  "invalid expression: invalid duration value for search attribute ExecutionDuration: foo",
+	},
+	{
+		name: "ExecutionDuration negative value",
+		in:   "ExecutionDuration > -1000",
+		sql:  "TemporalNamespaceDivision is null and execution_duration > -1000",
+		es:   `{"bool":{"filter":{"range":{"ExecutionDuration":{"from":-1000,"include_lower":false,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "ExecutionDuration positive sign value",
+		in:   "ExecutionDuration > +1000",
+		sql:  "TemporalNamespaceDivision is null and execution_duration > 1000",
+		es:   `{"bool":{"filter":{"range":{"ExecutionDuration":{"from":1000,"include_lower":false,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "ExecutionDuration golang negative duration",
+		in:   "ExecutionDuration > '-10s'",
+		sql:  "TemporalNamespaceDivision is null and execution_duration > -10000000000",
+		es:   `{"bool":{"filter":{"range":{"ExecutionDuration":{"from":-10000000000,"include_lower":false,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "ExecutionDuration golang positive sign duration",
+		in:   "ExecutionDuration > '+10s'",
+		sql:  "TemporalNamespaceDivision is null and execution_duration > 10000000000",
+		es:   `{"bool":{"filter":{"range":{"ExecutionDuration":{"from":10000000000,"include_lower":false,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "ExecutionDuration negative golang duration",
+		in:   "ExecutionDuration > -'10s'",
+		err:  `invalid expression: unary operator not supported in "-'10s'"`,
+	},
+	{
+		name: "ExecutionDuration positive sign golang duration",
+		in:   "ExecutionDuration > +'10s'",
+		err:  `invalid expression: unary operator not supported in "+'10s'"`,
+	},
+	{
+		name: "ExecutionDuration negative hh:mm:ss",
+		in:   "ExecutionDuration > '-01:10:30'",
+		err:  "invalid expression: invalid duration value for search attribute ExecutionDuration: -01:10:30",
+	},
+	{
+		name: "ExecutionDuration unary negative hh:mm:ss",
+		in:   "ExecutionDuration > -'00:10:30'",
+		err:  `invalid expression: unary operator not supported in "-'00:10:30'"`,
+	},
+	{
+		name: "ExecutionDuration unary positive hh:mm:ss",
+		in:   "ExecutionDuration > +'00:10:30'",
+		err:  `invalid expression: unary operator not supported in "+'00:10:30'"`,
+	},
+	{
+		name: "ExecutionDuration with bool value",
+		in:   "ExecutionDuration > true",
+		err:  "invalid expression: invalid value type for search attribute ExecutionDuration of type Int: true (type: bool)",
+	},
+
+	// KeywordList type search attributes.
+	{
+		name:     "KeywordList equal",
+		in:       "AliasForKeywordList01 = 'foo'",
+		mysql:    "TemporalNamespaceDivision is null and 'foo' member of (KeywordList01)",
+		postgres: "TemporalNamespaceDivision is null and KeywordList01 @> jsonb_build_array('foo')",
+		sqlite:   `TemporalNamespaceDivision is null and rowid in (select rowid from executions_visibility_fts_keyword_list where executions_visibility_fts_keyword_list = 'KeywordList01 : ("foo")')`,
+		es:       `{"bool":{"filter":{"term":{"KeywordList01":"foo"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name:     "KeywordList not equal",
+		in:       "AliasForKeywordList01 != 'foo'",
+		mysql:    "TemporalNamespaceDivision is null and (not 'foo' member of (KeywordList01))",
+		postgres: "TemporalNamespaceDivision is null and (not KeywordList01 @> jsonb_build_array('foo'))",
+		sqlite:   `TemporalNamespaceDivision is null and rowid not in (select rowid from executions_visibility_fts_keyword_list where executions_visibility_fts_keyword_list = 'KeywordList01 : ("foo")')`,
+		es:       `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"term":{"KeywordList01":"foo"}}]}}`,
+	},
+	{
+		name:     "KeywordList in",
+		in:       "AliasForKeywordList01 IN ('foo', 'bar')",
+		mysql:    `TemporalNamespaceDivision is null and json_overlaps(KeywordList01, cast('["foo","bar"]' as json))`,
+		postgres: "TemporalNamespaceDivision is null and (KeywordList01 @> jsonb_build_array('foo') or KeywordList01 @> jsonb_build_array('bar'))",
+		sqlite:   `TemporalNamespaceDivision is null and rowid in (select rowid from executions_visibility_fts_keyword_list where executions_visibility_fts_keyword_list = 'KeywordList01 : ("foo" OR "bar")')`,
+		es:       `{"bool":{"filter":{"terms":{"KeywordList01":["foo","bar"]}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name:     "KeywordList not in",
+		in:       "AliasForKeywordList01 NOT IN ('foo', 'bar')",
+		mysql:    `TemporalNamespaceDivision is null and (not json_overlaps(KeywordList01, cast('["foo","bar"]' as json)))`,
+		postgres: "TemporalNamespaceDivision is null and (not (KeywordList01 @> jsonb_build_array('foo') or KeywordList01 @> jsonb_build_array('bar')))",
+		sqlite:   `TemporalNamespaceDivision is null and rowid not in (select rowid from executions_visibility_fts_keyword_list where executions_visibility_fts_keyword_list = 'KeywordList01 : ("foo" OR "bar")')`,
+		es:       `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"terms":{"KeywordList01":["foo","bar"]}}]}}`,
+	},
+	{
+		name:     "KeywordList predefined search attribute",
+		in:       "TemporalChangeVersion = 'foo'",
+		mysql:    "TemporalNamespaceDivision is null and 'foo' member of (TemporalChangeVersion)",
+		postgres: "TemporalNamespaceDivision is null and TemporalChangeVersion @> jsonb_build_array('foo')",
+		sqlite:   `TemporalNamespaceDivision is null and rowid in (select rowid from executions_visibility_fts_keyword_list where executions_visibility_fts_keyword_list = 'TemporalChangeVersion : ("foo")')`,
+		es:       `{"bool":{"filter":{"term":{"TemporalChangeVersion":"foo"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "KeywordList is null",
+		in:   "AliasForKeywordList01 IS NULL",
+		sql:  "TemporalNamespaceDivision is null and KeywordList01 is null",
+		es:   `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"exists":{"field":"KeywordList01"}}]}}`,
+	},
+	{
+		name: "KeywordList unsupported operator",
+		in:   "AliasForKeywordList01 > 'foo'",
+		err:  "operation is not supported: operator '>' not supported for KeywordList type search attribute 'AliasForKeywordList01'",
+	},
+	{
+		name: "KeywordList starts with not supported",
+		in:   "AliasForKeywordList01 STARTS_WITH 'foo'",
+		err:  "operation is not supported: operator 'STARTS_WITH' not supported for KeywordList type search attribute 'AliasForKeywordList01'",
+	},
+	{
+		name: "KeywordList invalid value type",
+		in:   "AliasForKeywordList01 = 123",
+		err:  "invalid expression: invalid value type for search attribute AliasForKeywordList01 of type KeywordList: 123 (type: int64)",
+	},
+	{
+		name: "KeywordList with negative value",
+		in:   "AliasForKeywordList01 = -'foo'",
+		err:  `invalid expression: unary operator not supported in "-'foo'"`,
+	},
+	{
+		name: "KeywordList with positive value",
+		in:   "AliasForKeywordList01 = +'foo'",
+		err:  `invalid expression: unary operator not supported in "+'foo'"`,
+	},
+	{
+		name: "KeywordList in with negative value",
+		in:   "AliasForKeywordList01 IN ('foo', -'bar')",
+		err:  `invalid expression: unary operator not supported in "-'bar'"`,
+	},
+	{
+		name: "KeywordList in with positive value",
+		in:   "AliasForKeywordList01 IN ('foo', +'bar')",
+		err:  `invalid expression: unary operator not supported in "+'bar'"`,
+	},
+	{
+		name: "KeywordList not in with negative value",
+		in:   "AliasForKeywordList01 NOT IN ('foo', -'bar')",
+		err:  `invalid expression: unary operator not supported in "-'bar'"`,
+	},
+	{
+		name: "KeywordList not in with positive value",
+		in:   "AliasForKeywordList01 NOT IN ('foo', +'bar')",
+		err:  `invalid expression: unary operator not supported in "+'bar'"`,
+	},
+
+	// Text type search attributes.
+	{
+		name:     "Text equal",
+		in:       "AliasForText01 = 'foo bar'",
+		mysql:    "TemporalNamespaceDivision is null and match(Text01) against ('foo bar' in natural language mode)",
+		postgres: "TemporalNamespaceDivision is null and Text01 @@ 'foo | bar'::tsquery",
+		sqlite:   `TemporalNamespaceDivision is null and rowid in (select rowid from executions_visibility_fts_text where executions_visibility_fts_text = 'Text01 : ("foo" OR "bar")')`,
+		es:       `{"bool":{"filter":{"match":{"Text01":{"query":"foo bar"}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name:     "Text not equal",
+		in:       "AliasForText01 != 'foo bar'",
+		mysql:    "TemporalNamespaceDivision is null and (not match(Text01) against ('foo bar' in natural language mode))",
+		postgres: "TemporalNamespaceDivision is null and (not Text01 @@ 'foo | bar'::tsquery)",
+		sqlite:   `TemporalNamespaceDivision is null and rowid not in (select rowid from executions_visibility_fts_text where executions_visibility_fts_text = 'Text01 : ("foo" OR "bar")')`,
+		es:       `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"match":{"Text01":{"query":"foo bar"}}}]}}`,
+	},
+	{
+		name: "Text empty value",
+		in:   "AliasForText01 = ''",
+		err:  "invalid expression: no tokens found filtering on Text type search attribute AliasForText01",
+	},
+	{
+		name: "Text blank value",
+		in:   "AliasForText01 = '   '",
+		err:  "invalid expression: no tokens found filtering on Text type search attribute AliasForText01",
+	},
+	{
+		// Only blank values are rejected: the value is passed as is to the store converters,
+		// which tokenize it.
+		name:     "Text value with surrounding spaces",
+		in:       "AliasForText01 = '  foo bar  '",
+		mysql:    "TemporalNamespaceDivision is null and match(Text01) against ('  foo bar  ' in natural language mode)",
+		postgres: "TemporalNamespaceDivision is null and Text01 @@ 'foo | bar'::tsquery",
+		sqlite:   `TemporalNamespaceDivision is null and rowid in (select rowid from executions_visibility_fts_text where executions_visibility_fts_text = 'Text01 : ("foo" OR "bar")')`,
+		es:       `{"bool":{"filter":{"match":{"Text01":{"query":"  foo bar  "}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "Text unsupported operator",
+		in:   "AliasForText01 > 'foo'",
+		err:  "operation is not supported: operator '>' not supported for Text type search attribute 'AliasForText01'",
+	},
+	{
+		name: "Text in not supported",
+		in:   "AliasForText01 IN ('foo', 'bar')",
+		err:  "operation is not supported: operator 'IN' not supported for Text type search attribute 'AliasForText01'",
+	},
+	{
+		name: "Text range condition not supported",
+		in:   "AliasForText01 BETWEEN 'a' AND 'b'",
+		err:  "invalid expression: cannot do range condition on search attribute 'AliasForText01' of type Text",
+	},
+	{
+		name: "Text invalid value type",
+		in:   "AliasForText01 = 123",
+		err:  "invalid expression: invalid value type for search attribute AliasForText01 of type Text: 123 (type: int64)",
+	},
+	{
+		name: "Text with negative value",
+		in:   "AliasForText01 = -'foo'",
+		err:  `invalid expression: unary operator not supported in "-'foo'"`,
+	},
+	{
+		name: "Text with positive value",
+		in:   "AliasForText01 = +'foo'",
+		err:  `invalid expression: unary operator not supported in "+'foo'"`,
+	},
+
+	// Search attribute name resolution.
+	{
+		name: "custom search attribute by field name",
+		in:   "Keyword01 = 'foo'",
+		sql:  "TemporalNamespaceDivision is null and Keyword01 = 'foo'",
+		es:   `{"bool":{"filter":{"term":{"Keyword01":"foo"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "custom search attribute with backticks",
+		in:   "`AliasForKeyword01` = 'foo'",
+		sql:  "TemporalNamespaceDivision is null and Keyword01 = 'foo'",
+		es:   `{"bool":{"filter":{"term":{"Keyword01":"foo"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "custom search attribute alias with hyphen",
+		in:   "`AliasWithHyphenFor-Keyword01` = 'foo'",
+		sql:  "TemporalNamespaceDivision is null and Keyword01 = 'foo'",
+		es:   `{"bool":{"filter":{"term":{"Keyword01":"foo"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name:     "predefined search attribute without Temporal prefix",
+		in:       "PauseInfo = 'foo'",
+		mysql:    "TemporalNamespaceDivision is null and 'foo' member of (TemporalPauseInfo)",
+		postgres: "TemporalNamespaceDivision is null and TemporalPauseInfo @> jsonb_build_array('foo')",
+		sqlite:   `TemporalNamespaceDivision is null and rowid in (select rowid from executions_visibility_fts_keyword_list where executions_visibility_fts_keyword_list = 'TemporalPauseInfo : ("foo")')`,
+		es:       `{"bool":{"filter":{"term":{"TemporalPauseInfo":"foo"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "system search attribute with Temporal prefix",
+		in:   "TemporalHistoryLength > 10",
+		sql:  "TemporalNamespaceDivision is null and history_length > 10",
+		es:   `{"bool":{"filter":{"range":{"HistoryLength":{"from":10,"include_lower":false,"include_upper":true,"to":null}}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "ScheduleId is mapped to WorkflowId",
+		in:   "ScheduleId = 'sched-id'",
+		sql:  "TemporalNamespaceDivision is null and workflow_id = 'sched-id'",
+		es:   `{"bool":{"filter":{"term":{"WorkflowId":"sched-id"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "TemporalScheduleId is mapped to WorkflowId",
+		in:   "TemporalScheduleId = 'sched-id'",
+		sql:  "TemporalNamespaceDivision is null and workflow_id = 'sched-id'",
+		es:   `{"bool":{"filter":{"term":{"WorkflowId":"sched-id"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "unknown search attribute",
+		in:   "Foo = 'bar'",
+		err:  "invalid expression: column name 'Foo' is not a valid search attribute",
+	},
+	{
+		name: "reserved field name is not a search attribute",
+		in:   "NamespaceId = 'foo'",
+		err:  "invalid expression: column name 'NamespaceId' is not a valid search attribute",
+	},
+
+	// Namespace division.
+	{
+		name: "explicit namespace division",
+		in:   "TemporalNamespaceDivision = 'foo'",
+		sql:  "TemporalNamespaceDivision = 'foo'",
+		es:   `{"term":{"TemporalNamespaceDivision":"foo"}}`,
+	},
+	{
+		name: "explicit namespace division is null",
+		in:   "TemporalNamespaceDivision IS NULL",
+		sql:  "TemporalNamespaceDivision is null",
+		es:   `{"bool":{"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "match any namespace division",
+		in:   "TemporalNamespaceDivision IS NULL OR TemporalNamespaceDivision IS NOT NULL",
+		sql:  "(TemporalNamespaceDivision is null or TemporalNamespaceDivision is not null)",
+		es:   `{"bool":{"minimum_should_match":"1","should":[{"bool":{"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}},{"exists":{"field":"TemporalNamespaceDivision"}}]}}`,
+	},
+	{
+		name: "namespace division in complex query",
+		in:   "WorkflowId = 'wid' AND (TemporalNamespaceDivision = 'foo' OR TemporalNamespaceDivision = 'bar')",
+		sql:  "(workflow_id = 'wid' and (TemporalNamespaceDivision = 'foo' or TemporalNamespaceDivision = 'bar'))",
+		es:   `{"bool":{"filter":[{"term":{"WorkflowId":"wid"}},{"bool":{"minimum_should_match":"1","should":[{"term":{"TemporalNamespaceDivision":"foo"}},{"term":{"TemporalNamespaceDivision":"bar"}}]}}]}}`,
+	},
+
+	// Logical operators.
+	{
+		name: "and expression",
+		in:   "WorkflowId = 'wid' AND ExecutionStatus = 'Running'",
+		sql:  "TemporalNamespaceDivision is null and (workflow_id = 'wid' and status = 1)",
+		es:   `{"bool":{"filter":[{"term":{"WorkflowId":"wid"}},{"term":{"ExecutionStatus":"Running"}}],"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "or expression",
+		in:   "WorkflowId = 'wid' OR RunId = 'rid'",
+		sql:  "TemporalNamespaceDivision is null and (workflow_id = 'wid' or run_id = 'rid')",
+		es:   `{"bool":{"filter":{"bool":{"minimum_should_match":"1","should":[{"term":{"WorkflowId":"wid"}},{"term":{"RunId":"rid"}}]}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "multiple and expressions",
+		in:   "WorkflowId = 'wid' AND RunId = 'rid' AND WorkflowType = 'wtype'",
+		sql:  "TemporalNamespaceDivision is null and ((workflow_id = 'wid' and run_id = 'rid') and workflow_type_name = 'wtype')",
+		es:   `{"bool":{"filter":[{"term":{"WorkflowId":"wid"}},{"term":{"RunId":"rid"}},{"term":{"WorkflowType":"wtype"}}],"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "multiple or expressions",
+		in:   "WorkflowId = 'wid' OR RunId = 'rid' OR WorkflowType = 'wtype'",
+		sql:  "TemporalNamespaceDivision is null and (workflow_id = 'wid' or run_id = 'rid' or workflow_type_name = 'wtype')",
+		es:   `{"bool":{"filter":{"bool":{"minimum_should_match":"1","should":[{"term":{"WorkflowId":"wid"}},{"term":{"RunId":"rid"}},{"term":{"WorkflowType":"wtype"}}]}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "and or precedence",
+		in:   "WorkflowId = 'wid' AND RunId = 'rid' OR WorkflowType = 'wtype'",
+		sql:  "TemporalNamespaceDivision is null and (workflow_id = 'wid' and run_id = 'rid' or workflow_type_name = 'wtype')",
+		es:   `{"bool":{"filter":{"bool":{"minimum_should_match":"1","should":[{"bool":{"filter":[{"term":{"WorkflowId":"wid"}},{"term":{"RunId":"rid"}}]}},{"term":{"WorkflowType":"wtype"}}]}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "parenthesized expression",
+		in:   "WorkflowId = 'wid' AND (RunId = 'rid' OR WorkflowType = 'wtype')",
+		sql:  "TemporalNamespaceDivision is null and (workflow_id = 'wid' and (run_id = 'rid' or workflow_type_name = 'wtype'))",
+		es:   `{"bool":{"filter":[{"term":{"WorkflowId":"wid"}},{"bool":{"minimum_should_match":"1","should":[{"term":{"RunId":"rid"}},{"term":{"WorkflowType":"wtype"}}]}}],"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "nested parenthesized expression",
+		in:   "((WorkflowId = 'wid'))",
+		sql:  "TemporalNamespaceDivision is null and workflow_id = 'wid'",
+		es:   `{"bool":{"filter":{"term":{"WorkflowId":"wid"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+	},
+	{
+		name: "not expression",
+		in:   "NOT WorkflowId = 'wid'",
+		sql:  "TemporalNamespaceDivision is null and (not workflow_id = 'wid')",
+		es:   `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"term":{"WorkflowId":"wid"}}]}}`,
+	},
+	{
+		name: "not parenthesized and expression",
+		in:   "NOT (WorkflowId = 'wid' AND RunId = 'rid')",
+		sql:  "TemporalNamespaceDivision is null and (not (workflow_id = 'wid' and run_id = 'rid'))",
+		es:   `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"bool":{"filter":[{"term":{"WorkflowId":"wid"}},{"term":{"RunId":"rid"}}]}}]}}`,
+	},
+	{
+		name: "not parenthesized or expression",
+		in:   "NOT (WorkflowId = 'wid' OR RunId = 'rid')",
+		sql:  "TemporalNamespaceDivision is null and (not (workflow_id = 'wid' or run_id = 'rid'))",
+		es:   `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"term":{"WorkflowId":"wid"}},{"term":{"RunId":"rid"}}]}}`,
+	},
+	{
+		name: "not is null expression",
+		in:   "NOT CloseTime IS NULL",
+		sql:  "TemporalNamespaceDivision is null and (not close_time is null)",
+		es:   `{"bool":{"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"bool":{"must_not":{"exists":{"field":"CloseTime"}}}}]}}`,
+	},
+	{
+		name: "complex query",
+		in: "WorkflowType = 'wtype' AND ExecutionStatus IN ('Running', 'Failed') " +
+			"AND (StartTime > '2020-01-02T15:04:05Z' OR CloseTime IS NULL) " +
+			"AND NOT AliasForKeyword01 STARTS_WITH 'foo'",
+		mysql: "TemporalNamespaceDivision is null and " +
+			"(((workflow_type_name = 'wtype' and status in (1, 3)) and " +
+			"(start_time > '2020-01-02 15:04:05' or close_time is null)) and " +
+			"(not Keyword01 like 'foo%' escape '!'))",
+		postgres: "TemporalNamespaceDivision is null and " +
+			"(((workflow_type_name = 'wtype' and status in (1, 3)) and " +
+			"(start_time > '2020-01-02 15:04:05' or close_time is null)) and " +
+			"(not Keyword01 like 'foo%' escape '!'))",
+		sqlite: "TemporalNamespaceDivision is null and " +
+			"(((workflow_type_name = 'wtype' and status in (1, 3)) and " +
+			"(start_time > '2020-01-02 15:04:05+00:00' or close_time is null)) and " +
+			"(not Keyword01 like 'foo%' escape '!'))",
+		es: `{"bool":{"filter":[{"term":{"WorkflowType":"wtype"}},` +
+			`{"terms":{"ExecutionStatus":["Running","Failed"]}},` +
+			`{"bool":{"minimum_should_match":"1","should":[` +
+			`{"range":{"StartTime":{"from":"2020-01-02T15:04:05Z","include_lower":false,"include_upper":true,"to":null}}},` +
+			`{"bool":{"must_not":{"exists":{"field":"CloseTime"}}}}]}}],` +
+			`"must_not":[{"exists":{"field":"TemporalNamespaceDivision"}},{"prefix":{"Keyword01":"foo"}}]}}`,
+	},
+	{
+		name: "error inside and expression",
+		in:   "WorkflowId = 'wid' AND Foo = 'bar'",
+		err:  "invalid expression: column name 'Foo' is not a valid search attribute",
+	},
+	{
+		name: "error inside or expression",
+		in:   "Foo = 'bar' OR WorkflowId = 'wid'",
+		err:  "invalid expression: column name 'Foo' is not a valid search attribute",
+	},
+	{
+		name: "error inside not expression",
+		in:   "NOT Foo = 'bar'",
+		err:  "invalid expression: column name 'Foo' is not a valid search attribute",
+	},
+
+	// GROUP BY clause.
+	{
+		name:    "group by execution status",
+		in:      "GROUP BY ExecutionStatus",
+		sql:     "TemporalNamespaceDivision is null",
+		es:      `{"bool":{"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+		groupBy: []string{"ExecutionStatus"},
+	},
+	{
+		name:    "group by with where clause",
+		in:      "WorkflowType = 'wtype' GROUP BY ExecutionStatus",
+		sql:     "TemporalNamespaceDivision is null and workflow_type_name = 'wtype'",
+		es:      `{"bool":{"filter":{"term":{"WorkflowType":"wtype"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+		groupBy: []string{"ExecutionStatus"},
+	},
+	{
+		name:    "group by namespace division",
+		in:      "GROUP BY TemporalNamespaceDivision",
+		groupBy: []string{"TemporalNamespaceDivision"},
+	},
+	{
+		name: "group by unsupported search attribute",
+		in:   "GROUP BY WorkflowId",
+		err:  "operation is not supported: 'GROUP BY' clause is not supported for search attribute WorkflowId",
+	},
+	{
+		name: "group by multiple search attributes",
+		in:   "GROUP BY ExecutionStatus, TemporalNamespaceDivision",
+		err:  "operation is not supported: 'GROUP BY' clause supports only a single field",
+	},
+	{
+		name: "group by unknown search attribute",
+		in:   "GROUP BY Foo",
+		err:  "invalid expression: column name 'Foo' is not a valid search attribute",
+	},
+
+	// ORDER BY clause.
+	{
+		name:    "order by",
+		in:      "ORDER BY StartTime",
+		sql:     "TemporalNamespaceDivision is null",
+		es:      `{"bool":{"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+		orderBy: "order by start_time asc",
+	},
+	{
+		name:    "order by desc",
+		in:      "ORDER BY CloseTime DESC",
+		sql:     "TemporalNamespaceDivision is null",
+		es:      `{"bool":{"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+		orderBy: "order by close_time desc",
+	},
+	{
+		name:    "order by multiple search attributes",
+		in:      "ORDER BY StartTime DESC, RunId ASC",
+		sql:     "TemporalNamespaceDivision is null",
+		es:      `{"bool":{"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+		orderBy: "order by start_time desc, run_id asc",
+	},
+	{
+		name:    "order by with where clause",
+		in:      "WorkflowId = 'wid' ORDER BY StartTime DESC",
+		sql:     "TemporalNamespaceDivision is null and workflow_id = 'wid'",
+		es:      `{"bool":{"filter":{"term":{"WorkflowId":"wid"}},"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+		orderBy: "order by start_time desc",
+	},
+	{
+		name:    "order by custom search attribute",
+		in:      "ORDER BY AliasForKeyword01",
+		sql:     "TemporalNamespaceDivision is null",
+		es:      `{"bool":{"must_not":{"exists":{"field":"TemporalNamespaceDivision"}}}}`,
+		orderBy: "order by Keyword01 asc",
+	},
+	{
+		name: "order by text search attribute",
+		in:   "ORDER BY AliasForText01",
+		err:  "operation is not supported: unable to sort by search attribute type Text",
+	},
+	{
+		name: "order by unknown search attribute",
+		in:   "ORDER BY Foo",
+		err:  "invalid expression: column name 'Foo' is not a valid search attribute",
+	},
+
+	// Malformed and unsupported queries.
+	{
+		name: "malformed query",
+		in:   "this is not a query",
+		err:  "malformed SQL query: syntax error at position 41 near 'a'",
+	},
+	{
+		name: "missing value",
+		in:   "WorkflowId =",
+		err:  "malformed SQL query: syntax error at position 40",
+	},
+	{
+		name: "incomplete expression",
+		in:   "WorkflowId",
+		err:  "invalid expression: incomplete expression",
+	},
+	{
+		name: "column name on right hand side",
+		in:   "WorkflowId = RunId",
+		err:  `operation is not supported: column name on the right side of comparison expression (did you forget to quote "RunId"?)`,
+	},
+	{
+		name: "function expression",
+		in:   "length(WorkflowId)",
+		err:  "operation is not supported: function expression",
+	},
+	{
+		name: "function expression on left hand side",
+		in:   "length(WorkflowId) = 5",
+		err:  "invalid expression: must be a column name but was *sqlparser.FuncExpr",
+	},
+	{
+		name: "function expression on right hand side",
+		in:   "WorkflowId = length('foo')",
+		err:  "operation is not supported: nested func",
+	},
+	{
+		name: "limit clause",
+		in:   "WorkflowId = 'wid' LIMIT 10",
+		err:  "operation is not supported: 'LIMIT' clause",
+	},
+	{
+		name: "subquery",
+		in:   "WorkflowId IN (SELECT * FROM table1)",
+		err:  "invalid expression: unexpected value type *sqlparser.Subquery",
+	},
+	{
+		name: "arithmetic expression",
+		in:   "HistoryLength = 1 + 1",
+		err:  "invalid expression: unexpected value type *sqlparser.BinaryExpr",
+	},
+	{
+		name: "unsupported unary operator",
+		in:   "AliasForInt01 = ~1",
+		err:  `operation is not supported: unary operator "~"`,
+	},
+}
+
+func runQueryConverterTest[T any](
+	t *testing.T,
+	store string,
+	newQueryConverter func() *query.QueryConverter[T],
+	serialize func(T) (string, error),
+) {
+	for _, tc := range queryConverterTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := require.New(t)
+			expectedOut, expectedErr := tc.expected(store)
+			// The query converter is stateful (e.g. it tracks if the query filtered by
+			// namespace division), thus each test case requires a new instance.
+			queryParams, err := newQueryConverter().Convert(tc.in)
+			if expectedErr != "" {
+				r.Error(err)
+				r.EqualError(err, expectedErr)
+				var converterErr *query.ConverterError
+				r.ErrorAs(err, &converterErr)
+				r.Nil(queryParams)
+				return
+			}
+			r.NoError(err)
+			out, err := serialize(queryParams.QueryExpr)
+			r.NoError(err)
+			r.Equal(expectedOut, out)
+
+			var groupBy []string
+			for _, col := range queryParams.GroupBy {
+				groupBy = append(groupBy, col.FieldName)
+			}
+			r.Equal(tc.groupBy, groupBy)
+			r.Equal(tc.orderBy, strings.TrimSpace(sqlparser.String(queryParams.OrderBy)))
+		})
+	}
+}
+
+func serializeSQLQuery(expr sqlparser.Expr) (string, error) {
+	if expr == nil {
+		return "", nil
+	}
+	return sqlparser.String(expr), nil
+}
+
+func serializeESQuery(q elastic.Query) (string, error) {
+	if q == nil {
+		return "", nil
+	}
+	source, err := q.Source()
+	if err != nil {
+		return "", err
+	}
+	data, err := json.Marshal(source)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func TestSQLQueryConverter(t *testing.T) {
+	t.Parallel()
+	for _, plugin := range sqlPlugins {
+		t.Run(plugin, func(t *testing.T) {
+			t.Parallel()
+			pluginVisQC, err := sql.GetPluginVisibilityQueryConverter(plugin)
+			require.NoError(t, err)
+			runQueryConverterTest(
+				t,
+				plugin,
+				func() *query.QueryConverter[sqlparser.Expr] {
+					return query.NewQueryConverter(
+						&vissql.SQLQueryConverter{VisibilityQueryConverter: pluginVisQC},
+						testNamespaceName,
+						searchattribute.TestNameTypeMap(),
+						&searchattribute.TestMapper{},
+						nil, // metricsHandler
+						log.NewNoopLogger(),
+					)
+				},
+				serializeSQLQuery,
+			)
+		})
+	}
+}
+
+func TestElasticsearchQueryConverter(t *testing.T) {
+	t.Parallel()
+	runQueryConverterTest(
+		t,
+		esStore,
+		func() *query.QueryConverter[elastic.Query] {
+			return elasticsearch.NewQueryConverter(
+				testNamespaceName,
+				searchattribute.TestNameTypeMap(),
+				&searchattribute.TestMapper{},
+				nil, // metricsHandler
+				log.NewNoopLogger(),
+			)
+		},
+		serializeESQuery,
+	)
+}

--- a/common/rpc/interceptor/mask_internal_error_test.go
+++ b/common/rpc/interceptor/mask_internal_error_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/common"
@@ -17,18 +17,20 @@ import (
 )
 
 func TestMaskUnknownOrInternalErrors(t *testing.T) {
-
 	statusOk := status.New(codes.OK, "OK")
 	testMaskUnknownOrInternalErrors(t, statusOk, false)
 
-	statusUnknown := status.New(codes.Unknown, "Unknown")
+	statusCanceled := status.New(codes.Canceled, "Canceled message")
+	testMaskUnknownOrInternalErrors(t, statusCanceled, false)
+
+	statusUnknown := status.New(codes.Unknown, "Unknown message")
 	testMaskUnknownOrInternalErrors(t, statusUnknown, true)
 
-	statusInternal := status.New(codes.Internal, "Internal")
+	statusInternal := status.New(codes.Internal, "Internal message")
 	testMaskUnknownOrInternalErrors(t, statusInternal, true)
 }
 
-func testMaskUnknownOrInternalErrors(t *testing.T, st *status.Status, expectRelpace bool) {
+func testMaskUnknownOrInternalErrors(t *testing.T, st *status.Status, expectReplace bool) {
 	controller := gomock.NewController(t)
 	mockRegistry := namespace.NewMockRegistry(controller)
 	mockLogger := log.NewMockLogger(controller)
@@ -36,27 +38,27 @@ func testMaskUnknownOrInternalErrors(t *testing.T, st *status.Status, expectRelp
 	errorMaskInterceptor := NewMaskInternalErrorDetailsInterceptor(
 		dynamicconfig.FrontendMaskInternalErrorDetails.Get(dc), mockRegistry, mockLogger)
 
-	err := serviceerror.FromStatus(st)
-	if expectRelpace {
+	err := st.Err()
+	if expectReplace {
 		mockLogger.EXPECT().Error(gomock.Any(), gomock.Any()).Times(1)
 	}
-	errorMessage := errorMaskInterceptor.maskUnknownOrInternalErrors(nil, "test", err)
-	if expectRelpace {
+	gotError := errorMaskInterceptor.maskUnknownOrInternalErrors(nil, "test", err)
+	if expectReplace {
 		errorHash := common.ErrorHash(err)
-		expectedMessage := fmt.Sprintf("rpc error: code = %s desc = %s (%s)", st.Message(), errorFrontendMasked, errorHash)
+		expectedMessage := fmt.Sprintf(
+			"rpc error: code = %s desc = %s (%s)",
+			st.Code(),
+			errorFrontendMasked,
+			errorHash,
+		)
 
-		assert.Equal(t, expectedMessage, errorMessage.Error())
+		require.Equal(t, expectedMessage, gotError.Error())
 	} else {
-		if err == nil {
-			assert.Equal(t, errorMessage, nil)
-		} else {
-			assert.Equal(t, errorMessage.Error(), st.Message())
-		}
+		require.Equal(t, err, gotError)
 	}
 }
 
 func TestMaskInternalErrorDetailsInterceptor(t *testing.T) {
-
 	controller := gomock.NewController(t)
 	mockRegistry := namespace.NewMockRegistry(controller)
 	dc := dynamicconfig.NewNoopCollection()
@@ -68,18 +70,18 @@ func TestMaskInternalErrorDetailsInterceptor(t *testing.T) {
 	test_namespace := "test-namespace"
 	req := &workflowservice.StartWorkflowExecutionRequest{Namespace: test_namespace}
 	mockRegistry.EXPECT().GetNamespace(namespace.Name(test_namespace)).Return(&namespace.Namespace{}, nil).AnyTimes()
-	assert.True(t, errorMask.shouldMaskErrors(req))
+	require.True(t, errorMask.shouldMaskErrors(req))
 
 	namespace_not_found := "namespace-not-found"
 	req = &workflowservice.StartWorkflowExecutionRequest{Namespace: namespace_not_found}
 	mockRegistry.EXPECT().GetNamespace(namespace.Name(namespace_not_found)).Return(nil, serviceerror.NewNamespaceNotFound("missing-namespace"))
-	assert.False(t, errorMask.shouldMaskErrors(req))
+	require.False(t, errorMask.shouldMaskErrors(req))
 
 	empty_namespace := ""
 	req = &workflowservice.StartWorkflowExecutionRequest{Namespace: empty_namespace}
 	mockRegistry.EXPECT().GetNamespace(namespace.Name(empty_namespace)).Return(nil, serviceerror.NewNamespaceNotFound("missing-namespace"))
-	assert.False(t, errorMask.shouldMaskErrors(req))
+	require.False(t, errorMask.shouldMaskErrors(req))
 
 	var ei any
-	assert.False(t, errorMask.shouldMaskErrors(ei))
+	require.False(t, errorMask.shouldMaskErrors(ei))
 }

--- a/common/rpc/interceptor/service_error_interceptor.go
+++ b/common/rpc/interceptor/service_error_interceptor.go
@@ -6,6 +6,8 @@ import (
 
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/util"
 	"google.golang.org/grpc"
@@ -16,13 +18,21 @@ const truncatedSuffix = "... <truncated>"
 
 type ServiceErrorInterceptor struct {
 	maxMessageLength dynamicconfig.IntPropertyFn
+
+	metricsHandler metrics.Handler
+	logger         log.Logger
 }
 
 func NewServiceErrorInterceptor(
 	maxMessageLength dynamicconfig.IntPropertyFn,
+	metricsHandler metrics.Handler,
+	logger log.Logger,
 ) *ServiceErrorInterceptor {
 	return &ServiceErrorInterceptor{
 		maxMessageLength: maxMessageLength,
+
+		metricsHandler: metricsHandler,
+		logger:         logger,
 	}
 }
 
@@ -32,7 +42,7 @@ func (i *ServiceErrorInterceptor) Intercept(
 	_ *grpc.UnaryServerInfo,
 	handler grpc.UnaryHandler,
 ) (any, error) {
-	resp, err := handler(ctx, req)
+	resp, err := i.capturePanicHandler(ctx, req, handler)
 
 	var deserializationError *serialization.DeserializationError
 	var serializationError *serialization.SerializationError
@@ -51,4 +61,13 @@ func (i *ServiceErrorInterceptor) Intercept(
 	}
 
 	return resp, st.Err()
+}
+
+func (i *ServiceErrorInterceptor) capturePanicHandler(
+	ctx context.Context,
+	req any,
+	handler grpc.UnaryHandler,
+) (_ any, retError error) {
+	defer metrics.CapturePanic(i.logger, i.metricsHandler, &retError)
+	return handler(ctx, req)
 }

--- a/common/rpc/interceptor/service_error_interceptor_test.go
+++ b/common/rpc/interceptor/service_error_interceptor_test.go
@@ -2,6 +2,8 @@ package interceptor
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -9,7 +11,11 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence/serialization"
+	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -31,7 +37,12 @@ func (e *ErrorWithoutStatus) Error() string {
 
 // Error returns string message.
 func TestServiceErrorInterceptorUnknown(t *testing.T) {
-	interceptor := NewServiceErrorInterceptor(dynamicconfig.GetIntPropertyFn(testMaxMessageLength))
+	ctrl := gomock.NewController(t)
+	interceptor := NewServiceErrorInterceptor(
+		dynamicconfig.GetIntPropertyFn(testMaxMessageLength),
+		metrics.NewMockHandler(ctrl),
+		log.NewTestLogger(),
+	)
 
 	_, err := interceptor.Intercept(t.Context(), nil, nil,
 		func(ctx context.Context, req any) (any, error) {
@@ -54,7 +65,12 @@ func TestServiceErrorInterceptorUnknown(t *testing.T) {
 }
 
 func TestServiceErrorInterceptorSer(t *testing.T) {
-	interceptor := NewServiceErrorInterceptor(dynamicconfig.GetIntPropertyFn(testMaxMessageLength))
+	ctrl := gomock.NewController(t)
+	interceptor := NewServiceErrorInterceptor(
+		dynamicconfig.GetIntPropertyFn(testMaxMessageLength),
+		metrics.NewMockHandler(ctrl),
+		log.NewTestLogger(),
+	)
 	serErrors := []error{
 		serialization.NewDeserializationError(enumspb.ENCODING_TYPE_PROTO3, nil),
 		serialization.NewSerializationError(enumspb.ENCODING_TYPE_PROTO3, nil),
@@ -69,7 +85,12 @@ func TestServiceErrorInterceptorSer(t *testing.T) {
 }
 
 func TestServiceErrorInterceptorTruncation(t *testing.T) {
-	interceptor := NewServiceErrorInterceptor(dynamicconfig.GetIntPropertyFn(testMaxMessageLength))
+	ctrl := gomock.NewController(t)
+	interceptor := NewServiceErrorInterceptor(
+		dynamicconfig.GetIntPropertyFn(testMaxMessageLength),
+		metrics.NewMockHandler(ctrl),
+		log.NewTestLogger(),
+	)
 
 	t.Run("nil error is not affected", func(t *testing.T) {
 		_, err := interceptor.Intercept(t.Context(), nil, nil,
@@ -145,4 +166,94 @@ func TestServiceErrorInterceptorTruncation(t *testing.T) {
 			require.Equal(t, '€', r)
 		}
 	})
+}
+
+func TestServiceErrorInterceptorPanic(t *testing.T) {
+	testCases := []struct {
+		name       string
+		panicObj   any
+		errMessage string
+	}{
+		{
+			name:       "panic with error is converted to internal error",
+			panicObj:   errors.New("panic error message"),
+			errMessage: "panic error message",
+		},
+		{
+			name:       "panic with non-error value is converted to internal error",
+			panicObj:   "something went wrong",
+			errMessage: "panic: something went wrong",
+		},
+		{
+			name:       "panic with service error is still converted to internal error",
+			panicObj:   serviceerror.NewNotFound("not found message"),
+			errMessage: "not found message",
+		},
+		{
+			name:       "captured panic message is truncated",
+			panicObj:   errors.New(strings.Repeat("a", testMaxMessageLength+100)),
+			errMessage: strings.Repeat("a", testMaxMessageLength-len(truncatedSuffix)) + truncatedSuffix,
+		},
+		{
+			name:       "no panic does not log",
+			panicObj:   nil,
+			errMessage: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			metricsHandlerMock := metrics.NewMockHandler(ctrl)
+			loggerMock := log.NewMockLogger(ctrl)
+			interceptor := NewServiceErrorInterceptor(
+				dynamicconfig.GetIntPropertyFn(testMaxMessageLength),
+				metricsHandlerMock,
+				loggerMock,
+			)
+
+			var loggedTags []tag.Tag
+			if tc.panicObj != nil {
+				counterMock := metrics.NewMockCounterIface(ctrl)
+				counterMock.EXPECT().Record(int64(1))
+				metricsHandlerMock.EXPECT().Counter(metrics.ServicePanic.Name()).Return(counterMock)
+				loggerMock.EXPECT().Error("Panic is captured", gomock.Any(), gomock.Any()).
+					Do(func(_ string, tags ...tag.Tag) {
+						loggedTags = tags
+					}).
+					Times(1)
+			}
+
+			resp, err := interceptor.Intercept(t.Context(), nil, nil,
+				func(_ context.Context, _ any) (any, error) {
+					if tc.panicObj != nil {
+						panic(tc.panicObj)
+					}
+					return "ok", nil
+				})
+
+			if tc.panicObj != nil {
+				expectedMessage := fmt.Sprintf(
+					"rpc error: code = Internal desc = %s",
+					tc.errMessage,
+				)
+				require.Nil(t, resp)
+				require.Error(t, err)
+				require.Equal(t, codes.Internal, status.Code(err))
+				require.Equal(t, expectedMessage, err.Error())
+
+				// Logs contains the stack trace
+				tagsByKey := make(map[string]tag.Tag, len(loggedTags))
+				for _, tg := range loggedTags {
+					tagsByKey[tg.Key()] = tg
+				}
+				require.Contains(t, tagsByKey, "sys-stack-trace")
+				require.Contains(t, tagsByKey["sys-stack-trace"].Value(), "service_error_interceptor_test.go")
+				require.Contains(t, tagsByKey, "error")
+			} else {
+				require.Equal(t, "ok", resp)
+				require.NoError(t, err)
+			}
+		})
+	}
 }

--- a/schema/postgresql/v12/visibility/versioned/v1.14/add_external_payload_size_and_count_search_attributes.sql
+++ b/schema/postgresql/v12/visibility/versioned/v1.14/add_external_payload_size_and_count_search_attributes.sql
@@ -1,9 +1,31 @@
 ALTER TABLE executions_visibility
-ADD COLUMN TemporalExternalPayloadSizeBytes BIGINT GENERATED ALWAYS AS ((search_attributes->'TemporalExternalPayloadSizeBytes')::bigint) STORED;
+  ADD COLUMN IF NOT EXISTS TemporalExternalPayloadSizeBytes BIGINT GENERATED ALWAYS AS ((search_attributes->'TemporalExternalPayloadSizeBytes')::bigint)  STORED,
+  ADD COLUMN IF NOT EXISTS TemporalExternalPayloadCount     BIGINT GENERATED ALWAYS AS ((search_attributes->'TemporalExternalPayloadCount')::bigint)      STORED;
 
-ALTER TABLE executions_visibility
-ADD COLUMN TemporalExternalPayloadCount BIGINT GENERATED ALWAYS AS ((search_attributes->'TemporalExternalPayloadCount')::bigint) STORED;
+-- Drop invalid indices
+DO LANGUAGE 'plpgsql' $$
+DECLARE
+  r RECORD;
+BEGIN
+  FOR r IN
+    SELECT i.relname as indexname
+    FROM
+      pg_class i,
+      pg_index ix
+    WHERE
+      i.oid = ix.indexrelid
+      AND ix.indrelid = (SELECT oid FROM pg_class WHERE relname = 'executions_visibility')
+      AND i.relname IN (
+        'by_temporal_external_payload_size_bytes',
+        'by_temporal_external_payload_count'
+      )
+      AND NOT ix.indisvalid
+  LOOP
+    EXECUTE format('DROP INDEX %I', r.indexname);
+    RAISE NOTICE 'Dropped invalid index %', r.indexname;
+  END LOOP;
+END $$;
 
-CREATE INDEX by_temporal_external_payload_size_bytes ON executions_visibility (namespace_id, TemporalExternalPayloadSizeBytes, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
 
-CREATE INDEX by_temporal_external_payload_count ON executions_visibility (namespace_id, TemporalExternalPayloadCount, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id); 
+CREATE INDEX CONCURRENTLY IF NOT EXISTS by_temporal_external_payload_size_bytes ON executions_visibility (namespace_id, TemporalExternalPayloadSizeBytes, (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS by_temporal_external_payload_count      ON executions_visibility (namespace_id, TemporalExternalPayloadCount,     (COALESCE(close_time, '9999-12-31 23:59:59')) DESC, start_time DESC, run_id);

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -360,9 +360,13 @@ func ConfigProvider(
 
 func ServiceErrorInterceptorProvider(
 	dc *dynamicconfig.Collection,
+	metricsHandler metrics.Handler,
+	logger log.Logger,
 ) *interceptor.ServiceErrorInterceptor {
 	return interceptor.NewServiceErrorInterceptor(
 		dynamicconfig.MaxServiceErrorMessageLength.Get(dc),
+		metricsHandler,
+		logger,
 	)
 }
 

--- a/service/frontend/fx_test.go
+++ b/service/frontend/fx_test.go
@@ -33,6 +33,8 @@ type rateLimitInterceptorTestCase struct {
 	name string
 	// t is the test object
 	t *testing.T
+	// ctrl is the mock controller
+	ctrl *gomock.Controller
 	// globalRPSLimit is the global RPS limit for all frontend hosts
 	globalRPSLimit int
 	// perInstanceRPSLimit is the RPS limit for each frontend host
@@ -183,7 +185,7 @@ func TestRateLimitInterceptorProvider(t *testing.T) {
 				tc.perInstanceRPSLimit = highPerInstanceRPSLimit
 				tc.operatorRPSRatio = operatorRPSRatio
 				tc.expectRateLimit = false
-				serviceResolver := membership.NewMockServiceResolver(gomock.NewController(tc.t))
+				serviceResolver := membership.NewMockServiceResolver(tc.ctrl)
 				serviceResolver.EXPECT().AvailableMemberCount().Return(0).AnyTimes()
 				tc.serviceResolver = serviceResolver
 			},
@@ -196,11 +198,11 @@ func TestRateLimitInterceptorProvider(t *testing.T) {
 
 			tc.numRequests = 10
 			tc.t = t
+			tc.ctrl = gomock.NewController(t)
 			{
 				// Create a mock service resolver which returns the number of frontend hosts.
 				// This may be overridden by the test case.
-				ctrl := gomock.NewController(t)
-				serviceResolver := membership.NewMockServiceResolver(ctrl)
+				serviceResolver := membership.NewMockServiceResolver(tc.ctrl)
 				serviceResolver.EXPECT().AvailableMemberCount().Return(numHosts).AnyTimes()
 				tc.serviceResolver = serviceResolver
 			}
@@ -208,6 +210,8 @@ func TestRateLimitInterceptorProvider(t *testing.T) {
 
 			serviceErrorInterceptor := interceptor.NewServiceErrorInterceptor(
 				dynamicconfig.GetIntPropertyFn(4000),
+				metrics.NewMockHandler(tc.ctrl),
+				log.NewTestLogger(),
 			)
 
 			// Create a rate limit interceptor which uses the per-instance and global RPS limits from the test case.
@@ -565,17 +569,20 @@ func TestNamespaceRateLimitInterceptorProvider(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			ctrl := gomock.NewController(t)
 
 			namespaceName := "test-namespace"
-			mockRegistry := namespace.NewMockRegistry(gomock.NewController(t))
+			mockRegistry := namespace.NewMockRegistry(ctrl)
 			mockRegistry.EXPECT().GetNamespace(namespace.Name(namespaceName)).Return(&namespace.Namespace{}, nil).AnyTimes()
-			serviceResolver := membership.NewMockServiceResolver(gomock.NewController(t))
+			serviceResolver := membership.NewMockServiceResolver(ctrl)
 			serviceResolver.EXPECT().AvailableMemberCount().Return(tc.frontendServiceCount).AnyTimes()
 
 			config := getTestConfig(tc)
 
 			serviceErrorInterceptor := interceptor.NewServiceErrorInterceptor(
 				dynamicconfig.GetIntPropertyFn(4000),
+				metrics.NewMockHandler(ctrl),
+				log.NewTestLogger(),
 			)
 
 			// Create a rate limit interceptor.
@@ -752,11 +759,12 @@ func TestNamespaceRateLimitMetrics(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			ctrl := gomock.NewController(t)
 
 			testNS := "test_namespace"
-			mockRegistry := namespace.NewMockRegistry(gomock.NewController(t))
+			mockRegistry := namespace.NewMockRegistry(ctrl)
 			mockRegistry.EXPECT().GetNamespace(namespace.Name(testNS)).Return(&namespace.Namespace{}, nil).AnyTimes()
-			serviceResolver := membership.NewMockServiceResolver(gomock.NewController(t))
+			serviceResolver := membership.NewMockServiceResolver(ctrl)
 			serviceResolver.EXPECT().AvailableMemberCount().Return(tc.frontendServiceCount).AnyTimes()
 			metricsHandler := metricstest.NewCaptureHandler()
 			capture := metricsHandler.StartCapture()
@@ -779,6 +787,8 @@ func TestNamespaceRateLimitMetrics(t *testing.T) {
 
 			serviceErrorInterceptor := interceptor.NewServiceErrorInterceptor(
 				dynamicconfig.GetIntPropertyFn(4000),
+				metrics.NewMockHandler(ctrl),
+				log.NewTestLogger(),
 			)
 
 			// Create a rate limit interceptor which uses the per-instance and global RPS limits from the test case.

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -5111,17 +5111,23 @@ func (wh *WorkflowHandler) ListSchedules(
 		return nil, errListNotAllowed
 	}
 
+	metricsHandler := wh.metricsScope(ctx).WithTags(metrics.HeaderCallsiteTag("ListSchedules"))
 	chasmEnabled := wh.chasmSchedulerEnabled(ctx, namespaceName.String())
-	query, err := wh.prepareSchedulerQuery(chasmEnabled, request.Query, namespaceName)
+	schedulerQuery, err := wh.prepareSchedulerQuery(
+		chasmEnabled,
+		request.Query,
+		namespaceName,
+		metricsHandler,
+	)
 	if err != nil {
 		return nil, err
 	}
 
 	if chasmEnabled {
 		// CHASM ListSchedules will include schedules created in the V1/workflow stack.
-		return wh.listSchedulesChasm(ctx, request, namespaceName, namespaceID, query)
+		return wh.listSchedulesChasm(ctx, request, namespaceName, namespaceID, schedulerQuery)
 	}
-	return wh.listSchedulesWorkflow(ctx, request, namespaceName, namespaceID, query)
+	return wh.listSchedulesWorkflow(ctx, request, namespaceName, namespaceID, schedulerQuery)
 }
 
 // prepareSchedulerQuery validates a scheduler RPC's query argument, and wraps it
@@ -5130,6 +5136,7 @@ func (wh *WorkflowHandler) prepareSchedulerQuery(
 	chasmEnabled bool,
 	query string,
 	namespaceName namespace.Name,
+	metricsHandler metrics.Handler,
 ) (string, error) {
 	// Use different base queries based on code path:
 	// - CHASM path uses TemporalSystemExecutionStatus (translated via archetype ID)
@@ -5164,6 +5171,8 @@ func (wh *WorkflowHandler) prepareSchedulerQuery(
 			chasmMapper,
 			wh.config.VisibilityEnableUnifiedQueryConverter,
 			query,
+			metricsHandler,
+			wh.logger,
 		); err != nil {
 			return "", err
 		}
@@ -5300,17 +5309,23 @@ func (wh *WorkflowHandler) CountSchedules(
 		return nil, errListNotAllowed
 	}
 
+	metricsHandler := wh.metricsScope(ctx).WithTags(metrics.HeaderCallsiteTag("CountSchedules"))
 	chasmEnabled := wh.chasmSchedulerEnabled(ctx, namespaceName.String())
-	query, err := wh.prepareSchedulerQuery(chasmEnabled, request.Query, namespaceName)
+	schedulerQuery, err := wh.prepareSchedulerQuery(
+		chasmEnabled,
+		request.Query,
+		namespaceName,
+		metricsHandler,
+	)
 	if err != nil {
 		return nil, err
 	}
 
 	// Route to CHASM or V1 based on config (same pattern as ListSchedules)
 	if chasmEnabled {
-		return wh.countSchedulesChasm(ctx, namespaceID, namespaceName, query)
+		return wh.countSchedulesChasm(ctx, namespaceID, namespaceName, schedulerQuery)
 	}
-	return wh.countSchedulesWorkflow(ctx, namespaceID, namespaceName, query)
+	return wh.countSchedulesWorkflow(ctx, namespaceID, namespaceName, schedulerQuery)
 }
 
 // countSchedulesChasm counts schedules using CHASM APIs

--- a/service/history/api/getworkflowexecutionhistory/api.go
+++ b/service/history/api/getworkflowexecutionhistory/api.go
@@ -256,6 +256,19 @@ func Invoke(
 			continuationToken.FirstEventId = continuationToken.GetNextEventId()
 			continuationToken.NextEventId = nextEventID
 			continuationToken.IsWorkflowRunning = isWorkflowRunning
+		} else {
+			if err = api.ValidateBranchTokenForExecution(
+				ctx,
+				shardContext,
+				workflowConsistencyChecker,
+				eventNotifier,
+				namespaceName,
+				namespaceID,
+				execution,
+				continuationToken.BranchToken,
+			); err != nil {
+				return nil, err
+			}
 		}
 	} else {
 		continuationToken = &tokenspb.HistoryContinuation{}

--- a/service/history/api/getworkflowexecutionhistoryreverse/api.go
+++ b/service/history/api/getworkflowexecutionhistoryreverse/api.go
@@ -103,6 +103,23 @@ func Invoke(
 		}
 
 		execution.RunId = continuationToken.GetRunId()
+
+		var namespaceName namespace.Name
+		if entry, err := shardContext.GetNamespaceRegistry().GetNamespaceByID(namespaceID); err == nil {
+			namespaceName = entry.Name()
+		}
+		if err = api.ValidateBranchTokenForExecution(
+			ctx,
+			shardContext,
+			workflowConsistencyChecker,
+			eventNotifier,
+			namespaceName,
+			namespaceID,
+			execution,
+			continuationToken.BranchToken,
+		); err != nil {
+			return nil, err
+		}
 	}
 
 	// TODO below is a temporal solution to guard against invalid event batch

--- a/service/history/api/token.go
+++ b/service/history/api/token.go
@@ -1,10 +1,20 @@
 package api
 
 import (
+	"bytes"
+	"context"
+
+	commonpb "go.temporal.io/api/common/v1"
 	historyspb "go.temporal.io/server/api/history/v1"
 	"go.temporal.io/server/api/historyservice/v1"
 	tokenspb "go.temporal.io/server/api/token/v1"
+	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
+	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/service/history/consts"
+	"go.temporal.io/server/service/history/events"
+	historyi "go.temporal.io/server/service/history/interfaces"
 )
 
 // NOTE: DO NOT MODIFY UNLESS ALSO APPLIED TO ./service/frontend/token_deprecated.go
@@ -115,4 +125,119 @@ func ValidatePaginationToken(
 		return consts.ErrInvalidPaginationToken
 	}
 	return nil
+}
+
+const (
+	// branchTokenMismatchReasonNonCurrent is a branch this execution records but no longer reads from.
+	branchTokenMismatchReasonNonCurrent metrics.ReasonString = "non_current_branch"
+	branchTokenMismatchReasonForeign    metrics.ReasonString = "foreign_branch"
+)
+
+// maxLoggedBranchTokenLen bounds caller-supplied bytes reaching the log.
+const maxLoggedBranchTokenLen = 4096
+
+func branchTokenMismatchReason(
+	currentBranchToken []byte,
+	requestBranchToken []byte,
+	versionHistories *historyspb.VersionHistories,
+) metrics.ReasonString {
+	if bytes.Equal(requestBranchToken, currentBranchToken) {
+		return ""
+	}
+	for _, versionHistory := range versionHistories.GetHistories() {
+		if bytes.Equal(versionHistory.GetBranchToken(), requestBranchToken) {
+			return branchTokenMismatchReasonNonCurrent
+		}
+	}
+	return branchTokenMismatchReasonForeign
+}
+
+func reportBranchTokenMismatch(
+	shardContext historyi.ShardContext,
+	namespaceName string,
+	execution *commonpb.WorkflowExecution,
+	reason metrics.ReasonString,
+	currentBranchToken []byte,
+	requestBranchToken []byte,
+) {
+	if namespaceName == "" {
+		namespaceName = metrics.NamespaceUnknownTag().Value
+	}
+	metrics.PaginationTokenBranchMismatchCounter.With(shardContext.GetMetricsHandler()).Record(
+		1,
+		metrics.NamespaceTag(namespaceName),
+		metrics.ReasonTag(reason),
+	)
+	loggedRequestToken := requestBranchToken[:min(len(requestBranchToken), maxLoggedBranchTokenLen)]
+	shardContext.GetLogger().Warn("Pagination branch token is not the execution's current branch token",
+		tag.WorkflowNamespace(namespaceName),
+		tag.WorkflowID(execution.GetWorkflowId()),
+		tag.WorkflowRunID(execution.GetRunId()),
+		tag.NewStringTag("reason", string(reason)),
+		tag.WorkflowBranchToken(currentBranchToken),
+		tag.WorkflowRequestBranchToken(loggedRequestToken),
+	)
+}
+
+// ValidateBranchTokenForExecution rejects a paging branch token that is not the execution's current
+// one.
+func ValidateBranchTokenForExecution(
+	ctx context.Context,
+	shardContext historyi.ShardContext,
+	workflowConsistencyChecker WorkflowConsistencyChecker,
+	eventNotifier events.Notifier,
+	namespaceName namespace.Name,
+	namespaceID namespace.ID,
+	execution *commonpb.WorkflowExecution,
+	requestBranchToken []byte,
+) error {
+	config := shardContext.GetConfig()
+	if !config.EnablePaginationTokenBranchValidation() {
+		return nil
+	}
+	if len(requestBranchToken) == 0 {
+		return consts.ErrInvalidNextPageToken
+	}
+
+	response, err := GetOrPollWorkflowMutableState(
+		ctx,
+		shardContext,
+		&historyservice.GetMutableStateRequest{
+			NamespaceId: namespaceID.String(),
+			Execution:   execution,
+		},
+		workflowConsistencyChecker,
+		eventNotifier,
+	)
+	if err != nil {
+		return err
+	}
+
+	currentBranchToken := response.GetCurrentBranchToken()
+	mismatchReason := branchTokenMismatchReason(
+		currentBranchToken,
+		requestBranchToken,
+		response.GetVersionHistories(),
+	)
+	if mismatchReason == "" {
+		return nil
+	}
+
+	reportBranchTokenMismatch(
+		shardContext,
+		namespaceName.String(),
+		execution,
+		mismatchReason,
+		currentBranchToken,
+		requestBranchToken,
+	)
+	if config.EnablePaginationTokenBranchValidationShadowMode() {
+		return nil
+	}
+	return serviceerrors.NewCurrentBranchChanged(
+		currentBranchToken,
+		requestBranchToken,
+		nil,
+		nil,
+	)
 }

--- a/service/history/api/token_test.go
+++ b/service/history/api/token_test.go
@@ -1,0 +1,117 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	historyspb "go.temporal.io/server/api/history/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/common/primitives"
+	"go.temporal.io/server/service/history/configs"
+	"go.temporal.io/server/service/history/consts"
+	historyi "go.temporal.io/server/service/history/interfaces"
+	"go.uber.org/mock/gomock"
+)
+
+func newTestBranchToken(
+	t *testing.T,
+	treeID string,
+	branchID string,
+	ancestors []*persistencespb.HistoryBranchRange,
+) []byte {
+	t.Helper()
+	branchUtil := persistence.NewHistoryBranchUtil(serialization.NewSerializer())
+	token, err := branchUtil.NewHistoryBranch(
+		"namespace-id", "workflow-id", "run-id", treeID, &branchID, ancestors, 0, 0, 0,
+	)
+	require.NoError(t, err)
+	return token
+}
+
+func testVersionHistories(tokens ...[]byte) *historyspb.VersionHistories {
+	versionHistories := &historyspb.VersionHistories{}
+	for _, token := range tokens {
+		versionHistories.Histories = append(
+			versionHistories.Histories,
+			&historyspb.VersionHistory{BranchToken: token},
+		)
+	}
+	return versionHistories
+}
+
+func TestBranchTokenMismatchReason(t *testing.T) {
+	treeID := primitives.NewUUID().String()
+	branchID := primitives.NewUUID().String()
+	otherTreeID := primitives.NewUUID().String()
+	otherBranchID := primitives.NewUUID().String()
+
+	current := newTestBranchToken(t, treeID, branchID, nil)
+	nonCurrent := newTestBranchToken(t, otherTreeID, otherBranchID, nil)
+
+	t.Run("matches the current branch token", func(t *testing.T) {
+		got := branchTokenMismatchReason(current, current, testVersionHistories(current))
+		require.Empty(t, got)
+	})
+
+	t.Run("matches the current token when an identical token is recorded twice", func(t *testing.T) {
+		got := branchTokenMismatchReason(current, current, testVersionHistories(current, current))
+		require.Empty(t, got)
+	})
+
+	t.Run("matches opaque tokens the branch parser cannot read", func(t *testing.T) {
+		opaque := []byte{1, 2, 3}
+		got := branchTokenMismatchReason(opaque, opaque, testVersionHistories(opaque))
+		require.Empty(t, got)
+	})
+
+	t.Run("reports a non-current branch when the token names an older history", func(t *testing.T) {
+		histories := testVersionHistories(nonCurrent, current)
+		got := branchTokenMismatchReason(current, nonCurrent, histories)
+		require.Equal(t, branchTokenMismatchReasonNonCurrent, got)
+	})
+
+	t.Run("reports foreign for a different branch in the same tree", func(t *testing.T) {
+		request := newTestBranchToken(t, treeID, otherBranchID, nil)
+		got := branchTokenMismatchReason(current, request, testVersionHistories(current))
+		require.Equal(t, branchTokenMismatchReasonForeign, got)
+	})
+
+	t.Run("reports foreign for the current branch carrying injected ancestors", func(t *testing.T) {
+		request := newTestBranchToken(t, treeID, branchID, []*persistencespb.HistoryBranchRange{
+			{BranchId: otherBranchID, BeginNodeId: 1, EndNodeId: 1000},
+		})
+		got := branchTokenMismatchReason(current, request, testVersionHistories(current))
+		require.Equal(t, branchTokenMismatchReasonForeign, got)
+	})
+
+	t.Run("reports foreign when there are no version histories", func(t *testing.T) {
+		got := branchTokenMismatchReason(current, nonCurrent, nil)
+		require.Equal(t, branchTokenMismatchReasonForeign, got)
+	})
+}
+
+func TestValidateBranchTokenForExecution_EmptyRequestToken(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		validation bool
+		wantErr    error
+	}{
+		{name: "rejected while validating", validation: true, wantErr: consts.ErrInvalidNextPageToken},
+		{name: "served once validation is disabled", validation: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			shardContext := historyi.NewMockShardContext(gomock.NewController(t))
+			shardContext.EXPECT().GetConfig().Return(&configs.Config{
+				EnablePaginationTokenBranchValidation: dynamicconfig.GetBoolPropertyFn(tc.validation),
+			}).AnyTimes()
+
+			err := ValidateBranchTokenForExecution(
+				context.Background(), shardContext, nil, nil, "", "", nil, nil)
+			require.ErrorIs(t, err, tc.wantErr)
+		})
+	}
+}

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -413,6 +413,9 @@ type Config struct {
 	SendRawHistoryBytesToMatchingService  dynamicconfig.BoolPropertyFn
 	SendRawWorkflowHistory                dynamicconfig.BoolPropertyFnWithNamespaceFilter
 
+	EnablePaginationTokenBranchValidation           dynamicconfig.BoolPropertyFn
+	EnablePaginationTokenBranchValidationShadowMode dynamicconfig.BoolPropertyFn
+
 	WorkflowIdReuseMinimalInterval           dynamicconfig.DurationPropertyFnWithNamespaceFilter
 	EnableWorkflowIdReuseStartTimeValidation dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	BusinessIDReuseRate                      dynamicconfig.IntPropertyFnWithNamespaceFilter
@@ -805,9 +808,13 @@ func NewConfig(
 		EnableUpdateWithStartRetryOnClosedWorkflowAbort:               dynamicconfig.EnableUpdateWithStartRetryOnClosedWorkflowAbort.Get(dc),
 		EnableUpdateWithStartRetryableErrorOnClosedWorkflowAbort:      dynamicconfig.EnableUpdateWithStartRetryableErrorOnClosedWorkflowAbort.Get(dc),
 
-		SendRawHistoryBetweenInternalServices:    dynamicconfig.SendRawHistoryBetweenInternalServices.Get(dc),
-		SendRawHistoryBytesToMatchingService:     dynamicconfig.SendRawHistoryBytesToMatchingService.Get(dc),
-		SendRawWorkflowHistory:                   dynamicconfig.SendRawWorkflowHistory.Get(dc),
+		SendRawHistoryBetweenInternalServices: dynamicconfig.SendRawHistoryBetweenInternalServices.Get(dc),
+		SendRawHistoryBytesToMatchingService:  dynamicconfig.SendRawHistoryBytesToMatchingService.Get(dc),
+		SendRawWorkflowHistory:                dynamicconfig.SendRawWorkflowHistory.Get(dc),
+
+		EnablePaginationTokenBranchValidation:           dynamicconfig.EnablePaginationTokenBranchValidation.Get(dc),
+		EnablePaginationTokenBranchValidationShadowMode: dynamicconfig.EnablePaginationTokenBranchValidationShadowMode.Get(dc),
+
 		WorkflowIdReuseMinimalInterval:           dynamicconfig.WorkflowIdReuseMinimalInterval.Get(dc),
 		EnableWorkflowIdReuseStartTimeValidation: dynamicconfig.EnableWorkflowIdReuseStartTimeValidation.Get(dc),
 		BusinessIDReuseRate:                      dynamicconfig.BusinessIDReuseRate.Get(dc),

--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -247,9 +247,13 @@ func ConfigProvider(
 
 func ServiceErrorInterceptorProvider(
 	dc *dynamicconfig.Collection,
+	metricsHandler metrics.Handler,
+	logger log.Logger,
 ) *interceptor.ServiceErrorInterceptor {
 	return interceptor.NewServiceErrorInterceptor(
 		dynamicconfig.MaxServiceErrorMessageLength.Get(dc),
+		metricsHandler,
+		logger,
 	)
 }
 

--- a/service/history/history_engine_test.go
+++ b/service/history/history_engine_test.go
@@ -49,12 +49,14 @@ import (
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/persistence/versionhistory"
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/rpc/interceptor"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/searchattribute/sadefs"
+	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/common/tasktoken"
 	"go.temporal.io/server/common/testing/protorequire"
 	"go.temporal.io/server/service/history/api"
@@ -7027,4 +7029,209 @@ func addFailWorkflowEvent(
 		"",
 	)
 	return event
+}
+
+func (s *engineSuite) mockExecutionWithForeignBranchToken(
+	we *commonpb.WorkflowExecution,
+) (ownedToken []byte, foreignToken []byte) {
+	branchUtil := persistence.NewHistoryBranchUtil(serialization.NewSerializer())
+	treeID := uuid.NewString()
+	ownedBranchID := uuid.NewString()
+	foreignBranchID := uuid.NewString()
+
+	ownedBranchToken, err := branchUtil.NewHistoryBranch(
+		tests.NamespaceID.String(), we.WorkflowId, we.RunId, treeID, &ownedBranchID, nil, 0, 0, 0)
+	s.NoError(err)
+	foreignBranchToken, err := branchUtil.NewHistoryBranch(
+		tests.NamespaceID.String(), we.WorkflowId, we.RunId, treeID, &foreignBranchID, nil, 0, 0, 0)
+	s.NoError(err)
+
+	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.GetWorkflowExecutionResponse{
+		State: &persistencespb.WorkflowMutableState{
+			ExecutionState: &persistencespb.WorkflowExecutionState{
+				State:  enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING,
+				Status: enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+				RunId:  we.RunId,
+			},
+			NextEventId: 5,
+			ExecutionInfo: &persistencespb.WorkflowExecutionInfo{
+				NamespaceId: tests.NamespaceID.String(),
+				WorkflowId:  we.WorkflowId,
+				VersionHistories: &historyspb.VersionHistories{
+					CurrentVersionHistoryIndex: 0,
+					Histories: []*historyspb.VersionHistory{
+						{
+							BranchToken: ownedBranchToken,
+							Items: []*historyspb.VersionHistoryItem{
+								{EventId: 4, Version: 0},
+							},
+						},
+					},
+				},
+			},
+		},
+		MutableStateStats: persistence.MutableStateStatistics{},
+	}, nil).AnyTimes()
+
+	return ownedBranchToken, foreignBranchToken
+}
+
+func (s *engineSuite) getHistoryRequestWithPageToken(
+	we *commonpb.WorkflowExecution,
+	continuation *tokenspb.HistoryContinuation,
+	waitNewEvent bool,
+) *historyservice.GetWorkflowExecutionHistoryRequest {
+	nextPageToken, err := api.SerializeHistoryToken(continuation)
+	s.NoError(err)
+	return &historyservice.GetWorkflowExecutionHistoryRequest{
+		NamespaceId: tests.NamespaceID.String(),
+		Request: &workflowservice.GetWorkflowExecutionHistoryRequest{
+			Execution:              we,
+			MaximumPageSize:        10,
+			NextPageToken:          nextPageToken,
+			WaitNewEvent:           waitNewEvent,
+			HistoryEventFilterType: enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT,
+			SkipArchival:           true,
+		},
+	}
+}
+
+// expectHistoryReadWithBranchToken allows the history read and pins the branch token it is issued with.
+func (s *engineSuite) expectHistoryReadWithBranchToken(branchToken []byte) {
+	s.mockSearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), false).
+		Return(searchattribute.TestNameTypeMap(), nil).AnyTimes()
+	s.mockVisibilityMgr.EXPECT().GetIndexName().Return(esIndexName).AnyTimes()
+	s.mockExecutionMgr.EXPECT().ReadHistoryBranch(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, request *persistence.ReadHistoryBranchRequest) (*persistence.ReadHistoryBranchResponse, error) {
+			s.Equal(branchToken, request.BranchToken)
+			return &persistence.ReadHistoryBranchResponse{HistoryEvents: []*historypb.HistoryEvent{}}, nil
+		},
+	).MinTimes(1)
+}
+
+func (s *engineSuite) TestGetWorkflowExecutionHistory_BranchTokenNotOwnedByExecution() {
+	we := commonpb.WorkflowExecution{WorkflowId: "wid-foreign-branch", RunId: uuid.NewString()}
+
+	engine, err := s.historyEngine.shardContext.GetEngine(context.Background())
+	s.NoError(err)
+
+	s.config.EnablePaginationTokenBranchValidationShadowMode = dynamicconfig.GetBoolPropertyFn(false)
+	_, foreignBranchToken := s.mockExecutionWithForeignBranchToken(&we)
+	req := s.getHistoryRequestWithPageToken(&we, &tokenspb.HistoryContinuation{
+		RunId:             we.GetRunId(),
+		FirstEventId:      common.FirstEventID,
+		NextEventId:       5,
+		PersistenceToken:  []byte("some random persistence token"),
+		BranchToken:       foreignBranchToken,
+		IsWorkflowRunning: true,
+	}, false)
+
+	// The history read must never be attempted, on either the decoded or the raw path.
+	s.mockExecutionMgr.EXPECT().ReadHistoryBranch(gomock.Any(), gomock.Any()).Times(0)
+	s.mockExecutionMgr.EXPECT().ReadRawHistoryBranch(gomock.Any(), gomock.Any()).Times(0)
+
+	for _, sendRawHistory := range []bool{false, true} {
+		s.config.SendRawWorkflowHistory = func(string) bool { return sendRawHistory }
+		_, err = engine.GetWorkflowExecutionHistory(context.Background(), req)
+		var branchErr *serviceerrors.CurrentBranchChanged
+		s.ErrorAs(err, &branchErr, "sendRawHistory=%v", sendRawHistory)
+	}
+}
+
+func (s *engineSuite) TestGetWorkflowExecutionHistory_ForeignBranchTokenServedWhenNotEnforcing() {
+	we := commonpb.WorkflowExecution{WorkflowId: "wid-foreign-branch-served", RunId: uuid.NewString()}
+
+	engine, err := s.historyEngine.shardContext.GetEngine(context.Background())
+	s.NoError(err)
+
+	s.config.SendRawWorkflowHistory = func(string) bool { return false }
+	_, foreignBranchToken := s.mockExecutionWithForeignBranchToken(&we)
+	// Not enforcing reads with the caller's token, exactly as before validation existed.
+	s.expectHistoryReadWithBranchToken(foreignBranchToken)
+
+	for _, tc := range []struct {
+		name       string
+		validation bool
+		shadow     bool
+	}{
+		{name: "shadow mode", validation: true, shadow: true},
+		{name: "validation disabled", validation: false, shadow: false},
+	} {
+		s.config.EnablePaginationTokenBranchValidation = dynamicconfig.GetBoolPropertyFn(tc.validation)
+		s.config.EnablePaginationTokenBranchValidationShadowMode = dynamicconfig.GetBoolPropertyFn(tc.shadow)
+		_, err = engine.GetWorkflowExecutionHistory(
+			context.Background(),
+			s.getHistoryRequestWithPageToken(&we, &tokenspb.HistoryContinuation{
+				RunId:             we.GetRunId(),
+				FirstEventId:      common.FirstEventID,
+				NextEventId:       5,
+				PersistenceToken:  []byte("some random persistence token"),
+				BranchToken:       foreignBranchToken,
+				IsWorkflowRunning: true,
+			}, false),
+		)
+		s.NoError(err, tc.name)
+	}
+}
+
+func (s *engineSuite) TestGetWorkflowExecutionHistory_LongPollDiscardsRequestBranchToken() {
+	we := commonpb.WorkflowExecution{WorkflowId: "wid-longpoll-overwrite", RunId: uuid.NewString()}
+
+	engine, err := s.historyEngine.shardContext.GetEngine(context.Background())
+	s.NoError(err)
+
+	s.config.EnablePaginationTokenBranchValidationShadowMode = dynamicconfig.GetBoolPropertyFn(false)
+	s.config.SendRawWorkflowHistory = func(string) bool { return false }
+	ownedBranchToken, foreignBranchToken := s.mockExecutionWithForeignBranchToken(&we)
+	s.expectHistoryReadWithBranchToken(ownedBranchToken)
+
+	// An empty persistence token and a next event ID behind mutable state select the long poll
+	// refresh, which replaces the caller's branch token instead of validating it.
+	req := s.getHistoryRequestWithPageToken(&we, &tokenspb.HistoryContinuation{
+		RunId:             we.GetRunId(),
+		FirstEventId:      common.FirstEventID,
+		NextEventId:       2,
+		PersistenceToken:  nil,
+		BranchToken:       foreignBranchToken,
+		IsWorkflowRunning: true,
+	}, true)
+
+	_, err = engine.GetWorkflowExecutionHistory(context.Background(), req)
+	s.NoError(err)
+}
+
+func (s *engineSuite) TestGetWorkflowExecutionHistoryReverse_BranchTokenNotOwnedByExecution() {
+	we := commonpb.WorkflowExecution{WorkflowId: "wid-foreign-branch-reverse", RunId: uuid.NewString()}
+
+	engine, err := s.historyEngine.shardContext.GetEngine(context.Background())
+	s.NoError(err)
+
+	s.config.EnablePaginationTokenBranchValidationShadowMode = dynamicconfig.GetBoolPropertyFn(false)
+	_, foreignBranchToken := s.mockExecutionWithForeignBranchToken(&we)
+
+	nextPageToken, err := api.SerializeHistoryToken(&tokenspb.HistoryContinuation{
+		RunId:            we.GetRunId(),
+		FirstEventId:     common.FirstEventID,
+		NextEventId:      5,
+		PersistenceToken: []byte("some random persistence token"),
+		BranchToken:      foreignBranchToken,
+	})
+	s.NoError(err)
+
+	// The history read must never be attempted.
+	s.mockExecutionMgr.EXPECT().ReadHistoryBranchReverse(gomock.Any(), gomock.Any()).Times(0)
+
+	_, err = engine.GetWorkflowExecutionHistoryReverse(
+		context.Background(),
+		&historyservice.GetWorkflowExecutionHistoryReverseRequest{
+			NamespaceId: tests.NamespaceID.String(),
+			Request: &workflowservice.GetWorkflowExecutionHistoryReverseRequest{
+				Execution:       &we,
+				MaximumPageSize: 10,
+				NextPageToken:   nextPageToken,
+			},
+		},
+	)
+	var branchErr *serviceerrors.CurrentBranchChanged
+	s.ErrorAs(err, &branchErr)
 }

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -2869,9 +2869,13 @@ func (ms *MutableStateImpl) ContinueAsNewMinBackoff(backoffDuration *durationpb.
 	// lifetime of previous execution
 	// todo@time-skipping: time skipping is naturally supported for continue as new backoff, and need to
 	// make sure the backoff is correctly applied in the time skipping case
-	lifetime := ms.timeSource.Now().Sub(ms.executionState.StartTime.AsTime().UTC())
+	now := ms.timeSource.Now()
+	lifetime := max(time.Duration(0), now.Sub(ms.executionState.StartTime.AsTime().UTC()))
 	if ms.executionInfo.ExecutionTime != nil {
-		lifetime = ms.timeSource.Now().Sub(ms.executionInfo.ExecutionTime.AsTime().UTC())
+		executionLifetime := now.Sub(ms.executionInfo.ExecutionTime.AsTime().UTC())
+		if executionLifetime >= 0 {
+			lifetime = executionLifetime
+		}
 	}
 
 	interval := lifetime

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -2215,6 +2215,36 @@ func (s *mutableStateSuite) TestContinueAsNewMinBackoff() {
 	s.True(minBackoff == backoff)
 }
 
+func (s *mutableStateSuite) TestContinueAsNewMinBackoffExecutionCompletesBeforeExecutionTime() {
+	s.mockConfig.WorkflowIdReuseMinimalInterval = func(namespace string) time.Duration {
+		return time.Second
+	}
+
+	now := time.Now()
+	s.mutableState.timeSource = clock.NewEventTimeSource().Update(now)
+
+	// Guard against clock skew or malformed state making StartTime later than now.
+	// The lifetime should be clamped at zero, so the full minimal interval is still applied.
+	s.mutableState.executionState.StartTime = timestamppb.New(now.Add(time.Second))
+	s.mutableState.executionInfo.ExecutionTime = nil
+
+	minBackoff := s.mutableState.ContinueAsNewMinBackoff(nil).AsDuration()
+	s.Equal(time.Second, minBackoff)
+
+	// Simulate a delayed-start run that actually executed and closed before its ExecutionTime.
+	// In that case lifetime should fall back to close - StartTime, not become negative.
+	s.mutableState.executionState.StartTime = timestamppb.New(now.Add(-100 * time.Millisecond))
+	s.mutableState.executionInfo.ExecutionTime = timestamppb.New(now.Add(time.Second))
+
+	minBackoff = s.mutableState.ContinueAsNewMinBackoff(nil).AsDuration()
+	s.Equal(900*time.Millisecond, minBackoff)
+
+	// Existing backoff already satisfies the minimal interval when combined with the fallback lifetime.
+	backoff := time.Second
+	minBackoff = s.mutableState.ContinueAsNewMinBackoff(durationpb.New(backoff)).AsDuration()
+	s.Equal(backoff, minBackoff)
+}
+
 func (s *mutableStateSuite) TestEventReapplied() {
 	runID := uuid.NewString()
 	eventID := int64(1)

--- a/service/matching/fx.go
+++ b/service/matching/fx.go
@@ -71,9 +71,13 @@ func ConfigProvider(
 
 func ServiceErrorInterceptorProvider(
 	dc *dynamicconfig.Collection,
+	metricsHandler metrics.Handler,
+	logger log.Logger,
 ) *interceptor.ServiceErrorInterceptor {
 	return interceptor.NewServiceErrorInterceptor(
 		dynamicconfig.MaxServiceErrorMessageLength.Get(dc),
+		metricsHandler,
+		logger,
 	)
 }
 

--- a/service/worker/scheduler/query.go
+++ b/service/worker/scheduler/query.go
@@ -7,6 +7,8 @@ import (
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence/visibility/store/elasticsearch"
 	"go.temporal.io/server/common/persistence/visibility/store/query"
@@ -72,6 +74,8 @@ func ValidateVisibilityQuery(
 	chasmMapper *chasm.VisibilitySearchAttributesMapper,
 	enableUnifiedQueryConverter dynamicconfig.BoolPropertyFn,
 	queryString string,
+	metricsHandler metrics.Handler,
+	logger log.Logger,
 ) error {
 	var fields []string
 	var err error
@@ -82,6 +86,8 @@ func ValidateVisibilityQuery(
 			saMapperProvider,
 			chasmMapper,
 			queryString,
+			metricsHandler,
+			logger,
 		)
 	} else {
 		fields, err = getQueryFieldsLegacy(namespaceName, saNameType, saMapperProvider, chasmMapper, queryString)
@@ -105,6 +111,8 @@ func getQueryFields(
 	saMapperProvider searchattribute.MapperProvider,
 	chasmMapper *chasm.VisibilitySearchAttributesMapper,
 	queryString string,
+	metricsHandler metrics.Handler,
+	logger log.Logger,
 ) ([]string, error) {
 	saMapper, err := saMapperProvider.GetMapper(namespaceName)
 	if err != nil {
@@ -115,6 +123,8 @@ func getQueryFields(
 		namespaceName,
 		saNameType,
 		saMapper,
+		metricsHandler,
+		logger,
 	).WithChasmMapper(chasmMapper).WithSearchAttributeInterceptor(saInterceptor)
 	_, err = queryConverter.Convert(queryString)
 	if err != nil {

--- a/service/worker/scheduler/query_test.go
+++ b/service/worker/scheduler/query_test.go
@@ -7,10 +7,13 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence/visibility/store/query"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/searchattribute/sadefs"
+	"go.uber.org/mock/gomock"
 )
 
 const (
@@ -256,12 +259,15 @@ func TestGetQueryFields(t *testing.T) {
 			tc.name,
 			func(t *testing.T) {
 				s := require.New(t)
+				ctrl := gomock.NewController(t)
 				fields, err := getQueryFields(
 					testNamespace,
 					searchattribute.TestNameTypeMap(),
 					searchattribute.NewTestMapperProvider(&searchattribute.TestMapper{}),
-					nil,
+					nil, // chasmMapper
 					tc.input,
+					metrics.NewMockHandler(ctrl),
+					log.NewNoopLogger(),
 				)
 				if tc.expectedErrMsg == "" {
 					s.NoError(err)
@@ -337,6 +343,7 @@ func TestValidateVisibilityQuery(t *testing.T) {
 			tc.name,
 			func(t *testing.T) {
 				s := require.New(t)
+				ctrl := gomock.NewController(t)
 				err := ValidateVisibilityQuery(
 					testNamespace,
 					searchattribute.TestNameTypeMap(),
@@ -344,6 +351,8 @@ func TestValidateVisibilityQuery(t *testing.T) {
 					nil,
 					dynamicconfig.GetBoolPropertyFn(true),
 					tc.input,
+					metrics.NewMockHandler(ctrl),
+					log.NewNoopLogger(),
 				)
 				if tc.expectedErrMsg == "" {
 					s.NoError(err)

--- a/tests/continue_as_new_test.go
+++ b/tests/continue_as_new_test.go
@@ -13,6 +13,7 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
+	protocolpb "go.temporal.io/api/protocol/v1"
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
@@ -586,6 +587,138 @@ func (s *ContinueAsNewTestSuite) TestContinueAsNewWithDelayStart() {
 	startedTime := finalEvents[0].GetEventTime().AsTime()
 	scheduledTime := finalEvents[1].GetEventTime().AsTime()
 	s.GreaterOrEqual(scheduledTime.Sub(startedTime), delayStart)
+}
+
+func (s *ContinueAsNewTestSuite) TestContinueAsNewMinBackoffDoesNotAccumulate() {
+	env := testcore.NewEnv(s.T())
+
+	const minimalInterval = 10 * time.Second
+	env.OverrideDynamicConfig(dynamicconfig.WorkflowIdReuseMinimalInterval, minimalInterval)
+
+	id := "functional-continue-as-new-min-backoff-does-not-accumulate-test"
+	wt := "functional-continue-as-new-min-backoff-does-not-accumulate-test-type"
+	tl := "functional-continue-as-new-min-backoff-does-not-accumulate-test-taskqueue"
+	identity := "worker1"
+
+	workflowType := &commonpb.WorkflowType{Name: wt}
+	taskQueue := &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL}
+
+	request := &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:           uuid.NewString(),
+		Namespace:           env.Namespace().String(),
+		WorkflowId:          id,
+		WorkflowType:        workflowType,
+		TaskQueue:           taskQueue,
+		WorkflowRunTimeout:  durationpb.New(100 * time.Second),
+		WorkflowTaskTimeout: durationpb.New(10 * time.Second),
+		Identity:            identity,
+	}
+
+	we, err := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
+	s.NoError(err)
+
+	const continueAsNewCount = 3
+	var firstWorkflowTaskBackoffs []time.Duration
+	runIDs := []string{we.RunId}
+	for i := range continueAsNewCount + 1 {
+		// Each task is polled after the run has been made executable. For continued runs,
+		// the admitted update below schedules a workflow task before ExecutionTime.
+		task, err := env.FrontendClient().PollWorkflowTaskQueue(s.Context(), &workflowservice.PollWorkflowTaskQueueRequest{
+			Namespace: env.Namespace().String(),
+			TaskQueue: taskQueue,
+			Identity:  identity,
+		})
+		s.NoError(err)
+		s.NotEmpty(task.GetTaskToken())
+
+		startAttrs := task.History.Events[0].GetWorkflowExecutionStartedEventAttributes()
+		firstWorkflowTaskBackoff := startAttrs.GetFirstWorkflowTaskBackoff().AsDuration()
+		firstWorkflowTaskBackoffs = append(firstWorkflowTaskBackoffs, firstWorkflowTaskBackoff)
+
+		var messages []*protocolpb.Message
+		var commands []*commandpb.Command
+		if i > 0 {
+			s.NotEmpty(task.Messages, "expected update message in task")
+			updateTV := env.Tv().
+				WithWorkflowID(id).
+				WithRunID(runIDs[i]).
+				WithUpdateIDNumber(i).
+				WithMessageIDNumber(i)
+			messages = env.UpdateAcceptCompleteMessages(updateTV, task.Messages[0])
+			commands = env.UpdateAcceptCompleteCommands(updateTV)
+		}
+		if i < continueAsNewCount {
+			// Continue as new without an explicit backoff. The server applies the default
+			// WorkflowIdReuseMinimalInterval because the previous run closes quickly.
+			commands = append(commands, &commandpb.Command{
+				CommandType: enumspb.COMMAND_TYPE_CONTINUE_AS_NEW_WORKFLOW_EXECUTION,
+				Attributes: &commandpb.Command_ContinueAsNewWorkflowExecutionCommandAttributes{
+					ContinueAsNewWorkflowExecutionCommandAttributes: &commandpb.ContinueAsNewWorkflowExecutionCommandAttributes{
+						WorkflowType:        workflowType,
+						TaskQueue:           taskQueue,
+						WorkflowRunTimeout:  durationpb.New(100 * time.Second),
+						WorkflowTaskTimeout: durationpb.New(10 * time.Second),
+					},
+				},
+			})
+		} else {
+			commands = append(commands, &commandpb.Command{
+				CommandType: enumspb.COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION,
+				Attributes: &commandpb.Command_CompleteWorkflowExecutionCommandAttributes{
+					CompleteWorkflowExecutionCommandAttributes: &commandpb.CompleteWorkflowExecutionCommandAttributes{
+						Result: payloads.EncodeString("Done"),
+					},
+				},
+			})
+		}
+
+		_, err = env.FrontendClient().RespondWorkflowTaskCompleted(s.Context(), &workflowservice.RespondWorkflowTaskCompletedRequest{
+			Namespace: env.Namespace().String(),
+			TaskToken: task.GetTaskToken(),
+			Identity:  identity,
+			Commands:  commands,
+			Messages:  messages,
+		})
+		s.NoError(err)
+
+		events := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{
+			WorkflowId: id,
+			RunId:      runIDs[len(runIDs)-1],
+		})
+		lastEvent := events[len(events)-1]
+		if i < continueAsNewCount {
+			s.Equal(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CONTINUED_AS_NEW, lastEvent.GetEventType())
+			newRunID := lastEvent.GetWorkflowExecutionContinuedAsNewEventAttributes().GetNewExecutionRunId()
+			runIDs = append(runIDs, newRunID)
+			// Admit a noop update on the delayed continued run. This schedules the next
+			// workflow task immediately, so the run can close before its ExecutionTime.
+			updateTV := env.Tv().
+				WithWorkflowID(id).
+				WithRunID(newRunID).
+				WithUpdateIDNumber(i + 1).
+				WithMessageIDNumber(i + 1)
+			go func(updateTV *testvars.TestVars) {
+				_, updateErr := env.FrontendClient().UpdateWorkflowExecution(
+					testcore.NewContext(),
+					updateWorkflowRequest(env, updateTV, nil),
+				)
+				if updateErr != nil {
+					s.T().Errorf("Update failed: %v", updateErr)
+				}
+			}(updateTV)
+			waitUpdateAdmitted(env, updateTV)
+		} else {
+			s.Equal(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED, lastEvent.GetEventType())
+		}
+	}
+
+	// The first run has no inherited backoff. Every continued run should stay capped at
+	// the default minimal interval instead of accumulating across the tight loop.
+	s.Len(firstWorkflowTaskBackoffs, continueAsNewCount+1)
+	s.Zero(firstWorkflowTaskBackoffs[0])
+	for i, firstWorkflowTaskBackoff := range firstWorkflowTaskBackoffs[1:] {
+		s.LessOrEqual(firstWorkflowTaskBackoff, minimalInterval, "firstWorkflowTaskBackoff accumulated at run %d: %v", i+1, firstWorkflowTaskBackoff)
+	}
 }
 
 type (

--- a/tests/gethistory_test.go
+++ b/tests/gethistory_test.go
@@ -2,21 +2,25 @@ package tests
 
 import (
 	"context"
+	"errors"
 	"slices"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 	commandpb "go.temporal.io/api/command/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
+	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
 	sdkclient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/testing/parallelsuite"
@@ -746,4 +750,129 @@ func (s *GetHistorySuite) getHistory(
 	s.NoError(err)
 
 	return responseInner.History.Events, responseInner.NextPageToken
+}
+
+// startMultiBatchWorkflow starts a workflow and signals it repeatedly. Each signal is its own
+// transaction and therefore its own history node, so a page size of 1 yields many pages and a
+// continuation taken from an early page is far from the last page.
+func startMultiBatchWorkflow(
+	ctx context.Context,
+	assertions *require.Assertions,
+	env *testcore.TestEnv,
+) {
+	_, err := env.FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:           uuid.NewString(),
+		Namespace:           env.Namespace().String(),
+		WorkflowId:          env.Tv().WorkflowID(),
+		WorkflowType:        env.Tv().WorkflowType(),
+		TaskQueue:           env.Tv().TaskQueue(),
+		WorkflowRunTimeout:  durationpb.New(100 * time.Second),
+		WorkflowTaskTimeout: durationpb.New(10 * time.Second),
+		Identity:            env.Tv().WorkerIdentity(),
+	})
+	assertions.NoError(err)
+
+	for range 6 {
+		_, err = env.FrontendClient().SignalWorkflowExecution(ctx, &workflowservice.SignalWorkflowExecutionRequest{
+			RequestId: uuid.NewString(),
+			Namespace: env.Namespace().String(),
+			WorkflowExecution: &commonpb.WorkflowExecution{
+				WorkflowId: env.Tv().WorkflowID(),
+			},
+			SignalName: "signal",
+			Identity:   env.Tv().WorkerIdentity(),
+		})
+		assertions.NoError(err)
+	}
+}
+
+func (s *GetHistorySuite) TestGetWorkflowExecutionHistory_ContinuationFromAnotherNamespace(
+	enableTransitionHistory bool,
+) {
+	// A single-shard cluster so both namespaces map to the same history shard. On SQL backends
+	// shard_id is part of the history_node primary key, so without this the replay would be
+	// rejected for the wrong reason; on Cassandra it is not part of the key at all.
+	env := s.newTestEnv(
+		enableTransitionHistory,
+		testcore.WithHistoryShardCount(1),
+		// Shadow mode reports the mismatch but still serves the page.
+		testcore.WithDynamicConfig(dynamicconfig.EnablePaginationTokenBranchValidationShadowMode, false),
+	)
+
+	otherNamespace := namespace.Name(testcore.RandomizeStr("other-namespace"))
+	_, err := env.RegisterNamespace(otherNamespace, 1, enumspb.ARCHIVAL_STATE_DISABLED, "", "")
+	s.Require().NoError(err)
+
+	startMultiBatchWorkflow(s.Context(), s.Require(), env)
+
+	// A genuine, non-final continuation obtained with legitimate access to the first namespace.
+	firstPage, err := env.FrontendClient().GetWorkflowExecutionHistory(
+		s.Context(),
+		&workflowservice.GetWorkflowExecutionHistoryRequest{
+			Namespace:              env.Namespace().String(),
+			Execution:              &commonpb.WorkflowExecution{WorkflowId: env.Tv().WorkflowID()},
+			MaximumPageSize:        1,
+			HistoryEventFilterType: enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT,
+		},
+	)
+	s.Require().NoError(err)
+	s.Require().NotEmpty(firstPage.NextPageToken, "need a non-final continuation for this test")
+
+	// Replayed against the other namespace. No run ID is sent, so nothing in the request itself
+	// refers to the workflow whose history the token points at.
+	resp, err := env.FrontendClient().GetWorkflowExecutionHistory(
+		s.Context(),
+		&workflowservice.GetWorkflowExecutionHistoryRequest{
+			Namespace:              otherNamespace.String(),
+			Execution:              &commonpb.WorkflowExecution{WorkflowId: env.Tv().WorkflowID()},
+			MaximumPageSize:        1,
+			NextPageToken:          firstPage.NextPageToken,
+			HistoryEventFilterType: enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT,
+		},
+	)
+	s.Error(err)
+	s.Empty(resp.GetHistory().GetEvents())
+	var invalidArgument *serviceerror.InvalidArgument
+	var notFound *serviceerror.NotFound
+	s.True(
+		errors.As(err, &invalidArgument) || errors.As(err, &notFound),
+		"expected InvalidArgument or NotFound, got %T: %v", err, err,
+	)
+}
+
+func (s *RawHistorySuite) TestGetWorkflowExecutionHistoryReverse_ContinuationFromAnotherNamespace() {
+	env := s.newTestEnv(
+		testcore.WithHistoryShardCount(1),
+		// Shadow mode reports the mismatch but still serves the page.
+		testcore.WithDynamicConfig(dynamicconfig.EnablePaginationTokenBranchValidationShadowMode, false),
+	)
+
+	otherNamespace := namespace.Name(testcore.RandomizeStr("other-namespace"))
+	_, err := env.RegisterNamespace(otherNamespace, 1, enumspb.ARCHIVAL_STATE_DISABLED, "", "")
+	s.Require().NoError(err)
+
+	startMultiBatchWorkflow(s.Context(), s.Require(), env)
+
+	firstPage, err := env.FrontendClient().GetWorkflowExecutionHistoryReverse(
+		s.Context(),
+		&workflowservice.GetWorkflowExecutionHistoryReverseRequest{
+			Namespace:       env.Namespace().String(),
+			Execution:       &commonpb.WorkflowExecution{WorkflowId: env.Tv().WorkflowID()},
+			MaximumPageSize: 1,
+		},
+	)
+	s.Require().NoError(err)
+	s.Require().NotEmpty(firstPage.NextPageToken, "need a non-final continuation for this test")
+
+	resp, err := env.FrontendClient().GetWorkflowExecutionHistoryReverse(
+		s.Context(),
+		&workflowservice.GetWorkflowExecutionHistoryReverseRequest{
+			Namespace:       otherNamespace.String(),
+			Execution:       &commonpb.WorkflowExecution{WorkflowId: env.Tv().WorkflowID()},
+			MaximumPageSize: 1,
+			NextPageToken:   firstPage.NextPageToken,
+		},
+	)
+	s.Error(err)
+	s.Empty(resp.GetHistory().GetEvents())
 }


### PR DESCRIPTION
## What changed?

Backports the remaining merged PRs labeled [release/1.32.0](https://github.com/temporalio/temporal/issues?q=state%3Aclosed%20label%3Arelease%2F1.32.0) onto release/v1.32.x, in main merge order:

- [#11599](https://github.com/temporalio/temporal/pull/11599) Optimize Visibility PostgreSQL upgrade schema v1.14
- [#11723](https://github.com/temporalio/temporal/pull/11723) Validate history pagination branch token against mutable state
- [#11800](https://github.com/temporalio/temporal/pull/11800) Capture panics in Visibility query converter
- [#11813](https://github.com/temporalio/temporal/pull/11813) Capture panic in ServiceErrorInterceptor
- [#11829](https://github.com/temporalio/temporal/pull/11829) Return empty Elasticsearch page token when the result is smaller than the page
- [#11839](https://github.com/temporalio/temporal/pull/11839) Fix FirstWorkflowTaskBackoff accumulation upon Continue-As-New
- [#11801](https://github.com/temporalio/temporal/pull/11801) Fix Visibility SQL query conversion

[#11265](https://github.com/temporalio/temporal/pull/11265) and [#11564](https://github.com/temporalio/temporal/pull/11564) were already present on release/v1.32.x and are not duplicated here.

## Testing

- Targeted unit tests for Visibility query conversion, RPC interception, History branch-token validation, and Continue-As-New backoff
- make GOLANGCI_LINT_FIX=false GOLANGCI_LINT_BASE_REV=origin/release/v1.32.x lint-code