### PR TITLE
Prioritize worker versioning workflows

### DIFF
--- a/service/worker/workerdeployment/util.go
+++ b/service/worker/workerdeployment/util.go
@@ -40,7 +40,8 @@ const (
 	WorkerDeploymentWorkflowType        = "temporal-sys-worker-deployment-workflow"
 
 	// Namespace division
-	WorkerDeploymentNamespaceDivision = "TemporalWorkerDeployment"
+	WorkerDeploymentNamespaceDivision   = "TemporalWorkerDeployment"
+	workerDeploymentWorkflowPriorityKey = 1
 
 	// Updates
 	RegisterWorkerInDeploymentVersion = "register-task-queue-worker"    // for Worker Deployment Version wf
@@ -430,6 +431,7 @@ func makeStartRequest(
 		SearchAttributes:         buildSearchAttributes(),
 		Memo:                     memo,
 		Identity:                 identity,
+		Priority:                 &commonpb.Priority{PriorityKey: workerDeploymentWorkflowPriorityKey},
 	}
 }
 

--- a/service/worker/workerdeployment/util_test.go
+++ b/service/worker/workerdeployment/util_test.go
@@ -370,6 +370,18 @@ func decodeAndValidateMemo(t *testing.T, filePath, deploymentName, buildID strin
 	require.Equal(t, buildID, result.RoutingConfig.GetCurrentDeploymentVersion().GetBuildId())
 }
 
+func TestMakeStartRequestSetsHighPriority(t *testing.T) {
+	ns := namespace.NewLocalNamespaceForTest(
+		&persistencespb.NamespaceInfo{Name: testNamespace},
+		nil,
+		"",
+	)
+
+	request := makeStartRequest("request-id", "workflow-id", "identity", "workflow-type", ns, nil, nil)
+
+	require.Equal(t, int32(workerDeploymentWorkflowPriorityKey), request.GetPriority().GetPriorityKey())
+}
+
 func TestIsRetryableUpdateError(t *testing.T) {
 	t.Run("returns true for errUpdateInProgress", func(t *testing.T) {
 		require.True(t, isRetryableUpdateError(errUpdateInProgress))


### PR DESCRIPTION
## What changed?
- assign priority key 1 to Worker Deployment and Worker Deployment Version workflow starts
- cover the shared start-request builder with a unit test

## Why?
Worker versioning workflows run on the per-namespace worker task queue alongside other system workflows. Giving their initial workflow tasks higher-than-default priority prevents versioning operations from being delayed behind default-priority work.

## How did you test it?
- `go test -tags test_dep ./service/worker/workerdeployment -run TestMakeStartRequestSetsHighPriority`
- `go vet -tags test_dep ./service/worker/workerdeployment`