### PR TITLE
Log context for version delete propagation failures

### DIFF
--- a/service/worker/workerdeployment/version_workflow.go
+++ b/service/worker/workerdeployment/version_workflow.go
@@ -619,12 +619,13 @@ func (d *VersionWorkflowRunner) deleteVersionFromTaskQueuesAsync(ctx workflow.Co
 	// Retryable failures retry indefinitely.
 	err := d.deleteVersionFromTaskQueues(ctx, workflow.WithActivityOptions(ctx, propagationActivityOptions))
 	if err != nil {
-		// Don't decrement asyncPropagationsInProgress — the workflow must stay open
-		// because task queues may still have stale version data. The metric below
-		// enables alerting for manual recovery.
-		d.logger.Error("failed to delete worker deployment version from task queues", "error", err)
+		d.logger.Error(
+			"failed to delete worker deployment version from task queues",
+			"error", err,
+			"taskQueues", workflow.DeterministicKeys(d.GetVersionState().GetTaskQueueFamilies()),
+			"revision", d.GetVersionState().GetRevisionNumber(),
+		)
 		d.metrics.Counter(metrics.WorkerDeploymentVersionDeletePropagationFailure.Name()).Inc(1)
-		return
 	}
 	d.asyncPropagationsInProgress--
 }

--- a/service/worker/workerdeployment/version_workflow.go
+++ b/service/worker/workerdeployment/version_workflow.go
@@ -619,6 +619,9 @@ func (d *VersionWorkflowRunner) deleteVersionFromTaskQueuesAsync(ctx workflow.Co
 	// Retryable failures retry indefinitely.
 	err := d.deleteVersionFromTaskQueues(ctx, workflow.WithActivityOptions(ctx, propagationActivityOptions))
 	if err != nil {
+		// Terminal failure. Task queues may retain stale version data, but we still
+		// decrement below so the workflow can complete; the log and metric support manual
+		// recovery. This matches syncTaskQueuesAsync, which also decrements on failure.
 		d.logger.Error(
 			"failed to delete worker deployment version from task queues",
 			"error", err,

--- a/service/worker/workerdeployment/version_workflow_test.go
+++ b/service/worker/workerdeployment/version_workflow_test.go
@@ -853,11 +853,9 @@ func (s *VersionWorkflowSuite) Test_DeleteVersion_AsyncPropagation() {
 	s.Require().NoError(s.env.GetWorkflowError())
 }
 
-// Test_DeleteVersion_AsyncPropagationFailureKeepsWorkflowOpen verifies that when
-// task-queue delete propagation fails with a non-retryable error, the version
-// workflow stays open (propagation counter is not decremented) so that the
-// system does not lose track of the incomplete cleanup.
-func (s *VersionWorkflowSuite) Test_DeleteVersion_AsyncPropagationFailureKeepsWorkflowOpen() {
+// Test_DeleteVersion_AsyncPropagationFailureCompletesWorkflow verifies that the
+// workflow completes after reporting a non-retryable propagation failure.
+func (s *VersionWorkflowSuite) Test_DeleteVersion_AsyncPropagationFailureCompletesWorkflow() {
 	tv := testvars.New(s.T())
 
 	var a *VersionActivities
@@ -882,13 +880,6 @@ func (s *VersionWorkflowSuite) Test_DeleteVersion_AsyncPropagationFailureKeepsWo
 		}, &deploymentspb.DeleteVersionArgs{AsyncPropagation: true})
 	}, time.Millisecond)
 
-	// Verify consequence: after propagation fails, check the workflow is still open.
-	observedOpen := false
-	s.env.RegisterDelayedCallback(func() {
-		observedOpen = !s.env.IsWorkflowCompleted()
-		s.env.CancelWorkflow()
-	}, 100*time.Millisecond)
-
 	s.env.ExecuteWorkflow(WorkerDeploymentVersionWorkflowType, &deploymentspb.WorkerDeploymentVersionWorkflowArgs{
 		NamespaceName: tv.NamespaceName().String(),
 		NamespaceId:   tv.NamespaceID().String(),
@@ -911,8 +902,8 @@ func (s *VersionWorkflowSuite) Test_DeleteVersion_AsyncPropagationFailureKeepsWo
 		},
 	})
 
-	s.True(observedOpen, "workflow should remain open when delete propagation fails")
-	s.True(temporal.IsCanceledError(s.env.GetWorkflowError()))
+	s.True(s.env.IsWorkflowCompleted())
+	s.Require().NoError(s.env.GetWorkflowError())
 }
 
 // Test_DeleteVersion_AsyncPropagation_BlocksWorkerRegistration tests that:


### PR DESCRIPTION
## What changed?
- Revert https://github.com/temporalio/temporal/pull/11698/changes since that had introduced a NDE change
- The NDE change was that we were returning without decrementing a counter, which controls the CAN'ing rate of a version workflow.
- The NDE could occur if some version workflow had already CAN'ed earlier and with this change, it would not CAN again.
- Also added some more logs here so that when this does happen, we have alerts + logs for manual repair.

## Why?
Provide enough context to investigate terminal task-queue deletion propagation failures without leaving the version workflow open indefinitely.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] updated unit test
- [ ] added new functional test(s)

Focused test:
env GOWORK=off go test -tags test_dep ./service/worker/workerdeployment -run TestVersionWorkflowSuite/Test_DeleteVersion_AsyncPropagationFailureCompletesWorkflow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes terminal-delete failure handling and workflow lifetime; stale task-queue version data may persist, but metrics/logs are the recovery path and the prior keep-open behavior risked NDE/CaN issues.
> 
> **Overview**
> Reverts the behavior where a **terminal failure** during async task-queue delete propagation left the worker deployment **version workflow running** by skipping `asyncPropagationsInProgress` decrement. That path now **always decrements** the counter after logging and emitting the failure metric, so delete can finish and the workflow can exit—aligned with **`syncTaskQueuesAsync`**.
> 
> Failure logging now includes **`taskQueues`** and **`revision`** for investigation when task queues may still hold stale version data. The unit test was updated to expect **workflow completion** (no error) instead of an indefinitely open workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0ad2202f0863de1ff6a4ed12b40de8c6a08511d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->