### PR TITLE
Fix CHASM sentinel handling during scheduler migration

### DIFF
--- a/chasm/lib/scheduler/handler.go
+++ b/chasm/lib/scheduler/handler.go
@@ -96,7 +96,7 @@ func (h *handler) CreateFromMigrationState(ctx context.Context, req *schedulerpb
 		// Check if the existing schedule is a sentinel. Sentinels are
 		// auto-deleted SentinelIdleTime after schedule creation; the
 		// V1 schedule will keep retrying migration until it expires.
-		_, readErr := chasm.ReadComponent(
+		isSentinel, readErr := chasm.ReadComponent(
 			ctx,
 			chasm.NewComponentRef[*Scheduler](
 				chasm.ExecutionKey{
@@ -104,23 +104,20 @@ func (h *handler) CreateFromMigrationState(ctx context.Context, req *schedulerpb
 					BusinessID:  scheduleID,
 				},
 			),
-			func(s *Scheduler, ctx chasm.Context, _ *struct{}) (*struct{}, error) {
-				if s.IsSentinel() {
-					return nil, ErrSentinel
-				}
-				return nil, nil
+			func(s *Scheduler, _ chasm.Context, _ *struct{}) (bool, error) {
+				return s.IsSentinel(), nil
 			},
 			(*struct{})(nil),
 		)
 		if readErr != nil {
-			if errors.Is(readErr, ErrSentinel) {
-				h.logger.Warn(
-					fmt.Sprintf("Migration blocked by sentinel schedule; sentinel will auto-delete %v after schedule creation", SentinelIdleTime),
-					tag.NewStringTag("schedule-id", scheduleID),
-				)
-				return nil, ErrSentinelBlocked
-			}
 			return nil, readErr
+		}
+		if isSentinel {
+			h.logger.Warn(
+				fmt.Sprintf("Migration blocked by sentinel schedule; sentinel will auto-delete %v after schedule creation", SentinelIdleTime),
+				tag.NewStringTag("schedule-id", scheduleID),
+			)
+			return nil, ErrSentinelBlocked
 		}
 		return nil, serviceerror.NewAlreadyExistsf("schedule %q is already registered", scheduleID)
 	}

--- a/chasm/lib/scheduler/handler.go
+++ b/chasm/lib/scheduler/handler.go
@@ -28,6 +28,22 @@ func newHandler(logger log.Logger, specBuilder *legacyscheduler.SpecBuilder) *ha
 	}
 }
 
+func isSchedulerSentinel(ctx context.Context, namespaceID, scheduleID string) (bool, error) {
+	return chasm.ReadComponent(
+		ctx,
+		chasm.NewComponentRef[*Scheduler](
+			chasm.ExecutionKey{
+				NamespaceID: namespaceID,
+				BusinessID:  scheduleID,
+			},
+		),
+		func(s *Scheduler, _ chasm.Context, _ *struct{}) (bool, error) {
+			return s.IsSentinel(), nil
+		},
+		(*struct{})(nil),
+	)
+}
+
 func (h *handler) CreateSchedule(ctx context.Context, req *schedulerpb.CreateScheduleRequest) (resp *schedulerpb.CreateScheduleResponse, err error) {
 	defer log.CapturePanic(h.logger, &err)
 
@@ -47,24 +63,12 @@ func (h *handler) CreateSchedule(ctx context.Context, req *schedulerpb.CreateSch
 		//
 		// TODO lina@ - this can be removed (as well as all other sentinel business)
 		// after fully migrated to CHASM schedulers.
-		_, readErr := chasm.ReadComponent(
-			ctx,
-			chasm.NewComponentRef[*Scheduler](
-				chasm.ExecutionKey{
-					NamespaceID: req.NamespaceId,
-					BusinessID:  req.FrontendRequest.ScheduleId,
-				},
-			),
-			func(s *Scheduler, ctx chasm.Context, _ *struct{}) (*struct{}, error) {
-				if s.IsSentinel() {
-					return nil, ErrSentinel
-				}
-				return nil, nil
-			},
-			(*struct{})(nil),
-		)
+		isSentinel, readErr := isSchedulerSentinel(ctx, req.NamespaceId, req.FrontendRequest.ScheduleId)
 		if readErr != nil {
-			return nil, readErr // Returns ErrSentinel (404) if sentinel
+			return nil, readErr
+		}
+		if isSentinel {
+			return nil, ErrSentinel
 		}
 		return nil, serviceerror.NewAlreadyExistsf("schedule %q is already registered", req.FrontendRequest.ScheduleId)
 	}
@@ -96,19 +100,7 @@ func (h *handler) CreateFromMigrationState(ctx context.Context, req *schedulerpb
 		// Check if the existing schedule is a sentinel. Sentinels are
 		// auto-deleted SentinelIdleTime after schedule creation; the
 		// V1 schedule will keep retrying migration until it expires.
-		isSentinel, readErr := chasm.ReadComponent(
-			ctx,
-			chasm.NewComponentRef[*Scheduler](
-				chasm.ExecutionKey{
-					NamespaceID: req.NamespaceId,
-					BusinessID:  scheduleID,
-				},
-			),
-			func(s *Scheduler, _ chasm.Context, _ *struct{}) (bool, error) {
-				return s.IsSentinel(), nil
-			},
-			(*struct{})(nil),
-		)
+		isSentinel, readErr := isSchedulerSentinel(ctx, req.NamespaceId, scheduleID)
 		if readErr != nil {
 			return nil, readErr
 		}

--- a/chasm/lib/scheduler/handler.go
+++ b/chasm/lib/scheduler/handler.go
@@ -220,12 +220,14 @@ func (h *handler) MigrateToWorkflow(ctx context.Context, req *schedulerpb.Migrat
 				BusinessID:  req.ScheduleId,
 			},
 		),
-		(*Scheduler).MigrateToWorkflow,
+		func(s *Scheduler, ctx chasm.MutableContext, req *schedulerpb.MigrateToWorkflowRequest) (*schedulerpb.MigrateToWorkflowResponse, error) {
+			if s.IsSentinel() {
+				return nil, ErrSentinelBlocked
+			}
+			return s.MigrateToWorkflow(ctx, req)
+		},
 		req,
 	)
-	if errors.Is(err, ErrSentinel) {
-		return nil, ErrSentinelBlocked
-	}
 	return resp, err
 }
 

