### PR TITLE
Docs: fix case-mismatched anchor and duplicated-word typos in architecture docs

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -50,7 +50,7 @@ These premises have led to a system architecture which is divided into user-host
 
 - The worker processes communicate with the Temporal server in two ways: they continuously poll the server for Workflow and Activity tasks, and on completion of each task they send information to the server.
   (For a Workflow task they send commands to the server specifying what must be done to further advance the Workflow execution, and for an Activity task they send the task result or failure information.)
-  See [Tasks](#Tasks) below.
+  See [Tasks](#tasks) below.
 
 ### Temporal Cluster
 

--- a/docs/architecture/nexus.md
+++ b/docs/architecture/nexus.md
@@ -129,7 +129,7 @@ polling.
 
 ## Outbound Task Queue
 
-The outbound task queue is a task queue that is internal to the history service. Similarly to the the [transfer task
+The outbound task queue is a task queue that is internal to the history service. Similarly to the [transfer task
 queue](./history-service.md#transfer-task-queue), the outbound queue is a sharded "immediate" queue. The difference
 between the transfer queue and the outbound queue is that outbound tasks target external destinations, meaning that
 tasks are allowed to make long running (typically up to 10 seconds) external requests. The outbound queue groups tasks

--- a/docs/architecture/speculative-workflow-task.md
+++ b/docs/architecture/speculative-workflow-task.md
@@ -82,8 +82,8 @@ can't be properly handled outside of the Workflow lock, or returned to the user.
 the speculative Workflow Task is converted to a normal one and creates a transfer task which will
 eventually reach matching and the worker.
 
-The timeout timer task is is created for a `SCHEDULE_TO_START` timeout for every speculative
-Workflow Task - even if it is on a *normal* task queue. In comparision, for a normal Workflow Task, the
+The timeout timer task is created for a `SCHEDULE_TO_START` timeout for every speculative
+Workflow Task - even if it is on a *normal* task queue. In comparison, for a normal Workflow Task, the
 `SCHEDULE_TO_START` timeout timer is only created for *sticky* task queues.
 
 ## Start of Speculative Workflow Task


### PR DESCRIPTION
Four small docs fixes in `docs/architecture/`:

- `README.md`: `[Tasks](#Tasks)` — GitHub slugs are lowercase, so the link didn't jump; now `#tasks`
- `nexus.md`: "Similarly to **the the** [transfer task" 
- `speculative-workflow-task.md`: "**is is** created" and "In **comparision**" → "In comparison"

CLA note: happy to sign the Temporal CLA if this moves toward merge.