### PR TITLE
Keep retrying failed replication DLQ writes

### DIFF
--- a/service/history/replication/executable_task.go
+++ b/service/history/replication/executable_task.go
@@ -119,12 +119,11 @@ type (
 		replicationTask   *replicationspb.ReplicationTask
 
 		// mutable data
-		taskState              int32
-		attempt                int32
-		namespace              atomic.Value
-		markPoisonPillAttempts int
-		isDuplicated           bool
-		taskExecuteStartTime   time.Time
+		taskState            int32
+		attempt              int32
+		namespace            atomic.Value
+		isDuplicated         bool
+		taskExecuteStartTime time.Time
 	}
 )
 
@@ -139,18 +138,17 @@ func NewExecutableTask(
 	replicationTask *replicationspb.ReplicationTask,
 ) *ExecutableTaskImpl {
 	return &ExecutableTaskImpl{
-		ProcessToolBox:         processToolBox,
-		taskID:                 taskID,
-		metricsTag:             metricsTag,
-		taskCreationTime:       taskCreationTime,
-		taskReceivedTime:       taskReceivedTime,
-		sourceClusterName:      sourceClusterName,
-		sourceShardKey:         sourceShardKey,
-		taskPriority:           replicationTask.GetPriority(),
-		replicationTask:        replicationTask,
-		taskState:              taskStatePending,
-		attempt:                1,
-		markPoisonPillAttempts: 0,
+		ProcessToolBox:    processToolBox,
+		taskID:            taskID,
+		metricsTag:        metricsTag,
+		taskCreationTime:  taskCreationTime,
+		taskReceivedTime:  taskReceivedTime,
+		sourceClusterName: sourceClusterName,
+		sourceShardKey:    sourceShardKey,
+		taskPriority:      replicationTask.GetPriority(),
+		replicationTask:   replicationTask,
+		taskState:         taskStatePending,
+		attempt:           1,
 	}
 }
 