--- a/chasm/lib/scheduler/handler_test.go
+++ b/chasm/lib/scheduler/handler_test.go
@@ -132,8 +132,6 @@ func TestHandler_CreateSchedule_Sentinel(t *testing.T) {
 	})
 
 	require.ErrorIs(t, err, scheduler.ErrSentinel)
-	var notFoundErr *serviceerror.NotFound
-	require.ErrorAs(t, err, &notFoundErr)
 }
 
 func TestHandler_CreateFromMigrationState_Sentinel(t *testing.T) {

--- a/chasm/lib/scheduler/handler_test.go
+++ b/chasm/lib/scheduler/handler_test.go
@@ -107,6 +107,35 @@ func TestSentinelHandler_MigrateToWorkflow(t *testing.T) {
 	})
 }
 
+func TestHandler_CreateSchedule_Sentinel(t *testing.T) {
+	logger := log.NewTestLogger()
+	h := scheduler.NewTestHandler(logger)
+	_, engineCtx := newTestEngineContext(t, logger)
+	_, err := chasm.StartExecution(
+		engineCtx,
+		chasm.ExecutionKey{
+			NamespaceID: namespaceID,
+			BusinessID:  scheduleID,
+		},
+		func(ctx chasm.MutableContext, _ struct{}) (*scheduler.Scheduler, error) {
+			return scheduler.NewSentinel(ctx, namespace, namespaceID, scheduleID), nil
+		},
+		struct{}{},
+	)
+	require.NoError(t, err)
+
+	_, err = h.CreateSchedule(engineCtx, &schedulerpb.CreateScheduleRequest{
+		NamespaceId: namespaceID,
+		FrontendRequest: &workflowservice.CreateScheduleRequest{
+			ScheduleId: scheduleID,
+		},
+	})
+
+	require.ErrorIs(t, err, scheduler.ErrSentinel)
+	var notFoundErr *serviceerror.NotFound
+	require.ErrorAs(t, err, &notFoundErr)
+}
+
 func TestHandler_CreateFromMigrationState_Sentinel(t *testing.T) {
 	logger := log.NewTestLogger()
 	h := scheduler.NewTestHandler(logger)

--- a/tests/schedule_migration_test.go
+++ b/tests/schedule_migration_test.go
@@ -339,6 +339,39 @@ func (s *ScheduleMigrationTestSuite) TestCreateFromMigrationStateBlockedBySentin
 	s.Contains(unavailableErr.Message, "sentinel")
 }
 
