### PR TITLE
Clarify history.defaultActivityRetryPolicy documentation

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2708,8 +2708,9 @@ the oldest task of each immediate queue category that has a backlog`,
 	DefaultActivityRetryPolicy = NewNamespaceTypedSetting(
 		"history.defaultActivityRetryPolicy",
 		retrypolicy.DefaultDefaultRetrySettings,
-		`DefaultActivityRetryPolicy represents the out-of-box retry policy for activities where
-the user has not specified an explicit RetryPolicy`,
+		`DefaultActivityRetryPolicy represents the out-of-box retry policy for activities. It
+applies both when the user has not specified any RetryPolicy and, field by field, to fill
+in fields that are unset (or set to their zero value) in an explicit RetryPolicy`,
 	)
 	DefaultWorkflowRetryPolicy = NewNamespaceTypedSetting(
 		"history.defaultWorkflowRetryPolicy",


### PR DESCRIPTION
## What changed?

Update the `history.defaultActivityRetryPolicy` setting description in `common/dynamicconfig/constants.go`.

## Why?

In #11721, the current behavior was confirmed as intentional but the setting's documentation was noted as not matching it. The description says the policy applies "where the user has not specified an explicit RetryPolicy", but `EnsureDefaults` also fills unset (zero-value) fields of explicit policies field by field — including an explicit `MaximumAttempts` of 0, which proto3 cannot distinguish from unset on the wire. The sibling `history.defaultWorkflowRetryPolicy` description already describes the field-filling behavior accurately.

## How did you test it?

Doc-string-only change; `go build ./common/dynamicconfig/` passes.

## Potential risks

None — no behavior change.

References #11721