### PR TITLE
Fix activity batch reset and cancellation test flakes

### DIFF
--- a/tests/activity_api_batch_reset_test.go
+++ b/tests/activity_api_batch_reset_test.go
@@ -311,7 +311,6 @@ func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_Success_Pr
 
 func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_RunningWorkflowsResetAttempts() {
 	env := newBatchResetEnv(s.T())
-	ctx := s.Context()
 
 	const workflowCount = 10
 	workflowTypeName := testcore.RandomizeStr("activity-batch-reset-running-workflow")
@@ -325,7 +324,7 @@ func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_RunningWor
 
 	workflowRuns := make([]sdkclient.WorkflowRun, 0, workflowCount)
 	for range workflowCount {
-		workflowRun, err := env.SdkClient().ExecuteWorkflow(ctx, sdkclient.StartWorkflowOptions{
+		workflowRun, err := env.SdkClient().ExecuteWorkflow(s.Context(), sdkclient.StartWorkflowOptions{
 			ID:        testcore.RandomizeStr("wf_id-" + s.T().Name()),
 			TaskQueue: env.WorkerTaskQueue(),
 		}, workflowTypeName)
@@ -357,7 +356,7 @@ func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_RunningWor
 	}, 5*time.Second, 500*time.Millisecond)
 
 	jobID := uuid.NewString()
-	_, err := env.SdkClient().WorkflowService().StartBatchOperation(ctx, &workflowservice.StartBatchOperationRequest{
+	_, err := env.SdkClient().WorkflowService().StartBatchOperation(s.Context(), &workflowservice.StartBatchOperationRequest{
 		Namespace: env.Namespace().String(),
 		Operation: &workflowservice.StartBatchOperationRequest_ResetActivitiesOperation{
 			ResetActivitiesOperation: &batchpb.BatchOperationResetActivities{
@@ -382,14 +381,14 @@ func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_RunningWor
 	}, 15*time.Second, 100*time.Millisecond)
 
 	for _, workflowRun := range workflowRuns {
-		description, err := env.SdkClient().DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
+		description, err := env.SdkClient().DescribeWorkflowExecution(s.Context(), workflowRun.GetID(), workflowRun.GetRunID())
 		s.NoError(err)
 		s.Len(description.PendingActivities, 1)
 		s.Equal(int32(1), description.PendingActivities[0].Attempt)
 	}
 
 	// Await may have refreshed the suite context; renew it for workflow completion.
-	ctx = testcontext.EnsureRemaining(s.Context(), s.T(), testcontext.DefaultTimeout())
+	ctx := testcontext.EnsureRemaining(s.Context(), s.T(), testcontext.DefaultTimeout())
 	internalWorkflow.letActivitySucceed.Store(true)
 
 	replacementWorker := sdkworker.New(env.SdkClient(), env.WorkerTaskQueue(), sdkworker.Options{})

--- a/tests/activity_api_batch_reset_test.go
+++ b/tests/activity_api_batch_reset_test.go
@@ -20,6 +20,7 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.temporal.io/server/common/testing/parallelsuite"
+	"go.temporal.io/server/common/testing/testcontext"
 	"go.temporal.io/server/tests/testcore"
 	"google.golang.org/grpc/codes"
 )
@@ -387,6 +388,8 @@ func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_RunningWor
 		s.Equal(int32(1), description.PendingActivities[0].Attempt)
 	}
 
+	// Await may have refreshed the suite context; renew it for workflow completion.
+	ctx = testcontext.EnsureRemaining(s.Context(), s.T(), testcontext.DefaultTimeout())
 	internalWorkflow.letActivitySucceed.Store(true)
 
 	replacementWorker := sdkworker.New(env.SdkClient(), env.WorkerTaskQueue(), sdkworker.Options{})

--- a/tests/activity_api_batch_reset_test.go
+++ b/tests/activity_api_batch_reset_test.go
@@ -387,8 +387,6 @@ func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_RunningWor
 		s.Equal(int32(1), description.PendingActivities[0].Attempt)
 	}
 
-	// Await may have refreshed the suite context; renew it for workflow completion.
-	ctx := testcontext.EnsureRemaining(s.Context(), s.T(), testcontext.DefaultTimeout())
 	internalWorkflow.letActivitySucceed.Store(true)
 
 	replacementWorker := sdkworker.New(env.SdkClient(), env.WorkerTaskQueue(), sdkworker.Options{})
@@ -397,6 +395,8 @@ func (s *ActivityAPIBatchResetClientTestSuite) TestActivityBatchReset_RunningWor
 	s.NoError(replacementWorker.Start())
 	defer replacementWorker.Stop()
 
+	// Extend the deadline for workflow completion after the polling above.
+	ctx := testcontext.EnsureRemaining(s.Context(), s.T(), testcontext.DefaultTimeout())
 	for _, workflowRun := range workflowRuns {
 		var out string
 		err = workflowRun.Get(ctx, &out)

--- a/tests/activity_test.go
+++ b/tests/activity_test.go
@@ -982,10 +982,27 @@ func (s *ActivityTestSuite) TestTryActivityCancellationFromWorkflow() {
 		}}, nil
 	}
 
+	// Hold the activity after it starts so cancellation targets a running task.
+	// Release it only after the cancellation command is recorded, making its next
+	// heartbeat deterministically observe CancelRequested.
+	activityStartedCh := make(chan struct{})
+	continueActivityCh := make(chan struct{})
+	activityPollErrCh := make(chan error, 1)
+	var continueActivityOnce sync.Once
+	continueActivity := func() {
+		continueActivityOnce.Do(func() {
+			close(continueActivityCh)
+		})
+	}
+	defer continueActivity()
+
 	activityCanceled := false
 	atHandler := func(task *workflowservice.PollActivityTaskQueueResponse) (*commonpb.Payloads, bool, error) {
 		s.Equal(id, task.WorkflowExecution.GetWorkflowId())
 		s.Equal(activityName, task.ActivityType.GetName())
+		close(activityStartedCh)
+		<-continueActivityCh
+
 		for i := range 10 {
 			env.Logger.Info("Heartbeating for activity", tag.ActivityID(task.ActivityId), tag.Counter(i))
 			response, err := env.FrontendClient().RecordActivityTaskHeartbeat(s.Context(),
@@ -1018,35 +1035,32 @@ func (s *ActivityTestSuite) TestTryActivityCancellationFromWorkflow() {
 	_, err := poller.PollAndProcessWorkflowTask()
 	s.True(err == nil || errors.Is(err, testcore.ErrNoTasks))
 
-	cancelCh := make(chan struct{})
 	go func() {
-		env.Logger.Info("Trying to cancel the task in a different thread")
-		// Send signal so that worker can send an activity cancel
-		_, err1 := env.FrontendClient().SignalWorkflowExecution(s.Context(), &workflowservice.SignalWorkflowExecutionRequest{
-			Namespace: env.Namespace().String(),
-			WorkflowExecution: &commonpb.WorkflowExecution{
-				WorkflowId: id,
-				RunId:      we.RunId,
-			},
-			SignalName: "my signal",
-			Input:      nil,
-			Identity:   identity,
-		})
-		s.NoError(err1)
-
-		scheduleActivity = false
-		requestCancellation = true
-		_, err2 := poller.PollAndProcessWorkflowTask()
-		s.NoError(err2)
-		close(cancelCh)
+		activityPollErrCh <- poller.PollAndProcessActivityTask(false)
 	}()
 
-	env.Logger.Info("Start activity.")
-	err = poller.PollAndProcessActivityTask(false)
-	s.True(err == nil || errors.Is(err, testcore.ErrNoTasks))
+	await.Rcv(s.T(), activityStartedCh)
 
-	env.Logger.Info("Waiting for cancel to complete.", tag.WorkflowRunID(we.RunId))
-	await.Rcv(s.T(), cancelCh)
+	_, err = env.FrontendClient().SignalWorkflowExecution(s.Context(), &workflowservice.SignalWorkflowExecutionRequest{
+		Namespace: env.Namespace().String(),
+		WorkflowExecution: &commonpb.WorkflowExecution{
+			WorkflowId: id,
+			RunId:      we.RunId,
+		},
+		SignalName: "my signal",
+		Input:      nil,
+		Identity:   identity,
+	})
+	s.Require().NoError(err)
+
+	scheduleActivity = false
+	requestCancellation = true
+	_, err = poller.PollAndProcessWorkflowTask()
+	s.Require().NoError(err)
+	continueActivity()
+
+	err = await.Rcv(s.T(), activityPollErrCh)
+	s.Require().NoError(err)
 	s.True(activityCanceled, "Activity was not cancelled.")
 	env.Logger.Info("Activity cancelled.", tag.WorkflowRunID(we.RunId))
 }

--- a/tests/activity_test.go
+++ b/tests/activity_test.go
@@ -985,7 +985,7 @@ func (s *ActivityTestSuite) TestTryActivityCancellationFromWorkflow() {
 	// Hold the activity after it starts so cancellation targets a running task.
 	// Release it only after the cancellation command is recorded, making its next
 	// heartbeat deterministically observe CancelRequested.
-	activityStartedCh := make(chan *workflowservice.PollActivityTaskQueueResponse)
+	activityStartedCh := make(chan *workflowservice.PollActivityTaskQueueResponse, 1)
 	continueActivityCh := make(chan struct{})
 	type activityPollResult struct {
 		err      error
@@ -1050,11 +1050,14 @@ func (s *ActivityTestSuite) TestTryActivityCancellationFromWorkflow() {
 	}()
 
 	var activityTask *workflowservice.PollActivityTaskQueueResponse
+	ctx := s.Context()
 	select {
 	case activityTask = <-activityStartedCh:
 	case result := <-activityPollResultCh:
 		s.Require().NoError(result.err)
 		s.FailNow("activity poll completed before the activity started")
+	case <-ctx.Done():
+		s.FailNowf("activity poll did not start before the test context ended", "error: %v", ctx.Err())
 	}
 	s.Equal(id, activityTask.WorkflowExecution.GetWorkflowId())
 	s.Equal(activityName, activityTask.ActivityType.GetName())

--- a/tests/activity_test.go
+++ b/tests/activity_test.go
@@ -985,9 +985,13 @@ func (s *ActivityTestSuite) TestTryActivityCancellationFromWorkflow() {
 	// Hold the activity after it starts so cancellation targets a running task.
 	// Release it only after the cancellation command is recorded, making its next
 	// heartbeat deterministically observe CancelRequested.
-	activityStartedCh := make(chan struct{})
+	activityStartedCh := make(chan *workflowservice.PollActivityTaskQueueResponse)
 	continueActivityCh := make(chan struct{})
-	activityPollErrCh := make(chan error, 1)
+	type activityPollResult struct {
+		err      error
+		canceled bool
+	}
+	activityPollResultCh := make(chan activityPollResult, 1)
 	var continueActivityOnce sync.Once
 	continueActivity := func() {
 		continueActivityOnce.Do(func() {
@@ -996,11 +1000,10 @@ func (s *ActivityTestSuite) TestTryActivityCancellationFromWorkflow() {
 	}
 	defer continueActivity()
 
+	var activityHandlerErr error
 	activityCanceled := false
 	atHandler := func(task *workflowservice.PollActivityTaskQueueResponse) (*commonpb.Payloads, bool, error) {
-		s.Equal(id, task.WorkflowExecution.GetWorkflowId())
-		s.Equal(activityName, task.ActivityType.GetName())
-		close(activityStartedCh)
+		activityStartedCh <- task
 		<-continueActivityCh
 
 		for i := range 10 {
@@ -1015,7 +1018,10 @@ func (s *ActivityTestSuite) TestTryActivityCancellationFromWorkflow() {
 				activityCanceled = true
 				return payloads.EncodeString("Activity Cancelled"), true, nil
 			}
-			s.NoError(err)
+			if err != nil {
+				activityHandlerErr = err
+				return nil, false, err
+			}
 			time.Sleep(10 * time.Millisecond) //nolint:forbidigo
 		}
 		return payloads.EncodeString("Activity Result"), false, nil
@@ -1036,10 +1042,22 @@ func (s *ActivityTestSuite) TestTryActivityCancellationFromWorkflow() {
 	s.True(err == nil || errors.Is(err, testcore.ErrNoTasks))
 
 	go func() {
-		activityPollErrCh <- poller.PollAndProcessActivityTask(false)
+		pollErr := poller.PollAndProcessActivityTask(false)
+		if activityHandlerErr != nil {
+			pollErr = errors.Join(pollErr, activityHandlerErr)
+		}
+		activityPollResultCh <- activityPollResult{err: pollErr, canceled: activityCanceled}
 	}()
 
-	await.Rcv(s.T(), activityStartedCh)
+	var activityTask *workflowservice.PollActivityTaskQueueResponse
+	select {
+	case activityTask = <-activityStartedCh:
+	case result := <-activityPollResultCh:
+		s.Require().NoError(result.err)
+		s.FailNow("activity poll completed before the activity started")
+	}
+	s.Equal(id, activityTask.WorkflowExecution.GetWorkflowId())
+	s.Equal(activityName, activityTask.ActivityType.GetName())
 
 	_, err = env.FrontendClient().SignalWorkflowExecution(s.Context(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace: env.Namespace().String(),
@@ -1059,9 +1077,9 @@ func (s *ActivityTestSuite) TestTryActivityCancellationFromWorkflow() {
 	s.Require().NoError(err)
 	continueActivity()
 
-	err = await.Rcv(s.T(), activityPollErrCh)
-	s.Require().NoError(err)
-	s.True(activityCanceled, "Activity was not cancelled.")
+	result := await.Rcv(s.T(), activityPollResultCh)
+	s.Require().NoError(result.err)
+	s.True(result.canceled, "Activity was not cancelled.")
 	env.Logger.Info("Activity cancelled.", tag.WorkflowRunID(we.RunId))
 }
 


### PR DESCRIPTION
## What changed?
Stabilized two flaky activity functional tests:
  - Renewed the batch-reset test context before waiting for workflows to complete.
  - Made activity cancellation sequencing deterministic by waiting for the activity to start before recording cancellation, then releasing its heartbeat.

## Why?
- The batch-reset test saved its timeout context near the start. Its polling helpers later extend the test’s timeout, but the saved context is not updated. The final workflow-completion calls could therefore use the old, expired timeout and fail even though the workflows were completing normally
- The cancellation test raced activity execution against cancellation dispatch, allowing either side to complete first under CI load. It now explicitly orders activity start, cancellation dispatch, and the heartbeat that observes cancellation.
Both were evidence driven from CI history.

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

