### PR TITLE
Add strict state validation to passive replication tests

### DIFF
--- a/tests/passivepath/cluster.go
+++ b/tests/passivepath/cluster.go
@@ -21,6 +21,7 @@ import (
 
 func newSingleClusterWithGlobalNamespace(t *testing.T, logger log.Logger) *testcore.TestCluster {
 	clusterName := "passivepath_" + common.GenerateRandomString(5)
+	standbyClusterName := clusterName + "_standby"
 
 	persistenceDefaults := testcore.GetPersistenceTestDefaults()
 	persistenceDefaults.DBName += "_" + clusterName
@@ -36,12 +37,18 @@ func newSingleClusterWithGlobalNamespace(t *testing.T, logger log.Logger) *testc
 					Enabled:                true,
 					InitialFailoverVersion: 1,
 				},
+				standbyClusterName: {
+					Enabled:                true,
+					InitialFailoverVersion: 2,
+					RPCAddress:             "127.0.0.1:1",
+				},
 			},
 		},
 		HistoryConfig: testcore.HistoryConfig{NumHistoryShards: 1},
 		Persistence:   persistenceDefaults,
 		DynamicConfigOverrides: map[dynamicconfig.Key]any{
-			dynamicconfig.EnableTransitionHistory.Key(): true,
+			dynamicconfig.EnableTransitionHistory.Key():   true,
+			dynamicconfig.FrontendPersistenceMaxQPS.Key(): 100_000,
 		},
 		EnableHistoryTaskRecorder: true,
 	}
