### PR TITLE
Fix links for repeated updates

### DIFF
--- a/service/history/api/updateworkflow/api.go
+++ b/service/history/api/updateworkflow/api.go
@@ -54,6 +54,7 @@ type Updater struct {
 	scheduledEventID       int64
 	scheduleToStartTimeout time.Duration
 	workflowTaskStamp      int32
+	responseLink           *commonpb.Link
 }
 
 func NewUpdater(
@@ -105,7 +106,14 @@ func (u *Updater) ApplyRequest(
 	ctx context.Context,
 	updateReg update.Registry,
 	ms historyi.MutableState,
-) (*api.UpdateWorkflowAction, error) {
+) (action *api.UpdateWorkflowAction, err error) {
+	defer func() {
+		if err == nil {
+			// Capture the link for response as long as there isn't an error on apply.
+			u.responseLink = u.captureResponseLink(ms)
+		}
+	}()
+
 	if u.req.GetRequest().GetFirstExecutionRunId() != "" &&
 		ms.GetExecutionInfo().GetFirstExecutionRunId() != u.req.GetRequest().GetFirstExecutionRunId() {
 		return nil, consts.ErrWorkflowExecutionNotFound
@@ -154,10 +162,7 @@ func (u *Updater) ApplyRequest(
 		return nil, consts.ErrWorkflowClosing
 	}
 
-	var (
-		alreadyExisted bool
-		err            error
-	)
+	var alreadyExisted bool
 	if u.upd, alreadyExisted, err = updateReg.FindOrCreate(ctx, updateID); err != nil {
 		return nil, err
 	}
@@ -224,6 +229,66 @@ func (u *Updater) ApplyRequest(
 	}, nil
 }
 
+// captureResponseLink determines the link to be attached to the update.
+//
+// Cases:
+//
+//	requestID has an event recorded on it?
+//	  - Yes: use that event for a requestIdRef link.
+//	  - No: is the update accepted/completed?
+//	        - Yes: use the update accepted/completed event for an eventRef link.
+//	        - No: use the projected event for a requestIDRef as the update is still in-flight.
+func (u *Updater) captureResponseLink(ms historyi.MutableState) *commonpb.Link {
+
+	request := u.req.GetRequest().GetRequest()
+	requestID := request.GetRequestId()
+	updateID := request.GetMeta().GetUpdateId()
+
+	linkWfEvent := &commonpb.Link_WorkflowEvent{
+		Namespace:  u.req.Request.Namespace,
+		WorkflowId: u.wfKey.WorkflowID,
+		RunId:      u.wfKey.RunID,
+	}
+
+	if requestIDInfo := ms.GetExecutionState().GetRequestIds()[requestID]; requestIDInfo != nil {
+		// If the requestID already has an event in history, defer to it as it is the canonical event itself.
+		linkWfEvent.Reference = &commonpb.Link_WorkflowEvent_RequestIdRef{
+			RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
+				RequestId: requestID,
+				EventType: requestIDInfo.GetEventType(),
+			},
+		}
+	} else if acceptance := ms.GetExecutionInfo().GetUpdateInfos()[updateID].GetAcceptance(); acceptance != nil {
+		// The request ID has no event of its own, but the update is accepted - link to the accepted event.
+		linkWfEvent.Reference = &commonpb.Link_WorkflowEvent_EventRef{
+			EventRef: &commonpb.Link_WorkflowEvent_EventReference{
+				EventId:   acceptance.EventId,
+				EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED,
+			},
+		}
+	} else if completion := ms.GetExecutionInfo().GetUpdateInfos()[updateID].GetCompletion(); completion != nil {
+		// If requestID doesn't have a history event but is completed already, link to the completed event.
+		linkWfEvent.Reference = &commonpb.Link_WorkflowEvent_EventRef{
+			EventRef: &commonpb.Link_WorkflowEvent_EventReference{
+				EventId:   completion.EventId,
+				EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_COMPLETED,
+			},
+		}
+	} else {
+		// If neither of the above, the update is in flight - use the requestIDRef for projected event.
+		linkWfEvent.Reference = &commonpb.Link_WorkflowEvent_RequestIdRef{
+			RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
+				RequestId: requestID,
+				EventType: u.upd.EventLinkType(requestID),
+			},
+		}
+	}
+
+	return &commonpb.Link{
+		Variant: &commonpb.Link_WorkflowEvent_{WorkflowEvent: linkWfEvent},
+	}
+}
+
 func (u *Updater) OnSuccess(
 	ctx context.Context,
 ) (*historyservice.UpdateWorkflowExecutionResponse, error) {
@@ -275,11 +340,10 @@ func (u *Updater) OnSuccess(
 	}
 	resp := u.CreateResponse(u.wfKey, status.Outcome, status.Stage)
 
-	// Attach a link to the response. For accepted/completed updates, use a WorkflowEvent link
-	// with a RequestIdReference pointing to the accepted event. For rejected updates (stage
-	// COMPLETED with a failure outcome and no acceptance), use a Workflow link since rejected
-	// updates don't write any event to history.
-	requestID := u.req.GetRequest().GetRequest().GetRequestId()
+	// Attach a link to the response. For accepted/completed updates, use the WorkflowEvent
+	// link captured in ApplyRequest. For rejected updates (stage COMPLETED with a failure
+	// outcome and no acceptance), use a Workflow link since rejected updates don't write
+	// any event to history.
 	if status.Outcome.GetFailure() != nil && status.Stage == enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED {
 		// Rejected update: no event in history, link to the workflow itself.
 		resp.Response.Link = &commonpb.Link{
@@ -293,22 +357,7 @@ func (u *Updater) OnSuccess(
 			},
 		}
 	} else if status.Stage == enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED || status.Stage == enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED {
-		// Accepted or completed update: link to the accepted event.
-		resp.Response.Link = &commonpb.Link{
-			Variant: &commonpb.Link_WorkflowEvent_{
-				WorkflowEvent: &commonpb.Link_WorkflowEvent{
-					Namespace:  u.req.Request.Namespace,
-					WorkflowId: u.wfKey.WorkflowID,
-					RunId:      u.wfKey.RunID,
-					Reference: &commonpb.Link_WorkflowEvent_RequestIdRef{
-						RequestIdRef: &commonpb.Link_WorkflowEvent_RequestIdReference{
-							RequestId: requestID,
-							EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED,
-						},
-					},
-				},
-			},
-		}
+		resp.Response.Link = u.responseLink
 	}
 	return resp, nil
 }