@@ -915,20 +913,6 @@ FilterLoop:
 
 func (e *ExecutableTaskImpl) MarkPoisonPill() error {
 	taskInfo := e.ReplicationTask().GetRawTaskInfo()
-
-	if e.markPoisonPillAttempts >= MarkPoisonPillMaxAttempts {
-		e.Logger.Error("MarkPoisonPill reached max attempts",
-			tag.SourceCluster(e.SourceClusterName()),
-			tag.ReplicationTask(taskInfo),
-		)
-		e.emitReplicationTaskError(wideevents.ReplOperationDLQWrite, "Writing replication task to DLQ reached maximum attempts", nil, map[string]any{
-			"dlq_attempt": e.markPoisonPillAttempts,
-			"disposition": wideevents.ReplDispositionDiscarded,
-			"terminal":    true,
-		})
-		return nil
-	}
-	e.markPoisonPillAttempts++
 
 	shardContext, err := e.ShardController.GetShardByNamespaceWorkflow(
 		namespace.ID(e.replicationTask.RawTaskInfo.NamespaceId),

--- a/service/history/replication/executable_task_test.go
+++ b/service/history/replication/executable_task_test.go
@@ -1086,25 +1086,80 @@ func (s *executableTaskSuite) TestMarkPoisonPill() {
 	s.NoError(err)
 }
 
-func (s *executableTaskSuite) TestMarkPoisonPill_MaxAttemptsReached() {
-	s.task.markPoisonPillAttempts = MarkPoisonPillMaxAttempts - 1
-	shardID := rand.Int31()
-	shardContext := historyi.NewMockShardContext(s.controller)
-	s.shardController.EXPECT().GetShardByNamespaceWorkflow(
-		namespace.ID(s.namespaceId),
-		s.workflowId,
-	).Return(shardContext, nil).AnyTimes()
-	shardContext.EXPECT().GetShardID().Return(shardID).AnyTimes()
-	s.mockExecutionManager.EXPECT().PutReplicationTaskToDLQ(gomock.Any(), &persistence.PutReplicationTaskToDLQRequest{
-		ShardID:           shardID,
-		SourceClusterName: s.task.sourceClusterName,
-		TaskInfo:          s.task.replicationTask.RawTaskInfo,
-	}).Return(serviceerror.NewInternal("failed"))
+func TestExecutableTaskTrackerRetainsTaskUntilDLQWriteSucceeds(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		failShardLookup bool
+	}{
+		{name: "DLQ write failure"},
+		{name: "shard lookup failure", failShardLookup: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			shardController := shard.NewMockController(controller)
+			executionManager := persistence.NewMockExecutionManager(controller)
+			shardContext := historyi.NewMockShardContext(controller)
+			shardContext.EXPECT().GetShardID().Return(int32(2)).AnyTimes()
+			toolBox := ProcessToolBox{
+				Config:          tests.NewDynamicConfig(),
+				ShardController: shardController,
+				DLQWriter:       NewExecutionManagerDLQWriter(executionManager),
+				MetricsHandler:  metrics.NoopMetricsHandler,
+				Logger:          log.NewNoopLogger(),
+			}
+			taskInfo := &persistencespb.ReplicationTaskInfo{
+				NamespaceId: "namespace-id",
+				WorkflowId:  "workflow-id",
+				RunId:       "run-id",
+				TaskId:      100,
+			}
+			creationTime := time.Unix(100, 0)
+			task := &ExecutableWorkflowStateTask{
+				ExecutableTask: NewExecutableTask(
+					toolBox, taskInfo.TaskId, metrics.SyncWorkflowStateTaskScope,
+					creationTime, creationTime, "source-cluster", ClusterShardKey{ShardID: 1},
+					&replicationspb.ReplicationTask{RawTaskInfo: taskInfo},
+				),
+			}
+			task.Nack(errors.New("replication failed"))
+			tracker := NewExecutableTaskTracker(toolBox.Logger, toolBox.MetricsHandler)
+			highWatermark := WatermarkInfo{Watermark: taskInfo.TaskId + 1, Timestamp: creationTime.Add(time.Second)}
+			tracker.TrackTasks(highWatermark, task)
 
-	err := s.task.MarkPoisonPill()
-	s.Error(err)
-	err = s.task.MarkPoisonPill()
-	s.NoError(err)
+			const failedAttempts = 4
+			failure := serviceerror.NewUnavailable("temporarily unavailable")
+			request := &persistence.PutReplicationTaskToDLQRequest{
+				ShardID:           2,
+				SourceClusterName: "source-cluster",
+				TaskInfo:          taskInfo,
+			}
+			if tc.failShardLookup {
+				gomock.InOrder(
+					shardController.EXPECT().GetShardByNamespaceWorkflow(namespace.ID(taskInfo.NamespaceId), taskInfo.WorkflowId).
+						Return(nil, failure).Times(failedAttempts),
+					shardController.EXPECT().GetShardByNamespaceWorkflow(namespace.ID(taskInfo.NamespaceId), taskInfo.WorkflowId).
+						Return(shardContext, nil),
+				)
+				executionManager.EXPECT().PutReplicationTaskToDLQ(gomock.Any(), request).Return(nil)
+			} else {
+				shardController.EXPECT().GetShardByNamespaceWorkflow(namespace.ID(taskInfo.NamespaceId), taskInfo.WorkflowId).
+					Return(shardContext, nil).Times(failedAttempts + 1)
+				gomock.InOrder(
+					executionManager.EXPECT().PutReplicationTaskToDLQ(gomock.Any(), request).Return(failure).Times(failedAttempts),
+					executionManager.EXPECT().PutReplicationTaskToDLQ(gomock.Any(), request).Return(nil),
+				)
+			}
+
+			for attempt := range failedAttempts {
+				require.Equal(t, &WatermarkInfo{Watermark: taskInfo.TaskId, Timestamp: creationTime}, tracker.LowWatermark(),
+					"failed attempt %d must not acknowledge the task", attempt+1)
+				require.Equal(t, 1, tracker.Size())
+			}
+			require.Equal(t, &highWatermark, tracker.LowWatermark())
+			require.Zero(t, tracker.Size())
+			require.Equal(t, &highWatermark, tracker.LowWatermark())
+		})
+	}
 }
 
 func (s *executableTaskSuite) TestSyncState() {

--- a/service/history/replication/executable_task_tracker.go
+++ b/service/history/replication/executable_task_tracker.go
@@ -15,8 +15,6 @@ import (
 
 //go:generate mockgen -package $GOPACKAGE -source $GOFILE -destination executable_task_tracker_mock.go
 
-const MarkPoisonPillMaxAttempts = 3
-
 type (
 	TrackableExecutableTask interface {
 		ctasks.Task


### PR DESCRIPTION
## Summary

Retain replication tasks when the shared dead-letter queue (DLQ) handler fails, so repeated shard lookup or write failures cannot advance acknowledgement past the task.

## Problem

The shared streaming-replication DLQ handler gives a failed task three attempts to enter the DLQ. If all three fail, the next `ExecutableTaskImpl.MarkPoisonPill` call returns success without writing anything. The task tracker then removes the task and can acknowledge past it. The destination may therefore miss a workflow update with no DLQ entry available to replay.

The limit counts calls, including failures to find the destination shard; three attempts do not necessarily mean three storage writes.

## Approach

Remove the attempt cap and its counter. Each call reports the actual shard lookup or DLQ write result, so the tracker retains failed tasks and retries during subsequent stream status updates. A successful write releases the task and allows acknowledgement progress. Existing failure logs and the replication DLQ failure metric continue to expose errors.

## Validation

The new regression fails on the original code: both failure cases advance the watermark on the fourth attempt. With the fix, the full replication package passes:

- `go test -p 4 -tags test_dep ./service/history/replication -count=1`

The regression covers four consecutive DLQ write failures and four consecutive shard lookup failures. Each failure retains the task's acknowledgement boundary, and a later successful write releases it. Changed-package repository lint passes.

## Risks, rollout, and scope

A persistent DLQ failure now holds the acknowledgement boundary until it is repaired. Retained tasks still count toward the receiver's existing limit for outstanding tasks. This change uses the current status-update retry cadence and adds no new configuration or storage format. Existing task-specific handling of unknown task types and malformed history payloads is outside this shared-handler fix.
