### PR TITLE
[v1.31] Add Nexus callback source header inspection toggle

### DIFF
--- a/chasm/lib/callback/config.go
+++ b/chasm/lib/callback/config.go
@@ -32,9 +32,19 @@ var RetryPolicyMaximumInterval = dynamicconfig.NewGlobalDurationSetting(
 	`The maximum backoff interval between every callback request attempt for a given callback.`,
 )
 
+var InspectSourceHeader = dynamicconfig.NewGlobalBoolSetting(
+	"callback.inspectSourceHeader",
+	true,
+	`Controls whether the legacy "source" header should be inspected to determine if a Nexus callback request is internal
+or external. This defaults to true for mixed-version compatibility while worker callbacks migrate to the
+temporal://system URL. Disable it after migration because trusting a caller-controlled header can route external
+requests internally.`,
+)
+
 type Config struct {
-	RequestTimeout dynamicconfig.DurationPropertyFnWithDestinationFilter
-	RetryPolicy    func() backoff.RetryPolicy
+	RequestTimeout      dynamicconfig.DurationPropertyFnWithDestinationFilter
+	RetryPolicy         func() backoff.RetryPolicy
+	InspectSourceHeader dynamicconfig.BoolPropertyFn
 }
 
 func configProvider(dc *dynamicconfig.Collection) *Config {
@@ -49,6 +59,7 @@ func configProvider(dc *dynamicconfig.Collection) *Config {
 				backoff.NoInterval,
 			)
 		},
+		InspectSourceHeader: InspectSourceHeader.Get(dc),
 	}
 }
 