+func (s *ScheduleMigrationTestSuite) TestMigrateToWorkflowBlockedByCHASMSentinel() {
+	env := newScheduleEnv(
+		s.T(),
+		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
+	)
+
+	ctx := s.Context()
+	sid := testcore.RandomizeStr("sched-migrate-v2-to-v1-chasm-sentinel")
+	nsName := env.Namespace().String()
+	nsID := env.NamespaceID().String()
+
+	_, err := env.GetTestCluster().SchedulerClient().CreateSentinel(
+		ctx,
+		&schedulerpb.CreateSentinelRequest{
+			NamespaceId: nsID,
+			Namespace:   nsName,
+			ScheduleId:  sid,
+		},
+	)
+	s.Require().NoError(err)
+
+	_, err = env.GetTestCluster().SchedulerClient().MigrateToWorkflow(
+		ctx,
+		&schedulerpb.MigrateToWorkflowRequest{
+			NamespaceId: nsID,
+			ScheduleId:  sid,
+		},
+	)
+	var unavailableErr *serviceerror.Unavailable
+	s.Require().ErrorAs(err, &unavailableErr)
+	s.Contains(unavailableErr.Message, "sentinel")
+}
+
 func (s *ScheduleMigrationTestSuite) TestScheduleMigrationDynamicConfig() {
 	env := newScheduleEnv(
 		s.T(),

--- a/tests/schedule_migration_test.go
+++ b/tests/schedule_migration_test.go
@@ -350,29 +350,18 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV1ToV2RetriesAfterSent
 
 	ctx := s.Context()
 	sid := testcore.RandomizeStr("sched-migrate-v1-to-v2-sentinel-retry")
+	wid := testcore.RandomizeStr("sched-migrate-v1-to-v2-sentinel-retry-wf")
+	wt := testcore.RandomizeStr("sched-migrate-v1-to-v2-sentinel-retry-wt")
 	nsName := env.Namespace().String()
 	nsID := env.NamespaceID().String()
 	v1WorkflowID := scheduler.WorkflowIDPrefix + sid
 
 	// Keep the scheduler timerless so it cannot retry migration until the test wakes it.
-	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
-		Namespace:  nsName,
-		ScheduleId: sid,
-		Schedule: &schedulepb.Schedule{
-			Spec: &schedulepb.ScheduleSpec{
-				Interval: []*schedulepb.IntervalSpec{{Interval: durationpb.New(time.Hour)}},
-			},
-			Action: startWorkflowAction(
-				env,
-				testcore.RandomizeStr("sched-migrate-v1-to-v2-sentinel-retry-wf"),
-				testcore.RandomizeStr("sched-migrate-v1-to-v2-sentinel-retry-wt"),
-			),
-			State: &schedulepb.ScheduleState{Paused: true},
-		},
-		Identity:  "test",
-		RequestId: uuid.NewString(),
+	createSchedule(ctx, s.T(), env, sid, &schedulepb.Schedule{
+		Spec:   intervalSpec(noOpInterval),
+		Action: startWorkflowAction(env, wid, wt),
+		State:  &schedulepb.ScheduleState{Paused: true},
 	})
-	s.Require().NoError(err)
 
 	// Wait for the V1 scheduler to process its first workflow task and go to sleep.
 	s.Eventually(func() bool {
@@ -387,7 +376,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV1ToV2RetriesAfterSent
 			},
 		)
 		return err == nil && desc.GetWorkflowExecutionInfo().GetHistoryLength() > 3
-	}, 10*time.Second, 100*time.Millisecond)
+	}, awaitTimeout, pollInterval)
 
 	sentinelResp, err := env.AdminClient().DescribeMutableState(ctx, &adminservice.DescribeMutableStateRequest{
 		Namespace: nsName,
@@ -440,20 +429,9 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV1ToV2RetriesAfterSent
 		return failureTypes, succeeded, nil
 	}
 
-	// A patch signal wakes the paused V1 scheduler without starting an action.
-	wakeV1Scheduler := func(note string) {
-		_, err := env.FrontendClient().PatchSchedule(ctx, &workflowservice.PatchScheduleRequest{
-			Namespace:  nsName,
-			ScheduleId: sid,
-			Patch:      &schedulepb.SchedulePatch{Pause: note},
-			Identity:   "test",
-			RequestId:  uuid.NewString(),
-		})
-		s.Require().NoError(err)
-	}
-
 	env.OverrideDynamicConfig(dynamicconfig.EnableCHASMSchedulerMigration, true)
-	wakeV1Scheduler("wake migration blocked by sentinel")
+	// A patch signal wakes the paused V1 scheduler without starting an action.
+	patchSchedule(ctx, s.T(), env, sid, &schedulepb.SchedulePatch{Pause: "wake migration blocked by sentinel"})
 
 	var failureTypes []string
 	var succeededMarkers int
@@ -461,7 +439,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV1ToV2RetriesAfterSent
 	s.Eventually(func() bool {
 		failureTypes, succeededMarkers, markerErr = migrationMarkerOutcomes()
 		return markerErr == nil && len(failureTypes) == 1
-	}, 10*time.Second, 100*time.Millisecond)
+	}, awaitTimeout, pollInterval)
 	s.Require().NoError(markerErr)
 	s.Require().Equal([]string{util.ErrorType(serviceerror.NewUnavailable(""))}, failureTypes)
 	s.Require().Zero(succeededMarkers)
