### PR TITLE
Improve slack data race notification

### DIFF
--- a/tools/ci-notify/datarace.go
+++ b/tools/ci-notify/datarace.go
@@ -6,7 +6,6 @@ import (
 	"regexp"
 	"slices"
 	"strings"
-	"time"
 
 	"go.temporal.io/server/tools/common/github"
 )
@@ -46,18 +45,15 @@ type DataRace struct {
 	JobID string
 }
 
-// DataRaceReport aggregates the data races found in a single CI run along with
-// the commit context needed to attribute and link them.
+// DataRaceReport aggregates the data races found in a single CI run.
 type DataRaceReport struct {
 	Run       github.Run
-	Author    string
-	Title     string
 	DataRaces []DataRace
 }
 
-// BuildDataRaceReport fetches the run's test summaries, extracts any data races,
-// and enriches them with commit metadata. It returns a report with an empty
-// DataRaces slice when no races were detected.
+// BuildDataRaceReport fetches the run's test summaries and extracts any data
+// races. It returns a report with an empty DataRaces slice when no races were
+// detected.
 func BuildDataRaceReport(runID string) (*DataRaceReport, error) {
 	run, err := getWorkflowRun(runID)
 	if err != nil {
@@ -71,18 +67,7 @@ func BuildDataRaceReport(runID string) (*DataRaceReport, error) {
 
 	report := &DataRaceReport{
 		Run:       *run,
-		Title:     run.DisplayTitle,
 		DataRaces: races,
-	}
-
-	// Commit metadata is best-effort: a missing author must not suppress the alert.
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	if commit, err := github.GetCommit(ctx, temporalRepository, run.HeadSHA); err == nil {
-		report.Author = commit.Commit.Author.Name
-		if title := commit.Title(); title != "" {
-			report.Title = title
-		}
 	}
 
 	return report, nil

--- a/tools/ci-notify/datarace_test.go
+++ b/tools/ci-notify/datarace_test.go
@@ -182,9 +182,6 @@ func TestBuildDataRaceMessageFormatsRaceAndLinksToJob(t *testing.T) {
 
 	require.Contains(t, rendered, "Data Race Detected on Main Branch")
 	require.Contains(t, rendered, "```\nservice/matching.(*cache).put\nRead at (goroutine 8): service/history/mutable_state.go:127\nPrevious write at (goroutine 7): service/history/mutable_state.go:130\n```")
-	require.NotContains(t, rendered, "Commit:")
-	require.NotContains(t, rendered, "Author:")
-	require.NotContains(t, rendered, "Commit message:")
 	// Links to the specific job, not just the top-level run.
 	require.Contains(t, rendered, "actions/runs/123456/job/789")
 	// Runtime shim frames and raw stacktrace noise are not dumped into Slack.

--- a/tools/ci-notify/datarace_test.go
+++ b/tools/ci-notify/datarace_test.go
@@ -167,28 +167,24 @@ func TestRaceSites(t *testing.T) {
 	require.Empty(t, raceSites("some unrelated text"))
 }
 
-func TestBuildDataRaceMessageLinksToJob(t *testing.T) {
+func TestBuildDataRaceMessageFormatsRaceAndLinksToJob(t *testing.T) {
 	report := &DataRaceReport{
 		Run: github.Run{
 			DatabaseID: 123456,
-			HeadSHA:    "abc1234567890defghijk",
 			URL:        "https://github.com/temporalio/temporal/actions/runs/123456",
 		},
-		Author: "Test Author",
-		Title:  "Some commit title",
 		DataRaces: []DataRace{
-			{Location: "service/history.TestMutableState", Details: readWriteRaceDetails, JobID: "789"},
+			{Location: "service/matching.(*cache).put", Details: readWriteRaceDetails, JobID: "789"},
 		},
 	}
 
 	rendered := BuildDataRaceMessage(report).RenderMarkdown()
 
 	require.Contains(t, rendered, "Data Race Detected on Main Branch")
-	require.Contains(t, rendered, "Test Author")
-	require.Contains(t, rendered, "service/history.TestMutableState")
-	require.Contains(t, rendered, "Read at (goroutine 8): service/history/mutable_state.go:127")
-	require.Contains(t, rendered, "Previous write at (goroutine 7): service/history/mutable_state.go:130")
-	require.Contains(t, rendered, "abc1234") // short SHA link
+	require.Contains(t, rendered, "```\nservice/matching.(*cache).put\nRead at (goroutine 8): service/history/mutable_state.go:127\nPrevious write at (goroutine 7): service/history/mutable_state.go:130\n```")
+	require.NotContains(t, rendered, "Commit:")
+	require.NotContains(t, rendered, "Author:")
+	require.NotContains(t, rendered, "Commit message:")
 	// Links to the specific job, not just the top-level run.
 	require.Contains(t, rendered, "actions/runs/123456/job/789")
 	// Runtime shim frames and raw stacktrace noise are not dumped into Slack.
@@ -197,13 +193,12 @@ func TestBuildDataRaceMessageLinksToJob(t *testing.T) {
 
 func TestBuildDataRaceMessageFallsBackToRunLink(t *testing.T) {
 	report := &DataRaceReport{
-		Run:       github.Run{DatabaseID: 123456, HeadSHA: "abc1234567890"},
+		Run:       github.Run{DatabaseID: 123456},
 		DataRaces: []DataRace{{Location: "pkg.TestRacy", Details: "unparseable"}}, // no JobID
 	}
 
 	rendered := BuildDataRaceMessage(report).RenderMarkdown()
 
-	require.Contains(t, rendered, "Unknown") // author
 	require.Contains(t, rendered, "pkg.TestRacy")
 	require.Contains(t, rendered, "actions/runs/123456")
 	require.NotContains(t, rendered, "/job/")

--- a/tools/ci-notify/slack.go
+++ b/tools/ci-notify/slack.go
@@ -82,38 +82,24 @@ func FormatMessageForDebug(report *FailureReport) string {
 // BuildDataRaceMessage creates a Slack message announcing data races on main.
 func BuildDataRaceMessage(report *DataRaceReport) *slack.Message {
 	runID := strconv.FormatInt(report.Run.DatabaseID, 10)
-	commitURL := github.CommitURL(temporalRepository, report.Run.HeadSHA)
 
 	message := slack.NewMessage(fmt.Sprintf("Data Race Detected on Main (%d)", len(report.DataRaces)))
 	message.AddSection(":rotating_light: *Data Race Detected on Main Branch* :rotating_light:")
-	message.AddFields(
-		fmt.Sprintf("*Commit:*\n<%s|%s>", commitURL, report.Run.ShortSHA()),
-		fmt.Sprintf("*Author:*\n%s", orUnknown(report.Author)),
-	)
-	if report.Title != "" {
-		message.AddSection(fmt.Sprintf("*Commit message:*\n%s", report.Title))
-	}
 
 	for _, race := range report.DataRaces {
-		var sb strings.Builder
+		lines := raceSites(race.Details)
 		if race.Location != "" {
-			fmt.Fprintf(&sb, "*%s*", race.Location)
+			lines = append([]string{race.Location}, lines...)
 		}
-		for _, site := range raceSites(race.Details) {
-			fmt.Fprintf(&sb, "\n• %s", site)
+		var sb strings.Builder
+		if len(lines) > 0 {
+			fmt.Fprintf(&sb, "```\n%s\n```\n", strings.Join(lines, "\n"))
 		}
-		fmt.Fprintf(&sb, "\n<%s|View job logs>", raceLink(runID, race))
+		fmt.Fprintf(&sb, "<%s|View job logs>", raceLink(runID, race))
 		message.AddSection(sb.String())
 	}
 
 	return message
-}
-
-func orUnknown(s string) string {
-	if s == "" {
-		return "Unknown"
-	}
-	return s
 }
 
 // raceLink points at the specific job that reported the race so the alert is


### PR DESCRIPTION
## What changed?
Remove commit and author from notification. Wrap stack trace in code block.

## Why?
latest commit and author for the CI run can be irrelevant for data race issues since they are sporadic.

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)