### PR TITLE
[Visibility] Adds a feature to route around unreachable ES IPs via per-IP failure cache

### DIFF
--- a/common/persistence/visibility/store/elasticsearch/client/client_v7.go
+++ b/common/persistence/visibility/store/elasticsearch/client/client_v7.go
@@ -65,6 +65,11 @@ func newClient(cfg *Config, httpClient *http.Client, logger log.Logger) (*client
 			httpClient = http.DefaultClient
 		}
 	}
+	if httpClient == nil || httpClient == http.DefaultClient {
+		httpClient = &http.Client{Timeout: 60 * time.Second}
+	} else {
+		httpClient.Timeout = 60 * time.Second
+	}
 
 	// TODO (alex): Remove this when https://github.com/olivere/elastic/pull/1507 is merged.
 	if cfg.CloseIdleConnectionsInterval != time.Duration(0) {

--- a/common/persistence/visibility/store/elasticsearch/client/client_v7.go
+++ b/common/persistence/visibility/store/elasticsearch/client/client_v7.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/olivere/elastic/v7"
@@ -127,8 +128,63 @@ func buildTLSHTTPClient(config *auth.TLS) (*http.Client, error) {
 	return tlsClient, nil
 }
 
-// wrapDialLogger wraps the transport's DialContext to log the remote IP for each new TCP connection
-// to Elasticsearch. Helps diagnose which node is being dialed during zone partition experiments.
+const (
+	// dialFailureCacheTTL is how long an IP stays marked unhealthy before
+	// it is probed again. Short enough to recover quickly after a partition
+	// heals; long enough to avoid hammering a dead node every few seconds.
+	dialFailureCacheTTL = 30 * time.Second
+
+	// dialFailureCacheDialTimeout is the per-IP TCP dial deadline. A SYN
+	// silently dropped by a NACL would otherwise hang until the HTTP-client
+	// timeout (60 s). This short deadline lets each unhealthy IP fail fast so
+	// the loop can proceed to the next candidate.
+	dialFailureCacheDialTimeout = 3 * time.Second
+)
+
+// dialFailureCache tracks recently-failed Elasticsearch node IPs. When a
+// zone partition severs connectivity to some ES nodes, the cache marks those
+// IPs unhealthy and routes new dials to healthy nodes instead, rather than
+// retrying the dead connection at the HTTP-client-timeout cadence.
+type dialFailureCache struct {
+	mu     sync.RWMutex
+	badIPs map[string]time.Time
+	ttl    time.Duration
+}
+
+func newDialFailureCache() *dialFailureCache {
+	return &dialFailureCache{
+		badIPs: make(map[string]time.Time),
+		ttl:    dialFailureCacheTTL,
+	}
+}
+
+func (c *dialFailureCache) isBad(ip string) bool {
+	c.mu.RLock()
+	t, ok := c.badIPs[ip]
+	c.mu.RUnlock()
+	return ok && time.Since(t) < c.ttl
+}
+
+func (c *dialFailureCache) markBad(ip string) {
+	c.mu.Lock()
+	c.badIPs[ip] = time.Now()
+	c.mu.Unlock()
+}
+
+func (c *dialFailureCache) markGood(ip string) {
+	c.mu.Lock()
+	delete(c.badIPs, ip)
+	c.mu.Unlock()
+}
+
+// wrapDialLogger wraps the transport's DialContext to:
+//  1. Log the remote IP for each new TCP connection to Elasticsearch.
+//  2. Route new connections away from recently-failed IPs via a per-IP
+//     failure cache. On each dial the hostname is resolved to all IPs;
+//     IPs not currently marked unhealthy are tried first. A short per-IP
+//     deadline (dialFailureCacheDialTimeout) ensures that a node whose
+//     SYN packets are silently dropped (e.g. by a NACL) fails fast rather
+//     than consuming the full HTTP-client timeout.
 func wrapDialLogger(httpClient *http.Client, logger log.Logger) {
 	var transport *http.Transport
 	switch t := httpClient.Transport.(type) {
@@ -150,16 +206,69 @@ func wrapDialLogger(httpClient *http.Client, logger log.Logger) {
 		}
 		baseDialContext = d.DialContext
 	}
+
+	cb := newDialFailureCache()
+
 	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-		conn, err := baseDialContext(ctx, network, addr)
+		host, port, err := net.SplitHostPort(addr)
 		if err != nil {
-			return nil, err
+			// Malformed addr — fall back to original dialer unchanged.
+			return baseDialContext(ctx, network, addr)
 		}
-		logger.Info("Elasticsearch TCP connection established",
-			tag.NewStringTag("remote_addr", conn.RemoteAddr().String()),
-			tag.NewStringTag("local_addr", conn.LocalAddr().String()),
-		)
-		return conn, nil
+
+		// Resolve the hostname to discover all ES node IPs. This lets us
+		// select a healthy IP rather than relying on the transport to pick
+		// one at random, which may land on a partitioned node.
+		ips, resolveErr := net.DefaultResolver.LookupHost(ctx, host)
+		if resolveErr != nil || len(ips) == 0 {
+			// DNS failure — fall back to original dialer.
+			return baseDialContext(ctx, network, addr)
+		}
+
+		// Separate healthy IPs from recently-failed ones. Try healthy
+		// candidates first; fall back to bad ones only if all are marked
+		// unhealthy (e.g. total cluster outage).
+		var good, bad []string
+		for _, ip := range ips {
+			if cb.isBad(ip) {
+				bad = append(bad, ip)
+			} else {
+				good = append(good, ip)
+			}
+		}
+		candidates := append(good, bad...)
+
+		var lastErr error
+		for _, ip := range candidates {
+			// Short per-IP deadline: fail fast on NACL-dropped SYNs so the
+			// loop can immediately proceed to a reachable node.
+			ipCtx, cancel := context.WithTimeout(ctx, dialFailureCacheDialTimeout)
+			conn, dialErr := baseDialContext(ipCtx, network, net.JoinHostPort(ip, port))
+			cancel()
+
+			if dialErr != nil {
+				cb.markBad(ip)
+				logger.Debug("Elasticsearch TCP connection failed, marking IP unhealthy",
+					tag.NewStringTag("remote_ip", ip),
+					tag.NewStringTag("error", dialErr.Error()),
+				)
+				lastErr = dialErr
+				if ctx.Err() != nil {
+					// Parent context expired; no point trying remaining IPs.
+					break
+				}
+				continue
+			}
+
+			cb.markGood(ip)
+			logger.Debug("Elasticsearch TCP connection established",
+				tag.NewStringTag("remote_addr", conn.RemoteAddr().String()),
+				tag.NewStringTag("local_addr", conn.LocalAddr().String()),
+			)
+			return conn, nil
+		}
+
+		return nil, lastErr
 	}
 }
 

