### PR TITLE
Add programmable persistence fault injection in functional tests

### DIFF
--- a/common/faultinjection/gate.go
+++ b/common/faultinjection/gate.go
@@ -1,0 +1,105 @@
+package faultinjection
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+// ErrGateReleased means the gate opened before enough calls arrived.
+var ErrGateReleased = errors.New("faultinjection: gate released before enough calls arrived")
+
+// Gate blocks operations until it is released.
+// A released gate does not block new operations.
+type Gate struct {
+	mu        sync.Mutex
+	arrived   int
+	changed   chan struct{}
+	releaseCh chan struct{}
+	err       error
+	released  bool
+}
+
+// NewGate returns a gate that blocks operations.
+func NewGate() *Gate {
+	return &Gate{
+		changed:   make(chan struct{}),
+		releaseCh: make(chan struct{}),
+	}
+}
+
+// Wait blocks until the gate is released or ctx is canceled.
+func (g *Gate) Wait(ctx context.Context) error {
+	g.mu.Lock()
+	if g.released {
+		g.mu.Unlock()
+		return nil
+	}
+	g.arrived++
+	close(g.changed)
+	g.changed = make(chan struct{})
+	g.mu.Unlock()
+
+	select {
+	case <-g.releaseCh:
+		g.mu.Lock()
+		err := g.err
+		g.mu.Unlock()
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Arrived returns the number of calls that reached the closed gate.
+func (g *Gate) Arrived() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.arrived
+}
+
+// WaitForArrived waits for n calls, gate release, or context cancellation.
+func (g *Gate) WaitForArrived(ctx context.Context, n int) error {
+	for {
+		g.mu.Lock()
+		switch {
+		case g.arrived >= n:
+			g.mu.Unlock()
+			return nil
+		case g.released:
+			g.mu.Unlock()
+			return ErrGateReleased
+		}
+		changed := g.changed
+		g.mu.Unlock()
+
+		select {
+		case <-changed:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+// Release opens the gate without an error.
+func (g *Gate) Release() {
+	g.doRelease(nil)
+}
+
+// ReleaseWithError opens the gate and returns err from each blocked callback.
+func (g *Gate) ReleaseWithError(err error) {
+	g.doRelease(err)
+}
+
+func (g *Gate) doRelease(err error) {
+	g.mu.Lock()
+	if g.released {
+		g.mu.Unlock()
+		return
+	}
+	g.released = true
+	g.err = err
+	close(g.releaseCh)
+	close(g.changed)
+	g.mu.Unlock()
+}

--- a/common/faultinjection/gate_test.go
+++ b/common/faultinjection/gate_test.go
@@ -1,0 +1,137 @@
+package faultinjection
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/testing/await"
+)
+
+func TestGate_BlocksUntilReleased(t *testing.T) {
+	t.Parallel()
+
+	g := NewGate()
+
+	done := make(chan error, 1)
+	go func() { done <- g.Wait(context.Background()) }()
+
+	require.NoError(t, g.WaitForArrived(context.Background(), 1))
+	require.Equal(t, 1, g.Arrived())
+
+	require.Never(t, func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, 50*time.Millisecond, time.Millisecond)
+
+	g.Release()
+	require.NoError(t, await.Rcv(t, done))
+}
+
+func TestGate_ReleaseWithError(t *testing.T) {
+	t.Parallel()
+
+	g := NewGate()
+	errX := errors.New("x")
+
+	done := make(chan error, 1)
+	go func() { done <- g.Wait(context.Background()) }()
+
+	require.NoError(t, g.WaitForArrived(context.Background(), 1))
+	g.ReleaseWithError(errX)
+	require.ErrorIs(t, await.Rcv(t, done), errX)
+	require.NoError(t, g.Wait(context.Background()))
+	require.Equal(t, 1, g.Arrived())
+}
+
+func TestGate_OneShot(t *testing.T) {
+	t.Parallel()
+
+	g := NewGate()
+	g.Release()
+
+	// A call arriving after Release should not block.
+	done := make(chan error, 1)
+	go func() { done <- g.Wait(context.Background()) }()
+
+	require.NoError(t, await.Rcv(t, done))
+	require.Zero(t, g.Arrived())
+}
+
+func TestGate_ConcurrentArrivals(t *testing.T) {
+	t.Parallel()
+
+	g := NewGate()
+
+	const n = 20
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for range n {
+		go func() {
+			defer wg.Done()
+			_ = g.Wait(context.Background())
+		}()
+	}
+
+	require.NoError(t, g.WaitForArrived(context.Background(), n))
+	require.Equal(t, n, g.Arrived())
+
+	g.Release()
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	await.Rcv(t, done)
+}
+
+func TestGate_WaitForArrived_TimesOut(t *testing.T) {
+	t.Parallel()
+
+	g := NewGate()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	require.ErrorIs(t, g.WaitForArrived(ctx, 1), context.DeadlineExceeded)
+}
+
+func TestGate_WaitForArrived_UnblocksOnRelease(t *testing.T) {
+	t.Parallel()
+
+	g := NewGate()
+	done := make(chan error, 1)
+	go func() {
+		done <- g.WaitForArrived(context.Background(), 5) // no one will ever arrive
+	}()
+
+	g.Release()
+	require.ErrorIs(t, await.Rcv(t, done), ErrGateReleased)
+}
+
+func TestGate_DoubleReleaseIsSafe(t *testing.T) {
+	t.Parallel()
+
+	g := NewGate()
+	g.Release()
+	g.ReleaseWithError(errors.New("should be ignored"))
+
+	require.NoError(t, g.Wait(context.Background()), "the first Release should win")
+}
+
+func TestGate_WaitStopsWhenContextIsCanceled(t *testing.T) {
+	t.Parallel()
+
+	g := NewGate()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.ErrorIs(t, g.Wait(ctx), context.Canceled)
+	require.Equal(t, 1, g.Arrived())
+}

--- a/common/faultinjection/generator.go
+++ b/common/faultinjection/generator.go
@@ -1,4 +1,4 @@
-// Package faultinjection registers request and response faults for multiple transports.
+// Package faultinjection registers request and response fault callbacks.
 package faultinjection
 
 import (

--- a/common/faultinjection/generator_test.go
+++ b/common/faultinjection/generator_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
-	"go.temporal.io/server/common/rpc/faultinjection"
+	"go.temporal.io/server/common/faultinjection"
 	"go.temporal.io/server/common/testing/await"
 )
 

--- a/common/persistence/faultinjection/registry.go
+++ b/common/persistence/faultinjection/registry.go
@@ -1,0 +1,77 @@
+package faultinjection
+
+import (
+	"context"
+
+	"go.temporal.io/server/common/config"
+	commonfaults "go.temporal.io/server/common/faultinjection"
+)
+
+type (
+	// Target identifies a persistence operation.
+	Target = config.FaultInjectionTarget
+
+	// Callback returns the error to inject. Return nil to run the operation.
+	// Callbacks must be safe for concurrent use.
+	Callback func(Target) error
+
+	// A faultCallback supports faults that must run the operation first.
+	faultCallback func(Target) *fault
+
+	// FaultRegistry stores fault callbacks in registration order.
+	// It is safe for concurrent use.
+	FaultRegistry struct {
+		callbacks *commonfaults.CallbackGenerator[Target, *fault]
+	}
+)
+
+// NewFaultRegistry returns an empty FaultRegistry.
+func NewFaultRegistry() *FaultRegistry {
+	return &FaultRegistry{
+		callbacks: commonfaults.NewCallbackGenerator[Target, *fault](),
+	}
+}
+
+// RegisterCallback adds a callback. The returned function removes it.
+func (r *FaultRegistry) RegisterCallback(cb Callback) func() {
+	return r.register(func(t Target) *fault {
+		err := cb(t)
+		if err == nil {
+			return nil
+		}
+		f := newFaultFromError(err, 1.0)
+		return &f
+	})
+}
+
+func (r *FaultRegistry) register(cb faultCallback) func() {
+	if r == nil {
+		return func() {}
+	}
+	return r.callbacks.RegisterRequestCallback(commonfaults.Scope{}, func(_ context.Context, _ string, target Target) *commonfaults.Outcome[*fault] {
+		if generated := cb(target); generated != nil {
+			return &commonfaults.Outcome[*fault]{Response: generated}
+		}
+		return nil
+	})
+}
+
+func (r *FaultRegistry) generate(t Target) *fault {
+	if r == nil {
+		return nil
+	}
+	outcome := r.callbacks.GenerateRequest(context.Background(), t.Method, t)
+	if outcome == nil {
+		return nil
+	}
+	return outcome.Response
+}
+
+// Inject implements config.FaultInjector.
+func (r *FaultRegistry) Inject(t Target) error {
+	f := r.generate(t)
+	if f == nil {
+		return nil
+	}
+	return f.err
+}

--- a/common/persistence/faultinjection/registry_test.go
+++ b/common/persistence/faultinjection/registry_test.go
@@ -1,0 +1,88 @@
+package faultinjection
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/testing/await"
+)
+
+func TestFaultRegistry_NoCallbacks(t *testing.T) {
+	t.Parallel()
+
+	reg := NewFaultRegistry()
+	require.Nil(t, reg.generate(Target{Method: "M"}))
+	require.NoError(t, reg.Inject(Target{Method: "M"}))
+}
+
+func TestFaultRegistry_FirstCallbackWins(t *testing.T) {
+	t.Parallel()
+
+	reg := NewFaultRegistry()
+	errA := errors.New("a")
+	errB := errors.New("b")
+	reg.RegisterCallback(func(Target) error { return errA })
+	reg.RegisterCallback(func(Target) error { return errB })
+
+	require.ErrorIs(t, reg.Inject(Target{Method: "M"}), errA)
+}
+
+func TestFaultRegistry_NilErrorFallsThrough(t *testing.T) {
+	t.Parallel()
+
+	reg := NewFaultRegistry()
+	errB := errors.New("b")
+	reg.RegisterCallback(func(Target) error { return nil })
+	reg.RegisterCallback(func(Target) error { return errB })
+
+	require.ErrorIs(t, reg.Inject(Target{Method: "M"}), errB)
+}
+
+func TestFaultRegistry_CleanupRemovesCallback(t *testing.T) {
+	t.Parallel()
+
+	reg := NewFaultRegistry()
+	errA := errors.New("a")
+	cleanup := reg.RegisterCallback(func(Target) error { return errA })
+	cleanup()
+	cleanup()
+
+	require.NoError(t, reg.Inject(Target{Method: "M"}))
+}
+
+func TestFaultRegistry_CleanupDuringInject(t *testing.T) {
+	t.Parallel()
+
+	reg := NewFaultRegistry()
+	errA := errors.New("a")
+	started := make(chan struct{})
+	proceed := make(chan struct{})
+	unregister := reg.RegisterCallback(func(Target) error {
+		await.Snd(t, started, struct{}{})
+		await.Rcv(t, proceed)
+		return errA
+	})
+	result := make(chan error, 1)
+	go func() {
+		result <- reg.Inject(Target{Method: "M"})
+	}()
+
+	await.Rcv(t, started)
+	unregister()
+	await.Snd(t, proceed, struct{}{})
+	require.ErrorIs(t, await.Rcv(t, result), errA)
+	require.NoError(t, reg.Inject(Target{Method: "M"}))
+}
+
+func TestFaultRegistry_NilRegistry(t *testing.T) {
+	t.Parallel()
+
+	var reg *FaultRegistry
+	require.Nil(t, reg.generate(Target{Method: "M"}))
+	require.NoError(t, reg.Inject(Target{Method: "M"}))
+
+	unregister := reg.RegisterCallback(func(Target) error { return context.Canceled })
+	unregister()
+}

--- a/common/persistence/faultinjection/store_fault_generator.go
+++ b/common/persistence/faultinjection/store_fault_generator.go
@@ -5,41 +5,39 @@ import (
 )
 
 type (
-	// storeFaultInjector is an implementation of faultGenerator that will inject errors into the persistence layer
-	// using runtime injectors or per-method configuration.
+	// storeFaultInjector injects configured and runtime faults.
 	storeFaultInjector struct {
 		storeName config.DataStoreName
-		injectors []faultInjector
+		registry  *FaultRegistry
 	}
-
-	faultInjector func(config.FaultInjectionTarget) *fault
 )
 
-// newStoreFaultInjector returns a new instance of a data store fault injector that will inject errors
-// into the persistence layer based on the provided configuration.
+// newStoreFaultInjector returns false when the store has no fault source.
 func newStoreFaultInjector(
 	storeName config.DataStoreName,
 	cfg *config.FaultInjectionDataStoreConfig,
 	injector config.FaultInjector,
 ) (*storeFaultInjector, bool) {
-	var injectors []faultInjector
+	if injector == nil && len(cfg.Methods) == 0 {
+		return nil, false
+	}
+
+	registry := NewFaultRegistry()
+	// Runtime faults take priority over configured faults.
 	if injector != nil {
-		injectors = append(injectors, runtimeFaultInjector(injector))
+		registry.register(injectorCallback(injector))
 	}
 	if len(cfg.Methods) > 0 {
-		injectors = append(injectors, configuredFaultInjector(cfg))
-	}
-	if len(injectors) == 0 {
-		return nil, false
+		registry.register(configCallback(cfg))
 	}
 	return &storeFaultInjector{
 		storeName: storeName,
-		injectors: injectors,
+		registry:  registry,
 	}, true
 }
 
-func runtimeFaultInjector(injector config.FaultInjector) faultInjector {
-	return func(target config.FaultInjectionTarget) *fault {
+func injectorCallback(injector config.FaultInjector) faultCallback {
+	return func(target Target) *fault {
 		err := injector(target)
 		if err == nil {
 			return nil
@@ -49,7 +47,7 @@ func runtimeFaultInjector(injector config.FaultInjector) faultInjector {
 	}
 }
 
-func configuredFaultInjector(cfg *config.FaultInjectionDataStoreConfig) faultInjector {
+func configCallback(cfg *config.FaultInjectionDataStoreConfig) faultCallback {
 	methodFaultGenerators := make(map[string]faultGenerator, len(cfg.Methods))
 	for methodName, methodConfig := range cfg.Methods {
 		var faults []fault
@@ -58,7 +56,7 @@ func configuredFaultInjector(cfg *config.FaultInjectionDataStoreConfig) faultInj
 		}
 		methodFaultGenerators[methodName] = newMethodFaultGenerator(faults, methodConfig.Seed)
 	}
-	return func(target config.FaultInjectionTarget) *fault {
+	return func(target Target) *fault {
 		methodGenerator, ok := methodFaultGenerators[target.Method]
 		if !ok {
 			return nil
@@ -67,20 +65,13 @@ func configuredFaultInjector(cfg *config.FaultInjectionDataStoreConfig) faultInj
 	}
 }
 
-// generate returns a fault from the first injector that chooses to inject one.
-// When this method returns nil, the persistence layer uses the real implementation.
 func (d *storeFaultInjector) generate(methodName string, requests ...any) *fault {
-	target := config.FaultInjectionTarget{
+	target := Target{
 		Store:  d.storeName,
 		Method: methodName,
 	}
 	if len(requests) > 0 {
 		target.Request = requests[0]
 	}
-	for _, injector := range d.injectors {
-		if f := injector(target); f != nil {
-			return f
-		}
-	}
-	return nil
+	return d.registry.generate(target)
 }

--- a/common/persistence/faultinjection/store_fault_generator_test.go
+++ b/common/persistence/faultinjection/store_fault_generator_test.go
@@ -163,3 +163,52 @@ func TestFaultInjection_StoreNotConfigured(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp2)
 }
+
+func TestStoreFaultInjector_RuntimeFaultTakesPriority(t *testing.T) {
+	t.Parallel()
+
+	runtimeErr := errors.New("runtime")
+	request := &struct{}{}
+	var target config.FaultInjectionTarget
+	cfg := &config.FaultInjectionDataStoreConfig{
+		Methods: map[string]config.FaultInjectionMethodConfig{
+			"Method": {Errors: map[string]float64{"Timeout": 1}},
+		},
+	}
+	generator, ok := newStoreFaultInjector(config.ExecutionStoreName, cfg, func(got config.FaultInjectionTarget) error {
+		target = got
+		return runtimeErr
+	})
+	require.True(t, ok)
+
+	f := generator.generate("Method", request)
+	require.NotNil(t, f)
+	require.ErrorIs(t, f.err, runtimeErr)
+	require.Equal(t, config.ExecutionStoreName, target.Store)
+	require.Equal(t, "Method", target.Method)
+	require.Same(t, request, target.Request)
+}
+
+func TestStoreFaultInjector_ConfigCanRunOperationBeforeError(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.FaultInjectionDataStoreConfig{
+		Methods: map[string]config.FaultInjectionMethodConfig{
+			"Method": {Errors: map[string]float64{"ExecuteAndTimeout": 1}},
+		},
+	}
+	generator, ok := newStoreFaultInjector(config.ExecutionStoreName, cfg, nil)
+	require.True(t, ok)
+
+	f := generator.generate("Method")
+	require.NotNil(t, f)
+	executed := false
+	err := f.inject(func() error {
+		executed = true
+		return nil
+	})
+
+	require.True(t, executed)
+	var timeoutErr *persistence.TimeoutError
+	require.ErrorAs(t, err, &timeoutErr)
+}

--- a/common/rpc/grpcfaults/generator.go
+++ b/common/rpc/grpcfaults/generator.go
@@ -1,6 +1,6 @@
 package grpcfaults
 
-import "go.temporal.io/server/common/rpc/faultinjection"
+import "go.temporal.io/server/common/faultinjection"
 
 type (
 	// Outcome contains the result returned when a gRPC fault matches.

--- a/common/rpc/httpfaults/httpfaults.go
+++ b/common/rpc/httpfaults/httpfaults.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strings"
 
-	"go.temporal.io/server/common/rpc/faultinjection"
+	"go.temporal.io/server/common/faultinjection"
 )
 
 // Scope identifies a namespace for fault matching.

--- a/common/testing/faultinjectiontest/hooks_testdep.go
+++ b/common/testing/faultinjectiontest/hooks_testdep.go
@@ -5,8 +5,8 @@ package faultinjectiontest
 import (
 	"context"
 
+	"go.temporal.io/server/common/faultinjection"
 	"go.temporal.io/server/common/namespace"
-	"go.temporal.io/server/common/rpc/faultinjection"
 	"go.temporal.io/server/common/testing/testhooks"
 )
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -246,6 +246,27 @@ env.InjectHTTPRequestFault(func(ctx context.Context, req *http.Request) *httpfau
 })
 ```
 
+### Persistence fault injection
+
+Use `testcore.InjectPersistenceFault` to return custom errors from persistence calls. The fault is
+active before the test cluster starts. You can filter it by store and method.
+
+```go
+option := testcore.InjectPersistenceFault(t,
+    func(faultinjection.Target) error {
+        return context.DeadlineExceeded
+    },
+    testcore.WithStore(config.ShardStoreName),
+    testcore.WithMethod("UpdateShard"),
+)
+env := testcore.NewEnv(t, option)
+```
+
+Use `testcore.BlockPersistenceCall` when a test must control call order. Call `WaitUntilBlocked`
+before you check other state. Call `Gate.Release` to continue the persistence operation. Call
+`Gate.ReleaseWithError` to return an error from the blocked operation. The test fails if no matching
+call reaches the fault or gate.
+
 ### testhooks package
 
 The `testhooks` package injects test-specific behavior into production code paths that are otherwise

--- a/tests/acquire_shard_test.go
+++ b/tests/acquire_shard_test.go
@@ -3,12 +3,15 @@ package tests
 import (
 	"context"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/faultinjection"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/tests/testcore"
 )
@@ -75,10 +78,8 @@ func (r *logRecorder) record(msg string, tags ...tag.Tag) {
 	}
 }
 
-// newEnv builds a logs channel + logRecorder and starts a dedicated single-shard
-// cluster wired to that recorder with the given fault injection config. The
-// cluster is torn down automatically via t.Cleanup inside NewEnv.
-func (s *AcquireShardSuite) newEnv(fi *config.FaultInjection) chan logRecord {
+// newEnv starts a single-shard cluster with fault injection.
+func (s *AcquireShardSuite) newEnv(faultOpt testcore.TestOption) chan logRecord {
 	// Server startup happens when the cluster is created, but the test doesn't
 	// listen on the log channel until afterward. So the buffer needs to be big
 	// enough to hold all server-startup logs, which are currently about 190 lines.
@@ -87,7 +88,7 @@ func (s *AcquireShardSuite) newEnv(fi *config.FaultInjection) chan logRecord {
 		s.T(),
 		testcore.WithLogger(newLogRecorder(logs)),
 		testcore.WithHistoryShardCount(1),
-		testcore.WithPersistenceFaultInjection(fi),
+		faultOpt,
 	)
 	return logs
 }
@@ -95,8 +96,12 @@ func (s *AcquireShardSuite) newEnv(fi *config.FaultInjection) chan logRecord {
 // TestOwnershipLost_DoesNotRetry verifies that we do not retry acquiring the shard
 // when we get an ownership lost error.
 func (s *AcquireShardSuite) TestOwnershipLost_DoesNotRetry() {
-	logs := s.newEnv((&config.FaultInjection{}).
-		WithError(config.ShardStoreName, "UpdateShard", "ShardOwnershipLost", 1.0))
+	logs := s.newEnv(testcore.InjectPersistenceFault(s.T(),
+		func(faultinjection.Target) error {
+			return &persistence.ShardOwnershipLostError{Msg: "injected shard ownership lost"}
+		},
+		testcore.WithStore(config.ShardStoreName),
+		testcore.WithMethod("UpdateShard")))
 
 	ctx, cancel := context.WithTimeout(s.Context(), time.Second*10)
 	defer cancel()
@@ -130,8 +135,12 @@ func (s *AcquireShardSuite) TestOwnershipLost_DoesNotRetry() {
 // TestDeadlineExceeded_DoesRetry verifies that we do retry acquiring the shard when
 // we get a deadline exceeded error because that should be considered a transient error.
 func (s *AcquireShardSuite) TestDeadlineExceeded_DoesRetry() {
-	logs := s.newEnv((&config.FaultInjection{}).
-		WithError(config.ShardStoreName, "UpdateShard", "DeadlineExceeded", 1.0))
+	logs := s.newEnv(testcore.InjectPersistenceFault(s.T(),
+		func(faultinjection.Target) error {
+			return context.DeadlineExceeded
+		},
+		testcore.WithStore(config.ShardStoreName),
+		testcore.WithMethod("UpdateShard")))
 
 	ctx, cancel := context.WithTimeout(s.Context(), time.Second*10)
 	defer cancel()
@@ -158,13 +167,18 @@ func (s *AcquireShardSuite) TestDeadlineExceeded_DoesRetry() {
 	}
 }
 
-// TestEventualSuccess verifies that we eventually succeed in acquiring the shard when
-// we get a deadline exceeded error followed by a successful acquire shard call.
-// To make this test deterministic, the fault injection method seed is fixed.
+// TestEventualSuccess fails the first update and permits the retry.
 func (s *AcquireShardSuite) TestEventualSuccess() {
-	logs := s.newEnv((&config.FaultInjection{}).
-		WithError(config.ShardStoreName, "UpdateShard", "DeadlineExceeded", 0.5).
-		WithMethodSeed(config.ShardStoreName, "UpdateShard", 43))
+	var updateShardCalls atomic.Int32
+	logs := s.newEnv(testcore.InjectPersistenceFault(s.T(),
+		func(faultinjection.Target) error {
+			if updateShardCalls.Add(1) == 1 {
+				return context.DeadlineExceeded
+			}
+			return nil
+		},
+		testcore.WithStore(config.ShardStoreName),
+		testcore.WithMethod("UpdateShard")))
 
 	ctx, cancel := context.WithTimeout(s.Context(), time.Second*10)
 	defer cancel()
@@ -191,6 +205,31 @@ func (s *AcquireShardSuite) TestEventualSuccess() {
 			}
 		case <-ctx.Done():
 			s.FailNow("timed out waiting for retry")
+		}
+	}
+}
+
+// TestBlockedUpdateShard_AcquiresAfterRelease blocks the update until release.
+func (s *AcquireShardSuite) TestBlockedUpdateShard_AcquiresAfterRelease() {
+	gate, opt := testcore.BlockPersistenceCall(s.T(),
+		testcore.WithStore(config.ShardStoreName), testcore.WithMethod("UpdateShard"))
+	logs := s.newEnv(opt)
+
+	testcore.WaitUntilBlocked(s.T(), gate, time.Second*10)
+	s.Equal(1, gate.Arrived())
+
+	gate.Release()
+
+	ctx, cancel := context.WithTimeout(s.Context(), time.Second*10)
+	defer cancel()
+	for {
+		select {
+		case record := <-logs:
+			if strings.Contains(strings.ToLower(record.msg), "acquired shard") {
+				return
+			}
+		case <-ctx.Done():
+			s.FailNow("timed out waiting for shard to be acquired after release")
 		}
 	}
 }

--- a/tests/testcore/fault_injection.go
+++ b/tests/testcore/fault_injection.go
@@ -52,7 +52,7 @@ func (f *faultTracker) attach(unregister func()) func() {
 		f.loggingEnabled = false
 		f.mu.Unlock()
 		unregister()
-		if !f.fired.Load() {
+		if !f.t.Skipped() && !f.fired.Load() {
 			f.t.Error("fault injection was registered but never fired - the fault was never injected")
 		}
 	})

--- a/tests/testcore/persistence_fault.go
+++ b/tests/testcore/persistence_fault.go
@@ -1,0 +1,84 @@
+package testcore
+
+import (
+	"testing"
+
+	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/persistence/faultinjection"
+)
+
+// PersistenceFault returns the error to inject. Return nil to run the operation.
+type PersistenceFault func(target faultinjection.Target) error
+
+// PersistenceFaultOption limits which operations receive a fault.
+type PersistenceFaultOption func(*persistenceFaultOptions)
+
+type persistenceFaultOptions struct {
+	store  config.DataStoreName
+	method string
+}
+
+// WithStore limits a fault to one data store.
+func WithStore(store config.DataStoreName) PersistenceFaultOption {
+	return func(o *persistenceFaultOptions) {
+		o.store = store
+	}
+}
+
+// WithMethod limits a fault to one method.
+func WithMethod(method string) PersistenceFaultOption {
+	return func(o *persistenceFaultOptions) {
+		o.method = method
+	}
+}
+
+func (o persistenceFaultOptions) matches(target faultinjection.Target) bool {
+	if o.store != "" && target.Store != o.store {
+		return false
+	}
+	if o.method != "" && target.Method != o.method {
+		return false
+	}
+	return true
+}
+
+func applyPersistenceFaultOptions(opts []PersistenceFaultOption) persistenceFaultOptions {
+	var options persistenceFaultOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+	return options
+}
+
+func (o *testOptions) getPersistenceFaultRegistry() *faultinjection.FaultRegistry {
+	if o.persistenceFaultRegistry == nil {
+		o.persistenceFaultRegistry = faultinjection.NewFaultRegistry()
+		WithPersistenceFaultInjection(&config.FaultInjection{
+			Injector: o.persistenceFaultRegistry.Inject,
+		})(o)
+	}
+	return o.persistenceFaultRegistry
+}
+
+// InjectPersistenceFault adds a fault and enables it before cluster startup.
+// The test fails if the fault does not fire.
+func InjectPersistenceFault(t testing.TB, fault PersistenceFault, opts ...PersistenceFaultOption) TestOption {
+	t.Helper()
+
+	options := applyPersistenceFaultOptions(opts)
+	tracker := newFaultTracker(t)
+	return func(o *testOptions) {
+		unregister := o.getPersistenceFaultRegistry().RegisterCallback(func(target faultinjection.Target) error {
+			if !options.matches(target) {
+				return nil
+			}
+			injectedErr := fault(target)
+			if injectedErr == nil {
+				return nil
+			}
+			tracker.markFired(target)
+			return injectedErr
+		})
+		tracker.attach(unregister)
+	}
+}

--- a/tests/testcore/persistence_fault_gate.go
+++ b/tests/testcore/persistence_fault_gate.go
@@ -1,0 +1,52 @@
+package testcore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.temporal.io/server/common/faultinjection"
+	persistencefaults "go.temporal.io/server/common/persistence/faultinjection"
+)
+
+// BlockPersistenceCall blocks matching calls before cluster startup.
+// The test fails if no matching call reaches the gate.
+func BlockPersistenceCall(t testing.TB, opts ...PersistenceFaultOption) (*faultinjection.Gate, TestOption) {
+	t.Helper()
+
+	options := applyPersistenceFaultOptions(opts)
+
+	gate := faultinjection.NewGate()
+
+	// Open the gate before cluster cleanup starts.
+	go func() {
+		<-t.Context().Done()
+		gate.Release()
+	}()
+
+	return gate, func(o *testOptions) {
+		unregister := o.getPersistenceFaultRegistry().RegisterCallback(func(target persistencefaults.Target) error {
+			if !options.matches(target) {
+				return nil
+			}
+			return gate.Wait(context.Background())
+		})
+
+		t.Cleanup(func() {
+			unregister()
+			if !t.Skipped() && gate.Arrived() == 0 {
+				t.Error("persistence call block was registered but no matching call arrived")
+			}
+		})
+	}
+}
+
+// WaitUntilBlocked waits for one call to reach the gate.
+func WaitUntilBlocked(t testing.TB, gate *faultinjection.Gate, timeout time.Duration) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), timeout)
+	defer cancel()
+	if err := gate.WaitForArrived(ctx, 1); err != nil {
+		t.Fatalf("gate: no matching persistence call arrived within %s: %v", timeout, err)
+	}
+}

--- a/tests/testcore/persistence_fault_test.go
+++ b/tests/testcore/persistence_fault_test.go
@@ -1,0 +1,42 @@
+package testcore
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/config"
+	persistencefaults "go.temporal.io/server/common/persistence/faultinjection"
+)
+
+func TestInjectPersistenceFault_LazilyCreatesOneRegistry(t *testing.T) {
+	t.Parallel()
+
+	errOne := errors.New("one")
+	errTwo := errors.New("two")
+	first := InjectPersistenceFault(t, func(persistencefaults.Target) error {
+		return errOne
+	}, WithMethod("MethodOne"))
+	second := InjectPersistenceFault(t, func(persistencefaults.Target) error {
+		return errTwo
+	}, WithMethod("MethodTwo"))
+
+	var options testOptions
+	require.Nil(t, options.persistenceFaultRegistry)
+
+	first(&options)
+	registry := options.persistenceFaultRegistry
+	require.NotNil(t, registry)
+	require.Len(t, options.clusterOptions, 1)
+
+	second(&options)
+	require.Same(t, registry, options.persistenceFaultRegistry)
+	require.Len(t, options.clusterOptions, 1)
+	require.True(t, options.dedicatedCluster)
+
+	var params testClusterParams
+	options.clusterOptions[0](&params)
+	require.NotNil(t, params.FaultInjectionConfig)
+	require.ErrorIs(t, params.FaultInjectionConfig.Injector(config.FaultInjectionTarget{Method: "MethodOne"}), errOne)
+	require.ErrorIs(t, params.FaultInjectionConfig.Injector(config.FaultInjectionTarget{Method: "MethodTwo"}), errTwo)
+}

--- a/tests/testcore/test_env.go
+++ b/tests/testcore/test_env.go
@@ -29,6 +29,7 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/namespace"
+	persistencefaults "go.temporal.io/server/common/persistence/faultinjection"
 	"go.temporal.io/server/common/rpc/grpcfaults"
 	"go.temporal.io/server/common/rpc/httpfaults"
 	"go.temporal.io/server/common/testing/taskpoller"
@@ -83,6 +84,8 @@ type TestEnv struct {
 	tv             *testvars.TestVars
 	dedicatedGuard *dedicatedClusterGuard
 
+	persistenceFaultRegistry *persistencefaults.FaultRegistry
+
 	sdkClientOnce sync.Once
 	sdkClient     sdkclient.Client
 	sdkWorkerOnce sync.Once
@@ -101,6 +104,7 @@ type testOptions struct {
 	clusterOptions           []TestClusterOption
 	testVars                 func(*testvars.TestVars) *testvars.TestVars
 	historyTaskRecorder      bool
+	persistenceFaultRegistry *persistencefaults.FaultRegistry
 }
 
 type dynamicConfigOverride struct {
@@ -324,17 +328,18 @@ func NewEnv(t *testing.T, opts ...TestOption) *TestEnv {
 	testcontext.EnsureRemaining(testcontext.For(t), t, testcontext.DefaultTimeout())
 
 	env := &TestEnv{
-		FunctionalTestBase: base,
-		Assertions:         require.New(t),
-		cluster:            cluster,
-		nsName:             ns,
-		nsID:               nsID,
-		Logger:             base.Logger,
-		taskPoller:         taskpoller.New(t, cluster.FrontendClient(), ns.String()),
-		t:                  t,
-		tv:                 tv,
-		sdkWorkerTQ:        RandomizeStr("tq-" + t.Name()),
-		dedicatedGuard:     dedicatedGuard,
+		FunctionalTestBase:       base,
+		Assertions:               require.New(t),
+		cluster:                  cluster,
+		nsName:                   ns,
+		nsID:                     nsID,
+		Logger:                   base.Logger,
+		taskPoller:               taskpoller.New(t, cluster.FrontendClient(), ns.String()),
+		t:                        t,
+		tv:                       tv,
+		sdkWorkerTQ:              RandomizeStr("tq-" + t.Name()),
+		dedicatedGuard:           dedicatedGuard,
+		persistenceFaultRegistry: options.persistenceFaultRegistry,
 	}
 	t.Cleanup(func() {
 		defer func() { dedicatedGuard = nil }()


### PR DESCRIPTION
## What changed?

Similar to (very recent) prior art https://github.com/temporalio/temporal/pull/9076 and https://github.com/temporalio/temporal/pull/11892/ which add the ability to inject fault into gRPC and HTTP requests, this PR adds the ability to do so at the persistence layer.

This PR is slightly simpler in the sense that we already have the ability to inject persistence faults in CI/CD, this PR extends the core functionality so that we can reuse the underlying mechanism when writing functional tests.

## Why?

This will enable us to build a higher level "config-based pane" that injects fault in various places in the temporal server and make functional testing more robust.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)