--- a/chasm/lib/callback/config_test.go
+++ b/chasm/lib/callback/config_test.go
@@ -5,10 +5,15 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/nexus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+func TestInspectSourceHeaderDefault(t *testing.T) {
+	require.True(t, InspectSourceHeader.Get(dynamicconfig.NewNoopCollection())())
+}
 
 func Test_addressPatternToRegexp(t *testing.T) {
 	tests := []struct {

--- a/chasm/lib/callback/fx.go
+++ b/chasm/lib/callback/fx.go
@@ -29,6 +29,7 @@ func httpCallerProviderProvider(
 	rpcFactory common.RPCFactory,
 	httpClientCache *cluster.FrontendHTTPClientCache,
 	logger log.Logger,
+	config *Config,
 ) (HTTPCallerProvider, error) {
 	localClient, err := rpcFactory.CreateLocalFrontendHTTPClient()
 	if err != nil {
@@ -47,6 +48,7 @@ func httpCallerProviderProvider(
 				defaultClient,
 				localClient,
 				logger,
+				config.InspectSourceHeader(),
 			)
 		}
 	})

--- a/chasm/lib/callback/request.go
+++ b/chasm/lib/callback/request.go
@@ -14,8 +14,7 @@ import (
 	commonnexus "go.temporal.io/server/common/nexus"
 )
 
-// Header key used to identify callbacks that originate from and target the same cluster.
-// Note: this is the nexusoperations.NexusCallbackSourceHeader stripped of Nexus-Callback-
+// Legacy header key used to identify callbacks that originate from and target the same cluster.
 const callbackSourceHeader = "source"
 
 // routeSystemCallbackRequest routes a system callback request to the appropriate frontend client
@@ -87,13 +86,13 @@ func routeRequest(
 	defaultClient *http.Client,
 	localClient *common.FrontendHTTPClient,
 	logger log.Logger,
+	inspectSourceHeader bool,
 ) (*http.Response, error) {
 	if r.URL.String() == commonnexus.SystemCallbackURL {
 		return routeSystemCallbackRequest(r, clusterMetadata, namespaceRegistry, httpClientCache, callbackTokenGenerator, localClient, logger)
 	}
-	// This source header is populated in nexusoperations/tasks (via the ClientProvider) for worker targets
-	// if this header is not populated then we assume it's an external target.
-	if r.Header == nil || r.Header.Get(callbackSourceHeader) == "" {
+	// Older servers populated this header for worker targets. Treat the request as external unless legacy inspection is enabled.
+	if !inspectSourceHeader || r.Header == nil || r.Header.Get(callbackSourceHeader) == "" {
 		return defaultClient.Do(r)
 	}
 	// If we got here, we assume that the endpoint in the original call was a worker target, and we should route

--- a/chasm/lib/callback/request_test.go
+++ b/chasm/lib/callback/request_test.go
@@ -51,7 +51,7 @@ func TestRouteRequest_ExternalTarget(t *testing.T) {
 		ts.Client(),
 		nil, // localClient not needed for external targets
 		log.NewNoopLogger(),
-		false, // inspectSourceHeader
+		true, // inspectSourceHeader
 	)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()

--- a/chasm/lib/callback/request_test.go
+++ b/chasm/lib/callback/request_test.go
@@ -51,6 +51,36 @@ func TestRouteRequest_ExternalTarget(t *testing.T) {
 		ts.Client(),
 		nil, // localClient not needed for external targets
 		log.NewNoopLogger(),
+		false, // inspectSourceHeader
+	)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestRouteRequest_SourceHeaderIgnored(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	ctrl := gomock.NewController(t)
+	clusterMeta := cluster.NewMockMetadata(ctrl)
+
+	r, err := http.NewRequest(http.MethodPost, ts.URL+"/some/path", nil)
+	require.NoError(t, err)
+	r.Header.Set(callbackSourceHeader, "cluster-id-A")
+
+	resp, err := routeRequest(
+		r,
+		clusterMeta,
+		nil,
+		nil,
+		nil,
+		ts.Client(),
+		nil,
+		log.NewNoopLogger(),
+		false,
 	)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
@@ -86,6 +116,7 @@ func TestRouteRequest_SourceHeaderLocal(t *testing.T) {
 		&http.Client{},
 		localClient,
 		log.NewNoopLogger(),
+		true, // inspectSourceHeader
 	)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
@@ -121,6 +152,7 @@ func TestRouteRequest_SourceHeaderUnknownCluster(t *testing.T) {
 		&http.Client{},
 		localClient,
 		log.NewNoopLogger(),
+		true, // inspectSourceHeader
 	)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
@@ -317,6 +349,7 @@ func TestRouteRequest_SystemCallback(t *testing.T) {
 		&http.Client{},
 		localClient,
 		log.NewNoopLogger(),
+		false, // inspectSourceHeader
 	)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()

--- a/components/callbacks/config.go
+++ b/components/callbacks/config.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"go.temporal.io/server/chasm"
+	chasmcallbacks "go.temporal.io/server/chasm/lib/callback"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/nexus"
@@ -33,8 +34,9 @@ var RetryPolicyMaximumInterval = dynamicconfig.NewGlobalDurationSetting(
 )
 
 type Config struct {
-	RequestTimeout dynamicconfig.DurationPropertyFnWithDestinationFilter
-	RetryPolicy    func() backoff.RetryPolicy
+	RequestTimeout      dynamicconfig.DurationPropertyFnWithDestinationFilter
+	RetryPolicy         func() backoff.RetryPolicy
+	InspectSourceHeader dynamicconfig.BoolPropertyFn
 }
 
 func ConfigProvider(dc *dynamicconfig.Collection) *Config {
@@ -49,6 +51,7 @@ func ConfigProvider(dc *dynamicconfig.Collection) *Config {
 				backoff.NoInterval,
 			)
 		},
+		InspectSourceHeader: chasmcallbacks.InspectSourceHeader.Get(dc),
 	}
 }
 

--- a/components/callbacks/fx.go
+++ b/components/callbacks/fx.go
@@ -29,6 +29,7 @@ func HTTPCallerProviderProvider(
 	rpcFactory common.RPCFactory,
 	httpClientCache *cluster.FrontendHTTPClientCache,
 	logger log.Logger,
+	config *Config,
 ) (HTTPCallerProvider, error) {
 	localClient, err := rpcFactory.CreateLocalFrontendHTTPClient()
 	if err != nil {
@@ -47,6 +48,7 @@ func HTTPCallerProviderProvider(
 				defaultClient,
 				localClient,
 				logger,
+				config.InspectSourceHeader(),
 			)
 		}
 	})

--- a/components/callbacks/request.go
+++ b/components/callbacks/request.go
@@ -14,8 +14,7 @@ import (
 	commonnexus "go.temporal.io/server/common/nexus"
 )
 
-// Header key used to identify callbacks that originate from and target the same cluster.
-// Note: this is the nexusoperations.NexusCallbackSourceHeader stripped of Nexus-Callback-
+// Legacy header key used to identify callbacks that originate from and target the same cluster.
 const callbackSourceHeader = "source"
 
 // routeSystemCallbackRequest routes a system callback request to the appropriate frontend client
@@ -87,13 +86,13 @@ func routeRequest(
 	defaultClient *http.Client,
 	localClient *common.FrontendHTTPClient,
 	logger log.Logger,
+	inspectSourceHeader bool,
 ) (*http.Response, error) {
 	if r.URL.String() == commonnexus.SystemCallbackURL {
 		return routeSystemCallbackRequest(r, clusterMetadata, namespaceRegistry, httpClientCache, callbackTokenGenerator, localClient, logger)
 	}
-	// This source header is populated in nexusoperations/executors (via the ClientProvider) for worker targets
-	// if this header is not populated then we assume it's an external target.
-	if r.Header == nil || r.Header.Get(callbackSourceHeader) == "" {
+	// Older servers populated this header for worker targets. Treat the request as external unless legacy inspection is enabled.
+	if !inspectSourceHeader || r.Header == nil || r.Header.Get(callbackSourceHeader) == "" {
 		return defaultClient.Do(r)
 	}
 	// If we got here, we assume that the endpoint in the original call was a worker target, and we should route

--- a/components/callbacks/request_test.go
+++ b/components/callbacks/request_test.go
@@ -51,6 +51,36 @@ func TestRouteRequest_ExternalTarget(t *testing.T) {
 		ts.Client(),
 		nil, // localClient not needed for external targets
 		log.NewNoopLogger(),
+		false,
+	)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestRouteRequest_SourceHeaderIgnored(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	ctrl := gomock.NewController(t)
+	clusterMeta := cluster.NewMockMetadata(ctrl)
+
+	r, err := http.NewRequest(http.MethodPost, ts.URL+"/some/path", nil)
+	require.NoError(t, err)
+	r.Header.Set(callbackSourceHeader, "cluster-id-A")
+
+	resp, err := routeRequest(
+		r,
+		clusterMeta,
+		nil,
+		nil,
+		nil,
+		ts.Client(),
+		nil,
+		log.NewNoopLogger(),
+		false,
 	)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
@@ -86,6 +116,7 @@ func TestRouteRequest_SourceHeaderLocal(t *testing.T) {
 		&http.Client{},
 		localClient,
 		log.NewNoopLogger(),
+		true,
 	)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
@@ -121,6 +152,7 @@ func TestRouteRequest_SourceHeaderUnknownCluster(t *testing.T) {
 		&http.Client{},
 		localClient,
 		log.NewNoopLogger(),
+		true,
 	)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
@@ -317,6 +349,7 @@ func TestRouteRequest_SystemCallback(t *testing.T) {
 		&http.Client{},
 		localClient,
 		log.NewNoopLogger(),
+		false,
 	)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()

--- a/components/callbacks/request_test.go
+++ b/components/callbacks/request_test.go
@@ -51,7 +51,7 @@ func TestRouteRequest_ExternalTarget(t *testing.T) {
 		ts.Client(),
 		nil, // localClient not needed for external targets
 		log.NewNoopLogger(),
-		false,
+		true, // inspectSourceHeader
 	)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
@@ -116,7 +116,7 @@ func TestRouteRequest_SourceHeaderLocal(t *testing.T) {
 		&http.Client{},
 		localClient,
 		log.NewNoopLogger(),
-		true,
+		true, // inspectSourceHeader
 	)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
@@ -152,7 +152,7 @@ func TestRouteRequest_SourceHeaderUnknownCluster(t *testing.T) {
 		&http.Client{},
 		localClient,
 		log.NewNoopLogger(),
-		true,
+		true, // inspectSourceHeader
 	)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
@@ -349,7 +349,7 @@ func TestRouteRequest_SystemCallback(t *testing.T) {
 		&http.Client{},
 		localClient,
 		log.NewNoopLogger(),
-		false,
+		false, // inspectSourceHeader
 	)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()


### PR DESCRIPTION
## What

- gate legacy Nexus callback source-header routing behind `callback.inspectSourceHeader`
- default the setting to `true` during migration to `temporal://system` while retaining `UseSystemCallbackURL`
- cover both CHASM and legacy callback routing

## Why

For security reasons, it's not advisable to route based on the existence of the source header as it may lead to privilege escalation.