--- a/common/persistence/visibility/store/elasticsearch/client/client_v7.go
+++ b/common/persistence/visibility/store/elasticsearch/client/client_v7.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -14,6 +15,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/server/common/auth"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
 )
 
 type (
@@ -71,6 +73,8 @@ func newClient(cfg *Config, httpClient *http.Client, logger log.Logger) (*client
 		httpClient.Timeout = 60 * time.Second
 	}
 
+	wrapDialLogger(httpClient, logger)
+
 	// TODO (alex): Remove this when https://github.com/olivere/elastic/pull/1507 is merged.
 	if cfg.CloseIdleConnectionsInterval != time.Duration(0) {
 		if cfg.CloseIdleConnectionsInterval < minimumCloseIdleConnectionsInterval {
@@ -121,6 +125,42 @@ func buildTLSHTTPClient(config *auth.TLS) (*http.Client, error) {
 	tlsClient := &http.Client{Transport: transport}
 
 	return tlsClient, nil
+}
+
+// wrapDialLogger wraps the transport's DialContext to log the remote IP for each new TCP connection
+// to Elasticsearch. Helps diagnose which node is being dialed during zone partition experiments.
+func wrapDialLogger(httpClient *http.Client, logger log.Logger) {
+	var transport *http.Transport
+	switch t := httpClient.Transport.(type) {
+	case *http.Transport:
+		transport = t
+	case nil:
+		transport = http.DefaultTransport.(*http.Transport).Clone()
+		httpClient.Transport = transport
+	default:
+		// Non-*http.Transport (e.g. AWS RoundTripper) — cannot wrap DialContext.
+		return
+	}
+
+	baseDialContext := transport.DialContext
+	if baseDialContext == nil {
+		d := &net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}
+		baseDialContext = d.DialContext
+	}
+	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		conn, err := baseDialContext(ctx, network, addr)
+		if err != nil {
+			return nil, err
+		}
+		logger.Info("Elasticsearch TCP connection established",
+			tag.NewStringTag("remote_addr", conn.RemoteAddr().String()),
+			tag.NewStringTag("local_addr", conn.LocalAddr().String()),
+		)
+		return conn, nil
+	}
 }
 
 func (c *clientImpl) Get(ctx context.Context, index string, docID string) (*elastic.GetResult, error) {

--- a/common/persistence/visibility/store/elasticsearch/client/client_v7.go
+++ b/common/persistence/visibility/store/elasticsearch/client/client_v7.go
@@ -135,7 +135,7 @@ const (
 	dialFailureCacheTTL = 30 * time.Second
 
 	// dialFailureCacheDialTimeout is the per-IP TCP dial deadline. A SYN
-	// silently dropped by a NACL would otherwise hang until the HTTP-client
+	// silently dropped by a network call would otherwise hang until the HTTP-client
 	// timeout (60 s). This short deadline lets each unhealthy IP fail fast so
 	// the loop can proceed to the next candidate.
 	dialFailureCacheDialTimeout = 3 * time.Second
@@ -177,6 +177,32 @@ func (c *dialFailureCache) markGood(ip string) {
 	c.mu.Unlock()
 }
 
+// startCleanup starts a background goroutine that periodically evicts entries
+// whose TTL has expired. This prevents stale IPs from accumulating when ES
+// nodes are replaced (new IPs replacing old ones that were never seen again).
+// The goroutine stops when ctx is cancelled.
+func (c *dialFailureCache) startCleanup(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(c.ttl * 2)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				now := time.Now()
+				c.mu.Lock()
+				for ip, t := range c.badIPs {
+					if now.Sub(t) >= c.ttl {
+						delete(c.badIPs, ip)
+					}
+				}
+				c.mu.Unlock()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
 // wrapDialLogger wraps the transport's DialContext to:
 //  1. Log the remote IP for each new TCP connection to Elasticsearch.
 //  2. Route new connections away from recently-failed IPs via a per-IP
@@ -208,6 +234,7 @@ func wrapDialLogger(httpClient *http.Client, logger log.Logger) {
 	}
 
 	cb := newDialFailureCache()
+	cb.startCleanup(context.Background())
 
 	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 		host, port, err := net.SplitHostPort(addr)
@@ -218,7 +245,7 @@ func wrapDialLogger(httpClient *http.Client, logger log.Logger) {
 
 		// Resolve the hostname to discover all ES node IPs. This lets us
 		// select a healthy IP rather than relying on the transport to pick
-		// one at random, which may land on a partitioned node.
+		// one at random, which may land on a bad node.
 		ips, resolveErr := net.DefaultResolver.LookupHost(ctx, host)
 		if resolveErr != nil || len(ips) == 0 {
 			// DNS failure — fall back to original dialer.

--- a/common/persistence/visibility/store/elasticsearch/client/client_v7_test.go
+++ b/common/persistence/visibility/store/elasticsearch/client/client_v7_test.go
@@ -1,0 +1,246 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/log"
+)
+
+// nonHTTPTransport is a RoundTripper that is not *http.Transport, used to
+// verify that wrapDialLogger bails out on unsupported transport types.
+type nonHTTPTransport struct{}
+
+func (t *nonHTTPTransport) RoundTrip(*http.Request) (*http.Response, error) { return nil, nil }
+
+// ===== dialFailureCache =====
+
+func TestDialFailureCache_UnknownIP_IsNotBad(t *testing.T) {
+	c := newDialFailureCache()
+	assert.False(t, c.isBad("10.0.0.1"))
+}
+
+func TestDialFailureCache_MarkBad_IsBad(t *testing.T) {
+	c := newDialFailureCache()
+	c.markBad("10.0.0.1")
+	assert.True(t, c.isBad("10.0.0.1"))
+}
+
+func TestDialFailureCache_MarkGood_ClearsIP(t *testing.T) {
+	c := newDialFailureCache()
+	c.markBad("10.0.0.1")
+	c.markGood("10.0.0.1")
+	assert.False(t, c.isBad("10.0.0.1"))
+}
+
+func TestDialFailureCache_MarkGood_UnknownIP_NoOp(t *testing.T) {
+	c := newDialFailureCache()
+	c.markGood("10.0.0.1") // should not panic
+	assert.False(t, c.isBad("10.0.0.1"))
+}
+
+func TestDialFailureCache_TTLExpired_IsNotBad(t *testing.T) {
+	c := &dialFailureCache{
+		badIPs: make(map[string]time.Time),
+		ttl:    5 * time.Millisecond,
+	}
+	c.markBad("10.0.0.1")
+	assert.True(t, c.isBad("10.0.0.1"))
+	time.Sleep(10 * time.Millisecond)
+	assert.False(t, c.isBad("10.0.0.1"))
+}
+
+func TestDialFailureCache_Cleanup_RemovesExpiredEntries(t *testing.T) {
+	c := &dialFailureCache{
+		badIPs: make(map[string]time.Time),
+		ttl:    5 * time.Millisecond,
+	}
+	c.markBad("10.0.0.1")
+	c.markBad("10.0.0.2")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c.startCleanup(ctx)
+
+	// Cleanup interval is 2*ttl (10ms); wait long enough for it to fire.
+	time.Sleep(50 * time.Millisecond)
+
+	c.mu.RLock()
+	_, ip1Exists := c.badIPs["10.0.0.1"]
+	_, ip2Exists := c.badIPs["10.0.0.2"]
+	c.mu.RUnlock()
+	assert.False(t, ip1Exists, "expired entry should be evicted")
+	assert.False(t, ip2Exists, "expired entry should be evicted")
+}
+
+func TestDialFailureCache_Cleanup_DoesNotRemoveUnexpiredEntries(t *testing.T) {
+	c := &dialFailureCache{
+		badIPs: make(map[string]time.Time),
+		ttl:    10 * time.Second,
+	}
+	c.markBad("10.0.0.1")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c.startCleanup(ctx)
+
+	time.Sleep(10 * time.Millisecond)
+
+	c.mu.RLock()
+	_, exists := c.badIPs["10.0.0.1"]
+	c.mu.RUnlock()
+	assert.True(t, exists, "unexpired entry should not be evicted")
+}
+
+func TestDialFailureCache_Cleanup_StopsOnContextCancel(t *testing.T) {
+	c := newDialFailureCache()
+	ctx, cancel := context.WithCancel(context.Background())
+	c.startCleanup(ctx)
+	cancel() // goroutine should exit cleanly, no panic
+}
+
+// ===== wrapDialLogger =====
+
+func TestWrapDialLogger_NonHTTPTransport_Unchanged(t *testing.T) {
+	custom := &nonHTTPTransport{}
+	httpClient := &http.Client{Transport: custom}
+	wrapDialLogger(httpClient, log.NewNoopLogger())
+	assert.Equal(t, custom, httpClient.Transport, "non-*http.Transport should not be replaced")
+}
+
+func TestWrapDialLogger_NilTransport_SetsHTTPTransport(t *testing.T) {
+	httpClient := &http.Client{}
+	wrapDialLogger(httpClient, log.NewNoopLogger())
+	_, ok := httpClient.Transport.(*http.Transport)
+	assert.True(t, ok, "expected a *http.Transport to be set on the client")
+}
+
+func TestWrapDialLogger_DialSuccess_ReturnsConn(t *testing.T) {
+	server, pipe := net.Pipe()
+	defer server.Close()
+
+	transport := &http.Transport{}
+	transport.DialContext = func(_ context.Context, _, _ string) (net.Conn, error) {
+		return pipe, nil
+	}
+
+	httpClient := &http.Client{Transport: transport}
+	wrapDialLogger(httpClient, log.NewNoopLogger())
+
+	conn, err := transport.DialContext(context.Background(), "tcp", "127.0.0.1:9200")
+	require.NoError(t, err)
+	conn.Close()
+}
+
+func TestWrapDialLogger_DialFailure_ReturnsError(t *testing.T) {
+	transport := &http.Transport{}
+	transport.DialContext = func(_ context.Context, _, _ string) (net.Conn, error) {
+		return nil, errors.New("connection refused")
+	}
+
+	httpClient := &http.Client{Transport: transport}
+	wrapDialLogger(httpClient, log.NewNoopLogger())
+
+	_, err := transport.DialContext(context.Background(), "tcp", "127.0.0.1:9200")
+	assert.Error(t, err)
+}
+
+// TestWrapDialLogger_BaseDialer_CalledWithIP verifies that the wrapped DialContext
+// passes a bare IP address (not the original hostname) to the base dialer, so
+// the base dialer skips its own DNS resolution.
+func TestWrapDialLogger_BaseDialer_CalledWithIP(t *testing.T) {
+	server, pipe := net.Pipe()
+	defer server.Close()
+
+	var calledAddr string
+	transport := &http.Transport{}
+	transport.DialContext = func(_ context.Context, _, addr string) (net.Conn, error) {
+		calledAddr = addr
+		return pipe, nil
+	}
+
+	httpClient := &http.Client{Transport: transport}
+	wrapDialLogger(httpClient, log.NewNoopLogger())
+
+	conn, err := transport.DialContext(context.Background(), "tcp", "127.0.0.1:9200")
+	require.NoError(t, err)
+	conn.Close()
+
+	assert.Equal(t, "127.0.0.1:9200", calledAddr)
+}
+
+// TestWrapDialLogger_FailedDial_MarksIPBad verifies that after a dial failure the
+// IP is treated as unhealthy: a second dial to the same address still attempts
+// the IP (it is the only candidate) but the cache records it as bad.
+func TestWrapDialLogger_FailedDial_MarksIPBad(t *testing.T) {
+	callCount := 0
+	server, pipe := net.Pipe()
+	defer server.Close()
+
+	transport := &http.Transport{}
+	transport.DialContext = func(_ context.Context, _, _ string) (net.Conn, error) {
+		callCount++
+		if callCount == 1 {
+			return nil, errors.New("first dial fails")
+		}
+		return pipe, nil
+	}
+
+	httpClient := &http.Client{Transport: transport}
+	wrapDialLogger(httpClient, log.NewNoopLogger())
+
+	// First dial fails.
+	_, err := transport.DialContext(context.Background(), "tcp", "127.0.0.1:9200")
+	assert.Error(t, err)
+
+	// Second dial succeeds — IP is still tried (only candidate) but now marked good again.
+	conn, err := transport.DialContext(context.Background(), "tcp", "127.0.0.1:9200")
+	require.NoError(t, err)
+	conn.Close()
+
+	assert.Equal(t, 2, callCount)
+}
+
+func TestWrapDialLogger_MalformedAddr_FallsBackToBaseDialer(t *testing.T) {
+	server, pipe := net.Pipe()
+	defer server.Close()
+
+	var calledAddr string
+	transport := &http.Transport{}
+	transport.DialContext = func(_ context.Context, _, addr string) (net.Conn, error) {
+		calledAddr = addr
+		return pipe, nil
+	}
+
+	httpClient := &http.Client{Transport: transport}
+	wrapDialLogger(httpClient, log.NewNoopLogger())
+
+	conn, err := transport.DialContext(context.Background(), "tcp", "not-valid-addr")
+	require.NoError(t, err)
+	conn.Close()
+
+	// Malformed addr: wrapper cannot split host/port, so it falls back unchanged.
+	assert.Equal(t, "not-valid-addr", calledAddr)
+}
+
+func TestWrapDialLogger_CancelledContext_ReturnsError(t *testing.T) {
+	transport := &http.Transport{}
+	transport.DialContext = func(_ context.Context, _, _ string) (net.Conn, error) {
+		return nil, errors.New("dial error")
+	}
+
+	httpClient := &http.Client{Transport: transport}
+	wrapDialLogger(httpClient, log.NewNoopLogger())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := transport.DialContext(ctx, "tcp", "127.0.0.1:9200")
+	assert.Error(t, err)
+}

--- a/common/persistence/visibility/store/elasticsearch/client/client_v7_test.go
+++ b/common/persistence/visibility/store/elasticsearch/client/client_v7_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/testing/await"
 )
 
 // nonHTTPTransport is a RoundTripper that is not *http.Transport, used to
@@ -23,26 +23,26 @@ func (t *nonHTTPTransport) RoundTrip(*http.Request) (*http.Response, error) { re
 
 func TestDialFailureCache_UnknownIP_IsNotBad(t *testing.T) {
 	c := newDialFailureCache()
-	assert.False(t, c.isBad("10.0.0.1"))
+	require.False(t, c.isBad("10.0.0.1"))
 }
 
 func TestDialFailureCache_MarkBad_IsBad(t *testing.T) {
 	c := newDialFailureCache()
 	c.markBad("10.0.0.1")
-	assert.True(t, c.isBad("10.0.0.1"))
+	require.True(t, c.isBad("10.0.0.1"))
 }
 
 func TestDialFailureCache_MarkGood_ClearsIP(t *testing.T) {
 	c := newDialFailureCache()
 	c.markBad("10.0.0.1")
 	c.markGood("10.0.0.1")
-	assert.False(t, c.isBad("10.0.0.1"))
+	require.False(t, c.isBad("10.0.0.1"))
 }
 
 func TestDialFailureCache_MarkGood_UnknownIP_NoOp(t *testing.T) {
 	c := newDialFailureCache()
 	c.markGood("10.0.0.1") // should not panic
-	assert.False(t, c.isBad("10.0.0.1"))
+	require.False(t, c.isBad("10.0.0.1"))
 }
 
 func TestDialFailureCache_TTLExpired_IsNotBad(t *testing.T) {
@@ -51,9 +51,10 @@ func TestDialFailureCache_TTLExpired_IsNotBad(t *testing.T) {
 		ttl:    5 * time.Millisecond,
 	}
 	c.markBad("10.0.0.1")
-	assert.True(t, c.isBad("10.0.0.1"))
-	time.Sleep(10 * time.Millisecond)
-	assert.False(t, c.isBad("10.0.0.1"))
+	require.True(t, c.isBad("10.0.0.1"))
+	await.RequireTrue(t, func() bool {
+		return !c.isBad("10.0.0.1")
+	}, 100*time.Millisecond, 5*time.Millisecond)
 }
 
 func TestDialFailureCache_Cleanup_RemovesExpiredEntries(t *testing.T) {
@@ -64,45 +65,38 @@ func TestDialFailureCache_Cleanup_RemovesExpiredEntries(t *testing.T) {
 	c.markBad("10.0.0.1")
 	c.markBad("10.0.0.2")
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	c.startCleanup(ctx)
+	c.startCleanup(t.Context())
 
-	// Cleanup interval is 2*ttl (10ms); wait long enough for it to fire.
-	time.Sleep(50 * time.Millisecond)
-
-	c.mu.RLock()
-	_, ip1Exists := c.badIPs["10.0.0.1"]
-	_, ip2Exists := c.badIPs["10.0.0.2"]
-	c.mu.RUnlock()
-	assert.False(t, ip1Exists, "expired entry should be evicted")
-	assert.False(t, ip2Exists, "expired entry should be evicted")
+	// Cleanup interval is 2*ttl (10ms); poll until both entries are evicted.
+	await.RequireTrue(t, func() bool {
+		c.mu.RLock()
+		_, ip1Exists := c.badIPs["10.0.0.1"]
+		_, ip2Exists := c.badIPs["10.0.0.2"]
+		c.mu.RUnlock()
+		return !ip1Exists && !ip2Exists
+	}, 200*time.Millisecond, 5*time.Millisecond)
 }
 
 func TestDialFailureCache_Cleanup_DoesNotRemoveUnexpiredEntries(t *testing.T) {
 	c := &dialFailureCache{
 		badIPs: make(map[string]time.Time),
-		ttl:    10 * time.Second,
+		ttl:    10 * time.Second, // cleanup interval is 20s — cannot have fired yet
 	}
 	c.markBad("10.0.0.1")
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	c.startCleanup(ctx)
-
-	time.Sleep(10 * time.Millisecond)
+	c.startCleanup(t.Context())
 
 	c.mu.RLock()
 	_, exists := c.badIPs["10.0.0.1"]
 	c.mu.RUnlock()
-	assert.True(t, exists, "unexpired entry should not be evicted")
+	require.True(t, exists, "unexpired entry should not be evicted")
 }
 
 func TestDialFailureCache_Cleanup_StopsOnContextCancel(t *testing.T) {
 	c := newDialFailureCache()
 	ctx, cancel := context.WithCancel(context.Background())
 	c.startCleanup(ctx)
-	cancel() // goroutine should exit cleanly, no panic
+	cancel() // goroutine should exit cleanly
 }
 
 // ===== wrapDialLogger =====
@@ -111,19 +105,19 @@ func TestWrapDialLogger_NonHTTPTransport_Unchanged(t *testing.T) {
 	custom := &nonHTTPTransport{}
 	httpClient := &http.Client{Transport: custom}
 	wrapDialLogger(httpClient, log.NewNoopLogger())
-	assert.Equal(t, custom, httpClient.Transport, "non-*http.Transport should not be replaced")
+	require.Equal(t, custom, httpClient.Transport, "non-*http.Transport should not be replaced")
 }
 
 func TestWrapDialLogger_NilTransport_SetsHTTPTransport(t *testing.T) {
 	httpClient := &http.Client{}
 	wrapDialLogger(httpClient, log.NewNoopLogger())
 	_, ok := httpClient.Transport.(*http.Transport)
-	assert.True(t, ok, "expected a *http.Transport to be set on the client")
+	require.True(t, ok, "expected a *http.Transport to be set on the client")
 }
 
 func TestWrapDialLogger_DialSuccess_ReturnsConn(t *testing.T) {
 	server, pipe := net.Pipe()
-	defer server.Close()
+	t.Cleanup(func() { _ = server.Close() })
 
 	transport := &http.Transport{}
 	transport.DialContext = func(_ context.Context, _, _ string) (net.Conn, error) {
@@ -135,7 +129,7 @@ func TestWrapDialLogger_DialSuccess_ReturnsConn(t *testing.T) {
 
 	conn, err := transport.DialContext(context.Background(), "tcp", "127.0.0.1:9200")
 	require.NoError(t, err)
-	conn.Close()
+	_ = conn.Close()
 }
 
 func TestWrapDialLogger_DialFailure_ReturnsError(t *testing.T) {
@@ -148,7 +142,7 @@ func TestWrapDialLogger_DialFailure_ReturnsError(t *testing.T) {
 	wrapDialLogger(httpClient, log.NewNoopLogger())
 
 	_, err := transport.DialContext(context.Background(), "tcp", "127.0.0.1:9200")
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 // TestWrapDialLogger_BaseDialer_CalledWithIP verifies that the wrapped DialContext
@@ -156,7 +150,7 @@ func TestWrapDialLogger_DialFailure_ReturnsError(t *testing.T) {
 // the base dialer skips its own DNS resolution.
 func TestWrapDialLogger_BaseDialer_CalledWithIP(t *testing.T) {
 	server, pipe := net.Pipe()
-	defer server.Close()
+	t.Cleanup(func() { _ = server.Close() })
 
 	var calledAddr string
 	transport := &http.Transport{}
@@ -170,18 +164,18 @@ func TestWrapDialLogger_BaseDialer_CalledWithIP(t *testing.T) {
 
 	conn, err := transport.DialContext(context.Background(), "tcp", "127.0.0.1:9200")
 	require.NoError(t, err)
-	conn.Close()
+	_ = conn.Close()
 
-	assert.Equal(t, "127.0.0.1:9200", calledAddr)
+	require.Equal(t, "127.0.0.1:9200", calledAddr)
 }
 
 // TestWrapDialLogger_FailedDial_MarksIPBad verifies that after a dial failure the
-// IP is treated as unhealthy: a second dial to the same address still attempts
-// the IP (it is the only candidate) but the cache records it as bad.
+// IP is marked unhealthy and a subsequent dial still attempts it (only candidate)
+// but can succeed once the underlying issue is resolved.
 func TestWrapDialLogger_FailedDial_MarksIPBad(t *testing.T) {
 	callCount := 0
 	server, pipe := net.Pipe()
-	defer server.Close()
+	t.Cleanup(func() { _ = server.Close() })
 
 	transport := &http.Transport{}
 	transport.DialContext = func(_ context.Context, _, _ string) (net.Conn, error) {
@@ -197,19 +191,18 @@ func TestWrapDialLogger_FailedDial_MarksIPBad(t *testing.T) {
 
 	// First dial fails.
 	_, err := transport.DialContext(context.Background(), "tcp", "127.0.0.1:9200")
-	assert.Error(t, err)
+	require.Error(t, err)
 
-	// Second dial succeeds — IP is still tried (only candidate) but now marked good again.
+	// Second dial succeeds.
 	conn, err := transport.DialContext(context.Background(), "tcp", "127.0.0.1:9200")
 	require.NoError(t, err)
-	conn.Close()
-
-	assert.Equal(t, 2, callCount)
+	_ = conn.Close()
+	require.Equal(t, 2, callCount)
 }
 
 func TestWrapDialLogger_MalformedAddr_FallsBackToBaseDialer(t *testing.T) {
 	server, pipe := net.Pipe()
-	defer server.Close()
+	t.Cleanup(func() { _ = server.Close() })
 
 	var calledAddr string
 	transport := &http.Transport{}
@@ -221,12 +214,11 @@ func TestWrapDialLogger_MalformedAddr_FallsBackToBaseDialer(t *testing.T) {
 	httpClient := &http.Client{Transport: transport}
 	wrapDialLogger(httpClient, log.NewNoopLogger())
 
+	// Malformed addr: wrapper cannot split host/port, falls back to base dialer unchanged.
 	conn, err := transport.DialContext(context.Background(), "tcp", "not-valid-addr")
 	require.NoError(t, err)
-	conn.Close()
-
-	// Malformed addr: wrapper cannot split host/port, so it falls back unchanged.
-	assert.Equal(t, "not-valid-addr", calledAddr)
+	_ = conn.Close()
+	require.Equal(t, "not-valid-addr", calledAddr)
 }
 
 func TestWrapDialLogger_CancelledContext_ReturnsError(t *testing.T) {
@@ -242,5 +234,5 @@ func TestWrapDialLogger_CancelledContext_ReturnsError(t *testing.T) {
 	cancel()
 
 	_, err := transport.DialContext(ctx, "tcp", "127.0.0.1:9200")
-	assert.Error(t, err)
+	require.Error(t, err)
 }

--- a/common/persistence/visibility/store/elasticsearch/processor.go
+++ b/common/persistence/visibility/store/elasticsearch/processor.go
@@ -176,7 +176,9 @@ func (p *processorImpl) Add(request *client.BulkableRequest, visibilityTaskKey s
 		return nil
 	})
 	if !isDup {
+		p.logger.Info("Adding request to Elasticsearch bulk processor.", tag.Key(visibilityTaskKey), tag.ESDocID(request.ID))
 		p.bulkProcessor.Add(request)
+		p.logger.Info("Added request to Elasticsearch bulk processor.", tag.Key(visibilityTaskKey), tag.ESDocID(request.ID))
 		newFuture.recordAdd(p.metricsHandler)
 	}
 	return newFuture.future
@@ -184,6 +186,7 @@ func (p *processorImpl) Add(request *client.BulkableRequest, visibilityTaskKey s
 
 // bulkBeforeAction is triggered before bulk processor commit
 func (p *processorImpl) bulkBeforeAction(_ int64, requests []elastic.BulkableRequest) {
+	p.logger.Info("Elasticsearch bulk processor committing bulk.", tag.RequestCount(len(requests)))
 	metrics.ElasticsearchBulkProcessorRequests.With(p.metricsHandler).Record(int64(len(requests)))
 	p.metricsHandler.Histogram(metrics.ElasticsearchBulkProcessorBulkSize.Name(), metrics.ElasticsearchBulkProcessorBulkSize.Unit()).
 		Record(int64(len(requests)))
@@ -206,6 +209,7 @@ func (p *processorImpl) bulkBeforeAction(_ int64, requests []elastic.BulkableReq
 
 // bulkAfterAction is triggered after bulk processor commit
 func (p *processorImpl) bulkAfterAction(_ int64, requests []elastic.BulkableRequest, response *elastic.BulkResponse, err error) {
+	p.logger.Info("Elasticsearch bulk processor bulk committed.", tag.RequestCount(len(requests)), tag.Error(err))
 	if err != nil {
 		const logFirstNRequests = 5
 		var httpStatus int
@@ -291,6 +295,7 @@ func (p *processorImpl) buildResponseIndex(response *elastic.BulkResponse) map[s
 }
 
 func (p *processorImpl) notifyResult(visibilityTaskKey string, ack bool) {
+	p.logger.Info("Notifying ES indexing result.", tag.Key(visibilityTaskKey), tag.Value(ack))
 	// Use RemoveIf here to prevent race condition with de-dup logic in Add method.
 	_ = p.mapToAckFuture.RemoveIf(visibilityTaskKey, func(key any, value any) bool {
 		ackF, ok := value.(*ackFuture)

--- a/common/persistence/visibility/store/elasticsearch/processor.go
+++ b/common/persistence/visibility/store/elasticsearch/processor.go
@@ -176,9 +176,9 @@ func (p *processorImpl) Add(request *client.BulkableRequest, visibilityTaskKey s
 		return nil
 	})
 	if !isDup {
-		p.logger.Info("Adding request to Elasticsearch bulk processor.", tag.Key(visibilityTaskKey), tag.ESDocID(request.ID))
+		p.logger.Debug("Adding request to Elasticsearch bulk processor.", tag.Key(visibilityTaskKey), tag.ESDocID(request.ID))
 		p.bulkProcessor.Add(request)
-		p.logger.Info("Added request to Elasticsearch bulk processor.", tag.Key(visibilityTaskKey), tag.ESDocID(request.ID))
+		p.logger.Debug("Added request to Elasticsearch bulk processor.", tag.Key(visibilityTaskKey), tag.ESDocID(request.ID))
 		newFuture.recordAdd(p.metricsHandler)
 	}
 	return newFuture.future
@@ -186,7 +186,7 @@ func (p *processorImpl) Add(request *client.BulkableRequest, visibilityTaskKey s
 
 // bulkBeforeAction is triggered before bulk processor commit
 func (p *processorImpl) bulkBeforeAction(_ int64, requests []elastic.BulkableRequest) {
-	p.logger.Info("Elasticsearch bulk processor committing bulk.", tag.RequestCount(len(requests)))
+	p.logger.Debug("Elasticsearch bulk processor committing bulk.", tag.RequestCount(len(requests)))
 	metrics.ElasticsearchBulkProcessorRequests.With(p.metricsHandler).Record(int64(len(requests)))
 	p.metricsHandler.Histogram(metrics.ElasticsearchBulkProcessorBulkSize.Name(), metrics.ElasticsearchBulkProcessorBulkSize.Unit()).
 		Record(int64(len(requests)))
@@ -209,7 +209,7 @@ func (p *processorImpl) bulkBeforeAction(_ int64, requests []elastic.BulkableReq
 
 // bulkAfterAction is triggered after bulk processor commit
 func (p *processorImpl) bulkAfterAction(_ int64, requests []elastic.BulkableRequest, response *elastic.BulkResponse, err error) {
-	p.logger.Info("Elasticsearch bulk processor bulk committed.", tag.RequestCount(len(requests)), tag.Error(err))
+	p.logger.Debug("Elasticsearch bulk processor bulk committed.", tag.RequestCount(len(requests)), tag.Error(err))
 	if err != nil {
 		const logFirstNRequests = 5
 		var httpStatus int
@@ -295,7 +295,7 @@ func (p *processorImpl) buildResponseIndex(response *elastic.BulkResponse) map[s
 }
 
 func (p *processorImpl) notifyResult(visibilityTaskKey string, ack bool) {
-	p.logger.Info("Notifying ES indexing result.", tag.Key(visibilityTaskKey), tag.Value(ack))
+	p.logger.Debug("Notifying ES indexing result.", tag.Key(visibilityTaskKey), tag.Value(ack))
 	// Use RemoveIf here to prevent race condition with de-dup logic in Add method.
 	_ = p.mapToAckFuture.RemoveIf(visibilityTaskKey, func(key any, value any) bool {
 		ackF, ok := value.(*ackFuture)


### PR DESCRIPTION
## Problem

Existing HTTP client has no timeout and per IP health awareness if ES nodes become unreachable (especially when the traffic is silently dropped). There exists some healthchecks mechanism in the current client, but the health check only tracks at the hostname level (https://github.com/olivere/elastic/blob/release-branch.v7/connection.go#L17). Practically, the hostname returns more than one IP, with each IP representing a data node, so if there is a single bad IP, then all connections would be churned. There is also no guarantee that new connections will not land on the unreachable IPs.

## Changes

This PR introduces a small cache that tracks bad IPs and skips them when dialing the hostname via a custom DialContext. 

Specifically, the custom DialContext resolves the hostname first, and will try the healthy IPs first before trying the previously bad ones (so it should work if all IPs were temporarily down). Bad/failed IPs are cached seconds, and a clean up job is included to clean up the cache should there be any node replacements.

Note that this doesn't introduce any new traffic. DialContext should be called when the Transport pool doesn't have a connection that it needs, and that's where the new cache will be used
