### PR TITLE
Fix exponential retry overflow producing a 292-year backoff on arm64

### DIFF
--- a/common/backoff/retrypolicy.go
+++ b/common/backoff/retrypolicy.go
@@ -151,7 +151,7 @@ func (p *ExponentialRetryPolicy) ComputeNextDelay(elapsedTime time.Duration, num
 	}
 
 	nextInterval := float64(p.initialInterval) * math.Pow(p.backoffCoefficient, float64(numAttempts-1))
-	// Disallow retries if initialInterval is negative or nextInterval overflows
+	// Disallow retries if initialInterval is negative
 	if nextInterval <= 0 {
 		return done
 	}
@@ -162,6 +162,14 @@ func (p *ExponentialRetryPolicy) ComputeNextDelay(elapsedTime time.Duration, num
 	if p.expirationInterval != NoInterval {
 		remainingTime := float64(math.Max(0, float64(p.expirationInterval-elapsedTime)))
 		nextInterval = math.Min(remainingTime, nextInterval)
+	}
+
+	// Disallow retries if nextInterval still overflows time.Duration after capping. The
+	// conversion of an out-of-range float64 to int64 is platform-dependent: it wraps to a
+	// negative value on amd64 (caught by the check below) but saturates to MaxInt64 on
+	// arm64, which would produce a ~292-year backoff instead of stopping.
+	if nextInterval >= float64(math.MaxInt64) {
+		return done
 	}
 
 	// Bail out if the next interval is smaller than initial retry interval

--- a/common/backoff/retrypolicy_test.go
+++ b/common/backoff/retrypolicy_test.go
@@ -223,6 +223,28 @@ func (s *RetryPolicySuite) TestUnbounded() {
 	}
 }
 
+// Validate that a policy without maximum interval and expiration interval stops retrying once
+// the computed interval overflows time.Duration. The conversion of an out-of-range float64 to
+// int64 is platform-dependent (it saturates to MaxInt64 on arm64 but wraps negative on amd64),
+// so without an explicit overflow check the policy returns a ~292-year backoff on arm64.
+func (s *RetryPolicySuite) TestUnboundedOverflowReturnsDone() {
+	policy := createPolicy(time.Second)
+
+	// initialInterval * 2^(100-1) overflows int64 nanoseconds by a wide margin
+	s.Equal(done, policy.ComputeNextDelay(0, 100, nil))
+}
+
+// Validate that a policy with a maximum interval keeps retrying at the capped interval even
+// after the raw exponential computation overflows.
+func (s *RetryPolicySuite) TestOverflowWithMaximumIntervalStillRetries() {
+	policy := createPolicy(time.Second).WithMaximumInterval(10 * time.Second)
+
+	next := policy.ComputeNextDelay(0, 100, nil)
+	s.NotEqual(done, next)
+	s.Greater(next, time.Duration(0))
+	s.LessOrEqual(next, 10*time.Second)
+}
+
 // Validate that ErrorDependentRetryPolicy returns the expected delay for a given error, with and without jitter
 func (s *RetryPolicySuite) TestErrorDependentPolicy() {
 	var twoSecondError = fmt.Errorf("two seconds")


### PR DESCRIPTION
## What changed?

`ExponentialRetryPolicy.ComputeNextDelay` in `common/backoff/retrypolicy.go` now explicitly returns `done` when the computed interval reaches `MaxInt64` nanoseconds, after the maximum-interval and expiration caps are applied.

## Why?

With `maximumInterval == NoInterval` and `expirationInterval == NoInterval`, the float64 `nextInterval` can exceed `MaxInt64` ns, and Go's out-of-range float64→`time.Duration` conversion is platform-dependent: amd64 wraps negative (accidentally caught by the `nextDuration < initialInterval` check → `done`, matching the code comment), but arm64 saturates to `MaxInt64`, so `NextBackOff` returns ~292 years and the retrier waits effectively forever. This is the same bug class as #11225's fix for `ExponentialBackoffAlgorithm` in `retry.go`, which this `Retrier` path never received.

## How did you test it?

A regression test drives an uncapped policy past the overflow point and expects `done`; it fails on `main` on arm64 (observes `2562047h47m16.854775807s`) and passes with the fix on both architectures. A companion test asserts capped policies still retry, guarding against over-triggering. `go test ./common/backoff/... -count=1` is green; `go vet` clean.

## Potential risks

None expected: the branch only triggers when the computed interval reaches `MaxInt64` ns, which previously produced either the wrap (amd64, already `done`) or the saturation (arm64, effectively hung).

Closes #11991