### PR TITLE
Fix gradual change subscribers missing the transition when the timer fires at When()

### DIFF
--- a/common/dynamicconfig/gradual_change.go
+++ b/common/dynamicconfig/gradual_change.go
@@ -34,21 +34,33 @@ func (c *GradualChange[T]) Value(key []byte, now time.Time) T {
 		return c.New
 	} else if !now.After(c.Start) {
 		return c.Old
-	}
-	fraction := float64(now.Sub(c.Start)) / float64(c.End.Sub(c.Start))
-	threshold := uint32(fraction * float64(math.MaxUint32))
-	if farm.Fingerprint32(key) < threshold {
+	} else if !now.Before(c.switchTime(key)) {
 		return c.New
 	}
 	return c.Old
 }
 
 // When returns the time when the value for key will switch from old to new. It may be the zero
-// time for a static GradualChange.
+// time for a static GradualChange. Value is guaranteed to return New at (and after) this time,
+// so a timer set for this time can rely on observing the new value when it fires.
 func (c *GradualChange[T]) When(key []byte) time.Time {
-	fraction := float64(farm.Fingerprint32(key)) / float64(math.MaxUint32)
-	when := time.Duration(fraction * float64(c.End.Sub(c.Start)))
-	return c.Start.Add(when)
+	return c.switchTime(key)
+}
+
+// switchTime returns the time at which the value for key switches from Old to New. Switch times
+// are distributed uniformly over (Start, End] based on a fingerprint of the key. Both Value and
+// When derive the transition from this single computation so that they can never disagree about
+// whether a key has switched at a given time.
+func (c *GradualChange[T]) switchTime(key []byte) time.Time {
+	window := c.End.Sub(c.Start)
+	if window <= 0 {
+		return c.End
+	}
+	// Use fingerprint+1 and Ceil so the switch time is strictly after Start (Value returns Old
+	// at Start), and cap the offset at the window so it never exceeds End.
+	fraction := (float64(farm.Fingerprint32(key)) + 1) / float64(math.MaxUint32)
+	offset := time.Duration(math.Ceil(fraction * float64(window)))
+	return c.Start.Add(min(offset, window))
 }
 
 // ConvertGradualChange is a conversion function that can handle a plain T (which represents a

--- a/common/dynamicconfig/gradual_change_test.go
+++ b/common/dynamicconfig/gradual_change_test.go
@@ -96,6 +96,53 @@ func TestGradualChangeValue_Monotonic(t *testing.T) {
 	}
 }
 
+func TestGradualChangeValue_NewAtWhenTime(t *testing.T) {
+	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2024, 1, 11, 0, 0, 0, 0, time.UTC)
+	gc := GradualChange[string]{Old: "old", New: "new", Start: start, End: end}
+
+	for i := range 100 {
+		key := fmt.Appendf(nil, "key%d", i)
+		at := gc.When(key)
+		assert.Equal(t, "new", gc.Value(key, at),
+			"Value at the transition time returned by When must already be the new value, "+
+				"otherwise a subscriber whose timer fires exactly at When misses the transition")
+	}
+}
+
+func TestSubscribeGradualChange_TimerFiresExactlyAtTransitionTime(t *testing.T) {
+	ts := clock.NewEventTimeSource()
+	ts.UseAsyncTimers(true)
+
+	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2024, 1, 11, 0, 0, 0, 0, time.UTC)
+	ts.Update(start)
+
+	gc := GradualChange[bool]{Old: false, New: true, Start: start, End: end}
+
+	subscribable := func(cb func(GradualChange[bool])) (GradualChange[bool], func()) {
+		return gc, func() {}
+	}
+
+	key := []byte("test_key")
+	var callbackVals syncSlice[bool]
+	initial, cancel := SubscribeGradualChange(subscribable, key, func(v bool) {
+		callbackVals.append(v)
+	}, ts)
+	defer cancel()
+
+	assert.False(t, initial)
+
+	// Fire the rescheduled timer exactly at the key's transition time. In production this
+	// happens whenever the runtime timer fires within (End-Start)/2^32 of its deadline
+	// (~200us for this 10-day window). The subscriber must still observe the new value;
+	// otherwise it is stuck on the old value with no timer left to reevaluate.
+	ts.Update(gc.When(key))
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, []bool{true}, callbackVals.get())
+	}, time.Second, time.Millisecond)
+}
+
 func TestGradualChangeWhen_DifferentKeysHaveDifferentTimes(t *testing.T) {
 	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	end := time.Date(2024, 1, 11, 0, 0, 0, 0, time.UTC)


### PR DESCRIPTION
## What changed?

Derive the per-key switch time once in a new `switchTime()` helper used by both `Value` and `When` in `common/dynamicconfig/gradual_change.go`, so that `Value(key, When(key)) == New` holds by construction.

## Why?

`Value` computed a truncated `uint32` threshold with strict `fingerprint < threshold`, while `When` mapped the fingerprint back to a time with different rounding. `Value(key, When(key))` was therefore deterministically still Old, and stayed Old for up to `(End-Start)/2^32` after `When` (~200µs for a 10-day rollout). The subscription wrapper only schedules a new timer when `When(key)` is strictly in the future, so when the runtime timer fired within that quantum of its deadline — common, Go timers routinely fire sub-millisecond around the deadline — it reevaluated to Old, scheduled nothing, and the subscriber never received the New value until an unrelated config change. This affects the new-matcher and fairness rollouts consumed by `task_queue_partition_manager`.

Switch times remain uniformly distributed, strictly after `Start`, and capped at `End`.

## How did you test it?

Two regression tests: `Value(key, When(key))` now returns New for all tested keys, and a fake-clock subscription test where the timer fires exactly at the deadline now observes the transition. Both fail on `main` and pass with the fix; `go test ./common/dynamicconfig/... -count=1` is green and `go vet` is clean.

## Potential risks

Keys switch at most one time-quantum earlier than before (still within the configured window); no API change.

Closes #11989