### PR TITLE
Render alerts details as code blocks in test summaries

### DIFF
--- a/tools/testrunner/summary.go
+++ b/tools/testrunner/summary.go
@@ -117,13 +117,8 @@ func (row summaryRow) Markdown() string {
 		if strings.Contains(row.Details, summaryTruncatedMarker) {
 			details += "\n… (truncated — see full output in job logs)"
 		}
-		if row.Kind == failureTypeDataRace {
-			fmt.Fprintf(&sb, "<details><summary>%s</summary>\n\n%s\n\n</details>",
-				html.EscapeString(row.Name), markdownCodeBlock(details))
-		} else {
-			fmt.Fprintf(&sb, "<details><summary>%s</summary><pre>%s</pre></details>",
-				html.EscapeString(row.Name), html.EscapeString(details))
-		}
+		fmt.Fprintf(&sb, "<details><summary>%s</summary>\n\n%s\n\n</details>",
+			html.EscapeString(row.Name), markdownCodeBlock(details))
 	} else {
 		sb.WriteString(html.EscapeString(row.Name))
 	}

--- a/tools/testrunner/summary.go
+++ b/tools/testrunner/summary.go
@@ -113,12 +113,8 @@ func (row summaryRow) Markdown() string {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "<tr><td>%s</td><td>", html.EscapeString(kind))
 	if row.Details != "" {
-		details := row.Details
-		if strings.Contains(row.Details, summaryTruncatedMarker) {
-			details += "\n… (truncated — see full output in job logs)"
-		}
 		fmt.Fprintf(&sb, "<details><summary>%s</summary>\n\n%s\n\n</details>",
-			html.EscapeString(row.Name), markdownCodeBlock(details))
+			html.EscapeString(row.Name), markdownCodeBlock(row.Details))
 	} else {
 		sb.WriteString(html.EscapeString(row.Name))
 	}
@@ -131,14 +127,5 @@ func markdownCodeBlock(content string) string {
 	for strings.Contains(content, fence) {
 		fence += "`"
 	}
-
-	var sb strings.Builder
-	sb.WriteString(fence)
-	sb.WriteByte('\n')
-	sb.WriteString(content)
-	if !strings.HasSuffix(content, "\n") {
-		sb.WriteByte('\n')
-	}
-	sb.WriteString(fence)
-	return sb.String()
+	return fence + "\n" + strings.TrimSuffix(content, "\n") + "\n" + fence
 }

--- a/tools/testrunner/summary.go
+++ b/tools/testrunner/summary.go
@@ -113,15 +113,37 @@ func (row summaryRow) Markdown() string {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "<tr><td>%s</td><td>", html.EscapeString(kind))
 	if row.Details != "" {
-		escaped := html.EscapeString(row.Details)
+		details := row.Details
 		if strings.Contains(row.Details, summaryTruncatedMarker) {
-			escaped += "\n… (truncated — see full output in job logs)"
+			details += "\n… (truncated — see full output in job logs)"
 		}
-		fmt.Fprintf(&sb, "<details><summary>%s</summary><pre>%s</pre></details>",
-			html.EscapeString(row.Name), escaped)
+		if row.Kind == failureTypeDataRace {
+			fmt.Fprintf(&sb, "<details><summary>%s</summary>\n\n%s\n\n</details>",
+				html.EscapeString(row.Name), markdownCodeBlock(details))
+		} else {
+			fmt.Fprintf(&sb, "<details><summary>%s</summary><pre>%s</pre></details>",
+				html.EscapeString(row.Name), html.EscapeString(details))
+		}
 	} else {
 		sb.WriteString(html.EscapeString(row.Name))
 	}
 	sb.WriteString("</td></tr>\n")
+	return sb.String()
+}
+
+func markdownCodeBlock(content string) string {
+	fence := "```"
+	for strings.Contains(content, fence) {
+		fence += "`"
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fence)
+	sb.WriteByte('\n')
+	sb.WriteString(content)
+	if !strings.HasSuffix(content, "\n") {
+		sb.WriteByte('\n')
+	}
+	sb.WriteString(fence)
 	return sb.String()
 }

