### PR TITLE
history/queues: log the attempt that failed, not the next one.

### DIFF
--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -609,6 +609,9 @@ func (e *executableImpl) HandleErr(err error) (retErr error) {
 		return nil
 	}
 
+	// The attempt that just failed. incAttempt moves the counter on to the next attempt, so it can no longer
+	// answer "which attempt failed" for the logging below.
+	failedAttempt := e.attempt.Load()
 	e.incAttempt()
 
 	if alertable, causeTag := classifyAlertableError(err); alertable {
@@ -630,7 +633,7 @@ func (e *executableImpl) HandleErr(err error) (retErr error) {
 	logTags := []tag.Tag{
 		tag.Error(err),
 		tag.ErrorType(err),
-		tag.Attempt(int32(e.attempt.Load())),
+		tag.Attempt(int32(failedAttempt)),
 		tag.UnexpectedErrorAttempts(int32(e.unexpectedErrorAttempts)),
 		tag.LifeCycleProcessingFailed,
 		tag.String("task-category", e.GetCategory().Name()),

--- a/service/history/queues/executable_test.go
+++ b/service/history/queues/executable_test.go
@@ -19,6 +19,7 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/metrics/metricstest"
 	"go.temporal.io/server/common/namespace"
@@ -58,6 +59,7 @@ type (
 		maxUnexpectedErrorAttempts dynamicconfig.IntPropertyFn
 		dlqInternalErrors          dynamicconfig.BoolPropertyFn
 		dlqErrorPattern            dynamicconfig.StringPropertyFn
+		logger                     log.Logger
 	}
 	option func(*params)
 )
@@ -1135,6 +1137,30 @@ func (s *executableSuite) TestHandleErr_RandomErr() {
 	s.Error(executable.HandleErr(errors.New("random error")))
 }
 
+// The failure log reports the attempt that failed, not the one that will run next.
+func (s *executableSuite) TestHandleErr_UnexpectedError_LogsFailedAttempt() {
+	const numAttempts = 3
+
+	var loggedAttempts []int32
+	logger := log.NewMockLogger(s.controller)
+	logger.EXPECT().Warn("Fail to process task", gomock.Any()).Do(func(_ string, tags ...tag.Tag) {
+		for _, t := range tags {
+			if t.Key() == "attempt" {
+				loggedAttempts = append(loggedAttempts, t.Value().(int32))
+			}
+		}
+	}).Times(numAttempts)
+
+	executable := s.newTestExecutable(func(p *params) {
+		p.logger = logger
+	})
+	for range numAttempts {
+		s.Error(executable.HandleErr(errors.New("random error")))
+	}
+
+	s.Equal([]int32{1, 2, 3}, loggedAttempts)
+}
+
 func (s *executableSuite) TestTaskAck_ValidTask_NoRetry() {
 	executable := s.newTestExecutable()
 
@@ -1499,6 +1525,7 @@ func (s *executableSuite) newTestExecutable(opts ...option) queues.Executable {
 		dlqErrorPattern: func() string {
 			return ""
 		},
+		logger: log.NewTestLogger(),
 	}
 	for _, opt := range opts {
 		opt(&p)
@@ -1523,7 +1550,7 @@ func (s *executableSuite) newTestExecutable(opts ...option) queues.Executable {
 		s.mockClusterMetadata,
 		s.chasmRegistry,
 		queues.GetTaskTypeTagValue,
-		log.NewTestLogger(),
+		p.logger,
 		s.metricsHandler,
 		telemetry.NoopTracer,
 		func(params *queues.ExecutableParams) {


### PR DESCRIPTION
## What changed?

`HandleErr` increments the attempt counter before it builds the log tags, so the `Fail to process task` warning reports one more than the attempt that actually failed. This captures the counter first and logs that.

```go
failedAttempt := e.attempt.Load()
e.incAttempt()
...
tag.Attempt(int32(failedAttempt)),
```


## Why?

A task's very first failure logs `attempt=2`, which is confusing.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

`TestHandleErr_UnexpectedError_LogsFailedAttempt` asserts the logged tag across three failures. Without the fix it reports `[2 3 4]`.

## Potential risks

The log tag changes value, so any dashboard or saved query keyed on `attempt` for these warnings shifts down by one. Metrics and the critical-log threshold are untouched.
