### PR TITLE
Cherry-pick "Make Nexus callback source header opt-in (#11965)" into release/v1.32.x

### DIFF
--- a/chasm/lib/callback/config.go
+++ b/chasm/lib/callback/config.go
@@ -38,9 +38,19 @@ var RetryPolicyMaximumInterval = dynamicconfig.NewGlobalDurationSetting(
 	`The maximum backoff interval between every callback request attempt for a given callback.`,
 )
 
+var InspectSourceHeader = dynamicconfig.NewGlobalBoolSetting(
+	"callback.inspectSourceHeader",
+	false,
+	`Controls whether the legacy "source" header should be inspected to determine if a Nexus callback request is internal
+or external. This header was used before worker callbacks used the temporal://system URL. Leave this disabled unless it
+is required for mixed-version compatibility because trusting a caller-controlled header can route external requests
+internally.`,
+)
+
 type Config struct {
-	RequestTimeout dynamicconfig.DurationPropertyFnWithDestinationFilter
-	RetryPolicy    func() backoff.RetryPolicy
+	RequestTimeout      dynamicconfig.DurationPropertyFnWithDestinationFilter
+	RetryPolicy         dynamicconfig.TypedPropertyFn[backoff.RetryPolicy]
+	InspectSourceHeader dynamicconfig.BoolPropertyFn
 }
 
 func configProvider(dc *dynamicconfig.Collection) *Config {
@@ -55,6 +65,7 @@ func configProvider(dc *dynamicconfig.Collection) *Config {
 				backoff.NoInterval,
 			)
 		},
+		InspectSourceHeader: InspectSourceHeader.Get(dc),
 	}
 }
 

--- a/chasm/lib/callback/fx.go
+++ b/chasm/lib/callback/fx.go
@@ -29,6 +29,7 @@ func httpCallerProviderProvider(
 	rpcFactory common.RPCFactory,
 	httpClientCache *cluster.FrontendHTTPClientCache,
 	logger log.Logger,
+	config *Config,
 ) (HTTPCallerProvider, error) {
 	localClient, err := rpcFactory.CreateLocalFrontendHTTPClient()
 	if err != nil {
@@ -47,6 +48,7 @@ func httpCallerProviderProvider(
 				defaultClient,
 				localClient,
 				logger,
+				config.InspectSourceHeader(),
 			)
 		}
 	})

--- a/chasm/lib/callback/request.go
+++ b/chasm/lib/callback/request.go
@@ -15,8 +15,7 @@ import (
 	commonnexus "go.temporal.io/server/common/nexus"
 )
 
-// Header key used to identify callbacks that originate from and target the same cluster.
-// Note: this is the nexusoperations.NexusCallbackSourceHeader stripped of Nexus-Callback-
+// Legacy header key used to identify callbacks that originate from and target the same cluster.
 const callbackSourceHeader = "source"
 
 // routeSystemCallbackRequest routes a system callback request to the appropriate frontend client