@@ -476,7 +454,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV1ToV2RetriesAfterSent
 	})
 	s.Require().NoError(err)
 
-	wakeV1Scheduler("wake migration after sentinel deletion")
+	patchSchedule(ctx, s.T(), env, sid, &schedulepb.SchedulePatch{Pause: "wake migration after sentinel deletion"})
 	awaitV1SchedulerCompleted(ctx, s.T(), env, sid)
 
 	failureTypes, succeededMarkers, err = migrationMarkerOutcomes()

--- a/tests/schedule_migration_test.go
+++ b/tests/schedule_migration_test.go
@@ -339,6 +339,151 @@ func (s *ScheduleMigrationTestSuite) TestCreateFromMigrationStateBlockedBySentin
 	s.Contains(unavailableErr.Message, "sentinel")
 }
 
+func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV1ToV2RetriesAfterSentinelDeletion() {
+	env := newScheduleEnv(
+		s.T(),
+		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
+		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerCreation, false),
+		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSchedulerSentinels, true),
+	)
+
+	ctx := s.Context()
+	sid := testcore.RandomizeStr("sched-migrate-v1-to-v2-sentinel-retry")
+	nsName := env.Namespace().String()
+	nsID := env.NamespaceID().String()
+	v1WorkflowID := scheduler.WorkflowIDPrefix + sid
+
+	// Keep the scheduler timerless so it cannot retry migration until the test wakes it.
+	_, err := env.FrontendClient().CreateSchedule(ctx, &workflowservice.CreateScheduleRequest{
+		Namespace:  nsName,
+		ScheduleId: sid,
+		Schedule: &schedulepb.Schedule{
+			Spec: &schedulepb.ScheduleSpec{
+				Interval: []*schedulepb.IntervalSpec{{Interval: durationpb.New(time.Hour)}},
+			},
+			Action: startWorkflowAction(
+				env,
+				testcore.RandomizeStr("sched-migrate-v1-to-v2-sentinel-retry-wf"),
+				testcore.RandomizeStr("sched-migrate-v1-to-v2-sentinel-retry-wt"),
+			),
+			State: &schedulepb.ScheduleState{Paused: true},
+		},
+		Identity:  "test",
+		RequestId: uuid.NewString(),
+	})
+	s.Require().NoError(err)
+
+	// Wait for the V1 scheduler to process its first workflow task and go to sleep.
+	s.Eventually(func() bool {
+		desc, err := env.GetTestCluster().HistoryClient().DescribeWorkflowExecution(
+			ctx,
+			&historyservice.DescribeWorkflowExecutionRequest{
+				NamespaceId: nsID,
+				Request: &workflowservice.DescribeWorkflowExecutionRequest{
+					Namespace: nsName,
+					Execution: &commonpb.WorkflowExecution{WorkflowId: v1WorkflowID},
+				},
+			},
+		)
+		return err == nil && desc.GetWorkflowExecutionInfo().GetHistoryLength() > 3
+	}, 10*time.Second, 100*time.Millisecond)
+
+	sentinelResp, err := env.AdminClient().DescribeMutableState(ctx, &adminservice.DescribeMutableStateRequest{
+		Namespace: nsName,
+		Execution: &commonpb.WorkflowExecution{WorkflowId: sid},
+		Archetype: string(chasm.SchedulerArchetype),
+	})
+	s.Require().NoError(err)
+	sentinelNode := sentinelResp.GetDatabaseMutableState().GetChasmNodes()[""]
+	s.Require().NotNil(sentinelNode)
+	var sentinelState schedulerpb.SchedulerState
+	s.Require().NoError(proto.Unmarshal(sentinelNode.GetData().GetData(), &sentinelState))
+	s.Require().True(sentinelState.GetSentinel())
+	sentinelRunID := sentinelResp.GetDatabaseMutableState().GetExecutionState().GetRunId()
+	s.Require().NotEmpty(sentinelRunID)
+
+	migrationMarkerOutcomes := func() (failed, succeeded int, markerErr error) {
+		history, markerErr := env.FrontendClient().GetWorkflowExecutionHistory(ctx, &workflowservice.GetWorkflowExecutionHistoryRequest{
+			Namespace:       nsName,
+			Execution:       &commonpb.WorkflowExecution{WorkflowId: v1WorkflowID},
+			MaximumPageSize: 1000,
+		})
+		if markerErr != nil {
+			return 0, 0, markerErr
+		}
+
+		for _, event := range history.GetHistory().GetEvents() {
+			attrs := event.GetMarkerRecordedEventAttributes()
+			if attrs.GetMarkerName() != "LocalActivity" {
+				continue
+			}
+			markerPayloads, ok := attrs.GetDetails()["data"]
+			if !ok {
+				continue
+			}
+			var markerData struct {
+				ActivityType string
+			}
+			if markerErr := sdk.PreferProtoDataConverter.FromPayloads(markerPayloads, &markerData); markerErr != nil {
+				return 0, 0, markerErr
+			}
+			if markerData.ActivityType != "MigrateScheduleToChasm" {
+				continue
+			}
+			if attrs.GetFailure() == nil {
+				succeeded++
+			} else {
+				failed++
+			}
+		}
+		return failed, succeeded, nil
+	}
+
+	// A patch signal wakes the paused V1 scheduler without starting an action.
+	wakeV1Scheduler := func(note string) {
+		_, err := env.FrontendClient().PatchSchedule(ctx, &workflowservice.PatchScheduleRequest{
+			Namespace:  nsName,
+			ScheduleId: sid,
+			Patch:      &schedulepb.SchedulePatch{Pause: note},
+			Identity:   "test",
+			RequestId:  uuid.NewString(),
+		})
+		s.Require().NoError(err)
+	}
+
+	env.OverrideDynamicConfig(dynamicconfig.EnableCHASMSchedulerMigration, true)
+	wakeV1Scheduler("wake migration blocked by sentinel")
+
+	var failedMarkers, succeededMarkers int
+	var markerErr error
+	s.Eventually(func() bool {
+		failedMarkers, succeededMarkers, markerErr = migrationMarkerOutcomes()
+		return markerErr == nil && failedMarkers == 1
+	}, 10*time.Second, 100*time.Millisecond)
+	s.Require().NoError(markerErr)
+	s.Require().Equal(1, failedMarkers)
+	s.Require().Zero(succeededMarkers)
+
+	_, err = env.AdminClient().DeleteWorkflowExecution(ctx, &adminservice.DeleteWorkflowExecutionRequest{
+		Namespace: nsName,
+		Execution: &commonpb.WorkflowExecution{
+			WorkflowId: sid,
+			RunId:      sentinelRunID,
+		},
+		Archetype: string(chasm.SchedulerArchetype),
+	})
+	s.Require().NoError(err)
+
+	wakeV1Scheduler("wake migration after sentinel deletion")
+	awaitV1SchedulerCompleted(ctx, s.T(), env, sid)
+
+	failedMarkers, succeededMarkers, err = migrationMarkerOutcomes()
+	s.Require().NoError(err)
+	s.Require().Equal(1, failedMarkers)
+	s.Require().Equal(1, succeededMarkers)
+	requireV2ScheduleExists(ctx, s.T(), env, sid)
+}
+
 func (s *ScheduleMigrationTestSuite) TestMigrateToWorkflowBlockedByCHASMSentinel() {
 	env := newScheduleEnv(
 		s.T(),

--- a/tests/schedule_migration_test.go
+++ b/tests/schedule_migration_test.go
@@ -32,6 +32,7 @@ import (
 	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/common/testing/testcontext"
+	"go.temporal.io/server/common/util"
 	"go.temporal.io/server/service/worker/dummy"
 	"go.temporal.io/server/service/worker/scheduler"
 	"go.temporal.io/server/tests/testcore"
@@ -402,14 +403,14 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV1ToV2RetriesAfterSent
 	sentinelRunID := sentinelResp.GetDatabaseMutableState().GetExecutionState().GetRunId()
 	s.Require().NotEmpty(sentinelRunID)
 
-	migrationMarkerOutcomes := func() (failed, succeeded int, markerErr error) {
+	migrationMarkerOutcomes := func() (failureTypes []string, succeeded int, markerErr error) {
 		history, markerErr := env.FrontendClient().GetWorkflowExecutionHistory(ctx, &workflowservice.GetWorkflowExecutionHistoryRequest{
 			Namespace:       nsName,
 			Execution:       &commonpb.WorkflowExecution{WorkflowId: v1WorkflowID},
 			MaximumPageSize: 1000,
 		})
 		if markerErr != nil {
-			return 0, 0, markerErr
+			return nil, 0, markerErr
 		}
 
 		for _, event := range history.GetHistory().GetEvents() {
@@ -425,7 +426,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV1ToV2RetriesAfterSent
 				ActivityType string
 			}
 			if markerErr := sdk.PreferProtoDataConverter.FromPayloads(markerPayloads, &markerData); markerErr != nil {
-				return 0, 0, markerErr
+				return nil, 0, markerErr
 			}
 			if markerData.ActivityType != "MigrateScheduleToChasm" {
 				continue
@@ -433,10 +434,10 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV1ToV2RetriesAfterSent
 			if attrs.GetFailure() == nil {
 				succeeded++
 			} else {
-				failed++
+				failureTypes = append(failureTypes, attrs.GetFailure().GetApplicationFailureInfo().GetType())
 			}
 		}
-		return failed, succeeded, nil
+		return failureTypes, succeeded, nil
 	}
 
 	// A patch signal wakes the paused V1 scheduler without starting an action.
@@ -454,14 +455,15 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV1ToV2RetriesAfterSent
 	env.OverrideDynamicConfig(dynamicconfig.EnableCHASMSchedulerMigration, true)
 	wakeV1Scheduler("wake migration blocked by sentinel")
 
-	var failedMarkers, succeededMarkers int
+	var failureTypes []string
+	var succeededMarkers int
 	var markerErr error
 	s.Eventually(func() bool {
-		failedMarkers, succeededMarkers, markerErr = migrationMarkerOutcomes()
-		return markerErr == nil && failedMarkers == 1
+		failureTypes, succeededMarkers, markerErr = migrationMarkerOutcomes()
+		return markerErr == nil && len(failureTypes) == 1
 	}, 10*time.Second, 100*time.Millisecond)
 	s.Require().NoError(markerErr)
-	s.Require().Equal(1, failedMarkers)
+	s.Require().Equal([]string{util.ErrorType(serviceerror.NewUnavailable(""))}, failureTypes)
 	s.Require().Zero(succeededMarkers)
 
 	_, err = env.AdminClient().DeleteWorkflowExecution(ctx, &adminservice.DeleteWorkflowExecutionRequest{
@@ -477,9 +479,9 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV1ToV2RetriesAfterSent
 	wakeV1Scheduler("wake migration after sentinel deletion")
 	awaitV1SchedulerCompleted(ctx, s.T(), env, sid)
 
-	failedMarkers, succeededMarkers, err = migrationMarkerOutcomes()
+	failureTypes, succeededMarkers, err = migrationMarkerOutcomes()
 	s.Require().NoError(err)
-	s.Require().Equal(1, failedMarkers)
+	s.Require().Equal([]string{util.ErrorType(serviceerror.NewUnavailable(""))}, failureTypes)
 	s.Require().Equal(1, succeededMarkers)
 	requireV2ScheduleExists(ctx, s.T(), env, sid)
 }

--- a/tests/schedule_migration_test.go
+++ b/tests/schedule_migration_test.go
@@ -292,6 +292,53 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1BlockedBySentine
 	s.Contains(unavailableErr.Message, "sentinel")
 }
 
+func (s *ScheduleMigrationTestSuite) TestCreateFromMigrationStateBlockedBySentinel() {
+	env := newScheduleEnv(
+		s.T(),
+		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
+	)
+
+	ctx := s.Context()
+	sid := testcore.RandomizeStr("sched-migrate-v1-to-v2-sentinel")
+	nsName := env.Namespace().String()
+	nsID := env.NamespaceID().String()
+
+	_, err := env.GetTestCluster().SchedulerClient().CreateSentinel(
+		ctx,
+		&schedulerpb.CreateSentinelRequest{
+			NamespaceId: nsID,
+			Namespace:   nsName,
+			ScheduleId:  sid,
+		},
+	)
+	s.Require().NoError(err)
+
+	_, err = env.GetTestCluster().SchedulerClient().CreateFromMigrationState(
+		ctx,
+		&schedulerpb.CreateFromMigrationStateRequest{
+			NamespaceId: nsID,
+			State: &schedulerpb.SchedulerMigrationState{
+				SchedulerState: &schedulerpb.SchedulerState{
+					Namespace:   nsName,
+					NamespaceId: nsID,
+					ScheduleId:  sid,
+					Schedule: &schedulepb.Schedule{
+						Spec: &schedulepb.ScheduleSpec{
+							Interval: []*schedulepb.IntervalSpec{{Interval: durationpb.New(time.Hour)}},
+						},
+					},
+					Info: &schedulepb.ScheduleInfo{},
+				},
+				GeneratorState: &schedulerpb.GeneratorState{},
+				InvokerState:   &schedulerpb.InvokerState{},
+			},
+		},
+	)
+	var unavailableErr *serviceerror.Unavailable
+	s.Require().ErrorAs(err, &unavailableErr)
+	s.Contains(unavailableErr.Message, "sentinel")
+}
+
 func (s *ScheduleMigrationTestSuite) TestScheduleMigrationDynamicConfig() {
 	env := newScheduleEnv(
 		s.T(),


### PR DESCRIPTION
## What changed?

Detect an existing CHASM scheduler sentinel from the value returned by `ReadComponent` instead of returning a sentinel-specific `NotFound` error from its callback. Share that classification between normal CHASM creation and V1-to-V2 migration while preserving their distinct responses: `ErrSentinel` for normal routing and `ErrSentinelBlocked` for migration retry.

For migration to a workflow-backed schedule, classify the sentinel inside the atomic `UpdateComponent` callback and return `ErrSentinelBlocked` before the CHASM engine can rewrite it.

Add CHASM test-engine unit coverage for normal creation, `CreateFromMigrationState`, and `MigrateToWorkflow`. Add production-engine functional regression coverage for both migration handlers, plus the complete V1-to-V2 retry lifecycle: observe the sentinel-blocked migration local activity in workflow history, delete the sentinel, wake the V1 scheduler, and verify the subsequent migration succeeds.

## Why?

The production CHASM engine enriches `NotFound` errors returned from component reads and updates. That replaced the sentinel error with a new generic `NotFound`, so scheduler handlers could no longer recognize it with `errors.Is` and return the intended transient `Unavailable` response.

## Applicability

The compatibility-harness failure applies to V1-to-V2/CHASM migration when a V1 schedule's CHASM key is still occupied by its sentinel. It applies to both automatic rollout migration and admin-triggered migration because both use the V1 scheduler's `MigrateScheduleToChasm` activity and `CreateFromMigrationState`.

The same error-conversion pattern also affected a target-workflow migration request when V1 already owned the schedule and the CHASM key contained its sentinel. That is an already-V1/idempotency edge case, not migration of a real V2 schedule, but it should return the same transient sentinel-blocked response instead of a generic `NotFound`. Ordinary schedule create, describe, trigger, and update operations are unaffected.

## Why existing tests missed it

Existing migration handler unit coverage used the in-memory CHASM test engine, which preserves the original error identity. Existing end-to-end V1-to-V2 migration coverage creates the V1 schedule without a CHASM sentinel to avoid waiting for the sentinel idle timeout. Neither exercised the production error-conversion boundary with a sentinel present or verified that a blocked V1 scheduler later completes migration after the sentinel disappears.

## How did you test it?

- CHASM test-engine coverage verifies the intended response for normal creation, `CreateFromMigrationState`, and `MigrateToWorkflow`.
- Production-engine handler coverage verifies that both migration handlers return sentinel-blocked `Unavailable` rather than generic `NotFound`.
- A production-engine lifecycle test creates a V1 schedule through the normal sentinel-writing path, observes a failed `MigrateScheduleToChasm` marker with the serialized `Unavailable` type, removes the sentinel, and verifies a later successful marker and completed migration.

## Potential risks

The behavior change is restricted to sentinel classification. Normal creation still returns `NotFound` for a sentinel, migration returns `Unavailable`, non-sentinel CHASM schedules return `AlreadyExists`, and component read/update failures pass through unchanged. The workflow-migration mapping occurs inside the existing atomic CHASM update and does not add a separate persistence read.
