### PR TITLE
Add semantic attributes to persistence spans

### DIFF
--- a/common/persistence/execution_identity.go
+++ b/common/persistence/execution_identity.go
@@ -1,0 +1,74 @@
+package persistence
+
+import "go.temporal.io/server/chasm"
+
+// ExecutionIdentity returns the archetype and primary execution key for the request.
+func (r *InternalCreateWorkflowExecutionRequest) ExecutionIdentity() (chasm.ArchetypeID, chasm.ExecutionKey) {
+	return r.ArchetypeID, workflowSnapshotExecutionKey(r.NewWorkflowSnapshot)
+}
+
+// ExecutionIdentity returns the archetype and primary execution key for the request.
+func (r *InternalUpdateWorkflowExecutionRequest) ExecutionIdentity() (chasm.ArchetypeID, chasm.ExecutionKey) {
+	return r.ArchetypeID, workflowMutationExecutionKey(r.UpdateWorkflowMutation)
+}
+
+// ExecutionIdentity returns the archetype and primary execution key for the request.
+func (r *InternalConflictResolveWorkflowExecutionRequest) ExecutionIdentity() (chasm.ArchetypeID, chasm.ExecutionKey) {
+	return r.ArchetypeID, workflowSnapshotExecutionKey(r.ResetWorkflowSnapshot)
+}
+
+// ExecutionIdentity returns the archetype and primary execution key for the request.
+func (r *InternalSetWorkflowExecutionRequest) ExecutionIdentity() (chasm.ArchetypeID, chasm.ExecutionKey) {
+	return r.ArchetypeID, workflowSnapshotExecutionKey(r.SetWorkflowSnapshot)
+}
+
+// ExecutionIdentity returns the archetype and execution key for the request.
+func (r *GetCurrentExecutionRequest) ExecutionIdentity() (chasm.ArchetypeID, chasm.ExecutionKey) {
+	return r.ArchetypeID, chasm.ExecutionKey{
+		NamespaceID: r.NamespaceID,
+		BusinessID:  r.WorkflowID,
+	}
+}
+
+// ExecutionIdentity returns the archetype and execution key for the request.
+func (r *GetWorkflowExecutionRequest) ExecutionIdentity() (chasm.ArchetypeID, chasm.ExecutionKey) {
+	return r.ArchetypeID, chasm.ExecutionKey{
+		NamespaceID: r.NamespaceID,
+		BusinessID:  r.WorkflowID,
+		RunID:       r.RunID,
+	}
+}
+
+// ExecutionIdentity returns the archetype and execution key for the request.
+func (r *DeleteCurrentWorkflowExecutionRequest) ExecutionIdentity() (chasm.ArchetypeID, chasm.ExecutionKey) {
+	return r.ArchetypeID, chasm.ExecutionKey{
+		NamespaceID: r.NamespaceID,
+		BusinessID:  r.WorkflowID,
+		RunID:       r.RunID,
+	}
+}
+
+// ExecutionIdentity returns the archetype and execution key for the request.
+func (r *DeleteWorkflowExecutionRequest) ExecutionIdentity() (chasm.ArchetypeID, chasm.ExecutionKey) {
+	return r.ArchetypeID, chasm.ExecutionKey{
+		NamespaceID: r.NamespaceID,
+		BusinessID:  r.WorkflowID,
+		RunID:       r.RunID,
+	}
+}
+
+func workflowMutationExecutionKey(mutation InternalWorkflowMutation) chasm.ExecutionKey {
+	return chasm.ExecutionKey{
+		NamespaceID: mutation.NamespaceID,
+		BusinessID:  mutation.WorkflowID,
+		RunID:       mutation.RunID,
+	}
+}
+
+func workflowSnapshotExecutionKey(snapshot InternalWorkflowSnapshot) chasm.ExecutionKey {
+	return chasm.ExecutionKey{
+		NamespaceID: snapshot.NamespaceID,
+		BusinessID:  snapshot.WorkflowID,
+		RunID:       snapshot.RunID,
+	}
+}