@@ -54,13 +61,17 @@ func newSingleClusterWithGlobalNamespace(t *testing.T, logger log.Logger) *testc
 
 func registerGlobalNamespace(t *testing.T, tc *testcore.TestCluster, name string) namespace.ID {
 	clusterName := tc.ClusterName()
+	standbyClusterName := clusterName + "_standby"
 	_, err := tc.FrontendClient().RegisterNamespace(
 		testcore.NewContext(),
 		&workflowservice.RegisterNamespaceRequest{
-			Namespace:                        name,
-			IsGlobalNamespace:                true,
-			ActiveClusterName:                clusterName,
-			Clusters:                         []*replicationpb.ClusterReplicationConfig{{ClusterName: clusterName}},
+			Namespace:         name,
+			IsGlobalNamespace: true,
+			ActiveClusterName: clusterName,
+			Clusters: []*replicationpb.ClusterReplicationConfig{
+				{ClusterName: clusterName},
+				{ClusterName: standbyClusterName},
+			},
 			WorkflowExecutionRetentionPeriod: durationpb.New(24 * time.Hour),
 		})
 	require.NoError(t, err)

--- a/tests/passivepath/context.go
+++ b/tests/passivepath/context.go
@@ -330,8 +330,21 @@ func normalizeMutableStateForComparison(state *persistencespb.WorkflowMutableSta
 	if info == nil {
 		return
 	}
+	stateMachineTimers := info.StateMachineTimers
 	// Reuse the production definition of cluster- and shard-local mutable state.
 	workflow.SanitizeMutableState(state)
+	// StateMachineTimers are regenerated locally rather than replicated, but this
+	// single-cluster harness expects the passive refresh to reproduce the active timer
+	// schedule. Preserve them across sanitization and ignore only the cluster-local
+	// state machine transition counter embedded in each task reference.
+	info.StateMachineTimers = stateMachineTimers
+	for _, timerGroup := range info.StateMachineTimers {
+		for _, timerInfo := range timerGroup.GetInfos() {
+			if timerInfo.Ref != nil {
+				timerInfo.Ref.MachineTransitionCount = 0
+			}
+		}
+	}
 	for _, activityInfo := range state.ActivityInfos {
 		activityInfo.TimerTaskStatus = 0
 	}

--- a/tests/passivepath/context.go
+++ b/tests/passivepath/context.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	commonpb "go.temporal.io/api/common/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
@@ -16,8 +19,11 @@ import (
 	"go.temporal.io/server/common/testing/testhooks"
 	"go.temporal.io/server/service/history/consts"
 	historyi "go.temporal.io/server/service/history/interfaces"
+	historytasks "go.temporal.io/server/service/history/tasks"
 	"go.temporal.io/server/service/history/workflow"
 	wcache "go.temporal.io/server/service/history/workflow/cache"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
 )
 
 const applyTimeout = 30 * time.Second
@@ -53,7 +59,6 @@ func (h *Harness) InterceptUpdate(
 		h.recordBailout(reason)
 		return next()
 	}
-
 	if request.UpdateExecutionTransactionPolicy != historyi.TransactionPolicyActive {
 		h.recordBailout(BailPassivePolicy)
 		if err := request.PrepareMutableStateTransaction(); err != nil {
@@ -64,6 +69,12 @@ func (h *Harness) InterceptUpdate(
 			return err
 		}
 		if request.ExecutionContext != nil {
+			if err := h.comparePassiveState(
+				request.ExecutionContext.GetWorkflowKey(),
+				request.ExecutionContext.MutableState.CloneToProto(),
+			); err != nil {
+				return err
+			}
 			if err := h.comparePassiveTasks(
 				request.ExecutionContext.GetWorkflowKey(),
 				request.ExecutionContext.MutableState,
@@ -73,6 +84,12 @@ func (h *Harness) InterceptUpdate(
 			}
 		}
 		if request.NewMutableState != nil && transactionPayload.NewExecutionSnapshot != nil {
+			if err := h.comparePassiveState(
+				request.NewMutableState.GetWorkflowKey(),
+				request.NewMutableState.CloneToProto(),
+			); err != nil {
+				return err
+			}
 			if err := h.comparePassiveTasks(
 				request.NewMutableState.GetWorkflowKey(),
 				request.NewMutableState,
@@ -89,10 +106,6 @@ func (h *Harness) InterceptUpdate(
 		*request.NewExecutionTransactionPolicy != historyi.TransactionPolicyActive) {
 		return delegate(BailNewRun)
 	}
-	if request.UpdateMode != persistence.UpdateWorkflowModeUpdateCurrent {
-		return delegate(BailUpdateMode)
-	}
-
 	mutableState := request.ExecutionContext.MutableState
 	if mutableState == nil {
 		return delegate(BailNoMutableState)
@@ -100,10 +113,7 @@ func (h *Harness) InterceptUpdate(
 	if len(mutableState.GetExecutionInfo().TransitionHistory) == 0 {
 		return delegate(BailNoTransitionHistory)
 	}
-	if mutableState.HasBufferedEvents() {
-		return delegate(BailBufferedEvents)
-	}
-
+	hasBufferedEvents := mutableState.HasBufferedEvents()
 	exclusiveStart := transitionhistory.CopyVersionedTransition(mutableState.CurrentVersionedTransition())
 	if exclusiveStart == nil {
 		return delegate(BailNoTransitionHistory)
@@ -118,8 +128,24 @@ func (h *Harness) InterceptUpdate(
 	}
 	activeMutation := transactionPayload.ExecutionMutation
 	eventsSeq := transactionPayload.ExecutionEvents
-	if mutableState.HasBufferedEvents() {
-		return errors.New("passivepath: mutable state has buffered events after close")
+	expectedState := mutableState.CloneToProto()
+	replicationTask, err := syncVersionedTransitionTask(activeMutation.Tasks)
+	if err != nil {
+		return err
+	}
+	if transitionhistory.Compare(
+		replicationTask.VersionedTransition,
+		mutableState.CurrentVersionedTransition(),
+	) != 0 {
+		return fmt.Errorf(
+			"passivepath: replication task transition %v does not match mutable state transition %v",
+			replicationTask.VersionedTransition,
+			mutableState.CurrentVersionedTransition(),
+		)
+	}
+	if hasBufferedEvents || mutableState.HasBufferedEvents() {
+		h.recordBailout(BailBufferedEvents)
+		return request.ExecuteExecutionTransaction(transactionPayload)
 	}
 	if activeMutation.ClearBufferedEvents {
 		h.recordBailout(BailClearBufferedEvents)
@@ -132,6 +158,7 @@ func (h *Harness) InterceptUpdate(
 		request.ExecutionContext.GetWorkflowKey(),
 		mutableState,
 		exclusiveStart,
+		replicationTask.VersionedTransition,
 		eventsSeq,
 	)
 	if err != nil {
@@ -149,9 +176,17 @@ func (h *Harness) InterceptUpdate(
 			RunId:      request.NewMutableState.GetExecutionState().GetRunId(),
 			EventBatch: newRunEventBatches[0],
 		}
-		h.expectPassiveTasks(request.NewMutableState.GetWorkflowKey(), transactionPayload.NewExecutionSnapshot.Tasks)
+		h.expectPassiveState(request.NewMutableState.GetWorkflowKey(), request.NewMutableState.CloneToProto(), true)
+		h.expectPassiveTasks(
+			request.NewMutableState.GetWorkflowKey(),
+			tasksWithoutReplication(transactionPayload.NewExecutionSnapshot.Tasks),
+		)
 	}
-	h.expectPassiveTasks(request.ExecutionContext.GetWorkflowKey(), activeMutation.Tasks)
+	h.expectPassiveState(request.ExecutionContext.GetWorkflowKey(), expectedState, false)
+	h.expectPassiveTasks(
+		request.ExecutionContext.GetWorkflowKey(),
+		tasksWithoutReplication(activeMutation.Tasks),
+	)
 
 	workflowKeys := []definition.WorkflowKey{request.ExecutionContext.GetWorkflowKey()}
 	if newRun {
@@ -172,8 +207,154 @@ func (h *Harness) InterceptUpdate(
 		h.recordApplyError(err)
 		return err
 	}
+	if err := h.comparePersistedMutableState(
+		ctx,
+		request.ShardContext,
+		request.ExecutionContext.GetArchetypeID(),
+		request.ExecutionContext.GetWorkflowKey(),
+		expectedState,
+	); err != nil {
+		h.recordApplyError(err)
+		return err
+	}
 	h.recordApplied()
 	return nil
+}
+
+func syncVersionedTransitionTask(
+	tasksByCategory map[historytasks.Category][]historytasks.Task,
+) (*historytasks.SyncVersionedTransitionTask, error) {
+	var result *historytasks.SyncVersionedTransitionTask
+	for _, task := range tasksByCategory[historytasks.CategoryReplication] {
+		syncTask, ok := task.(*historytasks.SyncVersionedTransitionTask)
+		if !ok {
+			continue
+		}
+		if result != nil {
+			return nil, errors.New("passivepath: active transaction generated multiple sync versioned transition tasks")
+		}
+		result = syncTask
+	}
+	if result == nil {
+		return nil, errors.New("passivepath: active transaction generated no sync versioned transition task")
+	}
+	return result, nil
+}
+
+// tasksWithoutReplication removes the active-only replication envelope before task
+// parity is checked. The passive close must regenerate every other task category.
+func tasksWithoutReplication(
+	tasksByCategory map[historytasks.Category][]historytasks.Task,
+) map[historytasks.Category][]historytasks.Task {
+	result := maps.Clone(tasksByCategory)
+	delete(result, historytasks.CategoryReplication)
+	return result
+}
+
+func (h *Harness) comparePersistedMutableState(
+	ctx context.Context,
+	shardContext historyi.ShardContext,
+	archetypeID chasm.ArchetypeID,
+	workflowKey definition.WorkflowKey,
+	expected *persistencespb.WorkflowMutableState,
+) error {
+	response, err := shardContext.GetWorkflowExecution(ctx, &persistence.GetWorkflowExecutionRequest{
+		ShardID:     shardContext.GetShardID(),
+		NamespaceID: workflowKey.NamespaceID,
+		WorkflowID:  workflowKey.WorkflowID,
+		RunID:       workflowKey.RunID,
+		ArchetypeID: archetypeID,
+	})
+	if err != nil {
+		return fmt.Errorf("passivepath: load passively persisted mutable state for %s: %w", workflowKey.String(), err)
+	}
+
+	if diff := mutableStateDiff(expected, response.State); diff != "" {
+		return fmt.Errorf(
+			"passivepath: active/passive mutable state differs for %s (-active +passive):\n%s",
+			workflowKey.String(), diff,
+		)
+	}
+	return nil
+}
+
+func mutableStateDiff(expected, actual *persistencespb.WorkflowMutableState) string {
+	return mutableStateDiffWithOptions(expected, actual, false)
+}
+
+func mutableStateDiffWithOptions(
+	expected *persistencespb.WorkflowMutableState,
+	actual *persistencespb.WorkflowMutableState,
+	rebuiltFromEvents bool,
+) string {
+	expected = proto.Clone(expected).(*persistencespb.WorkflowMutableState)
+	actual = proto.Clone(actual).(*persistencespb.WorkflowMutableState)
+	normalizeMutableStateForComparison(expected)
+	normalizeMutableStateForComparison(actual)
+	if rebuiltFromEvents {
+		normalizeEventRebuiltMutableStateForComparison(expected)
+		normalizeEventRebuiltMutableStateForComparison(actual)
+	}
+	return cmp.Diff(expected, actual, protocmp.Transform())
+}
+
+func normalizeEventRebuiltMutableStateForComparison(state *persistencespb.WorkflowMutableState) {
+	info := state.ExecutionInfo
+	if info != nil {
+		for _, versionHistory := range info.GetVersionHistories().GetHistories() {
+			versionHistory.BranchToken = nil
+		}
+		info.SubStateMachineTombstoneBatches = slices.DeleteFunc(
+			info.SubStateMachineTombstoneBatches,
+			func(batch *persistencespb.StateMachineTombstoneBatch) bool {
+				return len(batch.GetStateMachineTombstones()) == 0
+			},
+		)
+		// Rebuilding the first event initializes this task-refresh watermark locally.
+		info.VisibilityLastUpdateVersionedTransition = nil
+		// The active close and event rebuild derive this timestamp independently and can
+		// differ at sub-millisecond precision without changing workflow semantics.
+		info.WorkflowTaskOriginalScheduledTime = nil
+	}
+	if executionState := state.ExecutionState; executionState != nil {
+		delete(executionState.RequestIds, executionState.CreateRequestId)
+		executionState.CreateRequestId = ""
+	}
+}
+
+func normalizeMutableStateForComparison(state *persistencespb.WorkflowMutableState) {
+	// SignalRequestedIds represents a set even though persistence encodes it as a list.
+	slices.Sort(state.SignalRequestedIds)
+
+	info := state.ExecutionInfo
+	if info == nil {
+		return
+	}
+	// Reuse the production definition of cluster- and shard-local mutable state.
+	workflow.SanitizeMutableState(state)
+	for _, activityInfo := range state.ActivityInfos {
+		activityInfo.TimerTaskStatus = 0
+	}
+	for _, timerInfo := range state.TimerInfos {
+		timerInfo.TaskStatus = 0
+	}
+	// These values describe the local persistence transaction rather than replicated
+	// workflow state. Closing the passive apply necessarily assigns them again.
+	info.LastUpdateTime = nil
+	info.StateTransitionCount = 0
+	// Sticky queues are local worker routing state and are deliberately cleared when
+	// mutable state is synchronized to another cluster.
+	info.StickyTaskQueue = ""
+	info.StickyScheduleToStartTimeout = nil
+	if info.WorkflowTaskStartedEventId == 0 {
+		info.WorkflowTaskStartedTime = nil
+	}
+	if info.ExecutionStats != nil {
+		info.ExecutionStats.HistorySize = 0
+	}
+	if len(info.AutoResetPoints.GetPoints()) == 0 {
+		info.AutoResetPoints = nil
+	}
 }
 
 func (h *Harness) buildArtifact(
@@ -182,12 +363,13 @@ func (h *Harness) buildArtifact(
 	workflowKey definition.WorkflowKey,
 	mutableState historyi.MutableState,
 	exclusiveStart *persistencespb.VersionedTransition,
+	replicationTaskTransition *persistencespb.VersionedTransition,
 	eventsSeq []*persistence.WorkflowEvents,
 ) (*replicationspb.VersionedTransitionArtifact, error) {
 	// SyncStateRetriever normally loads the already-persisted successor run when this
 	// field is set. In this test hook the successor is still only in memory, and its
 	// first event batch is supplied by InterceptUpdate below instead. Hide the ID from
-	// that lookup, then restore it on both mutable state and the generated mutation.
+	// that lookup, then restore it on both mutable state and the generated artifact.
 	successorRunID := mutableState.GetExecutionInfo().GetSuccessorRunId()
 	mutableState.GetExecutionInfo().SuccessorRunId = ""
 	defer func() {
@@ -198,23 +380,41 @@ func (h *Harness) buildArtifact(
 		workflowKey.NamespaceID,
 		&commonpb.WorkflowExecution{WorkflowId: workflowKey.WorkflowID, RunId: workflowKey.RunID},
 		mutableState,
-		exclusiveStart,
+		h.artifactStartTransition(exclusiveStart),
 		nil,
 		wcache.NoopReleaseFn,
 	)
 	if err != nil {
 		return nil, err
 	}
-	artifact := result.VersionedTransitionArtifact
-	if artifact.GetSyncWorkflowStateMutationAttributes() == nil {
-		return nil, fmt.Errorf("passivepath: expected mutation artifact for %s, got snapshot", workflowKey.String())
+	if artifactTransition := transitionhistory.LastVersionedTransition(result.VersionedTransitionHistory); transitionhistory.Compare(
+		artifactTransition,
+		replicationTaskTransition,
+	) != 0 {
+		return nil, fmt.Errorf(
+			"passivepath: artifact transition %v does not match replication task transition %v",
+			artifactTransition,
+			replicationTaskTransition,
+		)
 	}
+	artifact := result.VersionedTransitionArtifact
 	if successorRunID != "" {
-		mutation := artifact.GetSyncWorkflowStateMutationAttributes().GetStateMutation()
-		if mutation.GetExecutionInfo() == nil {
-			return nil, fmt.Errorf("passivepath: mutation for %s has no execution info", workflowKey.String())
+		switch {
+		case artifact.GetSyncWorkflowStateMutationAttributes() != nil:
+			mutation := artifact.GetSyncWorkflowStateMutationAttributes().GetStateMutation()
+			if mutation.GetExecutionInfo() == nil {
+				return nil, fmt.Errorf("passivepath: mutation for %s has no execution info", workflowKey.String())
+			}
+			mutation.ExecutionInfo.SuccessorRunId = successorRunID
+		case artifact.GetSyncWorkflowStateSnapshotAttributes() != nil:
+			snapshot := artifact.GetSyncWorkflowStateSnapshotAttributes().GetState()
+			if snapshot.GetExecutionInfo() == nil {
+				return nil, fmt.Errorf("passivepath: snapshot for %s has no execution info", workflowKey.String())
+			}
+			snapshot.ExecutionInfo.SuccessorRunId = successorRunID
+		default:
+			return nil, fmt.Errorf("passivepath: artifact for %s has no state", workflowKey.String())
 		}
-		mutation.ExecutionInfo.SuccessorRunId = successorRunID
 	}
 	eventBatches, err := h.serializeEvents(eventsSeq)
 	if err != nil {

--- a/tests/passivepath/harness.go
+++ b/tests/passivepath/harness.go
@@ -27,12 +27,14 @@ import (
 
 	enumspb "go.temporal.io/api/enums/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/persistence/serialization"
 	historyi "go.temporal.io/server/service/history/interfaces"
 	"go.temporal.io/server/service/history/replication"
 	historytasks "go.temporal.io/server/service/history/tasks"
+	"google.golang.org/protobuf/proto"
 )
 
 // BailReason records why a write was not diverted through the passive path.
@@ -45,8 +47,6 @@ const (
 	// BailNewRun is an incomplete or non-active update-with-new request. Supported
 	// active continue-as-new requests are diverted together with their successor run.
 	BailNewRun BailReason = "new-run"
-	// BailUpdateMode is an update mode other than UpdateCurrent (e.g. zombie workflows).
-	BailUpdateMode BailReason = "update-mode"
 	// BailNoTransitionHistory means transition history is empty, so there is nothing to
 	// anchor an artifact to. Requires dynamicconfig.EnableTransitionHistory.
 	BailNoTransitionHistory BailReason = "no-transition-history"
@@ -88,9 +88,16 @@ type Harness struct {
 
 	workflows         map[definition.WorkflowKey]struct{}
 	expectedTasks     map[definition.WorkflowKey]map[historytasks.Category][]historytasks.Task
+	expectedStates    map[definition.WorkflowKey]expectedMutableState
 	allowedExtraTasks map[string]struct{}
 	standbyExecutions int
 	compareTasks      bool
+	forceSnapshots    bool
+}
+
+type expectedMutableState struct {
+	state             *persistencespb.WorkflowMutableState
+	rebuiltFromEvents bool
 }
 
 // Intercepted is the number of workflow updates observed by the test hook.
@@ -121,9 +128,45 @@ func NewHarness(logger log.Logger) *Harness {
 		bailouts:          make(map[BailReason]int),
 		workflows:         make(map[definition.WorkflowKey]struct{}),
 		expectedTasks:     make(map[definition.WorkflowKey]map[historytasks.Category][]historytasks.Task),
+		expectedStates:    make(map[definition.WorkflowKey]expectedMutableState),
 		allowedExtraTasks: make(map[string]struct{}),
 		compareTasks:      true,
 	}
+}
+
+func (h *Harness) expectPassiveState(
+	workflowKey definition.WorkflowKey,
+	state *persistencespb.WorkflowMutableState,
+	rebuiltFromEvents bool,
+) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.expectedStates[workflowKey] = expectedMutableState{
+		state:             proto.Clone(state).(*persistencespb.WorkflowMutableState),
+		rebuiltFromEvents: rebuiltFromEvents,
+	}
+}
+
+func (h *Harness) comparePassiveState(
+	workflowKey definition.WorkflowKey,
+	state *persistencespb.WorkflowMutableState,
+) error {
+	h.mu.Lock()
+	expected, ok := h.expectedStates[workflowKey]
+	if ok {
+		delete(h.expectedStates, workflowKey)
+	}
+	h.mu.Unlock()
+	if !ok {
+		return nil
+	}
+	if diff := mutableStateDiffWithOptions(expected.state, state, expected.rebuiltFromEvents); diff != "" {
+		return fmt.Errorf(
+			"passivepath: active/passive mutable state differs for %s (-active +passive):\n%s",
+			workflowKey.String(), diff,
+		)
+	}
+	return nil
 }
 
 func (h *Harness) AllowPassiveOnlyTaskTypes(taskTypes ...string) {
@@ -138,6 +181,25 @@ func (h *Harness) DisableTaskComparison() {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.compareTasks = false
+}
+
+// ForceSnapshotReplication makes every diverted update replicate a full mutable-state
+// snapshot instead of the smallest mutation available from the transition history.
+func (h *Harness) ForceSnapshotReplication() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.forceSnapshots = true
+}
+
+func (h *Harness) artifactStartTransition(
+	exclusiveStart *persistencespb.VersionedTransition,
+) *persistencespb.VersionedTransition {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.forceSnapshots {
+		return nil
+	}
+	return exclusiveStart
 }
 
 func (h *Harness) expectPassiveTasks(
@@ -324,7 +386,7 @@ func (h *Harness) recordIntercepted() {
 // newRetriever builds a SyncStateRetriever for artifact construction.
 //
 // workflowCache, workflowConsistencyChecker and eventBlobCache are nil because the
-// mutation-only path neither takes another lease nor reads already-persisted events.
+// in-memory path neither takes another lease nor reads already-persisted events.
 func (h *Harness) newRetriever(shardContext historyi.ShardContext) replication.SyncStateRetriever {
 	return replication.NewSyncStateRetriever(shardContext, nil, nil, nil, h.logger)
 }

--- a/tests/passivepath/harness_test.go
+++ b/tests/passivepath/harness_test.go
@@ -7,12 +7,94 @@ import (
 
 	"github.com/stretchr/testify/require"
 	enumspb "go.temporal.io/api/enums/v1"
+	workflowpb "go.temporal.io/api/workflow/v1"
+	historyspb "go.temporal.io/server/api/history/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/log"
 	historyi "go.temporal.io/server/service/history/interfaces"
 	historytasks "go.temporal.io/server/service/history/tasks"
 	"go.temporal.io/server/service/history/workflow"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+func TestMutableStateDiffNormalizesOnlyLocalFields(t *testing.T) {
+	expected := &persistencespb.WorkflowMutableState{
+		ExecutionInfo: &persistencespb.WorkflowExecutionInfo{
+			LastUpdateTime:               timestamppb.New(time.Unix(1, 0)),
+			LastFirstEventTxnId:          11,
+			StateTransitionCount:         12,
+			CloseTransferTaskId:          14,
+			CloseVisibilityTaskId:        15,
+			StickyTaskQueue:              "active-sticky-queue",
+			StickyScheduleToStartTimeout: durationpb.New(time.Second),
+			ExecutionStats:               &persistencespb.ExecutionStats{HistorySize: 13},
+			UpdateCount:                  1,
+			WorkflowTaskStartedTime:      timestamppb.New(time.Unix(0, 0)),
+		},
+		SignalRequestedIds: []string{"b", "a"},
+	}
+	actual := &persistencespb.WorkflowMutableState{
+		ExecutionInfo: &persistencespb.WorkflowExecutionInfo{
+			LastUpdateTime:       timestamppb.New(time.Unix(2, 0)),
+			LastFirstEventTxnId:  21,
+			StateTransitionCount: 22,
+			AutoResetPoints:      &workflowpb.ResetPoints{},
+			ExecutionStats:       &persistencespb.ExecutionStats{HistorySize: 23},
+			UpdateCount:          1,
+		},
+		SignalRequestedIds: []string{"a", "b"},
+	}
+	require.Empty(t, mutableStateDiff(expected, actual))
+
+	actual.ExecutionInfo.UpdateCount = 2
+	require.Contains(t, mutableStateDiff(expected, actual), "update_count")
+}
+
+func TestForceSnapshotReplication(t *testing.T) {
+	harness := NewHarness(log.NewNoopLogger())
+	transition := &persistencespb.VersionedTransition{
+		NamespaceFailoverVersion: 1,
+		TransitionCount:          2,
+	}
+	require.Same(t, transition, harness.artifactStartTransition(transition))
+
+	harness.ForceSnapshotReplication()
+	require.Nil(t, harness.artifactStartTransition(transition))
+}
+
+func TestMutableStateDiffNormalizesEventRebuildFieldsOnlyForNewRun(t *testing.T) {
+	state := func(branchToken []byte, requestID string) *persistencespb.WorkflowMutableState {
+		return &persistencespb.WorkflowMutableState{
+			ExecutionInfo: &persistencespb.WorkflowExecutionInfo{
+				WorkflowId: "workflow",
+				VersionHistories: &historyspb.VersionHistories{
+					Histories: []*historyspb.VersionHistory{{BranchToken: branchToken}},
+				},
+				WorkflowTaskOriginalScheduledTime: timestamppb.New(time.Unix(1, 0)),
+			},
+			ExecutionState: &persistencespb.WorkflowExecutionState{
+				CreateRequestId: requestID,
+				RequestIds:      map[string]*persistencespb.RequestIDInfo{requestID: {}},
+			},
+		}
+	}
+	expected := state([]byte("active-branch"), "active-request")
+	expected.ExecutionInfo.SubStateMachineTombstoneBatches = []*persistencespb.StateMachineTombstoneBatch{{}}
+	actual := state([]byte("passive-branch"), "passive-request")
+	actual.ExecutionInfo.VisibilityLastUpdateVersionedTransition = &persistencespb.VersionedTransition{
+		NamespaceFailoverVersion: 1,
+		TransitionCount:          1,
+	}
+	actual.ExecutionInfo.WorkflowTaskOriginalScheduledTime = timestamppb.New(time.Unix(2, 0))
+
+	require.NotEmpty(t, mutableStateDiff(expected, actual))
+	require.Empty(t, mutableStateDiffWithOptions(expected, actual, true))
+
+	actual.ExecutionInfo.WorkflowId = "different-workflow"
+	require.Contains(t, mutableStateDiffWithOptions(expected, actual, true), "workflow_id")
+}
 
 func TestMissingTaskFingerprints(t *testing.T) {
 	require.Empty(t, missingTaskFingerprints(
@@ -27,6 +109,47 @@ func TestMissingTaskFingerprints(t *testing.T) {
 		[]string{"activity", "activity", "passive-only"},
 		[]string{"activity", "activity"},
 	))
+}
+
+func TestSyncVersionedTransitionTask(t *testing.T) {
+	_, err := syncVersionedTransitionTask(nil)
+	require.Error(t, err)
+
+	expected := &historytasks.SyncVersionedTransitionTask{}
+	tasksByCategory := map[historytasks.Category][]historytasks.Task{
+		historytasks.CategoryReplication: {
+			&historytasks.HistoryReplicationTask{},
+			expected,
+		},
+	}
+
+	actual, err := syncVersionedTransitionTask(tasksByCategory)
+	require.NoError(t, err)
+	require.Same(t, expected, actual)
+
+	tasksByCategory[historytasks.CategoryReplication] = append(
+		tasksByCategory[historytasks.CategoryReplication],
+		&historytasks.SyncVersionedTransitionTask{},
+	)
+	_, err = syncVersionedTransitionTask(tasksByCategory)
+	require.Error(t, err)
+}
+
+func TestTasksWithoutReplication(t *testing.T) {
+	workflowKey := definition.NewWorkflowKey("namespace", "workflow", "run")
+	tasksByCategory := map[historytasks.Category][]historytasks.Task{
+		historytasks.CategoryTransfer: {
+			&historytasks.WorkflowTask{WorkflowKey: workflowKey},
+		},
+		historytasks.CategoryReplication: {
+			&historytasks.SyncVersionedTransitionTask{WorkflowKey: workflowKey},
+		},
+	}
+
+	filtered := tasksWithoutReplication(tasksByCategory)
+	require.Contains(t, filtered, historytasks.CategoryTransfer)
+	require.NotContains(t, filtered, historytasks.CategoryReplication)
+	require.Contains(t, tasksByCategory, historytasks.CategoryReplication)
 }
 
 func TestTaskFingerprintsNormalizeOnlyPersistenceAndJitterFields(t *testing.T) {

--- a/tests/passivepath/harness_test.go
+++ b/tests/passivepath/harness_test.go
@@ -52,6 +52,50 @@ func TestMutableStateDiffNormalizesOnlyLocalFields(t *testing.T) {
 	require.Contains(t, mutableStateDiff(expected, actual), "update_count")
 }
 
+func TestMutableStateDiffComparesStateMachineTimers(t *testing.T) {
+	state := func(machineTransitionCount int64) *persistencespb.WorkflowMutableState {
+		return &persistencespb.WorkflowMutableState{
+			ExecutionInfo: &persistencespb.WorkflowExecutionInfo{
+				StateMachineTimers: []*persistencespb.StateMachineTimerGroup{{
+					Deadline:  timestamppb.New(time.Unix(10, 0)),
+					Scheduled: true,
+					Infos: []*persistencespb.StateMachineTaskInfo{{
+						Type: "callback-timeout",
+						Data: []byte("timer-data"),
+						Ref: &persistencespb.StateMachineRef{
+							Path: []*persistencespb.StateMachineKey{{Type: "callback", Id: "id"}},
+							MutableStateVersionedTransition: &persistencespb.VersionedTransition{
+								NamespaceFailoverVersion: 1,
+								TransitionCount:          2,
+							},
+							MachineInitialVersionedTransition: &persistencespb.VersionedTransition{
+								NamespaceFailoverVersion: 1,
+								TransitionCount:          1,
+							},
+							MachineLastUpdateVersionedTransition: &persistencespb.VersionedTransition{
+								NamespaceFailoverVersion: 1,
+								TransitionCount:          2,
+							},
+							MachineTransitionCount: machineTransitionCount,
+						},
+					}},
+				}},
+			},
+		}
+	}
+
+	expected := state(10)
+	actual := state(20)
+	require.Empty(t, mutableStateDiff(expected, actual))
+
+	actual.ExecutionInfo.StateMachineTimers[0].Scheduled = false
+	require.Contains(t, mutableStateDiff(expected, actual), "scheduled")
+
+	actual = state(20)
+	actual.ExecutionInfo.StateMachineTimers[0].Infos[0].Data = []byte("different")
+	require.Contains(t, mutableStateDiff(expected, actual), "data")
+}
+
 func TestForceSnapshotReplication(t *testing.T) {
 	harness := NewHarness(log.NewNoopLogger())
 	transition := &persistencespb.VersionedTransition{

--- a/tests/passivepath/server_test.go
+++ b/tests/passivepath/server_test.go
@@ -26,6 +26,7 @@ import (
 //	PASSIVEPATH_SERVER    must be "1"
 //	PASSIVEPATH_DURATION  how long to stay up (default 10m)
 //	PASSIVEPATH_NAMESPACE global namespace to pre-create (default "default")
+//	PASSIVEPATH_FORCE_SNAPSHOT set to "1" to replicate a full snapshot on every update
 //	PASSIVEPATH_ADDR_FILE file to write the frontend address to (default
 //	                      /tmp/passivepath_frontend_addr)
 //
@@ -54,6 +55,9 @@ func TestPassivePathServer(t *testing.T) {
 	}
 	logger := log.NewNoopLogger() // server logs would drown the stats output
 	harness := NewHarness(logger)
+	if os.Getenv("PASSIVEPATH_FORCE_SNAPSHOT") == "1" {
+		harness.ForceSnapshotReplication()
+	}
 	// Active execution can return the next workflow task inline and deliberately skip
 	// persisting its transfer task. Passive apply cannot use that active-side delivery,
 	// so TaskRefresher must persist the transfer task instead.


### PR DESCRIPTION
## Summary

- require each diverted active transaction to emit a sync-versioned-transition replication task and use its transition to validate the generated artifact
- compare active and passively persisted mutable state while normalizing only cluster-local fields
- compare pending entities, nested state machines, tombstones, and regenerated state machine timer schedules
- support forced-snapshot runs for exercising both mutation and snapshot replication
- add focused coverage for state normalization, replication-task selection, and state-machine timers

## Testing

- go test ./tests/passivepath -count=1 -timeout 5m
- go test -tags test_dep ./tests/passivepath -count=1 -timeout 5m
- OMES throughput_stress with Workflow Updates and same-namespace Nexus enabled: 291/291 diverted transactions applied, no task or mutable-state mismatches, applyErrs=0