### PR TITLE
Fixed edge case with transient persistent read failure for Nexus WF updates and add tests

### DIFF
--- a/chasm/lib/workflow/workflow_update_limits_test.go
+++ b/chasm/lib/workflow/workflow_update_limits_test.go
@@ -1,0 +1,115 @@
+package workflow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/chasm"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func nexusCallback(url string) *commonpb.Callback {
+	return &commonpb.Callback{
+		Variant: &commonpb.Callback_Nexus_{
+			Nexus: &commonpb.Callback_Nexus{Url: url},
+		},
+	}
+}
+
+// TestAddUpdateCompletionCallbacks verifies that:
+//   - if per-update limit is exceeded while workflow-wide limit is not exceeded,
+//     we reject attaching callbacks onto that update.
+//   - if workflow-wide limit is exceeded while per-update limit is not exceeded,
+//     we reject attaching callbacks onto that update.
+func TestAddUpdateCompletionCallbacks_LimitsExceeded(t *testing.T) {
+	tests := []struct {
+		name                    string
+		firstUpdateID           string
+		firstCallbacks          []*commonpb.Callback
+		secondUpdateID          string
+		secondCallbacks         []*commonpb.Callback
+		maxCallbacksPerWorkflow int
+		maxCallbacksPerUpdateID int
+		wantError               string
+		wantCallbackCounts      map[string]int
+	}{
+		{
+			name:          "per-update limit exceeded",
+			firstUpdateID: "u1",
+			firstCallbacks: []*commonpb.Callback{
+				nexusCallback("http://cb-1"),
+				nexusCallback("http://cb-2"),
+			},
+			secondUpdateID: "u1",
+			secondCallbacks: []*commonpb.Callback{
+				nexusCallback("http://cb-3"),
+			},
+			maxCallbacksPerWorkflow: 10,
+			maxCallbacksPerUpdateID: 2,
+			wantError:               `cannot attach more than 2 callbacks to update "u1"`,
+			wantCallbackCounts:      map[string]int{"u1": 2},
+		},
+		{
+			name:          "per-workflow limit exceeded",
+			firstUpdateID: "u1",
+			firstCallbacks: []*commonpb.Callback{
+				nexusCallback("http://cb-1"),
+				nexusCallback("http://cb-2"),
+			},
+			secondUpdateID: "u2",
+			secondCallbacks: []*commonpb.Callback{
+				nexusCallback("http://cb-3"),
+				nexusCallback("http://cb-4"),
+			},
+			maxCallbacksPerWorkflow: 3,
+			maxCallbacksPerUpdateID: 10,
+			wantError:               "cannot attach more than 3 callbacks to a workflow",
+			wantCallbackCounts:      map[string]int{"u1": 2},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := &chasm.MockMutableContext{}
+			wf := &Workflow{MSPointer: chasm.NewMSPointer(&chasm.MockNodeBackend{})}
+			eventTime := timestamppb.Now()
+
+			// Add the first set of callbacks, expect this to succeed.
+			require.NoError(t, wf.AddUpdateCompletionCallbacks(
+				ctx,
+				eventTime,
+				test.firstUpdateID,
+				"req-1",
+				test.firstCallbacks,
+				test.maxCallbacksPerWorkflow,
+				test.maxCallbacksPerUpdateID,
+			))
+
+			// Add the second set of callbacks, expect this to fail with the expected error.
+			err := wf.AddUpdateCompletionCallbacks(
+				ctx,
+				eventTime,
+				test.secondUpdateID,
+				"req-2",
+				test.secondCallbacks,
+				test.maxCallbacksPerWorkflow,
+				test.maxCallbacksPerUpdateID,
+			)
+			var failedPrecondition *serviceerror.FailedPrecondition
+			require.ErrorAs(t, err, &failedPrecondition)
+			require.ErrorContains(t, err, test.wantError)
+
+			// Verify the update state for already-added callbacks is unchanged.
+			require.Len(t, wf.Updates, len(test.wantCallbackCounts))
+			for updateID, wantCount := range test.wantCallbackCounts {
+				update, ok := wf.Updates[updateID]
+				require.True(t, ok)
+				require.Len(t, update.Get(ctx).Callbacks, wantCount)
+			}
+		})
+	}
+}

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -119,6 +119,9 @@ var (
 	// ErrPinnedWorkflowCannotTransition indicates attempt to start a transition on a pinned workflow
 	ErrPinnedWorkflowCannotTransition = serviceerror.NewInternal("unable to start transition on pinned workflows")
 
+	errUpdateNotFound    = serviceerror.NewNotFound("update not found")
+	errUpdateNotComplete = serviceerror.NewInternal("update has not completed")
+
 	timeZeroUTC = time.Unix(0, 0).UTC()
 )
 
