### PR TITLE
Cloud/v1.32.0 163

### DIFF
--- a/service/frontend/admin_handler.go
+++ b/service/frontend/admin_handler.go
@@ -2309,10 +2309,9 @@ func (adh *AdminHandler) migrateScheduleToWorkflow(
 	})
 	info := descResp.GetWorkflowExecutionInfo()
 	switch {
-	case common.IsNotFoundError(err):
-	case err != nil:
+	case err != nil && !common.IsNotFoundError(err):
 		return nil, err
-	case info.GetStatus() != enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING:
+	case common.IsNotFoundError(err) || info.GetStatus() != enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING:
 		// A closed workflow does not occupy the V1 ID: the create path only treats
 		// RUNNING workflows as occupying it (isRealSchedulerInV1KeySpace), and an
 		// expired sentinel completes rather than disappearing, staying describable

--- a/service/frontend/admin_handler.go
+++ b/service/frontend/admin_handler.go
@@ -2307,23 +2307,33 @@ func (adh *AdminHandler) migrateScheduleToWorkflow(
 			},
 		},
 	})
+	info := descResp.GetWorkflowExecutionInfo()
 	switch {
 	case common.IsNotFoundError(err):
 	case err != nil:
 		return nil, err
-	case descResp.GetWorkflowExecutionInfo().GetType().GetName() == dummy.DummyWFTypeName:
-		sentinelIdleTimeRemaining := max(time.Until(descResp.GetWorkflowExecutionInfo().GetStartTime().AsTime().Add(chasmscheduler.SentinelIdleTime)), 0)
+	case info.GetStatus() != enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING:
+		// A closed workflow does not occupy the V1 ID: the create path only treats
+		// RUNNING workflows as occupying it (isRealSchedulerInV1KeySpace), and an
+		// expired sentinel completes rather than disappearing, staying describable
+		// for the namespace's whole retention period. Blocking on it here would
+		// stall rollback for days instead of the 15 minutes a sentinel reserves.
+	case info.GetType().GetName() == dummy.DummyWFTypeName:
+		startTime := info.GetStartTime().AsTime()
 		adh.logger.Warn(
 			"schedule migration to workflow blocked by workflow sentinel",
 			tag.ScheduleID(request.GetScheduleId()),
-			tag.Duration("sentinel-idle-time", sentinelIdleTimeRemaining),
+			tag.Duration("sentinel-idle-time", max(time.Until(startTime.Add(chasmscheduler.SentinelIdleTime)), 0)),
+			// Age disambiguates a sentinel still inside its idle window from one
+			// running past it (idle-time reads 0s in both cases).
+			tag.Duration("sentinel-age", time.Since(startTime)),
 		)
 		return nil, chasmscheduler.ErrSentinelBlocked
 	default:
 		adh.logger.Warn(
 			"schedule migration to workflow found existing workflow",
 			tag.ScheduleID(request.GetScheduleId()),
-			tag.WorkflowType(descResp.GetWorkflowExecutionInfo().GetType().GetName()),
+			tag.WorkflowType(info.GetType().GetName()),
 		)
 	}
 

--- a/service/frontend/admin_handler_test.go
+++ b/service/frontend/admin_handler_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -72,6 +73,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type (
@@ -2192,7 +2194,8 @@ func (s *adminHandlerSuite) TestMigrateScheduleToWorkflowExistingWorkflow() {
 		},
 	}).Return(&historyservice.DescribeWorkflowExecutionResponse{
 		WorkflowExecutionInfo: &workflowpb.WorkflowExecutionInfo{
-			Type: &commonpb.WorkflowType{Name: legacyscheduler.WorkflowType},
+			Type:   &commonpb.WorkflowType{Name: legacyscheduler.WorkflowType},
+			Status: enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
 		},
 	}, nil)
 
@@ -2232,7 +2235,9 @@ func (s *adminHandlerSuite) TestMigrateScheduleToWorkflowBlockedByWorkflowSentin
 		},
 	}).Return(&historyservice.DescribeWorkflowExecutionResponse{
 		WorkflowExecutionInfo: &workflowpb.WorkflowExecutionInfo{
-			Type: &commonpb.WorkflowType{Name: dummy.DummyWFTypeName},
+			Type:      &commonpb.WorkflowType{Name: dummy.DummyWFTypeName},
+			Status:    enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			StartTime: timestamppb.New(time.Now()),
 		},
 	}, nil)
 