@@ -112,13 +111,13 @@ func routeRequest(
 	defaultClient *http.Client,
 	localClient *common.FrontendHTTPClient,
 	logger log.Logger,
+	inspectSourceHeader bool,
 ) (*http.Response, error) {
 	if r.URL.String() == commonnexus.SystemCallbackURL {
 		return routeSystemCallbackRequest(r, clusterMetadata, namespaceRegistry, httpClientCache, callbackTokenGenerator, localClient, logger)
 	}
-	// This source header is populated in nexusoperations/tasks (via the ClientProvider) for worker targets
-	// if this header is not populated then we assume it's an external target.
-	if r.Header == nil || r.Header.Get(callbackSourceHeader) == "" {
+	// Older servers populated this header for worker targets. Treat the request as external unless legacy inspection is enabled.
+	if !inspectSourceHeader || r.Header == nil || r.Header.Get(callbackSourceHeader) == "" {
 		return defaultClient.Do(r)
 	}
 	// If we got here, we assume that the endpoint in the original call was a worker target, and we should route

--- a/chasm/lib/callback/request_test.go
+++ b/chasm/lib/callback/request_test.go
@@ -50,6 +50,36 @@ func TestRouteRequest_ExternalTarget(t *testing.T) {
 		ts.Client(),
 		nil, // localClient not needed for external targets
 		log.NewNoopLogger(),
+		false, // inspectSourceHeader
+	)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestRouteRequest_SourceHeaderIgnored(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	ctrl := gomock.NewController(t)
+	clusterMeta := cluster.NewMockMetadata(ctrl)
+
+	r, err := http.NewRequest(http.MethodPost, ts.URL+"/some/path", nil)
+	require.NoError(t, err)
+	r.Header.Set(callbackSourceHeader, "cluster-id-A")
+
+	resp, err := routeRequest(
+		r,
+		clusterMeta,
+		nil,
+		nil,
+		nil,
+		ts.Client(),
+		nil,
+		log.NewNoopLogger(),
+		false,
 	)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
@@ -85,6 +115,7 @@ func TestRouteRequest_SourceHeaderLocal(t *testing.T) {
 		&http.Client{},
 		localClient,
 		log.NewNoopLogger(),
+		true, // inspectSourceHeader
 	)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
@@ -120,6 +151,7 @@ func TestRouteRequest_SourceHeaderUnknownCluster(t *testing.T) {
 		&http.Client{},
 		localClient,
 		log.NewNoopLogger(),
+		true, // inspectSourceHeader
 	)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
@@ -407,6 +439,7 @@ func TestRouteRequest_SystemCallback(t *testing.T) {
 		&http.Client{},
 		localClient,
 		log.NewNoopLogger(),
+		false, // inspectSourceHeader
 	)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()

--- a/chasm/lib/nexusoperation/config.go
+++ b/chasm/lib/nexusoperation/config.go
@@ -219,13 +219,6 @@ Adding high-cardinality tags (like unique operation names) can significantly inc
 query complexity. Consider the cardinality impact when enabling these tags.`,
 )
 
-var UseSystemCallbackURL = dynamicconfig.NewGlobalBoolSetting(
-	"nexusoperation.useSystemCallbackURL",
-	true,
-	`Controls how the executor generates callback URLs for worker targets in Nexus Operations.
-When true, uses the fixed system callback URL for all worker targets.`,
-)
-
 var MaxReasonLength = dynamicconfig.NewNamespaceIntSetting(
 	"nexusoperation.limit.reasonLength",
 	1000,
@@ -259,7 +252,6 @@ type Config struct {
 	MaxOperationScheduleToCloseTimeout         dynamicconfig.DurationPropertyFnWithNamespaceFilter
 	PayloadSizeLimit                           dynamicconfig.IntPropertyFnWithNamespaceFilter
 	CallbackURLTemplate                        dynamicconfig.TypedPropertyFn[*template.Template]
-	UseSystemCallbackURL                       dynamicconfig.BoolPropertyFn
 	PayloadSizeLimitWarn                       dynamicconfig.IntPropertyFnWithNamespaceFilter
 	MaxUserMetadataSummarySize                 dynamicconfig.IntPropertyFnWithNamespaceFilter
 	MaxUserMetadataDetailsSize                 dynamicconfig.IntPropertyFnWithNamespaceFilter
@@ -294,7 +286,6 @@ func configProvider(dc *dynamicconfig.Collection, cfg *config.Persistence) *Conf
 		MaxUserMetadataSummarySize:         dynamicconfig.MaxUserMetadataSummarySize.Get(dc),
 		MaxUserMetadataDetailsSize:         dynamicconfig.MaxUserMetadataDetailsSize.Get(dc),
 		CallbackURLTemplate:                CallbackURLTemplate.Get(dc),
-		UseSystemCallbackURL:               UseSystemCallbackURL.Get(dc),
 		UseNewFailureWireFormat:            UseNewFailureWireFormat.Get(dc),
 		VisibilityMaxPageSize:              dynamicconfig.FrontendVisibilityMaxPageSize.Get(dc),
 		MaxIDLengthLimit:                   dynamicconfig.MaxIDLengthLimit.Get(dc),

--- a/chasm/lib/nexusoperation/fx.go
+++ b/chasm/lib/nexusoperation/fx.go
@@ -23,8 +23,6 @@ import (
 	"go.uber.org/fx"
 )
 
-const nexusCallbackSourceHeader = "Nexus-Callback-Source"
-
 var Module = fx.Module(
 	"chasm.lib.nexusoperation",
 	fx.Provide(configProvider),
@@ -159,7 +157,6 @@ func clientProviderFactory(
 			httpClient = &cl.Client
 			if clusterID != "" {
 				httpCaller = func(r *http.Request) (*http.Response, error) {
-					r.Header.Set(nexusCallbackSourceHeader, clusterID)
 					resp, callErr := httpClient.Do(r)
 					commonnexus.SetFailureSourceOnContext(ctx, resp)
 					return resp, callErr

--- a/chasm/lib/nexusoperation/operation_tasks.go
+++ b/chasm/lib/nexusoperation/operation_tasks.go
@@ -102,7 +102,7 @@ func (h *operationInvocationTaskHandler) Execute(
 		return err
 	}
 
-	callbackURL, err := buildCallbackURL(h.config.UseSystemCallbackURL(), h.config.CallbackURLTemplate(), ns, endpoint)
+	callbackURL, err := buildCallbackURL(h.config.CallbackURLTemplate(), ns, endpoint)
 	if err != nil {
 		return fmt.Errorf("failed to build callback URL: %w", err)
 	}

--- a/chasm/lib/nexusoperation/operation_tasks_test.go
+++ b/chasm/lib/nexusoperation/operation_tasks_test.go
@@ -83,7 +83,6 @@ func newInvocationTaskTestEnv(
 				MinRequestTimeout:       dynamicconfig.GetDurationPropertyFnFilteredByNamespace(time.Millisecond),
 				PayloadSizeLimit:        dynamicconfig.GetIntPropertyFnFilteredByNamespace(2 * 1024 * 1024),
 				CallbackURLTemplate:     dynamicconfig.GetTypedPropertyFn(callbackTmpl),
-				UseSystemCallbackURL:    dynamicconfig.GetBoolPropertyFn(false),
 				UseNewFailureWireFormat: dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true),
 				RetryPolicy: dynamicconfig.GetTypedPropertyFn[backoff.RetryPolicy](
 					backoff.NewExponentialRetryPolicy(time.Second),

--- a/chasm/lib/nexusoperation/task_handler_base.go
+++ b/chasm/lib/nexusoperation/task_handler_base.go
@@ -83,23 +83,7 @@ func (b *nexusTaskHandlerBase) buildCallbackURL(
 	ns *namespace.Namespace,
 	endpoint *persistencespb.NexusEndpointEntry,
 ) (string, error) {
-	// endpoint is nil for system-internal operations where endpoint lookup is skipped.
-	// These always use the system callback URL since the callback is handled internally.
-	if endpoint == nil {
-		return commonnexus.SystemCallbackURL, nil
-	}
-	target := endpoint.GetEndpoint().GetSpec().GetTarget().GetVariant()
-	if !b.config.UseSystemCallbackURL() {
-		return buildCallbackFromTemplate(b.config.CallbackURLTemplate(), ns)
-	}
-	switch target.(type) {
-	case *persistencespb.NexusEndpointTarget_Worker_:
-		return commonnexus.SystemCallbackURL, nil
-	case *persistencespb.NexusEndpointTarget_External_:
-		return buildCallbackFromTemplate(b.config.CallbackURLTemplate(), ns)
-	default:
-		return "", fmt.Errorf("unknown endpoint target type: %T", target)
-	}
+	return buildCallbackURL(b.config.CallbackURLTemplate(), ns, endpoint)
 }
 
 func buildCallbackFromTemplate(callbackTemplate *template.Template, ns *namespace.Namespace) (string, error) {

--- a/chasm/lib/nexusoperation/task_handler_helpers.go
+++ b/chasm/lib/nexusoperation/task_handler_helpers.go
@@ -324,7 +324,6 @@ func operationErrorToFailure(opErr *nexus.OperationError) (*failurepb.Failure, e
 }
 
 func buildCallbackURL(
-	useSystemCallback bool,
 	callbackTemplate *template.Template,
 	ns *namespace.Namespace,
 	endpoint *persistencespb.NexusEndpointEntry,
@@ -333,9 +332,6 @@ func buildCallbackURL(
 		return commonnexus.SystemCallbackURL, nil
 	}
 	target := endpoint.GetEndpoint().GetSpec().GetTarget().GetVariant()
-	if !useSystemCallback {
-		return buildCallbackFromTemplate(callbackTemplate, ns)
-	}
 	switch target.(type) {
 	case *persistencespb.NexusEndpointTarget_Worker_:
 		return commonnexus.SystemCallbackURL, nil

--- a/chasm/lib/nexusoperation/task_handler_helpers_test.go
+++ b/chasm/lib/nexusoperation/task_handler_helpers_test.go
@@ -1,56 +1,50 @@
-package nexusoperations
+package nexusoperation
 
 import (
 	"testing"
+	"text/template"
 
 	"github.com/stretchr/testify/require"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/namespace"
+	commonnexus "go.temporal.io/server/common/nexus"
 )
 
 func TestBuildCallbackURL(t *testing.T) {
+	t.Parallel()
+
 	ns := namespace.NewLocalNamespaceForTest(
 		&persistencespb.NamespaceInfo{Name: "ns-name", Id: "ns-id"},
 		&persistencespb.NamespaceConfig{},
 		"active-cluster",
 	)
+	callbackTemplate, err := template.New("callback").Parse("http://example/callback/{{.NamespaceName}}-{{.NamespaceID}}")
+	require.NoError(t, err)
 
 	workerEndpoint := &persistencespb.NexusEndpointEntry{
 		Endpoint: &persistencespb.NexusEndpoint{
 			Spec: &persistencespb.NexusEndpointSpec{
-				Name: "endpoint",
 				Target: &persistencespb.NexusEndpointTarget{
-					Variant: &persistencespb.NexusEndpointTarget_Worker_{
-						Worker: &persistencespb.NexusEndpointTarget_Worker{
-							NamespaceId: "ns-id",
-							TaskQueue:   "nexus-tq",
-						},
-					},
+					Variant: &persistencespb.NexusEndpointTarget_Worker_{},
 				},
 			},
 		},
 	}
-
 	externalEndpoint := &persistencespb.NexusEndpointEntry{
 		Endpoint: &persistencespb.NexusEndpoint{
 			Spec: &persistencespb.NexusEndpointSpec{
-				Name: "endpoint",
 				Target: &persistencespb.NexusEndpointTarget{
-					Variant: &persistencespb.NexusEndpointTarget_External_{
-						External: &persistencespb.NexusEndpointTarget_External{Url: "https://api.example.com"},
-					},
+					Variant: &persistencespb.NexusEndpointTarget_External_{},
 				},
 			},
 		},
 	}
 
-	// When target is worker, return the system URL
-	got, err := buildCallbackURL("http://example/callback/{{.NamespaceName}}", ns, workerEndpoint)
+	got, err := buildCallbackURL(callbackTemplate, ns, workerEndpoint)
 	require.NoError(t, err)
-	require.Equal(t, "temporal://system", got)
+	require.Equal(t, commonnexus.SystemCallbackURL, got)
 
-	// When target is external, use the template
-	got, err = buildCallbackURL("http://example/callback/{{.NamespaceName}}-{{.NamespaceID}}", ns, externalEndpoint)
+	got, err = buildCallbackURL(callbackTemplate, ns, externalEndpoint)
 	require.NoError(t, err)
 	require.Equal(t, "http://example/callback/ns-name-ns-id", got)
 }

--- a/components/callbacks/config.go
+++ b/components/callbacks/config.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"go.temporal.io/server/chasm"
+	chasmcallbacks "go.temporal.io/server/chasm/lib/callback"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/nexus"
@@ -33,8 +34,9 @@ var RetryPolicyMaximumInterval = dynamicconfig.NewGlobalDurationSetting(
 )
 
 type Config struct {
-	RequestTimeout dynamicconfig.DurationPropertyFnWithDestinationFilter
-	RetryPolicy    func() backoff.RetryPolicy
+	RequestTimeout      dynamicconfig.DurationPropertyFnWithDestinationFilter
+	RetryPolicy         dynamicconfig.TypedPropertyFn[backoff.RetryPolicy]
+	InspectSourceHeader dynamicconfig.BoolPropertyFn
 }
 
 func ConfigProvider(dc *dynamicconfig.Collection) *Config {
@@ -49,6 +51,7 @@ func ConfigProvider(dc *dynamicconfig.Collection) *Config {
 				backoff.NoInterval,
 			)
 		},
+		InspectSourceHeader: chasmcallbacks.InspectSourceHeader.Get(dc),
 	}
 }
 

--- a/components/callbacks/fx.go
+++ b/components/callbacks/fx.go
@@ -29,6 +29,7 @@ func HTTPCallerProviderProvider(
 	rpcFactory common.RPCFactory,
 	httpClientCache *cluster.FrontendHTTPClientCache,
 	logger log.Logger,
+	config *Config,
 ) (HTTPCallerProvider, error) {
 	localClient, err := rpcFactory.CreateLocalFrontendHTTPClient()
 	if err != nil {
@@ -47,6 +48,7 @@ func HTTPCallerProviderProvider(
 				defaultClient,
 				localClient,
 				logger,
+				config.InspectSourceHeader(),
 			)
 		}
 	})

--- a/components/callbacks/request.go
+++ b/components/callbacks/request.go
@@ -14,8 +14,7 @@ import (
 	commonnexus "go.temporal.io/server/common/nexus"
 )
 
-// Header key used to identify callbacks that originate from and target the same cluster.
-// Note: this is the nexusoperations.NexusCallbackSourceHeader stripped of Nexus-Callback-
+// Legacy header key used to identify callbacks that originate from and target the same cluster.
 const callbackSourceHeader = "source"
 
 // routeSystemCallbackRequest routes a system callback request to the appropriate frontend client
@@ -96,13 +95,13 @@ func routeRequest(
 	defaultClient *http.Client,
 	localClient *common.FrontendHTTPClient,
 	logger log.Logger,
+	inspectSourceHeader bool,
 ) (*http.Response, error) {
 	if r.URL.String() == commonnexus.SystemCallbackURL {
 		return routeSystemCallbackRequest(r, clusterMetadata, namespaceRegistry, httpClientCache, callbackTokenGenerator, localClient, logger)
 	}
-	// This source header is populated in nexusoperations/executors (via the ClientProvider) for worker targets
-	// if this header is not populated then we assume it's an external target.
-	if r.Header == nil || r.Header.Get(callbackSourceHeader) == "" {
+	// Older servers populated this header for worker targets. Treat the request as external unless legacy inspection is enabled.
+	if !inspectSourceHeader || r.Header == nil || r.Header.Get(callbackSourceHeader) == "" {
 		return defaultClient.Do(r)
 	}
 	// If we got here, we assume that the endpoint in the original call was a worker target, and we should route

--- a/components/callbacks/request_test.go
+++ b/components/callbacks/request_test.go
@@ -51,6 +51,36 @@ func TestRouteRequest_ExternalTarget(t *testing.T) {
 		ts.Client(),
 		nil, // localClient not needed for external targets
 		log.NewNoopLogger(),
+		false,
+	)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestRouteRequest_SourceHeaderIgnored(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	ctrl := gomock.NewController(t)
+	clusterMeta := cluster.NewMockMetadata(ctrl)
+
+	r, err := http.NewRequest(http.MethodPost, ts.URL+"/some/path", nil)
+	require.NoError(t, err)
+	r.Header.Set(callbackSourceHeader, "cluster-id-A")
+
+	resp, err := routeRequest(
+		r,
+		clusterMeta,
+		nil,
+		nil,
+		nil,
+		ts.Client(),
+		nil,
+		log.NewNoopLogger(),
+		false,
 	)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
@@ -86,6 +116,7 @@ func TestRouteRequest_SourceHeaderLocal(t *testing.T) {
 		&http.Client{},
 		localClient,
 		log.NewNoopLogger(),
+		true,
 	)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
@@ -121,6 +152,7 @@ func TestRouteRequest_SourceHeaderUnknownCluster(t *testing.T) {
 		&http.Client{},
 		localClient,
 		log.NewNoopLogger(),
+		true,
 	)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
@@ -321,6 +353,7 @@ func TestRouteRequest_SystemCallback(t *testing.T) {
 		&http.Client{},
 		localClient,
 		log.NewNoopLogger(),
+		false,
 	)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()

--- a/components/nexusoperations/config.go
+++ b/components/nexusoperations/config.go
@@ -75,19 +75,6 @@ ScheduleNexusOperation commands with a "nexus_header" field that exceeds this li
 Uses Go's len() function on header keys and values to determine the total size.`,
 )
 
-var UseSystemCallbackURL = dynamicconfig.NewGlobalBoolSetting(
-	"component.nexusoperations.useSystemCallbackURL",
-	true,
-	`UseSystemCallbackURL is a global feature toggle that controls how the executor generates
-	callback URLs for worker targets in Nexus Operations.When set to true,
-	the executor will use the fixed system callback URL ("temporal://system") for all worker targets,
-	instead of generating URLs from the callback URL template.
-	This simplifies configuration and improves reliability for worker callbacks.
-	- false: The executor uses the callback URL template to generate callback URLs for worker targets.
-	- true (default): The executor uses the fixed system callback URL ("temporal://system") for worker targets.
-	Note: The default will switch to true in future releases.`,
-)
-
 var DisallowedOperationHeaders = dynamicconfig.NewGlobalTypedSettingWithConverter(
 	"component.nexusoperations.disallowedHeaders",
 	func(in any) ([]string, error) {
@@ -177,7 +164,6 @@ type Config struct {
 	MaxOperationScheduleToCloseTimeout  dynamicconfig.DurationPropertyFnWithNamespaceFilter
 	PayloadSizeLimit                    dynamicconfig.IntPropertyFnWithNamespaceFilter
 	CallbackURLTemplate                 dynamicconfig.StringPropertyFn
-	UseSystemCallbackURL                dynamicconfig.BoolPropertyFn
 	UseNewFailureWireFormat             dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	RecordCancelRequestCompletionEvents dynamicconfig.BoolPropertyFn
 	MetricTagConfig                     dynamicconfig.TypedPropertyFn[chasmnexus.NexusMetricTagConfig]
@@ -197,7 +183,6 @@ func ConfigProvider(dc *dynamicconfig.Collection, cfg *config.Persistence) *Conf
 		MaxOperationScheduleToCloseTimeout:  MaxOperationScheduleToCloseTimeout.Get(dc),
 		PayloadSizeLimit:                    dynamicconfig.BlobSizeLimitError.Get(dc),
 		CallbackURLTemplate:                 CallbackURLTemplate.Get(dc),
-		UseSystemCallbackURL:                UseSystemCallbackURL.Get(dc),
 		UseNewFailureWireFormat:             chasmnexus.UseNewFailureWireFormat.Get(dc),
 		RecordCancelRequestCompletionEvents: RecordCancelRequestCompletionEvents.Get(dc),
 		MetricTagConfig:                     MetricTagConfiguration.Get(dc),

--- a/components/nexusoperations/executors.go
+++ b/components/nexusoperations/executors.go
@@ -122,7 +122,6 @@ type taskExecutor struct {
 }
 
 func buildCallbackURL(
-	useSystemCallback bool,
 	callbackTemplate string,
 	ns *namespace.Namespace,
 	endpoint *persistencespb.NexusEndpointEntry,
@@ -131,9 +130,6 @@ func buildCallbackURL(
 		return commonnexus.SystemCallbackURL, nil
 	}
 	target := endpoint.GetEndpoint().GetSpec().GetTarget().GetVariant()
-	if !useSystemCallback {
-		return buildCallbackFromTemplate(callbackTemplate, ns)
-	}
 	switch target.(type) {
 	case *persistencespb.NexusEndpointTarget_Worker_:
 		return commonnexus.SystemCallbackURL, nil
@@ -195,7 +191,7 @@ func (e taskExecutor) executeInvocationTask(ctx context.Context, env hsm.Environ
 		}
 	}
 
-	callbackURL, err := buildCallbackURL(e.Config.UseSystemCallbackURL(), e.Config.CallbackURLTemplate(), ns, endpoint)
+	callbackURL, err := buildCallbackURL(e.Config.CallbackURLTemplate(), ns, endpoint)
 	if err != nil {
 		return fmt.Errorf("failed to build callback URL: %w", err)
 	}

--- a/components/nexusoperations/executors_test.go
+++ b/components/nexusoperations/executors_test.go
@@ -643,7 +643,6 @@ func TestProcessInvocationTask(t *testing.T) {
 					MinRequestTimeout:       dynamicconfig.GetDurationPropertyFnFilteredByNamespace(time.Millisecond),
 					PayloadSizeLimit:        dynamicconfig.GetIntPropertyFnFilteredByNamespace(2 * 1024 * 1024),
 					CallbackURLTemplate:     dynamicconfig.GetStringPropertyFn("http://localhost/callback"),
-					UseSystemCallbackURL:    dynamicconfig.GetBoolPropertyFn(true),
 					UseNewFailureWireFormat: dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true),
 					RetryPolicy: func() backoff.RetryPolicy {
 						return backoff.NewExponentialRetryPolicy(time.Second)
@@ -1892,7 +1891,6 @@ func TestProcessInvocationTask_SystemEndpoint(t *testing.T) {
 					PayloadSizeLimit:        dynamicconfig.GetIntPropertyFnFilteredByNamespace(2 * 1024 * 1024),
 					MaxOperationTokenLength: dynamicconfig.GetIntPropertyFnFilteredByNamespace(1000),
 					CallbackURLTemplate:     dynamicconfig.GetStringPropertyFn("http://localhost/callback"),
-					UseSystemCallbackURL:    dynamicconfig.GetBoolPropertyFn(true),
 					UseNewFailureWireFormat: dynamicconfig.GetBoolPropertyFnFilteredByNamespace(false),
 					NumHistoryShards:        4,
 					RetryPolicy: func() backoff.RetryPolicy {

--- a/components/nexusoperations/fx.go
+++ b/components/nexusoperations/fx.go
@@ -18,5 +18,3 @@ var Module = fx.Module(
 		return ClientProvider(cp)
 	}),
 )
-
-const NexusCallbackSourceHeader = "Nexus-Callback-Source"

--- a/docs/architecture/nexus.md
+++ b/docs/architecture/nexus.md
@@ -65,13 +65,8 @@ To enable Nexus in your deployment:
 
 2. Configure Nexus settings in the [dynamic config](https://docs.temporal.io/references/dynamic-configuration)
 
-- 2a. Since version 1.30.0, only turn on using the system callback URL (`temporal://system`), this flag will go away in
-the 1.31.0 release and will be made the default.
-
-    ```yaml
-   component.nexusoperations.useSystemCallbackURL:
-    - value: true
-   ```
+- 2a. Starting with version 1.31.0, callbacks for worker targets always use the system callback URL
+  (`temporal://system`). No callback URL configuration is required.
 
 - 2b. Prior to version 1.30.0, you must set a public callback URL, and allowed callback addresses. These configurations
   are also required for calling **experimental** external endpoint targets.

--- a/tests/testcore/dynamic_config_overrides.go
+++ b/tests/testcore/dynamic_config_overrides.go
@@ -71,7 +71,6 @@ var (
 		dynamicconfig.ForceNexusEndpointRefreshOnRead.Key():                 true,
 		dynamicconfig.RefreshNexusEndpointsMinWait.Key():                    1 * time.Millisecond,
 		nexusoperations.RecordCancelRequestCompletionEvents.Key():           true,
-		nexusoperations.UseSystemCallbackURL.Key():                          true,
 
 		// CHASM scheduler rollout percents default to 0 in production; in tests we
 		// dial them to 100 so existing tests that only flip the binary enable flag


### PR DESCRIPTION
## What changed?
Cherry pick https://github.com/temporalio/temporal/pull/11965 into release/v1.32.x

Fixed-merge conflcits:
* chasm/lib/callback/fx.go
* chasm/lib/callback/request.go
* chasm/lib/nexusoperation/fx.go
* chasm/lib/nexusoperation/task_handler_helpers_test.go - created with only the new TestBuildCallbackURL

## Why?
A caller-controlled source header could cause an external callback request to be routed internally. URL-scheme routing is now the default while retaining a mixed-version compatibility escape hatch.

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
_Any change is risky. Identify all risks you are aware of. If none, remove this section._