@@ -778,6 +781,13 @@ func (ms *MutableStateImpl) GetNexusUpdateCompletion(
 	cevent, err := ms.getUpdateOutcomeEvent(ctx, updateID)
 	var outcome *updatepb.Outcome
 	if err != nil {
+		// If the completion event ID is recorded but the read failed for a reason other than the
+		// event being absent, the failure is likely transient. Return it so the caller can retry.
+		if !errors.Is(err, errUpdateNotFound) &&
+			!errors.Is(err, errUpdateNotComplete) &&
+			!common.IsNotFoundError(err) {
+			return nexusrpc.CompleteOperationOptions{}, err
+		}
 		// If the workflow is complete but the update outcome is missing we need to respond to all callbacks
 		ce, errCE := ms.GetCompletionEvent(ctx)
 		if errors.Is(errCE, ErrMissingWorkflowCompletionEvent) {
@@ -1557,16 +1567,17 @@ func (ms *MutableStateImpl) getUpdateOutcomeEvent(
 	updateID string,
 ) (*historypb.HistoryEvent, error) {
 	if ms.executionInfo.UpdateInfos == nil {
-		return nil, serviceerror.NewNotFound("update not found")
+		return nil, errUpdateNotFound
 	}
 	ui, ok := ms.executionInfo.UpdateInfos[updateID]
 	if !ok {
-		return nil, serviceerror.NewNotFound("update not found")
+		return nil, errUpdateNotFound
 	}
 	completion := ui.GetCompletion()
 	if completion == nil {
-		return nil, serviceerror.NewInternal("update has not completed")
+		return nil, errUpdateNotComplete
 	}
+
 	currentBranchToken, version, err := ms.getCurrentBranchTokenAndEventVersion(completion.EventId)
 	if err != nil {
 		return nil, err

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -43,6 +43,7 @@ import (
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/nexus/nexusrpc"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/persistence/transitionhistory"
 	"go.temporal.io/server/common/persistence/versionhistory"
@@ -2915,6 +2916,72 @@ func (s *mutableStateSuite) TestUpdateInfos() {
 	_, err = s.mutableState.GetUpdateOutcome(ctx, "not_an_update_id")
 	s.Error(err)
 	s.IsType((*serviceerror.NotFound)(nil), err)
+}
+
+// TestGetNexusUpdateCompletion_TransientReadErrorPropagated verifies that we correctly propagate
+// an update completion event read error if the event was actually recorded in-memory.
+func (s *mutableStateSuite) TestGetNexusUpdateCompletion_TransientReadErrorPropagated() {
+	ctx := context.Background()
+
+	s.mockEventsCache.EXPECT().PutEvent(gomock.Any(), gomock.Any()).AnyTimes()
+
+	_, err := s.mutableState.AddWorkflowExecutionStartedEvent(
+		&commonpb.WorkflowExecution{WorkflowId: tests.WorkflowID, RunId: tests.RunID},
+		&historyservice.StartWorkflowExecutionRequest{StartRequest: &workflowservice.StartWorkflowExecutionRequest{}},
+	)
+	s.NoError(err)
+	_, err = s.mutableState.AddWorkflowTaskScheduledEvent(false, enumsspb.WORKFLOW_TASK_TYPE_NORMAL)
+	s.NoError(err)
+
+	updateID := s.T().Name() + "-update-id"
+	acptEvent, err := s.mutableState.AddWorkflowExecutionUpdateAcceptedEvent(
+		updateID, s.T().Name()+"-msg-id", 1,
+		&updatepb.Request{Meta: &updatepb.Meta{UpdateId: updateID}},
+	)
+	s.NoError(err)
+
+	completedEvent, err := s.mutableState.AddWorkflowExecutionUpdateCompletedEvent(
+		acptEvent.EventId,
+		&updatepb.Response{
+			Meta:    &updatepb.Meta{UpdateId: updateID},
+			Outcome: &updatepb.Outcome{Value: &updatepb.Outcome_Success{Success: testPayloads}},
+		},
+	)
+	s.NoError(err)
+
+	_, err = s.mutableState.AddCompletedWorkflowEvent(
+		completedEvent.GetEventId(),
+		&commandpb.CompleteWorkflowExecutionCommandAttributes{},
+		"",
+	)
+	s.NoError(err)
+
+	// Close the transaction to create the event version history used by the read.
+	_, _, err = s.mutableState.CloseTransactionAsMutation(context.Background(), historyi.TransactionPolicyActive)
+	s.NoError(err)
+
+	transientErr := serviceerror.NewUnavailablef("simulated transient read failure")
+	s.mockEventsCache.EXPECT().GetEvent(
+		gomock.Any(),
+		gomock.Any(),
+		gomock.Cond(func(key events.EventKey) bool { return key.EventID == completedEvent.GetEventId() }),
+		gomock.Any(),
+		gomock.Any(),
+	).Return(nil, transientErr)
+	s.mockEventsCache.EXPECT().GetEvent(
+		gomock.Any(),
+		gomock.Any(),
+		gomock.Cond(func(key events.EventKey) bool { return key.EventID != completedEvent.GetEventId() }),
+		gomock.Any(),
+		gomock.Any(),
+	).Return(&historypb.HistoryEvent{}, nil).AnyTimes()
+
+	// If the cache + persistence read returns a transient error but the completion is recorded, it must
+	// not be misclassified as another error.
+	opts, err := s.mutableState.GetNexusUpdateCompletion(ctx, updateID, "some-request-id")
+	var unavailableErr *serviceerror.Unavailable
+	s.Equal(nexusrpc.CompleteOperationOptions{}, opts)
+	s.ErrorAs(err, &unavailableErr, "expect transientErr to be propagated back to caller")
 }
 
 func (s *mutableStateSuite) TestApplyActivityTaskStartedEvent() {

--- a/tests/nexus_workflow_update_test.go
+++ b/tests/nexus_workflow_update_test.go
@@ -16,6 +16,7 @@ import (
 	updatepb "go.temporal.io/api/update/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
@@ -265,6 +266,7 @@ func (s *NexusWorkflowUpdateTestSuite) assertAcceptedUpdateCompletedWorkflowErro
 	var appErr *temporal.ApplicationError
 	s.ErrorAs(noe, &appErr)
 	s.Equal("AcceptedUpdateCompletedWorkflow", appErr.Type())
+	s.Contains(appErr.Error(), "completed before the Update completed")
 }
 
 // assertReappliedUpdateInNewRun verifies that updateID appears as an UpdateAdmitted event
@@ -955,6 +957,7 @@ func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateCallbackOnFailedUpdate(
 	// Target workflow: update handler returns an error after acceptance.
 	targetWF := func(ctx workflow.Context, input string) (string, error) {
 		if err := workflow.SetUpdateHandler(ctx, "update", func(ctx workflow.Context, input string) (string, error) {
+			workflow.GetSignalChannel(ctx, "fail-update").Receive(ctx, nil)
 			return "", temporal.NewApplicationError("update handler failed", "UpdateFailed", nil)
 		}); err != nil {
 			return "", err
@@ -983,6 +986,9 @@ func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateCallbackOnFailedUpdate(
 	}, callerWF)
 	s.NoError(err)
 
+	s.awaitUpdateAccepted(ctx, env, cfg.childWfID, "")
+	s.NoError(env.SdkClient().SignalWorkflow(ctx, cfg.childWfID, "", "fail-update", nil))
+
 	// The update is accepted but the handler returns an error -> update completes with
 	// failure -> callback fires -> nexus operation fails -> caller workflow fails.
 	var result string
@@ -990,7 +996,8 @@ func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateCallbackOnFailedUpdate(
 	s.Error(err, "expected caller workflow to fail because the update failed")
 
 	// Verify it's a NexusOperationError wrapping the update failure.
-	_ = s.requireNexusOperationError(err)
+	noe := s.requireNexusOperationError(err)
+	s.Contains(noe.Error(), "update handler failed")
 
 	// Clean up: stop the target workflow.
 	s.NoError(env.SdkClient().SignalWorkflow(ctx, cfg.childWfID, "", "stop", nil))
@@ -1057,6 +1064,60 @@ func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateCallbackOnWorkflowTermi
 	var result string
 	err = callerRun.Get(ctx, &result)
 	s.Error(err, "expected caller workflow to fail because the target was terminated")
+	s.assertAcceptedUpdateCompletedWorkflowError(err)
+}
+
+// TestWorkflowUpdateCallbackOnWorkflowCancel verifies that if the target workflow is canceled,
+// we will fail an accepted update and its Nexus operation.
+func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateCallbackOnWorkflowCancel() {
+	env := newNexusTestEnv(s.T(), true, enableUpdateCallbacksOpts()...)
+	ctx := s.Context()
+	cfg := newUpdateNexusTestConfig(s.T())
+	cfg.updateID = "cancel-update-id"
+
+	h := makeUpdateWithCallbackHandler(env, s.T(), cfg, nil)
+	endpointName := env.createRandomExternalNexusServer(ctx, s.T(), h)
+
+	targetTaskQueue := testcore.RandomizeStr("target-" + s.T().Name())
+
+	// Keep the update pending until the workflow is canceled.
+	targetWF := func(ctx workflow.Context, input string) (string, error) {
+		if err := workflow.SetUpdateHandler(ctx, "update", func(ctx workflow.Context, input string) (string, error) {
+			signalCh := workflow.GetSignalChannel(ctx, "complete-update")
+			signalCh.Receive(ctx, nil)
+			return "updated: " + input, nil
+		}); err != nil {
+			return "", err
+		}
+		ctx.Done().Receive(ctx, nil)
+		return "", ctx.Err()
+	}
+
+	s.startWorker(env, targetTaskQueue, targetWF)
+
+	_, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		ID:        cfg.childWfID,
+		TaskQueue: targetTaskQueue,
+	}, targetWF, "initial input")
+	s.NoError(err)
+
+	callerWF := s.newSimpleCallerWF(endpointName, cfg.childWfID)
+
+	s.startWorker(env, cfg.taskQueue, callerWF)
+
+	callerRun, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		TaskQueue:                cfg.taskQueue,
+		WorkflowExecutionTimeout: 30 * time.Second,
+	}, callerWF)
+	s.NoError(err)
+
+	s.awaitUpdateAccepted(ctx, env, cfg.childWfID, "")
+
+	s.NoError(env.SdkClient().CancelWorkflow(ctx, cfg.childWfID, ""))
+
+	var result string
+	err = callerRun.Get(ctx, &result)
+	s.Error(err, "expected caller workflow to fail because the target was canceled")
 	s.assertAcceptedUpdateCompletedWorkflowError(err)
 }
 
@@ -1247,6 +1308,210 @@ func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateCallbackOnWorkflowFaile
 	err = callerRun.Get(ctx, &result)
 	s.Error(err, "expected caller workflow to fail because the target workflow failed with retry")
 	s.assertAcceptedUpdateCompletedWorkflowError(err)
+}
+
+// TestWorkflowUpdateCallbackOnNexusOperationCancel verifies that a canceled Nexus
+// operation can complete once when the update completes.
+func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateCallbackOnNexusOperationCancel() {
+	env := newNexusTestEnv(s.T(), true, enableUpdateCallbacksOpts()...)
+	ctx := s.Context()
+	cfg := newUpdateNexusTestConfig(s.T())
+	cfg.updateID = "cancel-op-update-id"
+
+	var cancelReceived atomic.Bool
+	h := makeUpdateWithCallbackHandler(env, s.T(), cfg, nil)
+	h.OnCancelOperation = func(ctx context.Context, service, operation, token string, options nexus.CancelOperationOptions) error {
+		cancelReceived.Store(true)
+		return nil
+	}
+
+	// Start the target workflow, whose update handler blocks until the "complete-update" signal.
+	endpointName := env.createRandomExternalNexusServer(ctx, s.T(), h)
+	targetTaskQueue := testcore.RandomizeStr("target-" + s.T().Name())
+	targetWF := newUpdateChildWorkflow(true)
+	s.startWorker(env, targetTaskQueue, targetWF)
+	_, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		ID:        cfg.childWfID,
+		TaskQueue: targetTaskQueue,
+	}, targetWF, "initial input")
+	s.NoError(err)
+
+	callerWF := func(ctx workflow.Context) (string, error) {
+		nexusClient := workflow.NewNexusClient(endpointName, "test")
+		opCtx, cancelOp := workflow.WithCancel(ctx)
+		fut := nexusClient.ExecuteOperation(opCtx, "operation", cfg.childWfID, workflow.NexusOperationOptions{})
+		var exec workflow.NexusOperationExecution
+		if err := fut.GetNexusOperationExecution().Get(ctx, &exec); err != nil {
+			return "", err
+		}
+		workflow.GetSignalChannel(ctx, "cancel-op").Receive(ctx, nil)
+		cancelOp()
+		var result string
+		err := fut.Get(ctx, &result)
+		return result, err
+	}
+
+	// Kick off caller workflow, wait for update to be accepted, then cancel the nexus operation.
+	s.startWorker(env, cfg.taskQueue, callerWF)
+	callerRun, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		TaskQueue:                cfg.taskQueue,
+		WorkflowExecutionTimeout: 30 * time.Second,
+	}, callerWF)
+	s.NoError(err)
+	s.awaitUpdateAccepted(ctx, env, cfg.childWfID, "")
+	s.NoError(env.SdkClient().SignalWorkflow(ctx, callerRun.GetID(), callerRun.GetRunID(), "cancel-op", nil))
+
+	// The cancel request should be delivered to the nexus handler.
+	s.AwaitTruef(cancelReceived.Load, 10*time.Second, 100*time.Millisecond, "cancel request was not delivered")
+
+	// Signal the update handler to complete the update, then signal the target workflow to stop.
+	s.NoError(env.SdkClient().SignalWorkflow(ctx, cfg.childWfID, "", "complete-update", nil))
+	s.NoError(env.SdkClient().SignalWorkflow(ctx, cfg.childWfID, "", "stop", nil))
+
+	// Wait for workflow to finish before checking history.
+	var callerResult string
+	s.NoError(callerRun.Get(ctx, &callerResult))
+
+	// Caller workflow history must have no WFT failure events.
+	callerHist := env.SdkClient().GetWorkflowHistory(ctx, callerRun.GetID(), callerRun.GetRunID(), false, enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
+	for callerHist.HasNext() {
+		event, err := callerHist.Next()
+		s.Require().NoError(err)
+		s.NotEqual(enumspb.EVENT_TYPE_WORKFLOW_TASK_FAILED, event.EventType, "canceling the nexus operation must not crash the caller's workflow task")
+	}
+
+	// Target workflow history must show that the update completed, despite the nexus operation getting canceled
+	// (since we've already accepted the update).
+	await.Require(s.Context(), s.T(), func(t *await.T) {
+		targetHist := env.SdkClient().GetWorkflowHistory(ctx, cfg.childWfID, "", false, enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
+		completedCount := 0
+		for targetHist.HasNext() {
+			event, err := targetHist.Next()
+			require.NoError(t, err)
+			if event.EventType == enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_COMPLETED {
+				completedCount++
+			}
+		}
+		require.Equal(t, 1, completedCount, "the update must complete exactly once; canceling the caller's nexus operation must not duplicate delivery")
+	}, 10*time.Second, 500*time.Millisecond)
+}
+
+// TestWorkflowUpdateCallbackCustomDataConverter verifies callback completion with
+// encoded update input and output.
+func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateCallbackCustomDataConverter() {
+	env := newNexusTestEnv(s.T(), true, enableUpdateCallbacksOpts()...)
+	ctx := s.Context()
+	cfg := newUpdateNexusTestConfig(s.T())
+	cfg.updateID = "custom-converter-update-id"
+
+	dataConverter := converter.NewCodecDataConverter(
+		converter.GetDefaultDataConverter(),
+		converter.NewZlibCodec(converter.ZlibCodecOptions{AlwaysEncode: true}),
+	)
+
+	inputPayload, err := dataConverter.ToPayload("custom-converter-input")
+	s.NoError(err)
+
+	h := nexustest.Handler{
+		OnStartOperation: func(
+			ctx context.Context,
+			service, operation string,
+			input *nexus.LazyValue,
+			options nexus.StartOperationOptions,
+		) (nexus.HandlerStartOperationResult[any], error) {
+			_, err := env.FrontendClient().UpdateWorkflowExecution(ctx, &workflowservice.UpdateWorkflowExecutionRequest{
+				Namespace: env.Namespace().String(),
+				WorkflowExecution: &commonpb.WorkflowExecution{
+					WorkflowId: cfg.childWfID,
+				},
+				WaitPolicy: &updatepb.WaitPolicy{
+					LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+				},
+				Request: &updatepb.Request{
+					Meta: &updatepb.Meta{UpdateId: cfg.updateID},
+					Input: &updatepb.Input{
+						Name: "update",
+						Args: &commonpb.Payloads{Payloads: []*commonpb.Payload{inputPayload}},
+					},
+					RequestId: uuid.NewString(),
+					CompletionCallbacks: []*commonpb.Callback{
+						{
+							Variant: &commonpb.Callback_Nexus_{
+								Nexus: &commonpb.Callback_Nexus{
+									Url:    options.CallbackURL,
+									Header: options.CallbackHeader,
+								},
+							},
+						},
+					},
+				},
+			})
+			if err != nil {
+				return nil, nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "update call failed: %v", err)
+			}
+			return &nexus.HandlerStartOperationResultAsync{OperationToken: "test"}, nil
+		},
+	}
+	endpointName := env.createRandomExternalNexusServer(ctx, s.T(), h)
+
+	targetTaskQueue := testcore.RandomizeStr("target-" + s.T().Name())
+
+	targetClient, err := client.Dial(client.Options{
+		HostPort:      env.FrontendGRPCAddress(),
+		Namespace:     env.Namespace().String(),
+		DataConverter: dataConverter,
+	})
+	s.NoError(err)
+	s.T().Cleanup(targetClient.Close)
+
+	targetWF := func(ctx workflow.Context, input string) (string, error) {
+		if err := workflow.SetUpdateHandler(ctx, "update", func(ctx workflow.Context, input string) (string, error) {
+			workflow.GetSignalChannel(ctx, "complete-update").Receive(ctx, nil)
+			return "converted: " + input, nil
+		}); err != nil {
+			return "", err
+		}
+		workflow.GetSignalChannel(ctx, "stop").Receive(ctx, nil)
+		return "done: " + input, nil
+	}
+
+	targetWorker := worker.New(targetClient, targetTaskQueue, worker.Options{})
+	targetWorker.RegisterWorkflow(targetWF)
+	s.NoError(targetWorker.Start())
+	s.T().Cleanup(targetWorker.Stop)
+
+	_, err = targetClient.ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		ID:        cfg.childWfID,
+		TaskQueue: targetTaskQueue,
+	}, targetWF, "initial input")
+	s.NoError(err)
+
+	callerClient, err := client.Dial(client.Options{
+		HostPort:      env.FrontendGRPCAddress(),
+		Namespace:     env.Namespace().String(),
+		DataConverter: dataConverter,
+	})
+	s.NoError(err)
+	s.T().Cleanup(callerClient.Close)
+
+	callerWF := s.newSimpleCallerWF(endpointName, cfg.childWfID)
+	callerWorker := worker.New(callerClient, cfg.taskQueue, worker.Options{})
+	callerWorker.RegisterWorkflow(callerWF)
+	s.NoError(callerWorker.Start())
+	s.T().Cleanup(callerWorker.Stop)
+
+	callerRun, err := callerClient.ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		TaskQueue:                cfg.taskQueue,
+		WorkflowExecutionTimeout: 30 * time.Second,
+	}, callerWF)
+	s.NoError(err)
+
+	s.awaitUpdateAccepted(ctx, env, cfg.childWfID, "")
+	s.NoError(env.SdkClient().SignalWorkflow(ctx, cfg.childWfID, "", "complete-update", nil))
+
+	var result string
+	s.NoError(callerRun.Get(ctx, &result))
+	s.Equal("converted: custom-converter-input", result)
 }
 
 // TestWorkflowUpdateCallbackOnRejectedUpdate verifies that when an update is rejected