--- a/tools/testrunner/summary_test.go
+++ b/tools/testrunner/summary_test.go
@@ -116,12 +116,14 @@ func TestRenderSummaryFromReports_Markdown_RendersTrimmedFailureBody(t *testing.
 	require.NotContains(t, s, "some setup log")
 }
 
-func TestRenderSummaryFromReports_Markdown_RendersAlertRow(t *testing.T) {
+func TestRenderSummaryFromReports_Markdown_RendersDataRaceDetailsAsCodeBlock(t *testing.T) {
 	report := mustReadReportFixture(t, "testdata/junit-alert-data-race.xml")
+	report.Suites[0].Testcases[0].Failure.Data = "go.temporal.io/server/service/worker/scheduler.(*scheduler).run()\n```"
 
 	rendered := newSummaryFromReports([]*junitReport{report}).Markdown()
 	require.Contains(t, rendered, failureTypeDataRace)
-	require.Contains(t, rendered, "Write at 0x00c000123456 by goroutine 7")
+	require.Contains(t, rendered, "\n\n````\ngo.temporal.io/server/service/worker/scheduler.(*scheduler).run()\n```\n````\n\n")
+	require.NotContains(t, rendered, "<pre>")
 }
 
 func TestRenderSummaryFromReports_Markdown_EmptyWhenNoFailures(t *testing.T) {

--- a/tools/testrunner/summary_test.go
+++ b/tools/testrunner/summary_test.go
@@ -101,7 +101,8 @@ func TestRenderSummaryFromReports_Markdown_RendersFailureRows(t *testing.T) {
 	require.Contains(t, s, "<table>")
 	require.NotContains(t, s, "<th>Details</th>")
 	require.Contains(t, s, "<details><summary>TestFoo</summary>")
-	require.Contains(t, s, "<pre>FAIL\n</pre>")
+	require.Contains(t, s, "\n\n```\nFAIL\n```\n\n")
+	require.NotContains(t, s, "<pre>")
 	require.Contains(t, s, "<details><summary>panic test (retry 1) (final)</summary>")
 	require.Contains(t, s, "❌ PANIC")
 	require.Equal(t, 2, strings.Count(s, "<tr><td>"))
@@ -116,7 +117,7 @@ func TestRenderSummaryFromReports_Markdown_RendersTrimmedFailureBody(t *testing.
 	require.NotContains(t, s, "some setup log")
 }
 
-func TestRenderSummaryFromReports_Markdown_RendersDataRaceDetailsAsCodeBlock(t *testing.T) {
+func TestRenderSummaryFromReports_Markdown_RendersAlertRow(t *testing.T) {
 	report := mustReadReportFixture(t, "testdata/junit-alert-data-race.xml")
 	report.Suites[0].Testcases[0].Failure.Data = "go.temporal.io/server/service/worker/scheduler.(*scheduler).run()\n```"
 

--- a/tools/testrunner/summary_test.go
+++ b/tools/testrunner/summary_test.go
@@ -56,7 +56,7 @@ func TestNewSummaryFromReports_RendersAlertRow(t *testing.T) {
 	require.Equal(t, []summaryRow{{
 		Kind:    failureTypeDataRace,
 		Name:    "DATA RACE: Data race detected in TestFoo",
-		Details: "WARNING: DATA RACE\nWrite at 0x00c000123456 by goroutine 7:\n  main.TestFoo()\n      /path/to/foo_test.go:42 +0x123\n\nPrevious read at 0x00c000123456 by goroutine 8:\n  main.TestFoo()\n      /path/to/foo_test.go:43 +0x456",
+		Details: "WARNING: DATA RACE\nWrite at 0x00c000123456 by goroutine 7:\n  go.temporal.io/server/service/worker/scheduler.(*scheduler).updateTweakables.func1()\n      /path/to/workflow.go:1442 +0x123\n\nPrevious read at 0x00c000123456 by goroutine 8:\n  go.temporal.io/server/service/worker/scheduler.(*scheduler).run()\n      /path/to/workflow.go:466 +0x456",
 	}}, s.Rows)
 }
 
@@ -119,12 +119,16 @@ func TestRenderSummaryFromReports_Markdown_RendersTrimmedFailureBody(t *testing.
 
 func TestRenderSummaryFromReports_Markdown_RendersAlertRow(t *testing.T) {
 	report := mustReadReportFixture(t, "testdata/junit-alert-data-race.xml")
-	report.Suites[0].Testcases[0].Failure.Data = "go.temporal.io/server/service/worker/scheduler.(*scheduler).run()\n```"
 
 	rendered := newSummaryFromReports([]*junitReport{report}).Markdown()
 	require.Contains(t, rendered, failureTypeDataRace)
-	require.Contains(t, rendered, "\n\n````\ngo.temporal.io/server/service/worker/scheduler.(*scheduler).run()\n```\n````\n\n")
+	require.Contains(t, rendered, "\n\n```\nWARNING: DATA RACE")
+	require.Contains(t, rendered, "go.temporal.io/server/service/worker/scheduler.(*scheduler).run()")
 	require.NotContains(t, rendered, "<pre>")
+}
+
+func TestMarkdownCodeBlock_AvoidsFenceCollisions(t *testing.T) {
+	require.Equal(t, "````\nline\n```\n````", markdownCodeBlock("line\n```"))
 }
 
 func TestRenderSummaryFromReports_Markdown_EmptyWhenNoFailures(t *testing.T) {

--- a/tools/testrunner/summary_test.go
+++ b/tools/testrunner/summary_test.go
@@ -128,7 +128,19 @@ func TestRenderSummaryFromReports_Markdown_RendersAlertRow(t *testing.T) {
 }
 
 func TestMarkdownCodeBlock_AvoidsFenceCollisions(t *testing.T) {
-	require.Equal(t, "````\nline\n```\n````", markdownCodeBlock("line\n```"))
+	for _, tc := range []struct {
+		name     string
+		content  string
+		expected string
+	}{
+		{name: "no fence", content: "line", expected: "```\nline\n```"},
+		{name: "three backticks", content: "line\n```", expected: "````\nline\n```\n````"},
+		{name: "four backticks", content: "line\n````", expected: "`````\nline\n````\n`````"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, markdownCodeBlock(tc.content))
+		})
+	}
 }
 
 func TestRenderSummaryFromReports_Markdown_EmptyWhenNoFailures(t *testing.T) {
@@ -143,7 +155,7 @@ func TestRenderSummaryFromReports_Markdown_ShowsTruncatedDetail(t *testing.T) {
 	}
 
 	s := summary.Markdown()
-	require.Contains(t, s, "truncated")
+	require.Equal(t, 1, strings.Count(s, "truncated"))
 	require.Contains(t, s, "head")
 	require.Contains(t, s, "tail")
 	require.Less(t, len(s), summaryMarkdownMaxBytes)

--- a/tools/testrunner/testdata/junit-alert-data-race.xml
+++ b/tools/testrunner/testdata/junit-alert-data-race.xml
@@ -3,12 +3,12 @@
         <testcase name="DATA RACE: Data race detected in TestFoo">
             <failure message="DATA RACE" type="DATA RACE"><![CDATA[WARNING: DATA RACE
 Write at 0x00c000123456 by goroutine 7:
-  main.TestFoo()
-      /path/to/foo_test.go:42 +0x123
+  go.temporal.io/server/service/worker/scheduler.(*scheduler).updateTweakables.func1()
+      /path/to/workflow.go:1442 +0x123
 
 Previous read at 0x00c000123456 by goroutine 8:
-  main.TestFoo()
-      /path/to/foo_test.go:43 +0x456]]></failure>
+  go.temporal.io/server/service/worker/scheduler.(*scheduler).run()
+      /path/to/workflow.go:466 +0x456]]></failure>
         </testcase>
     </testsuite>
 </testsuites>


### PR DESCRIPTION
## What changed?

Render failure details in GitHub test summaries as fenced Markdown code blocks.

## Why?

Diagnostic output can contain Markdown-like syntax that GitHub interprets when presenting the test summary, making reports difficult to read. A data race exposed the issue, but all failure details are diagnostic output and should be displayed verbatim.

Example: https://github.com/temporalio/temporal/actions/runs/34251938653
