### PR TITLE
Return no error if child in stale branch

### DIFF
--- a/service/history/api/verifychildworkflowcompletionrecorded/api.go
+++ b/service/history/api/verifychildworkflowcompletionrecorded/api.go
@@ -72,7 +72,7 @@ func verifyChildExecution(
 
 	if !onCurrentBranch {
 		// Due to conflict resolution, the initiated event may be on a different branch of the workflow.
-		// The child is not associated with the current branch, so it cannot block the parent.
+		// The child is not associated with the current branch, so verification is complete.
 		return nil, nil, parentWorkflowState, nil
 	}
 

--- a/service/history/api/verifychildworkflowcompletionrecorded/api.go
+++ b/service/history/api/verifychildworkflowcompletionrecorded/api.go
@@ -71,10 +71,9 @@ func verifyChildExecution(
 	}
 
 	if !onCurrentBranch {
-		// due to conflict resolution, the initiated event may on a different branch of the workflow.
-		// we don't have to do anything and can simply return not found error. Standby logic
-		// after seeing this error will give up verification.
-		return nil, nil, parentWorkflowState, consts.ErrChildExecutionNotFound
+		// Due to conflict resolution, the initiated event may be on a different branch of the workflow.
+		// The child is not associated with the current branch, so it cannot block the parent.
+		return nil, nil, parentWorkflowState, nil
 	}
 
 	ci, isRunning := mutableState.GetChildExecutionInfo(request.ParentInitiatedId)

--- a/service/history/api/verifychildworkflowcompletionrecorded/api_test.go
+++ b/service/history/api/verifychildworkflowcompletionrecorded/api_test.go
@@ -1,0 +1,86 @@
+package verifychildworkflowcompletionrecorded
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumsspb "go.temporal.io/server/api/enums/v1"
+	historyspb "go.temporal.io/server/api/history/v1"
+	"go.temporal.io/server/api/historyservice/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/persistence/versionhistory"
+	"go.temporal.io/server/service/history/api"
+	historyi "go.temporal.io/server/service/history/interfaces"
+	"go.temporal.io/server/service/history/ndc"
+	"go.temporal.io/server/service/history/tests"
+	"go.uber.org/mock/gomock"
+)
+
+func TestVerifyChildExecution_InitiatedEventNotOnCurrentBranch(t *testing.T) {
+	const (
+		initiatedEventID       = int64(10)
+		currentBranchVersion   = int64(1)
+		alternateBranchVersion = int64(2)
+	)
+
+	versionHistories := &historyspb.VersionHistories{
+		CurrentVersionHistoryIndex: 0,
+		Histories: []*historyspb.VersionHistory{
+			versionhistory.NewVersionHistory(nil, []*historyspb.VersionHistoryItem{
+				versionhistory.NewVersionHistoryItem(initiatedEventID, currentBranchVersion),
+			}),
+			versionhistory.NewVersionHistory(nil, []*historyspb.VersionHistoryItem{
+				versionhistory.NewVersionHistoryItem(initiatedEventID, alternateBranchVersion),
+			}),
+		},
+	}
+	executionState := &persistencespb.WorkflowExecutionState{
+		State: enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING,
+	}
+	executionInfo := &persistencespb.WorkflowExecutionInfo{
+		VersionHistories: versionHistories,
+	}
+
+	controller := gomock.NewController(t)
+	mutableState := historyi.NewMockMutableState(controller)
+	mutableState.EXPECT().GetExecutionState().Return(executionState)
+	mutableState.EXPECT().IsWorkflowExecutionRunning().Return(true)
+	mutableState.EXPECT().GetExecutionInfo().Return(executionInfo)
+
+	workflowLease := ndc.NewMockWorkflow(controller)
+	workflowLease.EXPECT().GetMutableState().Return(mutableState)
+	workflowLease.EXPECT().GetReleaseFn().Return(func(error) {})
+
+	workflowConsistencyChecker := api.NewMockWorkflowConsistencyChecker(controller)
+	workflowConsistencyChecker.EXPECT().GetWorkflowLease(
+		gomock.Any(),
+		gomock.Any(),
+		gomock.Any(),
+		gomock.Any(),
+	).Return(workflowLease, nil)
+
+	request := &historyservice.VerifyChildExecutionCompletionRecordedRequest{
+		NamespaceId: tests.NamespaceID.String(),
+		ParentExecution: &commonpb.WorkflowExecution{
+			WorkflowId: tests.WorkflowID,
+			RunId:      tests.RunID,
+		},
+		ParentInitiatedId:      initiatedEventID,
+		ParentInitiatedVersion: alternateBranchVersion,
+		ChildExecution: &commonpb.WorkflowExecution{
+			WorkflowId: "child-workflow-id",
+			RunId:      "child-run-id",
+		},
+	}
+
+	versionedTransition, returnedVersionHistories, parentWorkflowState, err := verifyChildExecution(
+		t.Context(),
+		workflowConsistencyChecker,
+		request,
+	)
+	require.NoError(t, err)
+	require.Nil(t, versionedTransition)
+	require.Nil(t, returnedVersionHistories)
+	require.Equal(t, enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING.String(), parentWorkflowState)
+}

--- a/service/history/history_engine2_test.go
+++ b/service/history/history_engine2_test.go
@@ -4130,7 +4130,7 @@ func (s *engine2Suite) TestVerifyChildExecutionCompletionRecorded_InitiatedEvent
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(gwmsResponse, nil)
 
 	_, err := s.historyEngine.VerifyChildExecutionCompletionRecorded(metrics.AddMetricsContext(context.Background()), request)
-	s.IsType(&serviceerror.NotFound{}, err)
+	s.Require().NoError(err)
 }
 
 func (s *engine2Suite) TestVerifyChildExecutionCompletionRecorded_InitiatedEventFoundOnCurrentBranch() {


### PR DESCRIPTION
## What changed?
Return no error if child in stale branch

## Why?
Return no error if child in stale branch so the standby task verification will mark the task as complete and no retry.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

