### PR TITLE
Tag Nexus completion callback metrics with nexus_completion_source

### DIFF
--- a/chasm/lib/callback/component.go
+++ b/chasm/lib/callback/component.go
@@ -102,11 +102,12 @@ func (c *Callback) loadInvocationArgs(
 		}, nil
 	}
 	return invocableOutbound{
-		callback:   callback,
-		completion: completion,
-		workflowID: ctx.ExecutionKey().BusinessID,
-		runID:      ctx.ExecutionKey().RunID,
-		attempt:    c.Attempt,
+		callback:            callback,
+		completion:          completion,
+		completionSourceTag: c.CompletionSource.Fqn(),
+		workflowID:          ctx.ExecutionKey().BusinessID,
+		runID:               ctx.ExecutionKey().RunID,
+		attempt:             c.Attempt,
 	}, nil
 }
 

--- a/chasm/lib/callback/invocable_outbound.go
+++ b/chasm/lib/callback/invocable_outbound.go
@@ -22,10 +22,13 @@ import (
 // invocableOutbound is an invocable that delivers the Nexus operation completion data to an external destination for
 // cross-namespace or cross-cell callbacks.
 type invocableOutbound struct {
-	callback          *callbackspb.Callback_Nexus
-	completion        nexusrpc.CompleteOperationOptions
-	workflowID, runID string
-	attempt           int32
+	callback   *callbackspb.Callback_Nexus
+	completion nexusrpc.CompleteOperationOptions
+	// completionSourceTag is the fully qualified name of the CHASM component that produced this
+	// completion, e.g. "workflow.workflow" or "activity.activity".
+	completionSourceTag string
+	workflowID, runID   string
+	attempt             int32
 }
 
 func (n invocableOutbound) WrapError(result invocationResult, err error) error {
@@ -49,6 +52,7 @@ func (n invocableOutbound) Invoke(
 			tag.Destination(taskAttr.Destination),
 			tag.WorkflowID(n.workflowID),
 			tag.WorkflowRunID(n.runID),
+			tag.NexusCompletionSource(n.completionSourceTag),
 			tag.AttemptStart(time.Now().UTC()),
 			tag.Attempt(n.attempt),
 		)
@@ -73,12 +77,23 @@ func (n invocableOutbound) Invoke(
 	namespaceTag := metrics.NamespaceTag(ns.Name().String())
 	destTag := metrics.DestinationTag(taskAttr.Destination)
 	outcomeMetricTag := metrics.OutcomeTag(string(outboundOutcome(ctx, err)))
-	h.metricsHandler.Counter(RequestCounter.Name()).Record(1, namespaceTag, destTag, outcomeMetricTag)
-	h.metricsHandler.Timer(RequestLatencyHistogram.Name()).Record(time.Since(startTime), namespaceTag, destTag, outcomeMetricTag)
+	completionSourceMetricTag := metrics.NexusCompletionSourceTag(n.completionSourceTag)
+	h.metricsHandler.Counter(RequestCounter.Name()).Record(1, namespaceTag, destTag, outcomeMetricTag, completionSourceMetricTag)
+	h.metricsHandler.Timer(RequestLatencyHistogram.Name()).Record(time.Since(startTime), namespaceTag, destTag, outcomeMetricTag, completionSourceMetricTag)
 
 	if err != nil {
 		retryable := isRetryableCallError(err)
-		h.logger.Error("Callback request failed", tag.Error(err), tag.Bool("retryable", retryable))
+		h.logger.Error(
+			"Callback request failed",
+			tag.Error(err),
+			tag.WorkflowNamespace(ns.Name().String()),
+			tag.Destination(taskAttr.Destination),
+			tag.WorkflowID(n.workflowID),
+			tag.WorkflowRunID(n.runID),
+			tag.NexusCompletionSource(n.completionSourceTag),
+			tag.Attempt(n.attempt),
+			tag.Bool("retryable", retryable),
+		)
 		if retryable {
 			return invocationResultRetry{err}
 		}

--- a/chasm/lib/callback/tasks_test.go
+++ b/chasm/lib/callback/tasks_test.go
@@ -72,6 +72,8 @@ type mockNexusCompletionGetterLibrary struct {
 	chasm.UnimplementedLibrary
 }
 
+const testCompletionSourceFqn = "mock.nexusCompletionGetter"
+
 func (l *mockNexusCompletionGetterLibrary) Name() string {
 	return "mock"
 }
@@ -190,12 +192,14 @@ func TestExecuteInvocationTaskNexus_Outcomes(t *testing.T) {
 			counter.EXPECT().Record(int64(1),
 				metrics.NamespaceTag("namespace-name"),
 				metrics.DestinationTag("http://localhost"),
-				metrics.OutcomeTag(tc.expectedMetricOutcome))
+				metrics.OutcomeTag(tc.expectedMetricOutcome),
+				metrics.NexusCompletionSourceTag(testCompletionSourceFqn))
 			metricsHandler.EXPECT().Timer(RequestLatencyHistogram.Name()).Return(timer)
 			timer.EXPECT().Record(gomock.Any(),
 				metrics.NamespaceTag("namespace-name"),
 				metrics.DestinationTag("http://localhost"),
-				metrics.OutcomeTag(tc.expectedMetricOutcome))
+				metrics.OutcomeTag(tc.expectedMetricOutcome),
+				metrics.NexusCompletionSourceTag(testCompletionSourceFqn))
 
 			// The committed event is recorded for the outbound path too, not just the
 			// internal one, so a permanently dropped external callback is also visible.

--- a/chasm/parent_pointer.go
+++ b/chasm/parent_pointer.go
@@ -49,14 +49,39 @@ func (p ParentPtr[T]) Get(chasmContext Context) T {
 // application.
 func (p ParentPtr[T]) TryGet(chasmContext Context) (T, bool) {
 	var nilT T
+	parent, ok := p.parentNode()
+	if !ok {
+		return nilT, false
+	}
+
+	if err := parent.prepareComponentValue(chasmContext); err != nil {
+		// nolint:forbidigo // Panic is intended here for framework error handling.
+		panic(err)
+	}
+
+	if parent.value == nil {
+		return nilT, false
+	}
+
+	vT, isT := parent.value.(T)
+	if !isT {
+		// nolint:forbidigo // Panic is intended here for framework error handling.
+		panic(serviceerror.NewInternalf("parent component value doesn't implement %s", reflect.TypeFor[T]().Name()))
+	}
+	return vT, true
+}
+
+// parentNode returns the nearest ancestor node that is a component, skipping CHASM maps, and a
+// boolean indicating whether one was found.
+func (p ParentPtr[T]) parentNode() (*Node, bool) {
 	if p.Internal.currentNode == nil {
 		// ParentPtr not initialized
-		return nilT, false
+		return nil, false
 	}
 
 	parent := p.Internal.currentNode.parent
 	if parent == nil {
-		return nilT, false
+		return nil, false
 	}
 
 	for parent.isMap() {
@@ -84,19 +109,26 @@ func (p ParentPtr[T]) TryGet(chasmContext Context) (T, bool) {
 		))
 	}
 
-	if err := parent.prepareComponentValue(chasmContext); err != nil {
-		// nolint:forbidigo // Panic is intended here for framework error handling.
-		panic(err)
+	return parent, true
+}
+
+// Fqn returns the fully qualified name that the parent component is registered under, e.g.
+// "workflow.workflow". Returns "" if the ParentPtr is not initialized or the parent's type is not registered.
+func (p ParentPtr[T]) Fqn() string {
+	parent, ok := p.parentNode()
+	if !ok {
+		return ""
 	}
 
-	if parent.value == nil {
-		return nilT, false
+	if typeID := parent.serializedNode.GetMetadata().GetComponentAttributes().GetTypeId(); typeID != 0 {
+		if fqn, ok := parent.registry.ComponentFqnByID(typeID); ok {
+			return fqn
+		}
+	}
+	if rc, ok := parent.registry.componentFor(parent.value); ok {
+		return rc.fqType()
 	}
 
-	vT, isT := parent.value.(T)
-	if !isT {
-		// nolint:forbidigo // Panic is intended here for framework error handling.
-		panic(serviceerror.NewInternalf("parent component value doesn't implement %s", reflect.TypeFor[T]().Name()))
-	}
-	return vT, true
+	softassert.Fail(parent.logger, "parent component type is not registered with CHASM")
+	return ""
 }

--- a/chasm/parent_pointer_mock.go
+++ b/chasm/parent_pointer_mock.go
@@ -9,8 +9,10 @@ import (
 // that returns the given parent value when Get or TryGet is called.
 // This is intended for use in unit tests where a full CHASM tree is not needed.
 func NewMockParentPtr[T any](parent T) ParentPtr[T] {
+	logger := log.NewNoopLogger()
 	base := &nodeBase{
-		logger: log.NewNoopLogger(),
+		logger:   logger,
+		registry: NewRegistry(logger),
 	}
 
 	parentNode := newNode(base, nil, "")

--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -1037,6 +1037,11 @@ func NexusOperation(operation string) ZapTag {
 	return NewStringTag("nexus-operation", operation)
 }
 
+// NexusCompletionSource retuns a tag for the source of the Nexus completion callback.
+func NexusCompletionSource(source string) ZapTag {
+	return NewStringTag("nexus-completion-source", source)
+}
+
 func NexusService(service string) ZapTag {
 	return NewStringTag("nexus-service", service)
 }

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -22,6 +22,7 @@ const (
 	nexusServiceTagName            = "nexus_service"
 	nexusOperationTagName          = "nexus_operation"
 	outcomeTagName                 = "outcome"
+	nexusCompletionSourceTagName   = "nexus_completion_source"
 	versionedTagName               = "versioned"
 	resourceExhaustedTag           = "resource_exhausted_cause"
 	resourceExhaustedScopeTag      = "resource_exhausted_scope"

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -506,6 +506,16 @@ func DestinationTag(value string) Tag {
 	return Tag{Key: destination, Value: value}
 }
 
+// NexusCompletionSourceTag identifies the CHASM component that delivered a completion callback, by
+// its fully qualified name, e.g. "workflow.workflow". An empty value means the framework could not
+// resolve the callback's parent.
+func NexusCompletionSourceTag(value string) Tag {
+	if len(value) == 0 {
+		value = unknownValue
+	}
+	return Tag{Key: nexusCompletionSourceTagName, Value: value}
+}
+
 func VersioningBehaviorTag(behavior enumspb.VersioningBehavior) Tag {
 	return Tag{Key: versioningBehavior, Value: behavior.String()}
 }

--- a/service/history/hsm/callbacks/executors_test.go
+++ b/service/history/hsm/callbacks/executors_test.go
@@ -163,12 +163,14 @@ func TestProcessInvocationTaskNexus_Outcomes(t *testing.T) {
 			counter.EXPECT().Record(int64(1),
 				metrics.NamespaceTag("namespace-name"),
 				metrics.DestinationTag("http://localhost"),
-				metrics.OutcomeTag(tc.expectedMetricOutcome))
+				metrics.OutcomeTag(tc.expectedMetricOutcome),
+				metrics.NexusCompletionSourceTag(chasm.WorkflowArchetype))
 			metricsHandler.EXPECT().Timer(callbacks.RequestLatencyHistogram.Name()).Return(timer)
 			timer.EXPECT().Record(gomock.Any(),
 				metrics.NamespaceTag("namespace-name"),
 				metrics.DestinationTag("http://localhost"),
-				metrics.OutcomeTag(tc.expectedMetricOutcome))
+				metrics.OutcomeTag(tc.expectedMetricOutcome),
+				metrics.NexusCompletionSourceTag(chasm.WorkflowArchetype))
 
 			root := newRoot(t)
 			cb := callbacks.Callback{

--- a/service/history/hsm/callbacks/nexus_invocation.go
+++ b/service/history/hsm/callbacks/nexus_invocation.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/nexus-rpc/sdk-go/nexus"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
@@ -50,6 +51,7 @@ func (n nexusInvocation) Invoke(ctx context.Context, ns *namespace.Namespace, e 
 			tag.Destination(task.destination),
 			tag.WorkflowID(n.workflowID),
 			tag.WorkflowRunID(n.runID),
+			tag.NexusCompletionSource(chasm.WorkflowArchetype),
 			tag.AttemptStart(time.Now().UTC()),
 			tag.Attempt(n.attempt),
 		)
@@ -74,12 +76,23 @@ func (n nexusInvocation) Invoke(ctx context.Context, ns *namespace.Namespace, e 
 	namespaceTag := metrics.NamespaceTag(ns.Name().String())
 	destTag := metrics.DestinationTag(task.Destination())
 	statusCodeTag := metrics.OutcomeTag(outcomeTag(ctx, err))
-	e.MetricsHandler.Counter(RequestCounter.Name()).Record(1, namespaceTag, destTag, statusCodeTag)
-	e.MetricsHandler.Timer(RequestLatencyHistogram.Name()).Record(time.Since(startTime), namespaceTag, destTag, statusCodeTag)
+	completionSourceTag := metrics.NexusCompletionSourceTag(chasm.WorkflowArchetype)
+	e.MetricsHandler.Counter(RequestCounter.Name()).Record(1, namespaceTag, destTag, statusCodeTag, completionSourceTag)
+	e.MetricsHandler.Timer(RequestLatencyHistogram.Name()).Record(time.Since(startTime), namespaceTag, destTag, statusCodeTag, completionSourceTag)
 
 	if err != nil {
 		retryable := isRetryableCallError(err)
-		e.Logger.Error("Callback request failed", tag.Error(err), tag.Bool("retryable", retryable))
+		e.Logger.Error(
+			"Callback request failed",
+			tag.Error(err),
+			tag.WorkflowNamespace(ns.Name().String()),
+			tag.Destination(task.destination),
+			tag.WorkflowID(n.workflowID),
+			tag.WorkflowRunID(n.runID),
+			tag.NexusCompletionSource(chasm.WorkflowArchetype),
+			tag.Attempt(n.attempt),
+			tag.Bool("retryable", retryable),
+		)
 		if retryable {
 			return invocationResultRetry{err}
 		}

--- a/tests/nexus_workflow_test.go
+++ b/tests/nexus_workflow_test.go
@@ -37,6 +37,7 @@ import (
 	tokenspb "go.temporal.io/server/api/token/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/activity"
+	chasmcallback "go.temporal.io/server/chasm/lib/callback"
 	chasmnexus "go.temporal.io/server/chasm/lib/nexusoperation"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/authorization"
@@ -808,6 +809,23 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationStartsStandaloneActivityBidir
 	s.Equal(run.GetRunID(), nexusOpLink.GetRunId())
 }
 
+// requireNexusCompletionSource waits for a callback_outbound_requests recording tagged with the
+// given completion source.
+func requireNexusCompletionSource(t *testing.T, capture *testcore.NamespaceMetricCapture, want string) {
+	t.Helper()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		recordings := capture.Metric(chasmcallback.RequestCounter.Name())
+		require.NotEmpty(c, recordings, "no callback_outbound_requests recorded")
+		for _, rec := range recordings {
+			if rec.Tags["nexus_completion_source"] == want {
+				return
+			}
+		}
+		require.Fail(c, "callback_outbound_requests missing expected completion source",
+			"want %q, recorded tags: %v", want, recordings[0].Tags)
+	}, 10*time.Second, 100*time.Millisecond)
+}
+
 // TestNexusOperationAsyncStandaloneActivityCompletionBeforeStart verifies that when a standalone
 // activity completes and delivers its Nexus callback before the Nexus start request has been
 // responded to, Activity.GetNexusCompletion synthesizes a Link_Activity back-link. That link must
@@ -826,6 +844,8 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncStandaloneActivityComple
 	cluster.OverrideDynamicConfig(s.T(), activity.Enabled, nsValues)
 	cluster.OverrideDynamicConfig(s.T(), activity.EnableCallbacks, nsValues)
 	ctx := s.Context()
+
+	capture := env.StartNamespaceMetricCapture()
 
 	callerTQ := testcore.RandomizeStr(s.T().Name() + "-caller")
 	activityTQ := testcore.RandomizeStr(s.T().Name() + "-activity")
@@ -961,6 +981,8 @@ func (s *NexusWorkflowTestSuite) TestNexusOperationAsyncStandaloneActivityComple
 	s.Len(startedEvent.GetLinks(), 1, "fabricated started event must carry exactly the SAA back-link")
 	s.ProtoEqual(expectedLink, startedEvent.GetLinks()[0].GetActivity())
 	s.Equal(activityID, startedEvent.GetNexusOperationStartedEventAttributes().GetOperationToken())
+
+	requireNexusCompletionSource(s.T(), capture, "activity.activity")
 }
 
 func (s *NexusWorkflowTestSuite) TestNexusOperationSyncCompletion_LargePayload(chasmEnabled bool) {
@@ -2264,6 +2286,8 @@ func (s *NexusWorkflowTestSuite) TestNexusAsyncOperationWithNilIO(chasmEnabled b
 	s.NoError(handlerWorker.Start())
 	defer handlerWorker.Stop()
 
+	capture := env.StartNamespaceMetricCapture()
+
 	run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
 		TaskQueue: callerTaskQueue,
 	}, callerWF, nil)
@@ -2273,6 +2297,8 @@ func (s *NexusWorkflowTestSuite) TestNexusAsyncOperationWithNilIO(chasmEnabled b
 	hist := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{WorkflowId: run.GetID()})
 	completedEvent := s.RequireHistoryEvent(hist, enumspb.EVENT_TYPE_NEXUS_OPERATION_COMPLETED)
 	protorequire.ProtoEqual(s.T(), testcore.MustToPayload(s.T(), nil), completedEvent.GetNexusOperationCompletedEventAttributes().GetResult())
+
+	requireNexusCompletionSource(s.T(), capture, "workflow.workflow")
 }
 
 func (s *NexusWorkflowTestSuite) TestNexusSyncOperationErrorRehydration(chasmEnabled bool) {

--- a/tests/nexus_workflow_update_test.go
+++ b/tests/nexus_workflow_update_test.go
@@ -291,6 +291,8 @@ func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateAsyncNexusOperation() {
 	ctx := s.Context()
 	cfg := newUpdateNexusTestConfig(s.T())
 
+	capture := env.StartNamespaceMetricCapture()
+
 	h := makeUpdateWithCallbackHandler(env, s.T(), cfg, nil)
 	endpointName := env.createRandomExternalNexusServer(ctx, s.T(), h)
 
@@ -340,6 +342,8 @@ func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateAsyncNexusOperation() {
 		}
 	}
 	s.True(foundUpdateAccepted, "expected to find WorkflowExecutionUpdateAccepted event in child workflow history")
+
+	requireNexusCompletionSource(s.T(), capture, "workflow.update")
 }
 
 func (s *NexusWorkflowUpdateTestSuite) TestWorkflowUpdateAsyncAttachedNexusOperation() {


### PR DESCRIPTION
## What changed?
* Add an additional `nexus_completion_source` tag to currently emitted `callback_outbound_requests` and `callback_outbound_latency` metrics.
* Improve callback completion logs with additional tags.

## Why?
* To distinguish nexus completion callback sources so that we can track what kind of durable execution is backing the nexus operation on the handler side.
* To improve logging for better diagnose capabilities.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
It is a tag addition to existing metrics, will work with DevProd related to the tag addition.
