### PR TITLE
Skip search-attribute slot reseeding for ES-backed visibility

### DIFF
--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -706,10 +706,7 @@ func ApplyClusterMetadataConfigProvider(
 		svc.Persistence.GetVisibilityStoreConfig(),
 		svc.Persistence.GetSecondaryVisibilityStoreConfig(),
 	}
-	indexSearchAttributes := make(map[string]*persistencespb.IndexSearchAttributes)
-	for _, ds := range visDataStores {
-		indexSearchAttributes[ds.GetIndexName()] = sadefs.GetDBIndexSearchAttributes(visCSAOverride)
-	}
+	indexSearchAttributes := buildInitialIndexSearchAttributes(visDataStores, visCSAOverride)
 
 	clusterMetadata := svc.ClusterMetadata
 	if len(clusterMetadata.ClusterInformation) > 1 {
@@ -899,6 +896,23 @@ func overwriteCurrentClusterMetadataWithDBRecord(
 			tag.Value(currentClusterDBRecord.FailoverVersionIncrement))
 		svc.ClusterMetadata.FailoverVersionIncrement = currentClusterDBRecord.FailoverVersionIncrement
 	}
+}
+
+// buildInitialIndexSearchAttributes returns the default preallocated custom search
+// attributes for SQL and custom visibility stores. Elasticsearch-backed stores manage
+// their custom search attributes via AddSearchAttributes and are skipped.
+func buildInitialIndexSearchAttributes(
+	visDataStores []config.DataStore,
+	visCSAOverride map[enumspb.IndexedValueType]int,
+) map[string]*persistencespb.IndexSearchAttributes {
+	indexSearchAttributes := make(map[string]*persistencespb.IndexSearchAttributes)
+	for _, ds := range visDataStores {
+		if ds.Elasticsearch != nil {
+			continue
+		}
+		indexSearchAttributes[ds.GetIndexName()] = sadefs.GetDBIndexSearchAttributes(visCSAOverride)
+	}
+	return indexSearchAttributes
 }
 
 // updateIndexSearchAttributes updates the IndexSearchAttributes if needed.

--- a/temporal/fx_test.go
+++ b/temporal/fx_test.go
@@ -12,6 +12,8 @@ import (
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/persistence"
+	esclient "go.temporal.io/server/common/persistence/visibility/store/elasticsearch/client"
+	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.temporal.io/server/service/history/tasks"
 	"go.temporal.io/server/tests/testutils"
 	"go.uber.org/mock/gomock"
@@ -373,6 +375,59 @@ func TestUpdateIndexSearchAttributes(t *testing.T) {
 			out := updateIndexSearchAttributes(tc.initialISA, cm)
 			require.Equal(t, tc.out, out)
 			require.Equal(t, tc.expectedISA, cm.IndexSearchAttributes)
+		})
+	}
+}
+
+func TestBuildInitialIndexSearchAttributes(t *testing.T) {
+	defaultAttrs := sadefs.GetDBIndexSearchAttributes(nil)
+
+	testCases := []struct {
+		name          string
+		visDataStores []config.DataStore
+		expected      map[string]*persistencespb.IndexSearchAttributes
+	}{
+		{
+			name: "SQL store is seeded with default slots",
+			visDataStores: []config.DataStore{
+				{SQL: &config.SQL{DatabaseName: "sql-index"}},
+			},
+			expected: map[string]*persistencespb.IndexSearchAttributes{
+				"sql-index": defaultAttrs,
+			},
+		},
+		{
+			name: "custom store is seeded with default slots",
+			visDataStores: []config.DataStore{
+				{CustomDataStoreConfig: &config.CustomDatastoreConfig{IndexName: "custom-index"}},
+			},
+			expected: map[string]*persistencespb.IndexSearchAttributes{
+				"custom-index": defaultAttrs,
+			},
+		},
+		{
+			name: "elasticsearch store is skipped",
+			visDataStores: []config.DataStore{
+				{Elasticsearch: &esclient.Config{}},
+			},
+			expected: map[string]*persistencespb.IndexSearchAttributes{},
+		},
+		{
+			name: "primary SQL and secondary elasticsearch: only SQL is seeded",
+			visDataStores: []config.DataStore{
+				{SQL: &config.SQL{DatabaseName: "sql-index"}},
+				{Elasticsearch: &esclient.Config{}},
+			},
+			expected: map[string]*persistencespb.IndexSearchAttributes{
+				"sql-index": defaultAttrs,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := buildInitialIndexSearchAttributes(tc.visDataStores, nil)
+			require.Equal(t, tc.expected, out)
 		})
 	}
 }


### PR DESCRIPTION
## What changed?

`ApplyClusterMetadataConfigProvider` preallocates default custom search attribute slots (`Bool01`, `Keyword01`, `Datetime01`, etc.) for every visibility data store on every server start. For Elasticsearch-backed visibility stores, these slots are managed via `AddSearchAttributes` and should not be seeded. Doing so creates spurious generic search attributes in the ES index.

## Why?

PR [#8397](https://github.com/temporalio/temporal/pull/8397) (commit `68f8c22520`) introduced a guard clause that skipped ES-backed stores when seeding slots:

```go
if ds.SQL != nil || ds.CustomDataStoreConfig != nil {
    indexSearchAttributes[ds.GetIndexName()] = sadefs.GetDBIndexSearchAttributes(visCSAOverride)
}
```

PR [#9664](https://github.com/temporalio/temporal/pull/9664) accidentally removed this guard when enabling the namespace mapper with fallbacks, causing the regression starting in `v1.31.0`:

```go
// Guard clause removed; all stores now seeded
for _, ds := range visDataStores {
    indexSearchAttributes[ds.GetIndexName()] = sadefs.GetDBIndexSearchAttributes(visCSAOverride)
}
```

This causes generic search attribute slots to appear in Elasticsearch after every server start/upgrade:

```
Bool01, Bool02, Bool03, Datetime01, Datetime02, ...
Double01, Double02, Int01, Int02, Keyword01, ..., KeywordList01, ...
Text01, Text02, Text03
```

These should not be present in an ES-backed visibility store.

## How did you test it?

- [X] built
- [X] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)

Added `TestBuildInitialIndexSearchAttributes` covering:
- SQL store is seeded with default slots
- Custom store is seeded with default slots
- Elasticsearch store is skipped
- Primary SQL + secondary ES: only SQL is seeded

## Notes

The new guard uses `ds.Elasticsearch != nil` (skip ES) rather than the original `ds.SQL != nil || ds.CustomDataStoreConfig != nil` (allow only SQL/custom). The inverse condition is clearer and more future-proof — any new non-ES store type will be seeded by default.

The logic is extracted into a named helper (`buildInitialIndexSearchAttributes`) for testability.