--- a/service/history/historybuilder/event_store.go
+++ b/service/history/historybuilder/event_store.go
@@ -443,6 +443,12 @@ func (b *EventStore) wireEventIDs(
 			if attributes.GetAttachedRequestId() != "" {
 				b.requestIDToEventID[attributes.AttachedRequestId] = event.GetEventId()
 			}
+			// Request IDs of duplicate updates are recorded per update, not on the event.
+			for _, updateOptions := range attributes.GetWorkflowUpdateOptions() {
+				if updateOptions.GetAttachedRequestId() != "" {
+					b.requestIDToEventID[updateOptions.AttachedRequestId] = event.GetEventId()
+				}
+			}
 
 		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED:
 			attributes := event.GetWorkflowExecutionSignaledEventAttributes()

--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -275,6 +275,7 @@ func (r *registry) TryResurrect(_ context.Context, acptOrRejMsg *protocolpb.Mess
 		r.remover(updateID),
 		withInstrumentation(&r.instrumentation),
 	)
+	upd.originalReqID = reqMsg.RequestId
 	r.updates[updateID] = upd
 
 	return upd, nil

--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -47,6 +47,7 @@ type (
 		// 3. Furthermore, it is possible that many UpdateAdmitted events were created after a Reset or during conflict
 		//    resolution. In that situation, we *must not* attempt to load all the payloads into the Registry.
 		request         *anypb.Any // of type *updatepb.Request
+		originalReqID   string
 		acceptedEventID int64
 		onComplete      func()
 		checkLimits     func(*updatepb.Request) error
@@ -349,6 +350,7 @@ func (u *Update) Admit(
 		return serviceerror.NewInvalidArgumentf("unable to unmarshal request: %v", err)
 	}
 	u.request = reqAny
+	u.originalReqID = req.GetRequestId()
 
 	prevState := u.setState(stateProvisionallyAdmitted)
 	eventStore.OnAfterCommit(func(context.Context) {
@@ -448,6 +450,14 @@ func (u *Update) AttachCallbacks(
 	}
 }
 
+// EventLinkType reports the projected event type for an Update's RequestIDRef link.
+func (u *Update) EventLinkType(requestID string) enumspb.EventType {
+	if u.originalReqID == requestID {
+		return enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED
+	}
+	return enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED
+}
+
 // persistPendingCallbacks writes one WorkflowExecutionOptionsUpdatedEvent per
 // buffered AttachCallbacks callback, skipping any whose requestID is already persisted.
 // Called from onAcceptanceMsg after the acceptance event has been written.
@@ -484,8 +494,15 @@ func (u *Update) persistCallback(
 	if requestID != "" && eventStore.HasRequestID(requestID) {
 		return true, nil
 	}
+	// Copy Nexus links to the event so that backlinks are preserved in history.
+	var callbackLinks []*commonpb.Link
+	for _, callback := range completionCallbacks {
+		if callback.GetNexus() != nil {
+			callbackLinks = append(callbackLinks, callback.GetLinks()...)
+		}
+	}
 	_, err = eventStore.AddWorkflowExecutionOptionsUpdatedEvent(
-		nil, false, "", nil, nil, "", nil, nil, false,
+		nil, false, "", nil, callbackLinks, "", nil, nil, false,
 		[]*historypb.WorkflowExecutionOptionsUpdatedEventAttributes_WorkflowUpdateOptionsUpdate{{
 			UpdateId:                    u.id,
 			AttachedRequestId:           requestID,

--- a/tests/nexus_workflow_update_test.go
+++ b/tests/nexus_workflow_update_test.go
@@ -41,6 +41,8 @@ type updateNexusTestConfig struct {
 	taskQueue string
 	childWfID string
 	updateID  string
+	// helper to assert on the expected event type for repeated update cases
+	nextExpectedEventType func() enumspb.EventType
 }
 
 // newUpdateNexusTestConfig creates a config with randomized names to avoid collisions.
@@ -63,6 +65,12 @@ func makeUpdateWithCallbackHandler(
 	cfg updateNexusTestConfig,
 	onStart func(),
 ) nexustest.Handler {
+	if cfg.nextExpectedEventType == nil {
+		// by default, always return an accepted event for verifications.
+		cfg.nextExpectedEventType = func() enumspb.EventType {
+			return enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED
+		}
+	}
 	return nexustest.Handler{
 		OnStartOperation: func(
 			ctx context.Context,
@@ -114,9 +122,14 @@ func makeUpdateWithCallbackHandler(
 			link := resp.GetLink()
 			require.NotNil(t, link, "update response should contain a link")
 			if workflowEvent := link.GetWorkflowEvent(); workflowEvent != nil {
-				// Accepted/completed update: link points to the accepted event.
 				require.Equal(t, cfg.childWfID, workflowEvent.GetWorkflowId())
-				require.Equal(t, enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED, workflowEvent.GetRequestIdRef().GetEventType())
+				if workflowEvent.GetRequestIdRef() != nil {
+					// Accepted update: link points to either the accepted event or the options updated event.
+					require.Equal(t, cfg.nextExpectedEventType(), workflowEvent.GetRequestIdRef().GetEventType())
+				} else {
+					// Completed update: link points to the completed event.
+					require.Equal(t, enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_COMPLETED, workflowEvent.GetEventRef().GetEventType())
+				}
 			} else if wfLink := link.GetWorkflow(); wfLink != nil {
 				// Rejected update: link points to the workflow with a reason.
 				require.Equal(t, cfg.childWfID, wfLink.GetWorkflowId())
@@ -334,7 +347,15 @@ func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateAsyncAttachedNexusOpera
 	ctx := s.Context()
 	cfg := newUpdateNexusTestConfig(s.T())
 
-	h := makeUpdateWithCallbackHandler(env, s.T(), cfg, nil)
+	var operationCount atomic.Int32
+	cfg.nextExpectedEventType = func() enumspb.EventType {
+		if operationCount.Load() > 1 { // for all duplicates
+			return enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED
+		}
+		return enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED
+	}
+
+	h := makeUpdateWithCallbackHandler(env, s.T(), cfg, func() { operationCount.Add(1) })
 	endpointName := env.createRandomExternalNexusServer(ctx, s.T(), h)
 
 	childWF := newUpdateChildWorkflow(true)
@@ -1358,6 +1379,99 @@ func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateRequestIDInAcceptedEven
 		}
 	}
 	s.True(foundAccepted, "expected to find WorkflowExecutionUpdateAccepted event")
+
+	// Clean up.
+	s.NoError(env.SdkClient().SignalWorkflow(ctx, run.GetID(), run.GetRunID(), "stop", nil))
+}
+
+func (s *NexusWorkflowUpdateTestSuite) TestLinksOnRepeatedUpdates() {
+	env := newNexusTestEnv(s.T(), true, enableUpdateCallbacksOpts()...)
+	ctx := s.Context()
+	taskQueue := testcore.RandomizeStr(s.T().Name())
+	updateID := "repeated-update-links-test"
+
+	// blockOnSignal keeps the update Accepted-but-not-Completed, so the first
+	// duplicate arrives while it's accepted.
+	wf := newUpdateChildWorkflow(true)
+	s.startWorker(env, taskQueue, wf)
+
+	run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		TaskQueue: taskQueue,
+	}, wf, "initial input")
+	s.Require().NoError(err)
+
+	sendUpdate := func(requestID string) (*workflowservice.UpdateWorkflowExecutionResponse, error) {
+		return env.FrontendClient().UpdateWorkflowExecution(ctx, &workflowservice.UpdateWorkflowExecutionRequest{
+			Namespace: env.Namespace().String(),
+			WorkflowExecution: &commonpb.WorkflowExecution{
+				WorkflowId: run.GetID(),
+				RunId:      run.GetRunID(),
+			},
+			WaitPolicy: &updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED},
+			Request: &updatepb.Request{
+				Meta: &updatepb.Meta{UpdateId: updateID},
+				Input: &updatepb.Input{
+					Name: "update",
+					Args: &commonpb.Payloads{Payloads: []*commonpb.Payload{testcore.MustToPayload(s.T(), "test")}},
+				},
+				RequestId: requestID,
+				CompletionCallbacks: []*commonpb.Callback{{
+					Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: "http://localhost:9999/callback"}},
+				}},
+			},
+		})
+	}
+
+	firstRequestID := uuid.NewString()
+	firstResp, err := sendUpdate(firstRequestID)
+	s.Require().NoError(err)
+
+	// Second call reuses the same update ID once the first is already accepted, so
+	// it resolves immediately as a duplicate rather than waiting on a new WFT.
+	secondRequestID := uuid.NewString()
+	secondResp, err := sendUpdate(secondRequestID)
+	s.Require().NoError(err)
+
+	requireRequestIDLink := func(resp *workflowservice.UpdateWorkflowExecutionResponse, requestID string, eventType enumspb.EventType) {
+		requestIDRef := resp.GetLink().GetWorkflowEvent().GetRequestIdRef()
+		s.Require().NotNil(requestIDRef, "link should be a RequestIdReference")
+		s.Require().Equal(requestID, requestIDRef.GetRequestId())
+		s.Require().Equal(eventType, requestIDRef.GetEventType())
+	}
+	requireRequestIDLink(firstResp, firstRequestID, enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED)
+	requireRequestIDLink(secondResp, secondRequestID, enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED)
+
+	// Complete the update before sending another update to verify completed updates getting Completed links.
+	s.NoError(env.SdkClient().SignalWorkflow(ctx, run.GetID(), run.GetRunID(), "complete-update", nil))
+	_, err = env.FrontendClient().PollWorkflowExecutionUpdate(ctx, &workflowservice.PollWorkflowExecutionUpdateRequest{
+		Namespace: env.Namespace().String(),
+		UpdateRef: &updatepb.UpdateRef{
+			WorkflowExecution: &commonpb.WorkflowExecution{
+				WorkflowId: run.GetID(),
+				RunId:      run.GetRunID(),
+			},
+			UpdateId: updateID,
+		},
+		WaitPolicy: &updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED},
+	})
+	s.Require().NoError(err)
+
+	// Verify history has the OptionsUpdated event with the second requestID attached.
+	hist := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: run.GetID()})
+	updatedEvent := s.RequireHistoryEvent(hist, enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_OPTIONS_UPDATED)
+	updateOptions := updatedEvent.GetWorkflowExecutionOptionsUpdatedEventAttributes().GetWorkflowUpdateOptions()
+	s.Require().Len(updateOptions, 1)
+	s.Require().Equal(secondRequestID, updateOptions[0].GetAttachedRequestId())
+
+	thirdRequestID := uuid.NewString()
+	thirdResp, err := sendUpdate(thirdRequestID)
+	s.Require().NoError(err)
+	eventRef := thirdResp.GetLink().GetWorkflowEvent().GetEventRef()
+	s.Require().NotNil(eventRef, "link should be an EventReference")
+
+	updateCompletedEvent := s.RequireHistoryEvent(hist, enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_COMPLETED)
+	s.Require().Equal(updateCompletedEvent.EventId, eventRef.EventId, "eventID should match the Completed eventID of the original request")
+	s.Require().Equal(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_COMPLETED, eventRef.EventType)
 
 	// Clean up.
 	s.NoError(env.SdkClient().SignalWorkflow(ctx, run.GetID(), run.GetRunID(), "stop", nil))

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -26,6 +26,7 @@ import (
 	"go.temporal.io/server/common/metrics"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/common/testing/parallelsuite"
+	"go.temporal.io/server/common/testing/protorequire"
 	"go.temporal.io/server/common/testing/protoutils"
 	"go.temporal.io/server/common/testing/taskpoller"
 	"go.temporal.io/server/common/testing/testhooks"
@@ -852,10 +853,27 @@ func (s *WorkflowUpdateSuite) TestCompletedWorkflow() {
 		updateResult1 := <-updateResultCh
 		s.NotNil(updateResult1.GetOutcome().GetSuccess())
 
-		// Send same Update request again, receiving the same Update result.
+		completedEvent := s.RequireHistoryEvent(
+			env.GetHistory(env.Namespace().String(), env.Tv().WorkflowExecution()),
+			enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_COMPLETED,
+		)
+		// Send same Update request again, receiving the same Update outcome
+		// and pointing to the corresponding completed event of the original.
 		updateResultCh = sendUpdateNoError(env, env.Tv())
 		updateResult2 := <-updateResultCh
-		s.Equal(updateResult1, updateResult2)
+		protorequire.ProtoEqual(s.T(), updateResult1.GetUpdateRef(), updateResult2.GetUpdateRef())
+		protorequire.ProtoEqual(s.T(), updateResult1.GetOutcome(), updateResult2.GetOutcome())
+		s.Equal(updateResult1.GetStage(), updateResult2.GetStage())
+
+		acceptedReqLink := updateResult1.GetLink().GetWorkflowEvent().GetRequestIdRef()
+		s.NotNil(acceptedReqLink)
+		s.Equal(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED, acceptedReqLink.GetEventType())
+
+		completedReqLink := updateResult2.GetLink().GetWorkflowEvent().GetEventRef()
+		s.NotNil(completedReqLink)
+		s.Equal(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_COMPLETED, completedReqLink.GetEventType())
+
+		s.Equal(completedEvent.GetEventId(), completedReqLink.GetEventId())
 	})
 
 	s.Run("receive update failure from accepted Update", func(s *WorkflowUpdateSuite) {


### PR DESCRIPTION
## What changed?
Fixed links for repeated updates

## Why?
Repeated Nexus Update Ops(same updateID, different reqID) point to non-existent event - this is because if update is already seen(updateID), subsequent updates are not written into history. As a result, when the caller clicks on the link, they see an empty history. It should instead point to the “Update Completed” event associated with that Update event. 

Also fixes issue where links for OptionsUpdated event arent set causing backlinks to not show up 

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [x] added new functional test(s)

