### PR TITLE
Simplify non-occupying workflow handling in schedule migration

### DIFF
--- a/service/frontend/admin_handler.go
+++ b/service/frontend/admin_handler.go
@@ -2309,10 +2309,9 @@ func (adh *AdminHandler) migrateScheduleToWorkflow(
 	})
 	info := descResp.GetWorkflowExecutionInfo()
 	switch {
-	case common.IsNotFoundError(err):
-	case err != nil:
+	case err != nil && !common.IsNotFoundError(err):
 		return nil, err
-	case info.GetStatus() != enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING:
+	case common.IsNotFoundError(err) || info.GetStatus() != enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING:
 		// A closed workflow does not occupy the V1 ID: the create path only treats
 		// RUNNING workflows as occupying it (isRealSchedulerInV1KeySpace), and an
 		// expired sentinel completes rather than disappearing, staying describable


### PR DESCRIPTION
## What changed?
Combined the not-found and non-running workflow states into one non-occupying branch during V2-to-V1 schedule migration. Non-NotFound errors are still returned before workflow status is inspected.

## Why?
Follow-up to #11955 and the review suggestion at https://github.com/temporalio/temporal/pull/11955#discussion_r3959366715

Both a missing workflow and a closed sentinel leave the V1 workflow ID available for migration.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

Ran:
- go test -tags test_dep ./service/frontend -run TestAdminHandlerSuite/TestMigrateScheduleToWorkflow -count=1
- go test -tags test_dep ./tests -run TestScheduleMigrationTestSuite/TestScheduleMigrationV2ToV1BlockedOnlyByRunningSentinel -count=1 -timeout=10m
- make lint-code-fast

## Potential risks
Low: this only consolidates two existing success branches while preserving non-NotFound error handling.