--- a/tests/update_workflow_sdk_test.go
+++ b/tests/update_workflow_sdk_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/nexus-rpc/sdk-go/nexus"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
@@ -17,6 +19,7 @@ import (
 	"go.temporal.io/sdk/workflow"
 	"go.temporal.io/server/chasm/lib/callback"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/tests/testcore"
 )
@@ -502,4 +505,88 @@ func (s *UpdateWorkflowSdkSuite) TestUpdateRejectsInvalidCallbackURL() {
 	var invalidArgument *serviceerror.InvalidArgument
 	s.ErrorAs(err, &invalidArgument)
 	s.ErrorContains(err, "invalid url: unknown scheme")
+}
+
+// TestUpdateCallbackCloseWhenWorkflowCloses verifies that the
+// callback contains the update outcome when the workflow closes in the same WFT.
+func (s *UpdateWorkflowSdkSuite) TestUpdateCallbackCloseWhenWorkflowCloses() {
+	env := testcore.NewEnv(s.T(),
+		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
+		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMCallbacks, true),
+		testcore.WithDynamicConfig(dynamicconfig.EnableWorkflowUpdateCallbacks, true),
+		testcore.WithDynamicConfig(
+			callback.AllowedAddresses,
+			[]any{map[string]any{"Pattern": "*", "AllowInsecure": true}},
+		),
+	)
+
+	completionHandler, callbackAddress := newNexusCompletionHandler(s.T())
+
+	// Register a workflow that simply waits for the update handler to be invoked and then returns immediately.
+	wfName := testcore.RandomizeStr("update-close-same-wft")
+	updateResult := "update result"
+	wf := func(ctx workflow.Context) (string, error) {
+		updateComplete := false
+		if err := workflow.SetUpdateHandler(ctx, env.Tv().HandlerName(), func(workflow.Context, string) (string, error) {
+			updateComplete = true
+			return updateResult, nil
+		}); err != nil {
+			return "", err
+		}
+		if err := workflow.Await(ctx, func() bool { return updateComplete }); err != nil {
+			return "", err
+		}
+		return "workflow result", nil
+	}
+	env.SdkWorker().RegisterWorkflowWithOptions(wf, workflow.RegisterOptions{Name: wfName})
+
+	run, err := env.SdkClient().ExecuteWorkflow(s.Context(), sdkclient.StartWorkflowOptions{
+		ID:        env.Tv().WorkflowID(),
+		TaskQueue: env.WorkerTaskQueue(),
+	}, wfName)
+	s.NoError(err)
+
+	_, err = env.FrontendClient().UpdateWorkflowExecution(s.Context(), &workflowservice.UpdateWorkflowExecutionRequest{
+		Namespace:         env.Namespace().String(),
+		WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: run.GetID(), RunId: run.GetRunID()},
+		WaitPolicy:        &updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED},
+		Request: &updatepb.Request{
+			Meta:      &updatepb.Meta{UpdateId: env.Tv().UpdateID()},
+			Input:     &updatepb.Input{Name: env.Tv().HandlerName(), Args: &commonpb.Payloads{Payloads: []*commonpb.Payload{testcore.MustToPayload(s.T(), "input")}}},
+			RequestId: uuid.NewString(),
+			CompletionCallbacks: []*commonpb.Callback{{
+				Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: callbackAddress + "/update"}},
+			}},
+		},
+	})
+	s.NoError(err)
+
+	completion := await.Rcv(s.T(), completionHandler.requestCh)
+	s.Equal(nexus.OperationStateSucceeded, completion.State)
+	var result string
+	s.NoError(completion.Result.Consume(&result))
+	s.Equal(updateResult, result)
+	await.Snd(s.T(), completionHandler.requestCompleteCh, nil)
+
+	var workflowResult string
+	s.NoError(run.Get(s.Context(), &workflowResult))
+	s.Equal("workflow result", workflowResult)
+
+	// Expect a single workflow task followed by the update completion and workflow completion events.
+	s.EqualHistoryEventsSuffix(`
+WorkflowTaskCompleted
+WorkflowExecutionUpdateAccepted
+WorkflowExecutionUpdateCompleted
+WorkflowExecutionCompleted`, env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{
+		WorkflowId: run.GetID(),
+		RunId:      run.GetRunID(),
+	}))
+
+	description, err := env.FrontendClient().DescribeWorkflowExecution(s.Context(), &workflowservice.DescribeWorkflowExecutionRequest{
+		Namespace: env.Namespace().String(),
+		Execution: &commonpb.WorkflowExecution{WorkflowId: run.GetID(), RunId: run.GetRunID()},
+	})
+	s.NoError(err)
+	s.Len(description.GetCallbacks(), 1)
+	s.Equal(enumspb.CALLBACK_STATE_SUCCEEDED, description.GetCallbacks()[0].GetState())
 }


### PR DESCRIPTION
## What changed?

It seems possible that in a case where:
1. Workflow is closed
2. Completion event is recorded in `UpdateInfos`, but
3. When getting the event from persistence, we get cache miss and persistence read transiently fails

We'd want to propagate the persistence read failure so caller can retry the read later. Without the change in mutable_state_impl.go, we'll instead return a Nexus operation error in `GetNexusUpdateCompletion(...)` with the error string: `"Workflow Update failed because the Workflow completed before the Update completed."`

Added tests for this, and also add more tests for Nexus + WF update scenarios.

## Why?

Hardening feature + add more tests.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)