### PR TITLE
Fix SQLite transaction cancellation test race

### DIFF
--- a/common/persistence/tests/sqlite_test.go
+++ b/common/persistence/tests/sqlite_test.go
@@ -1597,6 +1597,5 @@ func TestSQLiteTransactionContextCancellation(t *testing.T) {
 		RangeHash:   0,
 		TaskQueueID: []byte("test-queue"),
 	}, sqlplugin.MatchingTaskVersion1)
-	assert.NotContains(t, err.Error(), "no such table")
 	require.ErrorIs(t, err, gosql.ErrNoRows)
 }

--- a/common/persistence/tests/sqlite_test.go
+++ b/common/persistence/tests/sqlite_test.go
@@ -1598,5 +1598,5 @@ func TestSQLiteTransactionContextCancellation(t *testing.T) {
 		TaskQueueID: []byte("test-queue"),
 	}, sqlplugin.MatchingTaskVersion1)
 	assert.NotContains(t, err.Error(), "no such table")
-	assert.ErrorAs(t, err, &gosql.ErrNoRows)
+	require.ErrorIs(t, err, gosql.ErrNoRows)
 }


### PR DESCRIPTION
Fix a test data race caused by passing the address of `sql.ErrNoRows` to `assert.ErrorAs`.

Since `errors.As` writes the matching error into its target, the assertion could mutate the package-level sentinel while parallel persistence tests read it.

Use `require.ErrorIs` to verify sentinel identity without mutating global state.
