### PR TITLE
Address review feedback on the callback instrumentation

### DIFF
--- a/chasm/lib/callback/invocable_internal.go
+++ b/chasm/lib/callback/invocable_internal.go
@@ -66,9 +66,9 @@ func (c invocableInternal) Invoke(
 	defer func() {
 		namespaceTag := metrics.NamespaceTag(ns.Name().String())
 		destTag := metrics.DestinationTag(taskAttr.Destination)
-		outcomeTag := metrics.OutcomeTag(outcome)
-		h.metricsHandler.Counter(InternalRequestCounter.Name()).Record(1, namespaceTag, destTag, outcomeTag)
-		h.metricsHandler.Timer(InternalRequestLatencyHistogram.Name()).Record(time.Since(startTime), namespaceTag, destTag, outcomeTag)
+		outcomeMetricTag := metrics.OutcomeTag(string(outcome))
+		h.metricsHandler.Counter(InternalRequestCounter.Name()).Record(1, namespaceTag, destTag, outcomeMetricTag)
+		h.metricsHandler.Timer(InternalRequestLatencyHistogram.Name()).Record(time.Since(startTime), namespaceTag, destTag, outcomeMetricTag)
 	}()
 
 	header := nexus.Header(c.callback.GetHeader())
@@ -113,9 +113,9 @@ func (c invocableInternal) Invoke(
 		// GetRPCStatus, not status.Code: the internode interceptor returns serviceerror
 		// types, which expose Status() rather than GRPCStatus(), so status.Code reports
 		// Unknown for all of them. IsRetryableRPCError below reads the code the same way.
-		outcome = "error:" + codes.Unknown.String()
+		outcome = outcomeTag(errorOutcomePrefix + codes.Unknown.String())
 		if st, ok := common.GetRPCStatus(err); ok {
-			outcome = "error:" + st.Code().String()
+			outcome = outcomeTag(errorOutcomePrefix + st.Code().String())
 		}
 		if ctx.Err() != nil {
 			outcome = outcomeRequestTimeout

--- a/chasm/lib/callback/invocable_outbound.go
+++ b/chasm/lib/callback/invocable_outbound.go
@@ -72,9 +72,9 @@ func (n invocableOutbound) Invoke(
 
 	namespaceTag := metrics.NamespaceTag(ns.Name().String())
 	destTag := metrics.DestinationTag(taskAttr.Destination)
-	outcomeTag := metrics.OutcomeTag(outcomeTag(ctx, err))
-	h.metricsHandler.Counter(RequestCounter.Name()).Record(1, namespaceTag, destTag, outcomeTag)
-	h.metricsHandler.Timer(RequestLatencyHistogram.Name()).Record(time.Since(startTime), namespaceTag, destTag, outcomeTag)
+	outcomeMetricTag := metrics.OutcomeTag(string(outboundOutcome(ctx, err)))
+	h.metricsHandler.Counter(RequestCounter.Name()).Record(1, namespaceTag, destTag, outcomeMetricTag)
+	h.metricsHandler.Timer(RequestLatencyHistogram.Name()).Record(time.Since(startTime), namespaceTag, destTag, outcomeMetricTag)
 
 	if err != nil {
 		retryable := isRetryableCallError(err)
@@ -94,15 +94,19 @@ func isRetryableCallError(err error) bool {
 	return true
 }
 
-func outcomeTag(callCtx context.Context, callErr error) string {
+func outboundOutcome(callCtx context.Context, callErr error) outcomeTag {
 	if callErr != nil {
 		if callCtx.Err() != nil {
 			return outcomeRequestTimeout
 		}
 		if handlerErr, ok := errors.AsType[*nexus.HandlerError](callErr); ok {
-			return "handler-error:" + string(handlerErr.Type)
+			return handlerErrorOutcome(handlerErr)
 		}
-		return "unknown-error"
+		return outcomeUnknownError
 	}
 	return outcomeSuccess
+}
+
+func handlerErrorOutcome(handlerErr *nexus.HandlerError) outcomeTag {
+	return outcomeTag(handlerErrorOutcomePrefix + commonnexus.BoundHandlerErrorType(string(handlerErr.Type)))
 }

--- a/chasm/lib/callback/metrics.go
+++ b/chasm/lib/callback/metrics.go
@@ -26,33 +26,42 @@ var (
 	)
 
 	// Emitted for both the internal and outbound paths, once the transition has committed.
-	InvocationResultCounter = metrics.NewCounterDef(
-		"callback_invocation_results",
-		metrics.WithDescription("Committed callback invocation results, by disposition: succeeded, retrying, or failed. A failed result is terminal."),
+	InvocationEventCounter = metrics.NewCounterDef(
+		"callback_invocation_events",
+		metrics.WithDescription("Committed callback invocation events. Per callback: (retryable-error)* (success | nonretryable-error)."),
 	)
 	InvocationAttemptsHistogram = metrics.NewDimensionlessHistogramDef(
 		"callback_invocation_attempts",
-		metrics.WithDescription("Attempts a callback had made on reaching a terminal disposition, by disposition."),
+		metrics.WithDescription("Attempts a callback had made on reaching a terminal event, by outcome."),
 	)
 )
 
-// Disposition tag values for InvocationResultCounter and InvocationAttemptsHistogram.
+// outcomeTag is a value of the outcome tag carried by the metrics above.
+type outcomeTag string
+
+// Invocation events; the terminal success event is outcomeSuccess below.
 const (
-	dispositionSucceeded = "succeeded"
-	dispositionRetrying  = "retrying"
-	dispositionFailed    = "failed"
+	outcomeRetryableError    outcomeTag = "retryable-error"
+	outcomeNonretryableError outcomeTag = "nonretryable-error"
 )
 
-// Internal-path outcomes decided before the RPC is issued. Failures after it are tagged by
-// gRPC status code.
+// Internal-path delivery outcomes decided before the RPC is issued. Failures after it are tagged by
+// gRPC status code, under errorOutcomePrefix.
 const (
 	// outcomeUnknown is the sentinel Invoke starts from, so a path that returns without
 	// setting an outcome shows up as unknown rather than as a success.
-	outcomeUnknown           = "unknown"
-	outcomeSuccess           = "success"
-	outcomeMissingToken      = "missing-token"
-	outcomeTokenDecodeError  = "token-decode-error"
-	outcomeInvalidRef        = "invalid-ref"
-	outcomeRequestBuildError = "request-build-error"
-	outcomeRequestTimeout    = "request-timeout"
+	outcomeUnknown           outcomeTag = "unknown"
+	outcomeSuccess           outcomeTag = "success"
+	outcomeMissingToken      outcomeTag = "missing-token"
+	outcomeTokenDecodeError  outcomeTag = "token-decode-error"
+	outcomeInvalidRef        outcomeTag = "invalid-ref"
+	outcomeRequestBuildError outcomeTag = "request-build-error"
+	outcomeRequestTimeout    outcomeTag = "request-timeout"
+	// An outbound failure that is not a Nexus handler error, e.g. a transport failure.
+	outcomeUnknownError outcomeTag = "unknown-error"
+)
+
+const (
+	handlerErrorOutcomePrefix = "handler-error:"
+	errorOutcomePrefix        = "error:"
 )

--- a/chasm/lib/callback/tasks.go
+++ b/chasm/lib/callback/tasks.go
@@ -148,26 +148,26 @@ func (h *invocationTaskHandler) Execute(
 	)
 	if saveErr == nil {
 		// Only after the transition commits; transitions can be rolled back.
-		h.recordDisposition(ns, taskAttr, task, result)
+		h.recordInvocationEvent(ns, taskAttr, task, result)
 	}
 	return invokable.WrapError(result, saveErr)
 }
 
-// recordDisposition emits the committed outcome of a single invocation.
-func (h *invocationTaskHandler) recordDisposition(
+// recordInvocationEvent emits the committed outcome of a single invocation attempt.
+func (h *invocationTaskHandler) recordInvocationEvent(
 	ns *namespace.Namespace,
 	taskAttr chasm.TaskAttributes,
 	task *callbackspb.InvocationTask,
 	result invocationResult,
 ) {
-	var disposition string
+	var outcome outcomeTag
 	switch result.(type) {
 	case invocationResultOK:
-		disposition = dispositionSucceeded
+		outcome = outcomeSuccess
 	case invocationResultRetry:
-		disposition = dispositionRetrying
+		outcome = outcomeRetryableError
 	case invocationResultFail:
-		disposition = dispositionFailed
+		outcome = outcomeNonretryableError
 	default:
 		// saveResult rejects anything else as an unprocessable task.
 		return
@@ -176,12 +176,12 @@ func (h *invocationTaskHandler) recordDisposition(
 	tags := []metrics.Tag{
 		metrics.NamespaceTag(ns.Name().String()),
 		metrics.DestinationTag(taskAttr.Destination),
-		metrics.OutcomeTag(disposition),
+		metrics.OutcomeTag(string(outcome)),
 	}
-	h.metricsHandler.Counter(InvocationResultCounter.Name()).Record(1, tags...)
+	h.metricsHandler.Counter(InvocationEventCounter.Name()).Record(1, tags...)
 
-	if disposition != dispositionRetrying {
-		// Attempt is 0-based, so +1 is the count. Only terminal dispositions have a final total.
+	if outcome != outcomeRetryableError {
+		// Attempt is 0-based, so +1 is the count. Only terminal events have a final total.
 		h.metricsHandler.Histogram(InvocationAttemptsHistogram.Name(), InvocationAttemptsHistogram.Unit()).
 			Record(int64(task.GetAttempt())+1, tags...)
 	}

--- a/chasm/lib/callback/tasks_test.go
+++ b/chasm/lib/callback/tasks_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -86,10 +88,10 @@ func TestExecuteInvocationTaskNexus_Outcomes(t *testing.T) {
 		name                  string
 		caller                HTTPCaller
 		expectedMetricOutcome string
-		// expectedDisposition is the outcome tag on callback_invocation_results, which is
+		// expectedEvent is the outcome tag on callback_invocation_events, which is
 		// recorded for the outbound path as well as the internal one.
-		expectedDisposition string
-		assertOutcome       func(*testing.T, *Callback, error)
+		expectedEvent string
+		assertOutcome func(*testing.T, *Callback, error)
 	}{
 		{
 			name: "success",
@@ -97,7 +99,7 @@ func TestExecuteInvocationTaskNexus_Outcomes(t *testing.T) {
 				return &http.Response{StatusCode: 200, Body: http.NoBody}, nil
 			},
 			expectedMetricOutcome: "success",
-			expectedDisposition:   "succeeded",
+			expectedEvent:         "success",
 			assertOutcome: func(t *testing.T, cb *Callback, err error) {
 				require.NoError(t, err)
 				require.Equal(t, callbackspb.CALLBACK_STATUS_SUCCEEDED, cb.Status)
@@ -109,7 +111,7 @@ func TestExecuteInvocationTaskNexus_Outcomes(t *testing.T) {
 				return nil, errors.New("fake failure")
 			},
 			expectedMetricOutcome: "unknown-error",
-			expectedDisposition:   "retrying",
+			expectedEvent:         "retryable-error",
 			assertOutcome: func(t *testing.T, cb *Callback, err error) {
 				var destDownErr *queueserrors.DestinationDownError
 				require.ErrorAs(t, err, &destDownErr)
@@ -122,7 +124,7 @@ func TestExecuteInvocationTaskNexus_Outcomes(t *testing.T) {
 				return &http.Response{StatusCode: 500, Body: http.NoBody}, nil
 			},
 			expectedMetricOutcome: "handler-error:INTERNAL",
-			expectedDisposition:   "retrying",
+			expectedEvent:         "retryable-error",
 			assertOutcome: func(t *testing.T, cb *Callback, err error) {
 				var destDownErr *queueserrors.DestinationDownError
 				require.ErrorAs(t, err, &destDownErr)
@@ -135,7 +137,26 @@ func TestExecuteInvocationTaskNexus_Outcomes(t *testing.T) {
 				return &http.Response{StatusCode: 400, Body: http.NoBody}, nil
 			},
 			expectedMetricOutcome: "handler-error:BAD_REQUEST",
-			expectedDisposition:   "failed",
+			expectedEvent:         "nonretryable-error",
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				require.NoError(t, err)
+				require.Equal(t, callbackspb.CALLBACK_STATUS_FAILED, cb.Status)
+			},
+		},
+		{
+			// A destination naming its own handler error type must not reach the tag.
+			name: "off-spec-handler-error-type",
+			caller: func(r *http.Request) (*http.Response, error) {
+				body := `{"message":"boom","metadata":{"type":"nexus.HandlerError"},` +
+					`"details":{"type":"MINTED_BY_THE_DESTINATION","retryableOverride":false}}`
+				return &http.Response{
+					StatusCode: 500,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body:       io.NopCloser(strings.NewReader(body)),
+				}, nil
+			},
+			expectedMetricOutcome: "handler-error:UNKNOWN",
+			expectedEvent:         "nonretryable-error",
 			assertOutcome: func(t *testing.T, cb *Callback, err error) {
 				require.NoError(t, err)
 				require.Equal(t, callbackspb.CALLBACK_STATUS_FAILED, cb.Status)
@@ -176,22 +197,22 @@ func TestExecuteInvocationTaskNexus_Outcomes(t *testing.T) {
 				metrics.DestinationTag("http://localhost"),
 				metrics.OutcomeTag(tc.expectedMetricOutcome))
 
-			// The committed disposition is recorded for the outbound path too, not just the
+			// The committed event is recorded for the outbound path too, not just the
 			// internal one, so a permanently dropped external callback is also visible.
-			dispositionTags := []metrics.Tag{
+			eventTags := []metrics.Tag{
 				metrics.NamespaceTag("namespace-name"),
 				metrics.DestinationTag("http://localhost"),
-				metrics.OutcomeTag(tc.expectedDisposition),
+				metrics.OutcomeTag(tc.expectedEvent),
 			}
-			dispositionCounter := metrics.NewMockCounterIface(ctrl)
-			metricsHandler.EXPECT().Counter(InvocationResultCounter.Name()).Return(dispositionCounter)
-			dispositionCounter.EXPECT().Record(int64(1), dispositionTags)
-			if tc.expectedDisposition != dispositionRetrying {
+			eventCounter := metrics.NewMockCounterIface(ctrl)
+			metricsHandler.EXPECT().Counter(InvocationEventCounter.Name()).Return(eventCounter)
+			eventCounter.EXPECT().Record(int64(1), eventTags)
+			if tc.expectedEvent != string(outcomeRetryableError) {
 				attemptHistogram := metrics.NewMockHistogramIface(ctrl)
 				metricsHandler.EXPECT().
 					Histogram(InvocationAttemptsHistogram.Name(), InvocationAttemptsHistogram.Unit()).
 					Return(attemptHistogram)
-				attemptHistogram.EXPECT().Record(int64(1), dispositionTags)
+				attemptHistogram.EXPECT().Record(int64(1), eventTags)
 			}
 
 			// Setup logger
@@ -386,8 +407,8 @@ func TestExecuteInvocationTaskChasm_Outcomes(t *testing.T) {
 		// Every path through Invoke must record exactly one sample: this counter is the only
 		// evidence the delivery was attempted at all.
 		wantDeliveryOutcome string
-		// wantDisposition is the outcome tag expected on callback_invocation_results.
-		wantDisposition string
+		// wantEvent is the outcome tag expected on callback_invocation_events.
+		wantEvent string
 		// wantAttemptSample is whether callback_invocation_attempts should be recorded, which
 		// happens only on a terminal disposition.
 		wantAttemptSample bool
@@ -426,7 +447,7 @@ func TestExecuteInvocationTaskChasm_Outcomes(t *testing.T) {
 				require.Equal(t, callbackspb.CALLBACK_STATUS_SUCCEEDED, cb.Status)
 			},
 			wantDeliveryOutcome: "success",
-			wantDisposition:     "succeeded",
+			wantEvent:           "success",
 			wantAttemptSample:   true,
 		},
 		{
@@ -460,7 +481,7 @@ func TestExecuteInvocationTaskChasm_Outcomes(t *testing.T) {
 				require.Equal(t, callbackspb.CALLBACK_STATUS_SUCCEEDED, cb.Status)
 			},
 			wantDeliveryOutcome: "success",
-			wantDisposition:     "succeeded",
+			wantEvent:           "success",
 			wantAttemptSample:   true,
 		},
 		{
@@ -484,7 +505,7 @@ func TestExecuteInvocationTaskChasm_Outcomes(t *testing.T) {
 				require.Equal(t, callbackspb.CALLBACK_STATUS_BACKING_OFF, cb.Status)
 			},
 			wantDeliveryOutcome: "error:Unavailable",
-			wantDisposition:     "retrying",
+			wantEvent:           "retryable-error",
 			wantAttemptSample:   false,
 		},
 		{
@@ -508,7 +529,7 @@ func TestExecuteInvocationTaskChasm_Outcomes(t *testing.T) {
 				require.Equal(t, callbackspb.CALLBACK_STATUS_FAILED, cb.Status)
 			},
 			wantDeliveryOutcome: "error:InvalidArgument",
-			wantDisposition:     "failed",
+			wantEvent:           "nonretryable-error",
 			wantAttemptSample:   true,
 		},
 		{
@@ -535,7 +556,7 @@ func TestExecuteInvocationTaskChasm_Outcomes(t *testing.T) {
 				require.Equal(t, callbackspb.CALLBACK_STATUS_FAILED, cb.Status)
 			},
 			wantDeliveryOutcome: "error:NotFound",
-			wantDisposition:     "failed",
+			wantEvent:           "nonretryable-error",
 			wantAttemptSample:   true,
 		},
 		{
@@ -556,7 +577,7 @@ func TestExecuteInvocationTaskChasm_Outcomes(t *testing.T) {
 				require.Equal(t, callbackspb.CALLBACK_STATUS_FAILED, cb.Status)
 			},
 			wantDeliveryOutcome: "missing-token",
-			wantDisposition:     "failed",
+			wantEvent:           "nonretryable-error",
 			wantAttemptSample:   true,
 		},
 		{
@@ -577,7 +598,7 @@ func TestExecuteInvocationTaskChasm_Outcomes(t *testing.T) {
 				require.Equal(t, callbackspb.CALLBACK_STATUS_FAILED, cb.Status)
 			},
 			wantDeliveryOutcome: "request-build-error",
-			wantDisposition:     "failed",
+			wantEvent:           "nonretryable-error",
 			wantAttemptSample:   true,
 		},
 		{
@@ -597,7 +618,7 @@ func TestExecuteInvocationTaskChasm_Outcomes(t *testing.T) {
 				require.Equal(t, callbackspb.CALLBACK_STATUS_FAILED, cb.Status)
 			},
 			wantDeliveryOutcome: "token-decode-error",
-			wantDisposition:     "failed",
+			wantEvent:           "nonretryable-error",
 			wantAttemptSample:   true,
 		},
 		{
@@ -617,7 +638,7 @@ func TestExecuteInvocationTaskChasm_Outcomes(t *testing.T) {
 				require.Equal(t, callbackspb.CALLBACK_STATUS_FAILED, cb.Status)
 			},
 			wantDeliveryOutcome: "invalid-ref",
-			wantDisposition:     "failed",
+			wantEvent:           "nonretryable-error",
 			wantAttemptSample:   true,
 		},
 	}
@@ -796,15 +817,15 @@ func TestExecuteInvocationTaskChasm_Outcomes(t *testing.T) {
 			require.Len(t, snapshot[InternalRequestLatencyHistogram.Name()], 1,
 				"latency must be recorded alongside the request counter")
 
-			results := snapshot[InvocationResultCounter.Name()]
+			results := snapshot[InvocationEventCounter.Name()]
 			require.Len(t, results, 1)
-			require.Equal(t, tc.wantDisposition, results[0].Tags["outcome"])
+			require.Equal(t, tc.wantEvent, results[0].Tags["outcome"])
 
 			attempts := snapshot[InvocationAttemptsHistogram.Name()]
 			if tc.wantAttemptSample {
 				require.Len(t, attempts, 1,
 					"a terminal disposition must record the attempt count")
-				require.Equal(t, tc.wantDisposition, attempts[0].Tags["outcome"])
+				require.Equal(t, tc.wantEvent, attempts[0].Tags["outcome"])
 				// task.Attempt is 0-based, and the task below is built with Attempt: 1.
 				require.Equal(t, int64(2), attempts[0].Value)
 			} else {

--- a/common/nexus/dispatch_outcome.go
+++ b/common/nexus/dispatch_outcome.go
@@ -288,7 +288,7 @@ func (r DispatchResult) metricOutcome() string {
 		DispatchOutcomeWorkerFailure:
 		// A worker failure has no handler error type to report and will map to UNKNOWN.
 		hErrType := r.Failure.GetNexusHandlerFailureInfo().GetType()
-		return "handler_error:" + boundHandlerErrorType(hErrType)
+		return "handler_error:" + BoundHandlerErrorType(hErrType)
 	case DispatchOutcomeRequestTimeout:
 		return "handler_timeout"
 	case DispatchOutcomeUnrecognized:
@@ -314,10 +314,10 @@ var handlerErrorTypes = map[string]struct{}{
 	string(nexus.HandlerErrorTypeUpstreamTimeout):   {},
 }
 
-// boundHandlerErrorType bounds the metric cardinality a worker can introduce through a handler error
-// type. Types in the Nexus spec pass through; anything else, including the empty string, collapses to
-// UNKNOWN.
-func boundHandlerErrorType(errType string) string {
+// BoundHandlerErrorType bounds the metric cardinality a worker or a remote handler can introduce
+// through a handler error type. Types in the Nexus spec pass through; anything else, including the
+// empty string, collapses to UNKNOWN. The caller supplies its own prefix.
+func BoundHandlerErrorType(errType string) string {
 	if _, ok := handlerErrorTypes[errType]; ok {
 		return errType
 	}

--- a/common/nexus/dispatch_outcome_test.go
+++ b/common/nexus/dispatch_outcome_test.go
@@ -590,10 +590,10 @@ func TestBoundHandlerErrorType(t *testing.T) {
 		"CONFLICT", "RESOURCE_EXHAUSTED", "INTERNAL", "NOT_IMPLEMENTED", "UNAVAILABLE",
 		"UPSTREAM_TIMEOUT",
 	} {
-		require.Equal(t, spec, boundHandlerErrorType(spec), "spec types pass through verbatim")
+		require.Equal(t, spec, BoundHandlerErrorType(spec), "spec types pass through verbatim")
 	}
 	// A worker picks this string, so it must not be able to mint new time series.
-	require.Equal(t, "UNKNOWN", boundHandlerErrorType("whatever-the-worker-said"))
-	require.Equal(t, "UNKNOWN", boundHandlerErrorType(""))
-	require.Equal(t, "UNKNOWN", boundHandlerErrorType("bad_request"), "matching is case sensitive")
+	require.Equal(t, "UNKNOWN", BoundHandlerErrorType("whatever-the-worker-said"))
+	require.Equal(t, "UNKNOWN", BoundHandlerErrorType(""))
+	require.Equal(t, "UNKNOWN", BoundHandlerErrorType("bad_request"), "matching is case sensitive")
 }

--- a/service/history/hsm/callbacks/executors_test.go
+++ b/service/history/hsm/callbacks/executors_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -115,6 +117,24 @@ func TestProcessInvocationTaskNexus_Outcomes(t *testing.T) {
 			},
 			retryable:             false,
 			expectedMetricOutcome: "handler-error:BAD_REQUEST",
+			assertOutcome: func(t *testing.T, cb callbacks.Callback) {
+				require.Equal(t, enumsspb.CALLBACK_STATE_FAILED, cb.State())
+			},
+		},
+		{
+			// A destination naming its own handler error type must not reach the tag.
+			name: "off-spec-handler-error-type",
+			caller: func(r *http.Request) (*http.Response, error) {
+				body := `{"message":"boom","metadata":{"type":"nexus.HandlerError"},` +
+					`"details":{"type":"MINTED_BY_THE_DESTINATION","retryableOverride":false}}`
+				return &http.Response{
+					StatusCode: 500,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body:       io.NopCloser(strings.NewReader(body)),
+				}, nil
+			},
+			retryable:             false,
+			expectedMetricOutcome: "handler-error:UNKNOWN",
 			assertOutcome: func(t *testing.T, cb callbacks.Callback) {
 				require.Equal(t, enumsspb.CALLBACK_STATE_FAILED, cb.State())
 			},

--- a/service/history/hsm/callbacks/nexus_invocation.go
+++ b/service/history/hsm/callbacks/nexus_invocation.go
@@ -94,7 +94,7 @@ func outcomeTag(callCtx context.Context, callErr error) string {
 			return "request-timeout"
 		}
 		if handlerErr, ok := errors.AsType[*nexus.HandlerError](callErr); ok {
-			return "handler-error:" + string(handlerErr.Type)
+			return "handler-error:" + commonnexus.BoundHandlerErrorType(string(handlerErr.Type))
 		}
 		return "unknown-error"
 	}

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -3753,19 +3753,19 @@ func testMigrationCallbackAttach(t *testing.T, newContext contextFactory) {
 
 // requireInternalCallbackDelivered asserts that at least one completion callback was
 // delivered over the internal (cross-shard) path and that the delivery is fully
-// instrumented: a successful delivery sample, a committed disposition, an attempt
+// instrumented: a successful delivery sample, a committed invocation event, an attempt
 // count, and no sample left at the "unknown" sentinel -- an outcome that would mean a
 // return path recorded no outcome at all, which is indistinguishable from never having
 // run.
 func requireInternalCallbackDelivered(t *testing.T, capture *testcore.NamespaceMetricCapture) {
 	t.Helper()
 
-	// The disposition is recorded after the callback's own state transition commits,
+	// The event is recorded after the callback's own state transition commits,
 	// which is strictly after the scheduler observed the completion, so poll.
 	await.RequireTruef(t, func() bool {
-		return countMetric(capture, callback.InvocationResultCounter.Name(),
-			map[string]string{"outcome": "succeeded", "destination": chasm.NexusCompletionHandlerURL}) >= 1
-	}, awaitTimeout, pollInterval, "a committed callback disposition should be recorded")
+		return countMetric(capture, callback.InvocationEventCounter.Name(),
+			map[string]string{"outcome": "success", "destination": chasm.NexusCompletionHandlerURL}) >= 1
+	}, awaitTimeout, pollInterval, "a committed callback event should be recorded")
 
 	deliveries := capture.Metric(callback.InternalRequestCounter.Name())
 	require.NotEmpty(t, deliveries, "internal callback delivery should be counted")
@@ -3785,14 +3785,14 @@ func requireInternalCallbackDelivered(t *testing.T, capture *testcore.NamespaceM
 			len(capture.Metric(callback.InternalRequestCounter.Name()))
 	}, awaitTimeout, pollInterval, "every counted delivery should also record a latency sample")
 
-	// Attempts are recorded only on a terminal disposition, where the total is final.
+	// Attempts are recorded only on a terminal event, where the total is final.
 	attempts := capture.CollectMetric(callback.InvocationAttemptsHistogram.Name(),
-		func(rec *metricstest.CapturedRecording) bool { return rec.Tags["outcome"] == "succeeded" })
-	require.NotEmpty(t, attempts, "a terminal disposition should record an attempt count")
+		func(rec *metricstest.CapturedRecording) bool { return rec.Tags["outcome"] == "success" })
+	require.NotEmpty(t, attempts, "a terminal event should record an attempt count")
 	require.GreaterOrEqual(t, attempts[0].Value, int64(1))
 
-	require.Zero(t, countMetric(capture, callback.InvocationResultCounter.Name(),
-		map[string]string{"outcome": "failed"}), "no callback should have been dropped permanently")
+	require.Zero(t, countMetric(capture, callback.InvocationEventCounter.Name(),
+		map[string]string{"outcome": "nonretryable-error"}), "no callback should have been dropped permanently")
 }
 
 // testCallbackCompletionMetrics pins the instrumentation on the V2 completion-callback


### PR DESCRIPTION
## Summary 

This is the second in a series of PRs where I'm attempting to the Nexus callback path, as it's very important for the reliability of the ScheduleV2 implementation. My [first PR](https://github.com/temporalio/temporal/pull/11912) was honestly pretty hurried and I was careless in putting autoland on a PR which had some (good) feedback on it. 

This is a followup to address those points. 

Broad stroke changes:
- Remove the cardinality for the error tags
- Remove the strangely phrased 'disposition' metric
- Fixed some incorrectly named 'result' metrics which were really event metrics which may not translate to a result

## LLM Summary:

> Regarding the circuitbreaker skew: `CircuitBreakerExecutable.Execute` (`service/history/queues/executable.go:1012`) calls `cb.Allow()` **before** `e.Executable.Execute()`, and on rejection returns a `ResourceExhausted` immediately. So a callback blocked by an open breaker never reaches `invocationTaskHandler.Execute`, and records neither a delivery sample nor an invocation event. It is already counted by `circuit_breaker_executable_blocked`, which the outbound queue factory tags with namespace and destination (`outbound_queue_factory.go:137-147`).
 
 > `DestinationDownError` flows the other way — the handler produces it via `invocableOutbound.WrapError` to *trip* the breaker, so by then the retryable-error event has already been recorded, correctly.
  
 > No "circuitbreaker-skipped-invocations" needed. I added one line to `metrics.go` saying the counter only covers invocations that reached the handler, since you're the second reader to ask.

## Testing 

- [X] Existing unit tests

