### PR TITLE
Use await.RequireTrue in matcher backlog-forwarding test.

### DIFF
--- a/service/matching/matcher_test.go
+++ b/service/matching/matcher_test.go
@@ -24,6 +24,7 @@ import (
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/quotas"
+	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/common/tqid"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc"
@@ -353,10 +354,9 @@ func (t *MatcherTestSuite) TestAvoidForwardingWhenBacklogIsOld() {
 	oldBacklogTask := newInternalTaskFromBacklog(randomTaskInfoWithAge(time.Minute), nil)
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
 	go t.childMatcher.MustOffer(ctx, oldBacklogTask, interruptC) //nolint:errcheck
-	t.Require().Eventually(
-		func() bool {
-			return t.childMatcher.getBacklogAge() > 0
-		}, maxWait, time.Millisecond/2)
+	await.RequireTrue(t.T(), func() bool {
+		return t.childMatcher.getBacklogAge() > 0
+	}, maxWait, time.Millisecond/2)
 
 	// poll the task
 	task, _ := t.childMatcher.Poll(ctx, &pollMetadata{})
@@ -364,10 +364,9 @@ func (t *MatcherTestSuite) TestAvoidForwardingWhenBacklogIsOld() {
 	cancel()
 
 	// should be back to no backlog
-	t.Require().Eventually(
-		func() bool {
-			return t.childMatcher.getBacklogAge() == emptyBacklogAge
-		}, maxWait, time.Millisecond/2)
+	await.RequireTrue(t.T(), func() bool {
+		return t.childMatcher.getBacklogAge() == emptyBacklogAge
+	}, maxWait, time.Millisecond/2)
 
 	// even old task is forwarded if last poll is not recent enough
 	time.Sleep(t.childConfig.MaxWaitForPollerBeforeFwd() + time.Millisecond) //nolint:forbidigo


### PR DESCRIPTION
## What changed?
Replaced `require.Eventually` with `await.RequireTrue` in `TestAvoidForwardingWhenBacklogIsOld`.

## Why?
`Eventually` can return on timeout while its condition goroutine is still running. That leftover callback reads `t.childMatcher` while the next test’s `SetupTest` writes it, which is the data race seen. `await.RequireTrue` waits for the current check to finish before returning.

## How did you test it?
- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

Ran `TestAvoidForwardingWhenBacklogIsOld*` ×20 and `TestMatcherSuite` ×5 with `-race`.