@@ -2254,6 +2259,51 @@ func (s *adminHandlerSuite) TestMigrateScheduleToWorkflowBlockedByWorkflowSentin
 	s.ErrorIs(err, chasmscheduler.ErrSentinelBlocked)
 	var unavailableErr *serviceerror.Unavailable
 	s.ErrorAs(err, &unavailableErr)
+}
+
+// A dummy sentinel completes after its idle window rather than disappearing, and stays
+// describable for the namespace's whole retention period. Blocking on it would stall rollback
+// for days instead of the minutes the sentinel is meant to reserve, so a closed sentinel must
+// not block.
+func (s *adminHandlerSuite) TestMigrateScheduleToWorkflowClosedSentinelDoesNotBlock() {
+	s.mockNamespaceCache.EXPECT().GetNamespaceID(s.namespace).Return(s.namespaceID, nil)
+	s.mockHistoryClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), &historyservice.DescribeWorkflowExecutionRequest{
+		NamespaceId: s.namespaceID.String(),
+		Request: &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: s.namespace.String(),
+			Execution: &commonpb.WorkflowExecution{
+				WorkflowId: legacyscheduler.WorkflowIDPrefix + "test-schedule",
+			},
+		},
+	}).Return(&historyservice.DescribeWorkflowExecutionResponse{
+		WorkflowExecutionInfo: &workflowpb.WorkflowExecutionInfo{
+			Type:      &commonpb.WorkflowType{Name: dummy.DummyWFTypeName},
+			Status:    enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+			StartTime: timestamppb.New(time.Now().Add(-chasmscheduler.SentinelIdleTime)),
+			CloseTime: timestamppb.New(time.Now()),
+		},
+	}, nil)
+
+	var capturedReq *schedulerpb.MigrateToWorkflowRequest
+	fake := &fakeSchedulerClient{
+		migrateToWorkflowFn: func(_ context.Context, req *schedulerpb.MigrateToWorkflowRequest) (*schedulerpb.MigrateToWorkflowResponse, error) {
+			capturedReq = req
+			return &schedulerpb.MigrateToWorkflowResponse{}, nil
+		},
+	}
+	s.handler.schedulerClient = fake
+
+	resp, err := s.handler.MigrateSchedule(context.Background(), &adminservice.MigrateScheduleRequest{
+		Namespace:  s.namespace.String(),
+		ScheduleId: "test-schedule",
+		Target:     adminservice.MigrateScheduleRequest_SCHEDULER_TARGET_WORKFLOW,
+		Identity:   "test-identity",
+		RequestId:  "test-request-id",
+	})
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Require().NotNil(capturedReq)
+	s.Equal("test-schedule", capturedReq.ScheduleId)
 }
 
 func (s *adminHandlerSuite) TestMigrateScheduleToWorkflowError() {

--- a/tests/schedule_migration_test.go
+++ b/tests/schedule_migration_test.go
@@ -213,7 +213,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2AlreadyExists() {
 	s.NoError(err)
 }
 
-func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1BlockedBySentinel() {
+func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1BlockedOnlyByRunningSentinel() {
 	env := newScheduleEnv(
 		s.T(),
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
@@ -228,6 +228,12 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1BlockedBySentine
 	nsName := env.Namespace().String()
 	nsID := env.NamespaceID().String()
 
+	completeSignal := "complete"
+	env.SdkWorker().RegisterWorkflowWithOptions(func(ctx workflow.Context) error {
+		workflow.GetSignalChannel(ctx, completeSignal).Receive(ctx, nil)
+		return nil
+	}, workflow.RegisterOptions{Name: dummy.DummyWFTypeName})
+
 	v1WorkflowID := scheduler.WorkflowIDPrefix + sid
 	_, err := env.GetTestCluster().HistoryClient().StartWorkflowExecution(
 		ctx,
@@ -237,7 +243,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1BlockedBySentine
 				Namespace:                nsName,
 				WorkflowId:               v1WorkflowID,
 				WorkflowType:             &commonpb.WorkflowType{Name: dummy.DummyWFTypeName},
-				TaskQueue:                &taskqueuepb.TaskQueue{Name: primitives.PerNSWorkerTaskQueue},
+				TaskQueue:                &taskqueuepb.TaskQueue{Name: env.WorkerTaskQueue()},
 				Identity:                 "test",
 				RequestId:                uuid.NewString(),
 				WorkflowIdReusePolicy:    enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
@@ -246,7 +252,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1BlockedBySentine
 			nil, nil, time.Now().UTC(),
 		),
 	)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	sched := &schedulepb.Schedule{
 		Spec: &schedulepb.ScheduleSpec{
@@ -278,7 +284,7 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1BlockedBySentine
 			},
 		},
 	)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	_, err = env.AdminClient().MigrateSchedule(ctx, &adminservice.MigrateScheduleRequest{
 		Namespace:  nsName,
@@ -288,8 +294,47 @@ func (s *ScheduleMigrationTestSuite) TestScheduleMigrationV2ToV1BlockedBySentine
 		RequestId:  uuid.NewString(),
 	})
 	var unavailableErr *serviceerror.Unavailable
-	s.ErrorAs(err, &unavailableErr)
+	s.Require().ErrorAs(err, &unavailableErr)
 	s.Contains(unavailableErr.Message, "sentinel")
+
+	_, err = env.FrontendClient().SignalWorkflowExecution(ctx, &workflowservice.SignalWorkflowExecutionRequest{
+		Namespace:         nsName,
+		WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: v1WorkflowID},
+		SignalName:        completeSignal,
+		Identity:          "test",
+	})
+	s.Require().NoError(err)
+
+	// The production sentinel completes after its idle timeout. This test uses a
+	// signal to reach the same retained COMPLETED state without waiting 15 minutes.
+	var closedSentinel *workflowservice.DescribeWorkflowExecutionResponse
+	s.Require().Eventually(func() bool {
+		closedSentinel, err = env.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: nsName,
+			Execution: &commonpb.WorkflowExecution{WorkflowId: v1WorkflowID},
+		})
+		return err == nil && closedSentinel.GetWorkflowExecutionInfo().GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED
+	}, 10*time.Second, 500*time.Millisecond)
+	s.Require().Equal(dummy.DummyWFTypeName, closedSentinel.GetWorkflowExecutionInfo().GetType().GetName())
+
+	_, err = env.AdminClient().MigrateSchedule(ctx, &adminservice.MigrateScheduleRequest{
+		Namespace:  nsName,
+		ScheduleId: sid,
+		Target:     adminservice.MigrateScheduleRequest_SCHEDULER_TARGET_WORKFLOW,
+		Identity:   "test",
+		RequestId:  uuid.NewString(),
+	})
+	s.Require().NoError(err)
+
+	var migrated *workflowservice.DescribeWorkflowExecutionResponse
+	s.Require().Eventually(func() bool {
+		migrated, err = env.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: nsName,
+			Execution: &commonpb.WorkflowExecution{WorkflowId: v1WorkflowID},
+		})
+		return err == nil && migrated.GetWorkflowExecutionInfo().GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
+	}, 10*time.Second, 500*time.Millisecond)
+	s.Require().Equal(scheduler.WorkflowType, migrated.GetWorkflowExecutionInfo().GetType().GetName())
 }
 
 func (s *ScheduleMigrationTestSuite) TestScheduleMigrationDynamicConfig() {

--- a/tools/tdbg/commands.go
+++ b/tools/tdbg/commands.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/urfave/cli/v2"
 	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/api/adminservice/v1"
@@ -999,17 +1000,30 @@ func countScheduleVisibility(c *cli.Context, wfClient workflowservice.WorkflowSe
 // v2ScheduleStatus is what was found, if anything, on the CHASM (V2) side of a schedule ID.
 type v2ScheduleStatus struct {
 	found    bool
+	running  bool // only meaningful when found
 	sentinel bool // only meaningful when found
 }
 
-// isGenuine reports whether this is a real V2 schedule, as opposed to a migration sentinel
-// reserving the ID.
-func (s v2ScheduleStatus) isGenuine() bool { return s.found && !s.sentinel }
+// holdsID reports whether anything at this ID still occupies it. A closed entity stays
+// describable until retention deletes the record, but no longer blocks creation or migration,
+// so it must not be reported as occupying the ID.
+func (s v2ScheduleStatus) holdsID() bool { return s.found && s.running }
+
+// isGenuine reports whether this is a real, live V2 schedule, as opposed to a migration
+// sentinel reserving the ID.
+func (s v2ScheduleStatus) isGenuine() bool { return s.holdsID() && !s.sentinel }
+
+// isSentinel reports whether a live sentinel is reserving the CHASM ID.
+func (s v2ScheduleStatus) isSentinel() bool { return s.holdsID() && s.sentinel }
 
 func (s v2ScheduleStatus) describe() string {
 	switch {
 	case !s.found:
 		return "not found"
+	case !s.running && s.sentinel:
+		return "expired sentinel (closed; no longer reserving the ID)"
+	case !s.running:
+		return "closed (retained until retention expires; not reserving the ID)"
 	case s.sentinel:
 		return "sentinel (V1→V2 migration placeholder)"
 	default:
@@ -1020,24 +1034,35 @@ func (s v2ScheduleStatus) describe() string {
 // v1ScheduleStatus is what was found, if anything, on the workflow (V1) side of a schedule ID.
 type v1ScheduleStatus struct {
 	found        bool
+	running      bool   // only meaningful when found
 	workflowType string // only meaningful when found
 }
 
-// isGenuine reports whether this is a real V1 scheduler workflow.
+// holdsID reports whether the V1 workflow ID is actually reserved. A closed execution stays
+// describable for the namespace's whole retention period, but the create path treats only
+// RUNNING workflows as occupying the ID (see isRealSchedulerInV1KeySpace), so a closed
+// execution -- including an expired dummy sentinel, which completes rather than disappearing --
+// must not be reported as holding it.
+func (s v1ScheduleStatus) holdsID() bool { return s.found && s.running }
+
+// isGenuine reports whether this is a real, running V1 scheduler workflow.
 func (s v1ScheduleStatus) isGenuine() bool {
-	return s.found && s.workflowType == scheduler.WorkflowType
+	return s.holdsID() && s.workflowType == scheduler.WorkflowType
 }
 
-// isSentinel reports whether this is a placeholder DummyWorkflow reserving the V1 workflow ID
-// during a V2->V1 rollback.
+// isSentinel reports whether a live placeholder DummyWorkflow is reserving the V1 workflow ID.
 func (s v1ScheduleStatus) isSentinel() bool {
-	return s.found && s.workflowType == dummy.DummyWFTypeName
+	return s.holdsID() && s.workflowType == dummy.DummyWFTypeName
 }
 
 func (s v1ScheduleStatus) describe() string {
 	switch {
 	case !s.found:
 		return "not found"
+	case !s.running && s.workflowType == dummy.DummyWFTypeName:
+		return "expired sentinel (closed; no longer reserving the ID)"
+	case !s.running:
+		return fmt.Sprintf("closed %q execution (retained until retention expires; not reserving the ID)", s.workflowType)
 	case s.isGenuine():
 		return "genuine"
 	case s.isSentinel():
@@ -1077,22 +1102,23 @@ func describeScheduleMigrationStatus(c *cli.Context, clientFactory ClientFactory
 
 	w := c.App.Writer
 	switch {
-	case v1.isGenuine() && !v2.found:
+	case v1.isGenuine() && !v2.holdsID():
 		_, _ = fmt.Fprintf(w, "Schedule %q is a V1 (workflow-backed) schedule.\n", scheduleID)
-	case !v1.found && v2.isGenuine():
+	case !v1.holdsID() && v2.isGenuine():
 		_, _ = fmt.Fprintf(w, "Schedule %q is a V2 (CHASM) schedule.\n", scheduleID)
-	case v1.isGenuine() && v2.sentinel:
+	case v1.isGenuine() && v2.isSentinel():
 		_, _ = fmt.Fprintf(w, "Schedule %q is a V1 (workflow-backed) schedule.\n", scheduleID)
 		_, _ = fmt.Fprintf(w, "Additionally, a placeholder (\"sentinel\") V2 entity exists at business ID %q, "+
-			"reserving that ID while a V1→V2 migration is in progress. This is expected during migration and "+
-			"requires no action — the V1 schedule above remains authoritative until the migration completes.\n",
+			"reserving that ID for a short window after the V1 schedule was created, or while a V1→V2 "+
+			"migration is in progress. This is expected and requires no action — it expires on its own, and "+
+			"the V1 schedule above remains authoritative.\n",
 			rawID)
 	case v1.isSentinel() && v2.isGenuine():
 		_, _ = fmt.Fprintf(w, "Schedule %q is a V2 (CHASM) schedule.\n", scheduleID)
 		_, _ = fmt.Fprintf(w, "Additionally, a placeholder (\"sentinel\") V1 workflow exists at workflow ID %q, "+
-			"reserving that ID while a V2→V1 rollback is in progress. This is expected during rollback and "+
-			"requires no action.\n", v1ID)
-	case !v1.found && !v2.found:
+			"reserving that ID for a short window after the V2 schedule was created, or while a V2→V1 "+
+			"rollback is in progress. This is expected and requires no action — it expires on its own.\n", v1ID)
+	case !v1.holdsID() && !v2.holdsID():
 		_, _ = fmt.Fprintf(w, "Schedule %q was not found as either a V1 (workflow-backed) or V2 (CHASM) schedule. "+
 			"It may not exist, may have been deleted, or the ID may be mistyped.\n", scheduleID)
 	default:
@@ -1138,7 +1164,11 @@ func describeSchedulerChasmState(c *cli.Context, adminClient adminservice.AdminS
 	if err := serialization.Decode(node.GetData(), &state); err != nil {
 		return v2ScheduleStatus{}, fmt.Errorf("failed to decode scheduler state: %w", err)
 	}
-	return v2ScheduleStatus{found: true, sentinel: state.GetSentinel()}, nil
+	return v2ScheduleStatus{
+		found:    true,
+		running:  isRunning(resp),
+		sentinel: state.GetSentinel(),
+	}, nil
 }
 
 // describeWorkflowTypeName looks up the workflow (V1) side of workflowID and reports its
@@ -1159,8 +1189,17 @@ func describeWorkflowTypeName(c *cli.Context, adminClient adminservice.AdminServ
 	}
 	return v1ScheduleStatus{
 		found:        true,
+		running:      isRunning(resp),
 		workflowType: resp.GetDatabaseMutableState().GetExecutionInfo().GetWorkflowTypeName(),
 	}, nil
+}
+
+// isRunning reports whether the described execution is still open. DescribeMutableState keeps
+// answering for closed executions until retention deletes them, so callers that care about ID
+// occupancy have to check this rather than treating "described" as "live".
+func isRunning(resp *adminservice.DescribeMutableStateResponse) bool {
+	return resp.GetDatabaseMutableState().GetExecutionState().GetStatus() ==
+		enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
 }
 
 // migrateSingleSchedule migrates one schedule and performs the migration immediately.

--- a/tools/tdbg/schedule_status_test.go
+++ b/tools/tdbg/schedule_status_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/api/adminservice/v1"
@@ -137,8 +138,20 @@ func chasmSchedulerStateResponse(t *testing.T, sentinel bool) *adminservice.Desc
 			ChasmNodes: map[string]*persistencespb.ChasmNode{
 				"": {Data: blob},
 			},
+			ExecutionState: runningState(),
 		},
 	}
+}
+
+// runningState is the execution state every live schedule and sentinel has; fixtures must set it
+// because a closed record stays describable until retention deletes it, and only the status
+// distinguishes the two.
+func runningState() *persistencespb.WorkflowExecutionState {
+	return &persistencespb.WorkflowExecutionState{Status: enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING}
+}
+
+func completedState() *persistencespb.WorkflowExecutionState {
+	return &persistencespb.WorkflowExecutionState{Status: enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED}
 }
 
 // workflowTypeResponse builds a DescribeMutableState response for a plain workflow execution of
@@ -147,7 +160,19 @@ func chasmSchedulerStateResponse(t *testing.T, sentinel bool) *adminservice.Desc
 func workflowTypeResponse(typeName string) *adminservice.DescribeMutableStateResponse {
 	return &adminservice.DescribeMutableStateResponse{
 		DatabaseMutableState: &persistencespb.WorkflowMutableState{
-			ExecutionInfo: &persistencespb.WorkflowExecutionInfo{WorkflowTypeName: typeName},
+			ExecutionInfo:  &persistencespb.WorkflowExecutionInfo{WorkflowTypeName: typeName},
+			ExecutionState: runningState(),
+		},
+	}
+}
+
+// closedWorkflowTypeResponse is the same execution after it completed: still describable, but no
+// longer holding the workflow ID. An expired dummy sentinel looks exactly like this.
+func closedWorkflowTypeResponse(typeName string) *adminservice.DescribeMutableStateResponse {
+	return &adminservice.DescribeMutableStateResponse{
+		DatabaseMutableState: &persistencespb.WorkflowMutableState{
+			ExecutionInfo:  &persistencespb.WorkflowExecutionInfo{WorkflowTypeName: typeName},
+			ExecutionState: completedState(),
 		},
 	}
 }
@@ -220,7 +245,7 @@ func TestScheduleStatus_SingleSchedule_V1GenuineWithV2Sentinel(t *testing.T) {
 
 	require.Contains(t, stdout, `Schedule "foo" is a V1 (workflow-backed) schedule.`+"\n")
 	require.Contains(t, stdout, "Additionally, a placeholder (\"sentinel\") V2 entity exists")
-	require.Contains(t, stdout, "V1→V2 migration is in progress")
+	require.Contains(t, stdout, "while a V1→V2 migration is in progress")
 }
 
 func TestScheduleStatus_SingleSchedule_V1SentinelWithV2Genuine(t *testing.T) {
@@ -234,7 +259,38 @@ func TestScheduleStatus_SingleSchedule_V1SentinelWithV2Genuine(t *testing.T) {
 
 	require.Contains(t, stdout, `Schedule "foo" is a V2 (CHASM) schedule.`+"\n")
 	require.Contains(t, stdout, "Additionally, a placeholder (\"sentinel\") V1 workflow exists")
-	require.Contains(t, stdout, "V2→V1 rollback is in progress")
+	require.Contains(t, stdout, "while a V2→V1 rollback is in progress")
+}
+
+// A dummy sentinel completes after its idle window rather than disappearing, so a V2 schedule
+// created minutes ago has a closed sentinel at its V1 ID for the whole retention period. That
+// must read as a plain V2 schedule, not as an ID still reserved by a rollback.
+func TestScheduleStatus_SingleSchedule_ClosedV1SentinelWithV2Genuine(t *testing.T) {
+	admin := &describeMutableStateAdminClient{responses: map[string]*adminservice.DescribeMutableStateResponse{
+		primitives.ScheduleWorkflowIDPrefix + "foo": closedWorkflowTypeResponse(dummy.DummyWFTypeName),
+		"foo": chasmSchedulerStateResponse(t, false),
+	}}
+
+	stdout, _, err := runScheduleStatusForSchedule(t, admin, "-n", "my-ns", "schedule", "migrate", "status", "--schedule-id", "foo")
+	require.NoError(t, err)
+
+	require.Contains(t, stdout, `Schedule "foo" is a V2 (CHASM) schedule.`+"\n")
+	require.NotContains(t, stdout, "Additionally")
+	require.Contains(t, stdout, "expired sentinel (closed; no longer reserving the ID)")
+}
+
+// A closed V1 scheduler workflow is a deleted or terminated schedule still inside retention.
+// Reporting it as a live V1 schedule would tell an operator a deleted schedule is running.
+func TestScheduleStatus_SingleSchedule_ClosedV1IsNotALiveSchedule(t *testing.T) {
+	admin := &describeMutableStateAdminClient{responses: map[string]*adminservice.DescribeMutableStateResponse{
+		primitives.ScheduleWorkflowIDPrefix + "foo": closedWorkflowTypeResponse(scheduler.WorkflowType),
+	}}
+
+	stdout, _, err := runScheduleStatusForSchedule(t, admin, "-n", "my-ns", "schedule", "migrate", "status", "--schedule-id", "foo")
+	require.NoError(t, err)
+
+	require.Contains(t, stdout, `Schedule "foo" was not found as either a V1 (workflow-backed) or V2 (CHASM) schedule.`)
+	require.Contains(t, stdout, "not reserving the ID")
 }
 
 func TestScheduleStatus_SingleSchedule_NotFoundBothSides(t *testing.T) {


### PR DESCRIPTION
## What changed?

git cherry-picks two changes (really one, I just added some formatting):

https://github.com/temporalio/temporal/pull/11955
https://github.com/temporalio/temporal/pull/11964

## Why?

This fixes a problem in V2->v1 rollback where the sentinel value was not being checked correctly (it runs for 15 minutes and then closes). The check was only seeing if the sentinel was present, not that it was running. Consequently, a sentinel which is closed would unintentionally block a rollback for the duration of the retention period. 

## How did you test it?
- [X] built
- [X] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [X] added new functional test(s)

## Potential risks
Pretty low risk, only affects an Admin API, low rollback risk since it doesn't affect any data or paths which might be affected by state or nondeterminitism. 