--- a/common/persistence/telemetry/cluster_metadata_store_gen.go
+++ b/common/persistence/telemetry/cluster_metadata_store_gen.go
@@ -46,8 +46,8 @@ func (d telemetryClusterMetadataStore) DeleteClusterMetadata(ctx context.Context
 		ctx,
 		"persistence.ClusterMetadataStore/DeleteClusterMetadata",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ClusterMetadataStore"),
-			attribute.Key("persistence.method").String("DeleteClusterMetadata"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("ClusterMetadataStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("DeleteClusterMetadata"),
 		))
 	defer span.End()
 
@@ -67,7 +67,7 @@ func (d telemetryClusterMetadataStore) DeleteClusterMetadata(ctx context.Context
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalDeleteClusterMetadataRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}
@@ -81,8 +81,8 @@ func (d telemetryClusterMetadataStore) GetClusterMembers(ctx context.Context, re
 		ctx,
 		"persistence.ClusterMetadataStore/GetClusterMembers",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ClusterMetadataStore"),
-			attribute.Key("persistence.method").String("GetClusterMembers"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("ClusterMetadataStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("GetClusterMembers"),
 		))
 	defer span.End()
 
@@ -102,14 +102,14 @@ func (d telemetryClusterMetadataStore) GetClusterMembers(ctx context.Context, re
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.GetClusterMembersRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(gp1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.GetClusterMembersResponse for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -123,8 +123,8 @@ func (d telemetryClusterMetadataStore) GetClusterMetadata(ctx context.Context, r
 		ctx,
 		"persistence.ClusterMetadataStore/GetClusterMetadata",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ClusterMetadataStore"),
-			attribute.Key("persistence.method").String("GetClusterMetadata"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("ClusterMetadataStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("GetClusterMetadata"),
 		))
 	defer span.End()
 
@@ -144,14 +144,14 @@ func (d telemetryClusterMetadataStore) GetClusterMetadata(ctx context.Context, r
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalGetClusterMetadataRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(ip1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalGetClusterMetadataResponse for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -165,8 +165,8 @@ func (d telemetryClusterMetadataStore) ListClusterMetadata(ctx context.Context, 
 		ctx,
 		"persistence.ClusterMetadataStore/ListClusterMetadata",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ClusterMetadataStore"),
-			attribute.Key("persistence.method").String("ListClusterMetadata"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("ClusterMetadataStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("ListClusterMetadata"),
 		))
 	defer span.End()
 
@@ -186,14 +186,14 @@ func (d telemetryClusterMetadataStore) ListClusterMetadata(ctx context.Context, 
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalListClusterMetadataRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(ip1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalListClusterMetadataResponse for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -207,8 +207,8 @@ func (d telemetryClusterMetadataStore) PruneClusterMembership(ctx context.Contex
 		ctx,
 		"persistence.ClusterMetadataStore/PruneClusterMembership",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ClusterMetadataStore"),
-			attribute.Key("persistence.method").String("PruneClusterMembership"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("ClusterMetadataStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("PruneClusterMembership"),
 		))
 	defer span.End()
 
@@ -228,7 +228,7 @@ func (d telemetryClusterMetadataStore) PruneClusterMembership(ctx context.Contex
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.PruneClusterMembershipRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}
@@ -242,8 +242,8 @@ func (d telemetryClusterMetadataStore) SaveClusterMetadata(ctx context.Context, 
 		ctx,
 		"persistence.ClusterMetadataStore/SaveClusterMetadata",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ClusterMetadataStore"),
-			attribute.Key("persistence.method").String("SaveClusterMetadata"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("ClusterMetadataStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("SaveClusterMetadata"),
 		))
 	defer span.End()
 
@@ -263,14 +263,14 @@ func (d telemetryClusterMetadataStore) SaveClusterMetadata(ctx context.Context, 
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalSaveClusterMetadataRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(b1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize bool for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -284,8 +284,8 @@ func (d telemetryClusterMetadataStore) UpsertClusterMembership(ctx context.Conte
 		ctx,
 		"persistence.ClusterMetadataStore/UpsertClusterMembership",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ClusterMetadataStore"),
-			attribute.Key("persistence.method").String("UpsertClusterMembership"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("ClusterMetadataStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("UpsertClusterMembership"),
 		))
 	defer span.End()
 
@@ -305,7 +305,7 @@ func (d telemetryClusterMetadataStore) UpsertClusterMembership(ctx context.Conte
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.UpsertClusterMembershipRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}

--- a/common/persistence/telemetry/execution_attributes.go
+++ b/common/persistence/telemetry/execution_attributes.go
@@ -1,0 +1,39 @@
+package telemetry
+
+import (
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/common/telemetry"
+)
+
+func executionSpanStartOption(request any) trace.SpanStartOption {
+	return trace.WithAttributes(executionSpanAttributes(request)...)
+}
+
+type executionIdentityProvider interface {
+	ExecutionIdentity() (chasm.ArchetypeID, chasm.ExecutionKey)
+}
+
+func executionSpanAttributes(request any) []attribute.KeyValue {
+	provider, ok := request.(executionIdentityProvider)
+	if !ok {
+		return nil
+	}
+	archetypeID, executionKey := provider.ExecutionIdentity()
+	if archetypeID == 0 {
+		return nil
+	}
+
+	attrs := make([]attribute.KeyValue, 0, 4)
+	if executionKey.NamespaceID != "" {
+		attrs = append(attrs, attribute.String(telemetry.NamespaceIDKey, executionKey.NamespaceID))
+	}
+	if executionKey.BusinessID != "" {
+		attrs = append(attrs, attribute.String(telemetry.BusinessIDKey, executionKey.BusinessID))
+	}
+	if executionKey.RunID != "" {
+		attrs = append(attrs, attribute.String(telemetry.RunIDKey, executionKey.RunID))
+	}
+	return append(attrs, attribute.Int64(telemetry.ChasmArchetypeIDKey, int64(archetypeID)))
+}

--- a/common/persistence/telemetry/execution_attributes_test.go
+++ b/common/persistence/telemetry/execution_attributes_test.go
@@ -1,0 +1,151 @@
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/common/persistence"
+)
+
+type testExecutionIdentityProvider struct{}
+
+func (testExecutionIdentityProvider) ExecutionIdentity() (chasm.ArchetypeID, chasm.ExecutionKey) {
+	return 4, chasm.ExecutionKey{
+		NamespaceID: "namespace-id",
+		BusinessID:  "business-id",
+		RunID:       "run-id",
+	}
+}
+
+func TestExecutionSpanAttributesUsesIdentityProvider(t *testing.T) {
+	attrs := executionSpanAttributes(testExecutionIdentityProvider{})
+	attrsByKey := make(map[string]any, len(attrs))
+	for _, attr := range attrs {
+		attrsByKey[string(attr.Key)] = attr.Value.AsInterface()
+	}
+
+	require.Equal(t, map[string]any{
+		"temporalBusinessID":       "business-id",
+		"temporalChasmArchetypeID": int64(4),
+		"temporalNamespaceID":      "namespace-id",
+		"temporalRunID":            "run-id",
+	}, attrsByKey)
+}
+
+func TestExecutionSpanAttributes(t *testing.T) {
+	archetypeID := chasm.ArchetypeID(4)
+	snapshot := persistence.InternalWorkflowSnapshot{
+		NamespaceID: "namespace-id",
+		WorkflowID:  "business-id",
+		RunID:       "run-id",
+	}
+	mutation := persistence.InternalWorkflowMutation{
+		NamespaceID: "namespace-id",
+		WorkflowID:  "business-id",
+		RunID:       "run-id",
+	}
+	for _, tc := range []struct {
+		name       string
+		request    any
+		includeRun bool
+	}{
+		{
+			name: "create",
+			request: &persistence.InternalCreateWorkflowExecutionRequest{
+				ArchetypeID:         archetypeID,
+				NewWorkflowSnapshot: snapshot,
+			},
+			includeRun: true,
+		},
+		{
+			name: "update",
+			request: &persistence.InternalUpdateWorkflowExecutionRequest{
+				ArchetypeID:            archetypeID,
+				UpdateWorkflowMutation: mutation,
+			},
+			includeRun: true,
+		},
+		{
+			name: "conflict resolve",
+			request: &persistence.InternalConflictResolveWorkflowExecutionRequest{
+				ArchetypeID:           archetypeID,
+				ResetWorkflowSnapshot: snapshot,
+			},
+			includeRun: true,
+		},
+		{
+			name: "set",
+			request: &persistence.InternalSetWorkflowExecutionRequest{
+				ArchetypeID:         archetypeID,
+				SetWorkflowSnapshot: snapshot,
+			},
+			includeRun: true,
+		},
+		{
+			name: "get current",
+			request: &persistence.GetCurrentExecutionRequest{
+				ArchetypeID: archetypeID,
+				NamespaceID: "namespace-id",
+				WorkflowID:  "business-id",
+			},
+		},
+		{
+			name: "get",
+			request: &persistence.GetWorkflowExecutionRequest{
+				ArchetypeID: archetypeID,
+				NamespaceID: "namespace-id",
+				WorkflowID:  "business-id",
+				RunID:       "run-id",
+			},
+			includeRun: true,
+		},
+		{
+			name: "delete current",
+			request: &persistence.DeleteCurrentWorkflowExecutionRequest{
+				ArchetypeID: archetypeID,
+				NamespaceID: "namespace-id",
+				WorkflowID:  "business-id",
+				RunID:       "run-id",
+			},
+			includeRun: true,
+		},
+		{
+			name: "delete",
+			request: &persistence.DeleteWorkflowExecutionRequest{
+				ArchetypeID: archetypeID,
+				NamespaceID: "namespace-id",
+				WorkflowID:  "business-id",
+				RunID:       "run-id",
+			},
+			includeRun: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			attrs := executionSpanAttributes(tc.request)
+			attrsByKey := make(map[string]any, len(attrs))
+			for _, attr := range attrs {
+				attrsByKey[string(attr.Key)] = attr.Value.AsInterface()
+			}
+			expected := map[string]any{
+				"temporalBusinessID":       "business-id",
+				"temporalChasmArchetypeID": int64(4),
+				"temporalNamespaceID":      "namespace-id",
+			}
+			if tc.includeRun {
+				expected["temporalRunID"] = "run-id"
+			}
+			require.Equal(t, expected, attrsByKey)
+		})
+	}
+
+	t.Run("workflow execution", func(t *testing.T) {
+		attrs := executionSpanAttributes(&persistence.GetWorkflowExecutionRequest{
+			NamespaceID: "namespace-id",
+			WorkflowID:  "workflow-id",
+			RunID:       "run-id",
+		})
+
+		require.Empty(t, attrs)
+	})
+}

--- a/common/persistence/telemetry/execution_store_gen.go
+++ b/common/persistence/telemetry/execution_store_gen.go
@@ -46,8 +46,8 @@ func (d telemetryExecutionStore) AddHistoryTasks(ctx context.Context, request *_
 		ctx,
 		"persistence.ExecutionStore/AddHistoryTasks",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ExecutionStore"),
-			attribute.Key("persistence.method").String("AddHistoryTasks"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("ExecutionStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("AddHistoryTasks"),
 		))
 	defer span.End()
 
@@ -67,7 +67,7 @@ func (d telemetryExecutionStore) AddHistoryTasks(ctx context.Context, request *_
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalAddHistoryTasksRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}
@@ -81,8 +81,8 @@ func (d telemetryExecutionStore) AppendHistoryNodes(ctx context.Context, request
 		ctx,
 		"persistence.ExecutionStore/AppendHistoryNodes",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ExecutionStore"),
-			attribute.Key("persistence.method").String("AppendHistoryNodes"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("ExecutionStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("AppendHistoryNodes"),
 		))
 	defer span.End()
 
@@ -102,7 +102,7 @@ func (d telemetryExecutionStore) AppendHistoryNodes(ctx context.Context, request
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalAppendHistoryNodesRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}
@@ -116,8 +116,8 @@ func (d telemetryExecutionStore) CompleteHistoryTask(ctx context.Context, reques
 		ctx,
 		"persistence.ExecutionStore/CompleteHistoryTask",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ExecutionStore"),
-			attribute.Key("persistence.method").String("CompleteHistoryTask"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("ExecutionStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("CompleteHistoryTask"),
 		))
 	defer span.End()
 
@@ -137,7 +137,7 @@ func (d telemetryExecutionStore) CompleteHistoryTask(ctx context.Context, reques
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.CompleteHistoryTaskRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}
@@ -151,9 +151,11 @@ func (d telemetryExecutionStore) ConflictResolveWorkflowExecution(ctx context.Co
 		ctx,
 		"persistence.ExecutionStore/ConflictResolveWorkflowExecution",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ExecutionStore"),
-			attribute.Key("persistence.method").String("ConflictResolveWorkflowExecution"),
-		))
+			attribute.Key(telemetry.PersistenceStoreKey).String("ExecutionStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("ConflictResolveWorkflowExecution"),
+		),
+		executionSpanStartOption(request),
+	)
 	defer span.End()
 
 	if deadline, ok := ctx.Deadline(); ok {
@@ -172,7 +174,7 @@ func (d telemetryExecutionStore) ConflictResolveWorkflowExecution(ctx context.Co
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalConflictResolveWorkflowExecutionRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}
@@ -186,9 +188,11 @@ func (d telemetryExecutionStore) CreateWorkflowExecution(ctx context.Context, re
 		ctx,
 		"persistence.ExecutionStore/CreateWorkflowExecution",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ExecutionStore"),
-			attribute.Key("persistence.method").String("CreateWorkflowExecution"),
-		))
+			attribute.Key(telemetry.PersistenceStoreKey).String("ExecutionStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("CreateWorkflowExecution"),
+		),
+		executionSpanStartOption(request),
+	)
 	defer span.End()
 
 	if deadline, ok := ctx.Deadline(); ok {
@@ -207,14 +211,14 @@ func (d telemetryExecutionStore) CreateWorkflowExecution(ctx context.Context, re
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalCreateWorkflowExecutionRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(ip1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalCreateWorkflowExecutionResponse for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -228,9 +232,11 @@ func (d telemetryExecutionStore) DeleteCurrentWorkflowExecution(ctx context.Cont
 		ctx,
 		"persistence.ExecutionStore/DeleteCurrentWorkflowExecution",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ExecutionStore"),
-			attribute.Key("persistence.method").String("DeleteCurrentWorkflowExecution"),
-		))
+			attribute.Key(telemetry.PersistenceStoreKey).String("ExecutionStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("DeleteCurrentWorkflowExecution"),
+		),
+		executionSpanStartOption(request),
+	)
 	defer span.End()
 
 	if deadline, ok := ctx.Deadline(); ok {
@@ -249,7 +255,7 @@ func (d telemetryExecutionStore) DeleteCurrentWorkflowExecution(ctx context.Cont
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.DeleteCurrentWorkflowExecutionRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}
@@ -263,8 +269,8 @@ func (d telemetryExecutionStore) DeleteHistoryBranch(ctx context.Context, reques
 		ctx,
 		"persistence.ExecutionStore/DeleteHistoryBranch",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ExecutionStore"),
-			attribute.Key("persistence.method").String("DeleteHistoryBranch"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("ExecutionStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("DeleteHistoryBranch"),
 		))
 	defer span.End()
 
@@ -284,7 +290,7 @@ func (d telemetryExecutionStore) DeleteHistoryBranch(ctx context.Context, reques
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalDeleteHistoryBranchRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}
@@ -298,8 +304,8 @@ func (d telemetryExecutionStore) DeleteHistoryNodes(ctx context.Context, request
 		ctx,
 		"persistence.ExecutionStore/DeleteHistoryNodes",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ExecutionStore"),
-			attribute.Key("persistence.method").String("DeleteHistoryNodes"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("ExecutionStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("DeleteHistoryNodes"),
 		))
 	defer span.End()
 
@@ -319,7 +325,7 @@ func (d telemetryExecutionStore) DeleteHistoryNodes(ctx context.Context, request
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalDeleteHistoryNodesRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}
@@ -333,8 +339,8 @@ func (d telemetryExecutionStore) DeleteReplicationTaskFromDLQ(ctx context.Contex
 		ctx,
 		"persistence.ExecutionStore/DeleteReplicationTaskFromDLQ",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ExecutionStore"),
-			attribute.Key("persistence.method").String("DeleteReplicationTaskFromDLQ"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("ExecutionStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("DeleteReplicationTaskFromDLQ"),
 		))
 	defer span.End()
 
@@ -354,7 +360,7 @@ func (d telemetryExecutionStore) DeleteReplicationTaskFromDLQ(ctx context.Contex
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.DeleteReplicationTaskFromDLQRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}
@@ -368,9 +374,11 @@ func (d telemetryExecutionStore) DeleteWorkflowExecution(ctx context.Context, re
 		ctx,
 		"persistence.ExecutionStore/DeleteWorkflowExecution",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ExecutionStore"),
-			attribute.Key("persistence.method").String("DeleteWorkflowExecution"),
-		))
+			attribute.Key(telemetry.PersistenceStoreKey).String("ExecutionStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("DeleteWorkflowExecution"),
+		),
+		executionSpanStartOption(request),
+	)
 	defer span.End()
 
 	if deadline, ok := ctx.Deadline(); ok {
@@ -389,7 +397,7 @@ func (d telemetryExecutionStore) DeleteWorkflowExecution(ctx context.Context, re
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.DeleteWorkflowExecutionRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}
@@ -403,8 +411,8 @@ func (d telemetryExecutionStore) ForkHistoryBranch(ctx context.Context, request 
 		ctx,
 		"persistence.ExecutionStore/ForkHistoryBranch",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ExecutionStore"),
-			attribute.Key("persistence.method").String("ForkHistoryBranch"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("ExecutionStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("ForkHistoryBranch"),
 		))
 	defer span.End()
 
@@ -424,7 +432,7 @@ func (d telemetryExecutionStore) ForkHistoryBranch(ctx context.Context, request 
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalForkHistoryBranchRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}
@@ -438,8 +446,8 @@ func (d telemetryExecutionStore) GetAllHistoryTreeBranches(ctx context.Context, 
 		ctx,
 		"persistence.ExecutionStore/GetAllHistoryTreeBranches",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ExecutionStore"),
-			attribute.Key("persistence.method").String("GetAllHistoryTreeBranches"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("ExecutionStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("GetAllHistoryTreeBranches"),
 		))
 	defer span.End()
 
@@ -459,14 +467,14 @@ func (d telemetryExecutionStore) GetAllHistoryTreeBranches(ctx context.Context, 
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.GetAllHistoryTreeBranchesRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(ip1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalGetAllHistoryTreeBranchesResponse for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -480,9 +488,11 @@ func (d telemetryExecutionStore) GetCurrentExecution(ctx context.Context, reques
 		ctx,
 		"persistence.ExecutionStore/GetCurrentExecution",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ExecutionStore"),
-			attribute.Key("persistence.method").String("GetCurrentExecution"),
-		))
+			attribute.Key(telemetry.PersistenceStoreKey).String("ExecutionStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("GetCurrentExecution"),
+		),
+		executionSpanStartOption(request),
+	)
 	defer span.End()
 
 	if deadline, ok := ctx.Deadline(); ok {
@@ -501,14 +511,14 @@ func (d telemetryExecutionStore) GetCurrentExecution(ctx context.Context, reques
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.GetCurrentExecutionRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(ip1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalGetCurrentExecutionResponse for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -522,8 +532,8 @@ func (d telemetryExecutionStore) GetHistoryTasks(ctx context.Context, request *_
 		ctx,
 		"persistence.ExecutionStore/GetHistoryTasks",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ExecutionStore"),
-			attribute.Key("persistence.method").String("GetHistoryTasks"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("ExecutionStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("GetHistoryTasks"),
 		))
 	defer span.End()
 
@@ -543,14 +553,14 @@ func (d telemetryExecutionStore) GetHistoryTasks(ctx context.Context, request *_
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.GetHistoryTasksRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(ip1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalGetHistoryTasksResponse for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -564,8 +574,8 @@ func (d telemetryExecutionStore) GetHistoryTreeContainingBranch(ctx context.Cont
 		ctx,
 		"persistence.ExecutionStore/GetHistoryTreeContainingBranch",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ExecutionStore"),
-			attribute.Key("persistence.method").String("GetHistoryTreeContainingBranch"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("ExecutionStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("GetHistoryTreeContainingBranch"),
 		))
 	defer span.End()
 
@@ -585,14 +595,14 @@ func (d telemetryExecutionStore) GetHistoryTreeContainingBranch(ctx context.Cont
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalGetHistoryTreeContainingBranchRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(ip1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalGetHistoryTreeContainingBranchResponse for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -606,8 +616,8 @@ func (d telemetryExecutionStore) GetReplicationTasksFromDLQ(ctx context.Context,
 		ctx,
 		"persistence.ExecutionStore/GetReplicationTasksFromDLQ",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ExecutionStore"),
-			attribute.Key("persistence.method").String("GetReplicationTasksFromDLQ"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("ExecutionStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("GetReplicationTasksFromDLQ"),
 		))
 	defer span.End()
 
@@ -627,14 +637,14 @@ func (d telemetryExecutionStore) GetReplicationTasksFromDLQ(ctx context.Context,
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.GetReplicationTasksFromDLQRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(ip1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalGetReplicationTasksFromDLQResponse for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -648,9 +658,11 @@ func (d telemetryExecutionStore) GetWorkflowExecution(ctx context.Context, reque
 		ctx,
 		"persistence.ExecutionStore/GetWorkflowExecution",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ExecutionStore"),
-			attribute.Key("persistence.method").String("GetWorkflowExecution"),
-		))
+			attribute.Key(telemetry.PersistenceStoreKey).String("ExecutionStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("GetWorkflowExecution"),
+		),
+		executionSpanStartOption(request),
+	)
 	defer span.End()
 
 	if deadline, ok := ctx.Deadline(); ok {
@@ -669,14 +681,14 @@ func (d telemetryExecutionStore) GetWorkflowExecution(ctx context.Context, reque
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.GetWorkflowExecutionRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(ip1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalGetWorkflowExecutionResponse for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -690,8 +702,8 @@ func (d telemetryExecutionStore) IsReplicationDLQEmpty(ctx context.Context, requ
 		ctx,
 		"persistence.ExecutionStore/IsReplicationDLQEmpty",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ExecutionStore"),
-			attribute.Key("persistence.method").String("IsReplicationDLQEmpty"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("ExecutionStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("IsReplicationDLQEmpty"),
 		))
 	defer span.End()
 
@@ -711,14 +723,14 @@ func (d telemetryExecutionStore) IsReplicationDLQEmpty(ctx context.Context, requ
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.GetReplicationTasksFromDLQRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(b1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize bool for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -732,8 +744,8 @@ func (d telemetryExecutionStore) ListConcreteExecutions(ctx context.Context, req
 		ctx,
 		"persistence.ExecutionStore/ListConcreteExecutions",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ExecutionStore"),
-			attribute.Key("persistence.method").String("ListConcreteExecutions"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("ExecutionStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("ListConcreteExecutions"),
 		))
 	defer span.End()
 
@@ -753,14 +765,14 @@ func (d telemetryExecutionStore) ListConcreteExecutions(ctx context.Context, req
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.ListConcreteExecutionsRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(ip1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalListConcreteExecutionsResponse for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -774,8 +786,8 @@ func (d telemetryExecutionStore) PutReplicationTaskToDLQ(ctx context.Context, re
 		ctx,
 		"persistence.ExecutionStore/PutReplicationTaskToDLQ",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ExecutionStore"),
-			attribute.Key("persistence.method").String("PutReplicationTaskToDLQ"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("ExecutionStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("PutReplicationTaskToDLQ"),
 		))
 	defer span.End()
 
@@ -795,7 +807,7 @@ func (d telemetryExecutionStore) PutReplicationTaskToDLQ(ctx context.Context, re
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.PutReplicationTaskToDLQRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}
@@ -809,8 +821,8 @@ func (d telemetryExecutionStore) RangeCompleteHistoryTasks(ctx context.Context, 
 		ctx,
 		"persistence.ExecutionStore/RangeCompleteHistoryTasks",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ExecutionStore"),
-			attribute.Key("persistence.method").String("RangeCompleteHistoryTasks"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("ExecutionStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("RangeCompleteHistoryTasks"),
 		))
 	defer span.End()
 
@@ -830,7 +842,7 @@ func (d telemetryExecutionStore) RangeCompleteHistoryTasks(ctx context.Context, 
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.RangeCompleteHistoryTasksRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}
@@ -844,8 +856,8 @@ func (d telemetryExecutionStore) RangeDeleteReplicationTaskFromDLQ(ctx context.C
 		ctx,
 		"persistence.ExecutionStore/RangeDeleteReplicationTaskFromDLQ",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ExecutionStore"),
-			attribute.Key("persistence.method").String("RangeDeleteReplicationTaskFromDLQ"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("ExecutionStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("RangeDeleteReplicationTaskFromDLQ"),
 		))
 	defer span.End()
 
@@ -865,7 +877,7 @@ func (d telemetryExecutionStore) RangeDeleteReplicationTaskFromDLQ(ctx context.C
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.RangeDeleteReplicationTaskFromDLQRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}
@@ -879,8 +891,8 @@ func (d telemetryExecutionStore) ReadHistoryBranch(ctx context.Context, request 
 		ctx,
 		"persistence.ExecutionStore/ReadHistoryBranch",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ExecutionStore"),
-			attribute.Key("persistence.method").String("ReadHistoryBranch"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("ExecutionStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("ReadHistoryBranch"),
 		))
 	defer span.End()
 
@@ -900,14 +912,14 @@ func (d telemetryExecutionStore) ReadHistoryBranch(ctx context.Context, request 
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalReadHistoryBranchRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(ip1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalReadHistoryBranchResponse for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -921,9 +933,11 @@ func (d telemetryExecutionStore) SetWorkflowExecution(ctx context.Context, reque
 		ctx,
 		"persistence.ExecutionStore/SetWorkflowExecution",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ExecutionStore"),
-			attribute.Key("persistence.method").String("SetWorkflowExecution"),
-		))
+			attribute.Key(telemetry.PersistenceStoreKey).String("ExecutionStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("SetWorkflowExecution"),
+		),
+		executionSpanStartOption(request),
+	)
 	defer span.End()
 
 	if deadline, ok := ctx.Deadline(); ok {
@@ -942,7 +956,7 @@ func (d telemetryExecutionStore) SetWorkflowExecution(ctx context.Context, reque
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalSetWorkflowExecutionRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}
@@ -956,9 +970,11 @@ func (d telemetryExecutionStore) UpdateWorkflowExecution(ctx context.Context, re
 		ctx,
 		"persistence.ExecutionStore/UpdateWorkflowExecution",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ExecutionStore"),
-			attribute.Key("persistence.method").String("UpdateWorkflowExecution"),
-		))
+			attribute.Key(telemetry.PersistenceStoreKey).String("ExecutionStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("UpdateWorkflowExecution"),
+		),
+		executionSpanStartOption(request),
+	)
 	defer span.End()
 
 	if deadline, ok := ctx.Deadline(); ok {
@@ -977,7 +993,7 @@ func (d telemetryExecutionStore) UpdateWorkflowExecution(ctx context.Context, re
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalUpdateWorkflowExecutionRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}

--- a/common/persistence/telemetry/gowrap_template
+++ b/common/persistence/telemetry/gowrap_template
@@ -26,13 +26,34 @@ func new{{upFirst $decorator}} (
         {{ $methodIdent := (printf "%s.%s" $.Interface.Name $method.Name) }}
         // {{$method.Name}} wraps {{ (printf "%s.%s" $.Interface.Name $method.Name) }}.
         func (d {{$decorator}}) {{$method.Declaration}} {
+            {{- if and (eq $.Interface.Name "ExecutionStore") (or
+                (eq $method.Name "ConflictResolveWorkflowExecution")
+                (eq $method.Name "CreateWorkflowExecution")
+                (eq $method.Name "DeleteCurrentWorkflowExecution")
+                (eq $method.Name "DeleteWorkflowExecution")
+                (eq $method.Name "GetCurrentExecution")
+                (eq $method.Name "GetWorkflowExecution")
+                (eq $method.Name "SetWorkflowExecution")
+                (eq $method.Name "UpdateWorkflowExecution")) }}
+            {{- $request := (index $method.Params 1) }}
             ctx, span := d.tracer.Start(
                 ctx,
                 "{{ printf "persistence.%s/%s" $.Interface.Name $method.Name }}",
                 trace.WithAttributes(
-                    attribute.Key("persistence.store").String("{{ $.Interface.Name }}"),
-                    attribute.Key("persistence.method").String("{{ $method.Name }}"),
+                    attribute.Key(telemetry.PersistenceStoreKey).String("{{ $.Interface.Name }}"),
+                    attribute.Key(telemetry.PersistenceMethodKey).String("{{ $method.Name }}"),
+                ),
+                executionSpanStartOption({{ $request.Name }}),
+            )
+            {{- else }}
+            ctx, span := d.tracer.Start(
+                ctx,
+                "{{ printf "persistence.%s/%s" $.Interface.Name $method.Name }}",
+                trace.WithAttributes(
+                    attribute.Key(telemetry.PersistenceStoreKey).String("{{ $.Interface.Name }}"),
+                    attribute.Key(telemetry.PersistenceMethodKey).String("{{ $method.Name }}"),
                 ))
+            {{- end }}
             defer span.End()
 
             if deadline, ok := ctx.Deadline(); ok {
@@ -54,7 +75,7 @@ func new{{upFirst $decorator}} (
                 if err != nil {
                     d.logger.Error("failed to serialize {{$request.Type}} for OTEL span", tag.Error(err))
                 } else {
-                    span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+                    span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
                 }
                 {{end}}
                 {{- if (gt (len $method.Results) 1) }}
@@ -63,7 +84,7 @@ func new{{upFirst $decorator}} (
                 if err != nil {
                     d.logger.Error("failed to serialize {{$result.Type}} for OTEL span", tag.Error(err))
                 } else {
-                    span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+                    span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
                 }
                 {{end}}
             }

--- a/common/persistence/telemetry/nexus_endpoint_store_gen.go
+++ b/common/persistence/telemetry/nexus_endpoint_store_gen.go
@@ -46,8 +46,8 @@ func (d telemetryNexusEndpointStore) CreateOrUpdateNexusEndpoint(ctx context.Con
 		ctx,
 		"persistence.NexusEndpointStore/CreateOrUpdateNexusEndpoint",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("NexusEndpointStore"),
-			attribute.Key("persistence.method").String("CreateOrUpdateNexusEndpoint"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("NexusEndpointStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("CreateOrUpdateNexusEndpoint"),
 		))
 	defer span.End()
 
@@ -67,7 +67,7 @@ func (d telemetryNexusEndpointStore) CreateOrUpdateNexusEndpoint(ctx context.Con
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalCreateOrUpdateNexusEndpointRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}
@@ -81,8 +81,8 @@ func (d telemetryNexusEndpointStore) DeleteNexusEndpoint(ctx context.Context, re
 		ctx,
 		"persistence.NexusEndpointStore/DeleteNexusEndpoint",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("NexusEndpointStore"),
-			attribute.Key("persistence.method").String("DeleteNexusEndpoint"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("NexusEndpointStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("DeleteNexusEndpoint"),
 		))
 	defer span.End()
 
@@ -102,7 +102,7 @@ func (d telemetryNexusEndpointStore) DeleteNexusEndpoint(ctx context.Context, re
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.DeleteNexusEndpointRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}
@@ -116,8 +116,8 @@ func (d telemetryNexusEndpointStore) GetNexusEndpoint(ctx context.Context, reque
 		ctx,
 		"persistence.NexusEndpointStore/GetNexusEndpoint",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("NexusEndpointStore"),
-			attribute.Key("persistence.method").String("GetNexusEndpoint"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("NexusEndpointStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("GetNexusEndpoint"),
 		))
 	defer span.End()
 
@@ -137,14 +137,14 @@ func (d telemetryNexusEndpointStore) GetNexusEndpoint(ctx context.Context, reque
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.GetNexusEndpointRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(ip1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalNexusEndpoint for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -158,8 +158,8 @@ func (d telemetryNexusEndpointStore) ListNexusEndpoints(ctx context.Context, req
 		ctx,
 		"persistence.NexusEndpointStore/ListNexusEndpoints",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("NexusEndpointStore"),
-			attribute.Key("persistence.method").String("ListNexusEndpoints"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("NexusEndpointStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("ListNexusEndpoints"),
 		))
 	defer span.End()
 
@@ -179,14 +179,14 @@ func (d telemetryNexusEndpointStore) ListNexusEndpoints(ctx context.Context, req
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.ListNexusEndpointsRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(ip1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalListNexusEndpointsResponse for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}

--- a/common/persistence/telemetry/queue_gen.go
+++ b/common/persistence/telemetry/queue_gen.go
@@ -47,8 +47,8 @@ func (d telemetryQueue) DeleteMessageFromDLQ(ctx context.Context, messageID int6
 		ctx,
 		"persistence.Queue/DeleteMessageFromDLQ",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("Queue"),
-			attribute.Key("persistence.method").String("DeleteMessageFromDLQ"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("Queue"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("DeleteMessageFromDLQ"),
 		))
 	defer span.End()
 
@@ -68,7 +68,7 @@ func (d telemetryQueue) DeleteMessageFromDLQ(ctx context.Context, messageID int6
 		if err != nil {
 			d.logger.Error("failed to serialize int64 for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}
@@ -82,8 +82,8 @@ func (d telemetryQueue) DeleteMessagesBefore(ctx context.Context, messageID int6
 		ctx,
 		"persistence.Queue/DeleteMessagesBefore",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("Queue"),
-			attribute.Key("persistence.method").String("DeleteMessagesBefore"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("Queue"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("DeleteMessagesBefore"),
 		))
 	defer span.End()
 
@@ -103,7 +103,7 @@ func (d telemetryQueue) DeleteMessagesBefore(ctx context.Context, messageID int6
 		if err != nil {
 			d.logger.Error("failed to serialize int64 for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}
@@ -117,8 +117,8 @@ func (d telemetryQueue) EnqueueMessage(ctx context.Context, blob *commonpb.DataB
 		ctx,
 		"persistence.Queue/EnqueueMessage",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("Queue"),
-			attribute.Key("persistence.method").String("EnqueueMessage"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("Queue"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("EnqueueMessage"),
 		))
 	defer span.End()
 
@@ -138,7 +138,7 @@ func (d telemetryQueue) EnqueueMessage(ctx context.Context, blob *commonpb.DataB
 		if err != nil {
 			d.logger.Error("failed to serialize *commonpb.DataBlob for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}
@@ -152,8 +152,8 @@ func (d telemetryQueue) EnqueueMessageToDLQ(ctx context.Context, blob *commonpb.
 		ctx,
 		"persistence.Queue/EnqueueMessageToDLQ",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("Queue"),
-			attribute.Key("persistence.method").String("EnqueueMessageToDLQ"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("Queue"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("EnqueueMessageToDLQ"),
 		))
 	defer span.End()
 
@@ -173,14 +173,14 @@ func (d telemetryQueue) EnqueueMessageToDLQ(ctx context.Context, blob *commonpb.
 		if err != nil {
 			d.logger.Error("failed to serialize *commonpb.DataBlob for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(i1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize int64 for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -194,8 +194,8 @@ func (d telemetryQueue) GetAckLevels(ctx context.Context) (ip1 *_sourcePersisten
 		ctx,
 		"persistence.Queue/GetAckLevels",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("Queue"),
-			attribute.Key("persistence.method").String("GetAckLevels"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("Queue"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("GetAckLevels"),
 		))
 	defer span.End()
 
@@ -215,7 +215,7 @@ func (d telemetryQueue) GetAckLevels(ctx context.Context) (ip1 *_sourcePersisten
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalQueueMetadata for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -229,8 +229,8 @@ func (d telemetryQueue) GetDLQAckLevels(ctx context.Context) (ip1 *_sourcePersis
 		ctx,
 		"persistence.Queue/GetDLQAckLevels",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("Queue"),
-			attribute.Key("persistence.method").String("GetDLQAckLevels"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("Queue"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("GetDLQAckLevels"),
 		))
 	defer span.End()
 
@@ -250,7 +250,7 @@ func (d telemetryQueue) GetDLQAckLevels(ctx context.Context) (ip1 *_sourcePersis
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalQueueMetadata for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -264,8 +264,8 @@ func (d telemetryQueue) Init(ctx context.Context, blob *commonpb.DataBlob) (err 
 		ctx,
 		"persistence.Queue/Init",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("Queue"),
-			attribute.Key("persistence.method").String("Init"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("Queue"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("Init"),
 		))
 	defer span.End()
 
@@ -285,7 +285,7 @@ func (d telemetryQueue) Init(ctx context.Context, blob *commonpb.DataBlob) (err 
 		if err != nil {
 			d.logger.Error("failed to serialize *commonpb.DataBlob for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}
@@ -299,8 +299,8 @@ func (d telemetryQueue) RangeDeleteMessagesFromDLQ(ctx context.Context, firstMes
 		ctx,
 		"persistence.Queue/RangeDeleteMessagesFromDLQ",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("Queue"),
-			attribute.Key("persistence.method").String("RangeDeleteMessagesFromDLQ"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("Queue"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("RangeDeleteMessagesFromDLQ"),
 		))
 	defer span.End()
 
@@ -320,7 +320,7 @@ func (d telemetryQueue) RangeDeleteMessagesFromDLQ(ctx context.Context, firstMes
 		if err != nil {
 			d.logger.Error("failed to serialize int64 for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}
@@ -334,8 +334,8 @@ func (d telemetryQueue) ReadMessages(ctx context.Context, lastMessageID int64, m
 		ctx,
 		"persistence.Queue/ReadMessages",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("Queue"),
-			attribute.Key("persistence.method").String("ReadMessages"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("Queue"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("ReadMessages"),
 		))
 	defer span.End()
 
@@ -355,14 +355,14 @@ func (d telemetryQueue) ReadMessages(ctx context.Context, lastMessageID int64, m
 		if err != nil {
 			d.logger.Error("failed to serialize int64 for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(qpa1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize []*_sourcePersistence.QueueMessage for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -376,8 +376,8 @@ func (d telemetryQueue) ReadMessagesFromDLQ(ctx context.Context, firstMessageID 
 		ctx,
 		"persistence.Queue/ReadMessagesFromDLQ",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("Queue"),
-			attribute.Key("persistence.method").String("ReadMessagesFromDLQ"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("Queue"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("ReadMessagesFromDLQ"),
 		))
 	defer span.End()
 
@@ -397,14 +397,14 @@ func (d telemetryQueue) ReadMessagesFromDLQ(ctx context.Context, firstMessageID 
 		if err != nil {
 			d.logger.Error("failed to serialize int64 for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(qpa1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize []*_sourcePersistence.QueueMessage for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -418,8 +418,8 @@ func (d telemetryQueue) UpdateAckLevel(ctx context.Context, metadata *_sourcePer
 		ctx,
 		"persistence.Queue/UpdateAckLevel",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("Queue"),
-			attribute.Key("persistence.method").String("UpdateAckLevel"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("Queue"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("UpdateAckLevel"),
 		))
 	defer span.End()
 
@@ -439,7 +439,7 @@ func (d telemetryQueue) UpdateAckLevel(ctx context.Context, metadata *_sourcePer
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalQueueMetadata for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}
@@ -453,8 +453,8 @@ func (d telemetryQueue) UpdateDLQAckLevel(ctx context.Context, metadata *_source
 		ctx,
 		"persistence.Queue/UpdateDLQAckLevel",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("Queue"),
-			attribute.Key("persistence.method").String("UpdateDLQAckLevel"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("Queue"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("UpdateDLQAckLevel"),
 		))
 	defer span.End()
 
@@ -474,7 +474,7 @@ func (d telemetryQueue) UpdateDLQAckLevel(ctx context.Context, metadata *_source
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalQueueMetadata for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}

--- a/common/persistence/telemetry/queue_v2_gen.go
+++ b/common/persistence/telemetry/queue_v2_gen.go
@@ -46,8 +46,8 @@ func (d telemetryQueueV2) CreateQueue(ctx context.Context, request *_sourcePersi
 		ctx,
 		"persistence.QueueV2/CreateQueue",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("QueueV2"),
-			attribute.Key("persistence.method").String("CreateQueue"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("QueueV2"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("CreateQueue"),
 		))
 	defer span.End()
 
@@ -67,14 +67,14 @@ func (d telemetryQueueV2) CreateQueue(ctx context.Context, request *_sourcePersi
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalCreateQueueRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(ip1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalCreateQueueResponse for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -88,8 +88,8 @@ func (d telemetryQueueV2) EnqueueMessage(ctx context.Context, request *_sourcePe
 		ctx,
 		"persistence.QueueV2/EnqueueMessage",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("QueueV2"),
-			attribute.Key("persistence.method").String("EnqueueMessage"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("QueueV2"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("EnqueueMessage"),
 		))
 	defer span.End()
 
@@ -109,14 +109,14 @@ func (d telemetryQueueV2) EnqueueMessage(ctx context.Context, request *_sourcePe
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalEnqueueMessageRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(ip1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalEnqueueMessageResponse for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -130,8 +130,8 @@ func (d telemetryQueueV2) ListQueues(ctx context.Context, request *_sourcePersis
 		ctx,
 		"persistence.QueueV2/ListQueues",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("QueueV2"),
-			attribute.Key("persistence.method").String("ListQueues"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("QueueV2"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("ListQueues"),
 		))
 	defer span.End()
 
@@ -151,14 +151,14 @@ func (d telemetryQueueV2) ListQueues(ctx context.Context, request *_sourcePersis
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalListQueuesRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(ip1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalListQueuesResponse for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -172,8 +172,8 @@ func (d telemetryQueueV2) RangeDeleteMessages(ctx context.Context, request *_sou
 		ctx,
 		"persistence.QueueV2/RangeDeleteMessages",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("QueueV2"),
-			attribute.Key("persistence.method").String("RangeDeleteMessages"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("QueueV2"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("RangeDeleteMessages"),
 		))
 	defer span.End()
 
@@ -193,14 +193,14 @@ func (d telemetryQueueV2) RangeDeleteMessages(ctx context.Context, request *_sou
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalRangeDeleteMessagesRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(ip1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalRangeDeleteMessagesResponse for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -214,8 +214,8 @@ func (d telemetryQueueV2) ReadMessages(ctx context.Context, request *_sourcePers
 		ctx,
 		"persistence.QueueV2/ReadMessages",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("QueueV2"),
-			attribute.Key("persistence.method").String("ReadMessages"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("QueueV2"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("ReadMessages"),
 		))
 	defer span.End()
 
@@ -235,14 +235,14 @@ func (d telemetryQueueV2) ReadMessages(ctx context.Context, request *_sourcePers
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalReadMessagesRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(ip1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalReadMessagesResponse for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}

--- a/common/persistence/telemetry/shard_store_gen.go
+++ b/common/persistence/telemetry/shard_store_gen.go
@@ -46,8 +46,8 @@ func (d telemetryMetadataStore) CreateNamespace(ctx context.Context, request *_s
 		ctx,
 		"persistence.MetadataStore/CreateNamespace",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("MetadataStore"),
-			attribute.Key("persistence.method").String("CreateNamespace"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("MetadataStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("CreateNamespace"),
 		))
 	defer span.End()
 
@@ -67,14 +67,14 @@ func (d telemetryMetadataStore) CreateNamespace(ctx context.Context, request *_s
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalCreateNamespaceRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(cp1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.CreateNamespaceResponse for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -88,8 +88,8 @@ func (d telemetryMetadataStore) DeleteNamespace(ctx context.Context, request *_s
 		ctx,
 		"persistence.MetadataStore/DeleteNamespace",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("MetadataStore"),
-			attribute.Key("persistence.method").String("DeleteNamespace"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("MetadataStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("DeleteNamespace"),
 		))
 	defer span.End()
 
@@ -109,7 +109,7 @@ func (d telemetryMetadataStore) DeleteNamespace(ctx context.Context, request *_s
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.DeleteNamespaceRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}
@@ -123,8 +123,8 @@ func (d telemetryMetadataStore) DeleteNamespaceByName(ctx context.Context, reque
 		ctx,
 		"persistence.MetadataStore/DeleteNamespaceByName",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("MetadataStore"),
-			attribute.Key("persistence.method").String("DeleteNamespaceByName"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("MetadataStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("DeleteNamespaceByName"),
 		))
 	defer span.End()
 
@@ -144,7 +144,7 @@ func (d telemetryMetadataStore) DeleteNamespaceByName(ctx context.Context, reque
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.DeleteNamespaceByNameRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}
@@ -158,8 +158,8 @@ func (d telemetryMetadataStore) GetMetadata(ctx context.Context) (gp1 *_sourcePe
 		ctx,
 		"persistence.MetadataStore/GetMetadata",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("MetadataStore"),
-			attribute.Key("persistence.method").String("GetMetadata"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("MetadataStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("GetMetadata"),
 		))
 	defer span.End()
 
@@ -179,7 +179,7 @@ func (d telemetryMetadataStore) GetMetadata(ctx context.Context) (gp1 *_sourcePe
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.GetMetadataResponse for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -193,8 +193,8 @@ func (d telemetryMetadataStore) GetNamespace(ctx context.Context, request *_sour
 		ctx,
 		"persistence.MetadataStore/GetNamespace",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("MetadataStore"),
-			attribute.Key("persistence.method").String("GetNamespace"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("MetadataStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("GetNamespace"),
 		))
 	defer span.End()
 
@@ -214,14 +214,14 @@ func (d telemetryMetadataStore) GetNamespace(ctx context.Context, request *_sour
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.GetNamespaceRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(ip1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalGetNamespaceResponse for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -235,8 +235,8 @@ func (d telemetryMetadataStore) ListNamespaces(ctx context.Context, request *_so
 		ctx,
 		"persistence.MetadataStore/ListNamespaces",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("MetadataStore"),
-			attribute.Key("persistence.method").String("ListNamespaces"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("MetadataStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("ListNamespaces"),
 		))
 	defer span.End()
 
@@ -256,14 +256,14 @@ func (d telemetryMetadataStore) ListNamespaces(ctx context.Context, request *_so
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalListNamespacesRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(ip1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalListNamespacesResponse for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -277,8 +277,8 @@ func (d telemetryMetadataStore) RenameNamespace(ctx context.Context, request *_s
 		ctx,
 		"persistence.MetadataStore/RenameNamespace",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("MetadataStore"),
-			attribute.Key("persistence.method").String("RenameNamespace"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("MetadataStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("RenameNamespace"),
 		))
 	defer span.End()
 
@@ -298,7 +298,7 @@ func (d telemetryMetadataStore) RenameNamespace(ctx context.Context, request *_s
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalRenameNamespaceRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}
@@ -312,8 +312,8 @@ func (d telemetryMetadataStore) UpdateNamespace(ctx context.Context, request *_s
 		ctx,
 		"persistence.MetadataStore/UpdateNamespace",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("MetadataStore"),
-			attribute.Key("persistence.method").String("UpdateNamespace"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("MetadataStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("UpdateNamespace"),
 		))
 	defer span.End()
 
@@ -333,7 +333,7 @@ func (d telemetryMetadataStore) UpdateNamespace(ctx context.Context, request *_s
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalUpdateNamespaceRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}

--- a/common/persistence/telemetry/shared_store_gen.go
+++ b/common/persistence/telemetry/shared_store_gen.go
@@ -46,8 +46,8 @@ func (d telemetryShardStore) AssertShardOwnership(ctx context.Context, request *
 		ctx,
 		"persistence.ShardStore/AssertShardOwnership",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ShardStore"),
-			attribute.Key("persistence.method").String("AssertShardOwnership"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("ShardStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("AssertShardOwnership"),
 		))
 	defer span.End()
 
@@ -67,7 +67,7 @@ func (d telemetryShardStore) AssertShardOwnership(ctx context.Context, request *
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.AssertShardOwnershipRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}
@@ -81,8 +81,8 @@ func (d telemetryShardStore) GetOrCreateShard(ctx context.Context, request *_sou
 		ctx,
 		"persistence.ShardStore/GetOrCreateShard",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ShardStore"),
-			attribute.Key("persistence.method").String("GetOrCreateShard"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("ShardStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("GetOrCreateShard"),
 		))
 	defer span.End()
 
@@ -102,14 +102,14 @@ func (d telemetryShardStore) GetOrCreateShard(ctx context.Context, request *_sou
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalGetOrCreateShardRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(ip1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalGetOrCreateShardResponse for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -123,8 +123,8 @@ func (d telemetryShardStore) UpdateShard(ctx context.Context, request *_sourcePe
 		ctx,
 		"persistence.ShardStore/UpdateShard",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("ShardStore"),
-			attribute.Key("persistence.method").String("UpdateShard"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("ShardStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("UpdateShard"),
 		))
 	defer span.End()
 
@@ -144,7 +144,7 @@ func (d telemetryShardStore) UpdateShard(ctx context.Context, request *_sourcePe
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalUpdateShardRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}

--- a/common/persistence/telemetry/task_store_gen.go
+++ b/common/persistence/telemetry/task_store_gen.go
@@ -46,8 +46,8 @@ func (d telemetryTaskStore) CompleteTasksLessThan(ctx context.Context, request *
 		ctx,
 		"persistence.TaskStore/CompleteTasksLessThan",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("TaskStore"),
-			attribute.Key("persistence.method").String("CompleteTasksLessThan"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("TaskStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("CompleteTasksLessThan"),
 		))
 	defer span.End()
 
@@ -67,14 +67,14 @@ func (d telemetryTaskStore) CompleteTasksLessThan(ctx context.Context, request *
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.CompleteTasksLessThanRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(i1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize int for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -88,8 +88,8 @@ func (d telemetryTaskStore) CountTaskQueuesByBuildId(ctx context.Context, reques
 		ctx,
 		"persistence.TaskStore/CountTaskQueuesByBuildId",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("TaskStore"),
-			attribute.Key("persistence.method").String("CountTaskQueuesByBuildId"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("TaskStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("CountTaskQueuesByBuildId"),
 		))
 	defer span.End()
 
@@ -109,14 +109,14 @@ func (d telemetryTaskStore) CountTaskQueuesByBuildId(ctx context.Context, reques
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.CountTaskQueuesByBuildIdRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(i1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize int for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -130,8 +130,8 @@ func (d telemetryTaskStore) CreateTaskQueue(ctx context.Context, request *_sourc
 		ctx,
 		"persistence.TaskStore/CreateTaskQueue",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("TaskStore"),
-			attribute.Key("persistence.method").String("CreateTaskQueue"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("TaskStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("CreateTaskQueue"),
 		))
 	defer span.End()
 
@@ -151,7 +151,7 @@ func (d telemetryTaskStore) CreateTaskQueue(ctx context.Context, request *_sourc
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalCreateTaskQueueRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}
@@ -165,8 +165,8 @@ func (d telemetryTaskStore) CreateTasks(ctx context.Context, request *_sourcePer
 		ctx,
 		"persistence.TaskStore/CreateTasks",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("TaskStore"),
-			attribute.Key("persistence.method").String("CreateTasks"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("TaskStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("CreateTasks"),
 		))
 	defer span.End()
 
@@ -186,14 +186,14 @@ func (d telemetryTaskStore) CreateTasks(ctx context.Context, request *_sourcePer
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalCreateTasksRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(cp1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.CreateTasksResponse for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -207,8 +207,8 @@ func (d telemetryTaskStore) DeleteTaskQueue(ctx context.Context, request *_sourc
 		ctx,
 		"persistence.TaskStore/DeleteTaskQueue",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("TaskStore"),
-			attribute.Key("persistence.method").String("DeleteTaskQueue"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("TaskStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("DeleteTaskQueue"),
 		))
 	defer span.End()
 
@@ -228,7 +228,7 @@ func (d telemetryTaskStore) DeleteTaskQueue(ctx context.Context, request *_sourc
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.DeleteTaskQueueRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}
@@ -242,8 +242,8 @@ func (d telemetryTaskStore) GetTaskQueue(ctx context.Context, request *_sourcePe
 		ctx,
 		"persistence.TaskStore/GetTaskQueue",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("TaskStore"),
-			attribute.Key("persistence.method").String("GetTaskQueue"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("TaskStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("GetTaskQueue"),
 		))
 	defer span.End()
 
@@ -263,14 +263,14 @@ func (d telemetryTaskStore) GetTaskQueue(ctx context.Context, request *_sourcePe
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalGetTaskQueueRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(ip1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalGetTaskQueueResponse for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -284,8 +284,8 @@ func (d telemetryTaskStore) GetTaskQueueUserData(ctx context.Context, request *_
 		ctx,
 		"persistence.TaskStore/GetTaskQueueUserData",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("TaskStore"),
-			attribute.Key("persistence.method").String("GetTaskQueueUserData"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("TaskStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("GetTaskQueueUserData"),
 		))
 	defer span.End()
 
@@ -305,14 +305,14 @@ func (d telemetryTaskStore) GetTaskQueueUserData(ctx context.Context, request *_
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.GetTaskQueueUserDataRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(ip1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalGetTaskQueueUserDataResponse for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -326,8 +326,8 @@ func (d telemetryTaskStore) GetTaskQueuesByBuildId(ctx context.Context, request 
 		ctx,
 		"persistence.TaskStore/GetTaskQueuesByBuildId",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("TaskStore"),
-			attribute.Key("persistence.method").String("GetTaskQueuesByBuildId"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("TaskStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("GetTaskQueuesByBuildId"),
 		))
 	defer span.End()
 
@@ -347,14 +347,14 @@ func (d telemetryTaskStore) GetTaskQueuesByBuildId(ctx context.Context, request 
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.GetTaskQueuesByBuildIdRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(sa1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize []string for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -368,8 +368,8 @@ func (d telemetryTaskStore) GetTasks(ctx context.Context, request *_sourcePersis
 		ctx,
 		"persistence.TaskStore/GetTasks",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("TaskStore"),
-			attribute.Key("persistence.method").String("GetTasks"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("TaskStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("GetTasks"),
 		))
 	defer span.End()
 
@@ -389,14 +389,14 @@ func (d telemetryTaskStore) GetTasks(ctx context.Context, request *_sourcePersis
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.GetTasksRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(ip1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalGetTasksResponse for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -410,8 +410,8 @@ func (d telemetryTaskStore) ListTaskQueue(ctx context.Context, request *_sourceP
 		ctx,
 		"persistence.TaskStore/ListTaskQueue",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("TaskStore"),
-			attribute.Key("persistence.method").String("ListTaskQueue"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("TaskStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("ListTaskQueue"),
 		))
 	defer span.End()
 
@@ -431,14 +431,14 @@ func (d telemetryTaskStore) ListTaskQueue(ctx context.Context, request *_sourceP
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.ListTaskQueueRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(ip1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalListTaskQueueResponse for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -452,8 +452,8 @@ func (d telemetryTaskStore) ListTaskQueueUserDataEntries(ctx context.Context, re
 		ctx,
 		"persistence.TaskStore/ListTaskQueueUserDataEntries",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("TaskStore"),
-			attribute.Key("persistence.method").String("ListTaskQueueUserDataEntries"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("TaskStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("ListTaskQueueUserDataEntries"),
 		))
 	defer span.End()
 
@@ -473,14 +473,14 @@ func (d telemetryTaskStore) ListTaskQueueUserDataEntries(ctx context.Context, re
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.ListTaskQueueUserDataEntriesRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(ip1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalListTaskQueueUserDataEntriesResponse for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -494,8 +494,8 @@ func (d telemetryTaskStore) UpdateTaskQueue(ctx context.Context, request *_sourc
 		ctx,
 		"persistence.TaskStore/UpdateTaskQueue",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("TaskStore"),
-			attribute.Key("persistence.method").String("UpdateTaskQueue"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("TaskStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("UpdateTaskQueue"),
 		))
 	defer span.End()
 
@@ -515,14 +515,14 @@ func (d telemetryTaskStore) UpdateTaskQueue(ctx context.Context, request *_sourc
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalUpdateTaskQueueRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 		responsePayload, err := json.MarshalIndent(up1, "", "    ")
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.UpdateTaskQueueResponse for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.response.payload").String(string(responsePayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceResponsePayloadKey).String(string(responsePayload)))
 		}
 
 	}
@@ -536,8 +536,8 @@ func (d telemetryTaskStore) UpdateTaskQueueUserData(ctx context.Context, request
 		ctx,
 		"persistence.TaskStore/UpdateTaskQueueUserData",
 		trace.WithAttributes(
-			attribute.Key("persistence.store").String("TaskStore"),
-			attribute.Key("persistence.method").String("UpdateTaskQueueUserData"),
+			attribute.Key(telemetry.PersistenceStoreKey).String("TaskStore"),
+			attribute.Key(telemetry.PersistenceMethodKey).String("UpdateTaskQueueUserData"),
 		))
 	defer span.End()
 
@@ -557,7 +557,7 @@ func (d telemetryTaskStore) UpdateTaskQueueUserData(ctx context.Context, request
 		if err != nil {
 			d.logger.Error("failed to serialize *_sourcePersistence.InternalUpdateTaskQueueUserDataRequest for OTEL span", tag.Error(err))
 		} else {
-			span.SetAttributes(attribute.Key("persistence.request.payload").String(string(requestPayload)))
+			span.SetAttributes(attribute.Key(telemetry.PersistenceRequestPayloadKey).String(string(requestPayload)))
 		}
 
 	}


### PR DESCRIPTION
Adds Temporal-owned persistence span attributes and attaches CHASM execution identity through a small request interface. This exposes namespace, archetype, business ID, and run ID for trace correlation.

Stacked on #11770.
