### PR TITLE
Cancel replication transports when closing them

### DIFF
--- a/service/history/replication/bi_direction_stream.go
+++ b/service/history/replication/bi_direction_stream.go
@@ -48,6 +48,7 @@ type (
 	}
 	BiDirectionStreamImpl[Req any, Resp any] struct {
 		ctx            context.Context
+		cancel         context.CancelFunc
 		clientProvider BiDirectionStreamClientProvider[Req, Resp]
 		metricsHandler metrics.Handler
 		logger         log.Logger
@@ -69,8 +70,10 @@ func NewBiDirectionStream[Req any, Resp any](
 	metricsHandler metrics.Handler,
 	logger log.Logger,
 ) *BiDirectionStreamImpl[Req, Resp] {
+	ctx, cancel := context.WithCancel(context.Background())
 	return &BiDirectionStreamImpl[Req, Resp]{
-		ctx:            context.Background(),
+		ctx:            ctx,
+		cancel:         cancel,
 		clientProvider: clientProvider,
 		metricsHandler: metricsHandler,
 		logger:         logger,
@@ -109,6 +112,8 @@ func (s *BiDirectionStreamImpl[Req, Resp]) Recv() (<-chan StreamResp[Resp], erro
 }
 
 func (s *BiDirectionStreamImpl[Req, Resp]) Close() {
+	// Get and Send hold the mutex during I/O. Cancel before waiting for them.
+	s.cancel()
 	s.Lock()
 	defer s.Unlock()
 
@@ -122,6 +127,7 @@ func (s *BiDirectionStreamImpl[Req, Resp]) IsValid() bool {
 }
 
 func (s *BiDirectionStreamImpl[Req, Resp]) closeLocked() {
+	s.cancel()
 	if s.status == streamStatusClosed {
 		return
 	}
@@ -159,10 +165,15 @@ func (s *BiDirectionStreamImpl[Req, Resp]) recvLoop() {
 	defer s.Close()
 
 	for {
+		if s.ctx.Err() != nil {
+			return
+		}
 		resp, err := s.streamingClient.Recv()
 		switch err {
 		case nil:
-			s.notifyRecvChannel(resp, nil)
+			if !s.notifyRecvChannel(resp, nil) {
+				return
+			}
 		case io.EOF:
 			return
 		default:
@@ -173,7 +184,10 @@ func (s *BiDirectionStreamImpl[Req, Resp]) recvLoop() {
 	}
 }
 
-func (s *BiDirectionStreamImpl[Req, Resp]) notifyRecvChannel(response Resp, err error) {
+func (s *BiDirectionStreamImpl[Req, Resp]) notifyRecvChannel(response Resp, err error) bool {
+	if s.ctx.Err() != nil {
+		return false
+	}
 	resp := StreamResp[Resp]{
 		Resp: response,
 		Err:  err,
@@ -181,10 +195,17 @@ func (s *BiDirectionStreamImpl[Req, Resp]) notifyRecvChannel(response Resp, err 
 
 	select {
 	case s.channel <- resp:
-		return
+		return true
+	case <-s.ctx.Done():
+		return false
 	default:
 		metrics.ReplicationStreamChannelFull.With(s.metricsHandler).Record(1)
-		s.channel <- resp
+	}
+	select {
+	case s.channel <- resp:
+		return true
+	case <-s.ctx.Done():
+		return false
 	}
 }
 

--- a/service/history/replication/bi_direction_stream_test.go
+++ b/service/history/replication/bi_direction_stream_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -157,6 +158,227 @@ func (s *biDirectionStreamSuite) TestRecv_Err() {
 	s.False(ok)
 	s.False(s.biDirectionStream.IsValid())
 
+}
+
+func TestBiDirectionStreamCloseFullReceiveChannel(t *testing.T) {
+	t.Parallel()
+
+	controller := gomock.NewController(t)
+	full := make(chan struct{})
+	handler := metrics.NewMockHandler(controller)
+	handler.EXPECT().Counter("replication_stream_channel_full").Return(metrics.CounterFunc(func(int64, ...metrics.Tag) {
+		close(full)
+	}))
+	client := &mockStreamClient{shutdownChan: make(chan struct{}), responseCount: 1}
+	stream := NewBiDirectionStream[int, int](&mockStreamClientProvider{streamClient: client}, handler, log.NewTestLogger())
+	stream.streamingClient = client
+	stream.status = streamStatusOpen
+	for i := 0; i < cap(stream.channel); i++ {
+		stream.channel <- StreamResp[int]{Resp: i}
+	}
+	done := make(chan struct{})
+	go func() {
+		stream.recvLoop()
+		close(done)
+	}()
+	t.Cleanup(func() {
+		close(client.shutdownChan)
+		deadline := time.NewTimer(5 * time.Second)
+		defer deadline.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-stream.channel:
+			case <-deadline.C:
+				t.Error("receive loop did not exit during cleanup")
+				return
+			}
+		}
+	})
+	select {
+	case <-full:
+	case <-time.After(5 * time.Second):
+		t.Fatal("receive loop did not reach the full-channel path")
+	}
+	stream.Close()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("closed transport kept its receive producer blocked on a full channel")
+	}
+	// Do not drain before the completion assertion: that would rescue the old implementation.
+	require.Len(t, stream.channel, defaultChanSize)
+	for range stream.channel {
+	}
+	require.False(t, stream.IsValid())
+}
+
+func TestBiDirectionStreamCloseBlockedIO(t *testing.T) {
+	t.Parallel()
+
+	for _, operation := range []string{"get", "send", "recv"} {
+		t.Run(operation, func(t *testing.T) {
+			t.Parallel()
+
+			entered := make(chan struct{})
+			release := make(chan struct{})
+			var clientCtx context.Context
+			provider := streamClientProviderFunc[int, int](func(ctx context.Context) (BiDirectionStreamClient[int, int], error) {
+				clientCtx = ctx
+				if operation == "get" {
+					close(entered)
+					return nil, waitForStreamCancellation(ctx, release)
+				}
+				return &streamClientStub[int, int]{
+					send: func(int) error {
+						close(entered)
+						return waitForStreamCancellation(ctx, release)
+					},
+					recv: func() (int, error) {
+						if operation == "recv" {
+							close(entered)
+						}
+						return 0, waitForStreamCancellation(ctx, release)
+					},
+				}, nil
+			})
+			stream := NewBiDirectionStream[int, int](provider, metrics.NoopMetricsHandler, log.NewTestLogger())
+			t.Cleanup(func() {
+				close(release)
+				stream.Close()
+			})
+			result := make(chan error, 1)
+			if operation == "recv" {
+				_, err := stream.Recv()
+				require.NoError(t, err)
+			} else {
+				go func() { result <- stream.Send(1) }()
+			}
+			waitForStreamSignal(t, entered, "I/O did not start")
+			closed := make(chan struct{})
+			go func() {
+				stream.Close()
+				close(closed)
+			}()
+			waitForStreamSignal(t, clientCtx.Done(), "Close did not cancel the provider context")
+			waitForStreamSignal(t, closed, "Close remained blocked behind I/O")
+			if operation != "recv" {
+				select {
+				case err := <-result:
+					require.Error(t, err)
+				case <-time.After(5 * time.Second):
+					t.Fatal("Send did not return after Close")
+				}
+			}
+			if operation != "get" {
+				select {
+				case _, ok := <-stream.channel:
+					require.False(t, ok, "intentional close should terminate the receive channel")
+				case <-time.After(5 * time.Second):
+					t.Fatal("receive channel stayed open after Close")
+				}
+			}
+			stream.Close()
+			require.False(t, stream.IsValid())
+		})
+	}
+}
+
+func TestBiDirectionStreamCloseBeforeInitialization(t *testing.T) {
+	t.Parallel()
+
+	provider := streamClientProviderFunc[int, int](func(context.Context) (BiDirectionStreamClient[int, int], error) {
+		t.Error("closed stream initialized its provider")
+		return nil, io.EOF
+	})
+	stream := NewBiDirectionStream[int, int](provider, metrics.NoopMetricsHandler, log.NewTestLogger())
+	stream.Close()
+	stream.Close()
+	require.False(t, stream.IsValid())
+	require.Error(t, stream.Send(1))
+	channel, err := stream.Recv()
+	require.Error(t, err)
+	require.Nil(t, channel)
+}
+
+func TestBiDirectionStreamCloseOnSendError(t *testing.T) {
+	t.Parallel()
+
+	recvEntered := make(chan struct{})
+	release := make(chan struct{})
+	var clientCtx context.Context
+	provider := streamClientProviderFunc[int, int](func(ctx context.Context) (BiDirectionStreamClient[int, int], error) {
+		clientCtx = ctx
+		return &streamClientStub[int, int]{
+			send: func(int) error {
+				select {
+				case <-recvEntered:
+				case <-release:
+				}
+				return io.ErrClosedPipe
+			},
+			recv: func() (int, error) {
+				close(recvEntered)
+				return 0, waitForStreamCancellation(ctx, release)
+			},
+		}, nil
+	})
+	stream := NewBiDirectionStream[int, int](provider, metrics.NoopMetricsHandler, log.NewTestLogger())
+	t.Cleanup(func() {
+		close(release)
+		stream.Close()
+	})
+	result := make(chan error, 1)
+	go func() { result <- stream.Send(1) }()
+	waitForStreamSignal(t, recvEntered, "receive did not start before Send failed")
+	select {
+	case err := <-result:
+		require.ErrorContains(t, err, io.ErrClosedPipe.Error())
+	case <-time.After(5 * time.Second):
+		t.Fatal("Send did not return its error")
+	}
+	waitForStreamSignal(t, clientCtx.Done(), "Send failure did not cancel the transport")
+	select {
+	case _, ok := <-stream.channel:
+		require.False(t, ok)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Send failure left Recv blocked")
+	}
+	require.False(t, stream.IsValid())
+}
+
+type streamClientProviderFunc[Req any, Resp any] func(context.Context) (BiDirectionStreamClient[Req, Resp], error)
+
+func (p streamClientProviderFunc[Req, Resp]) Get(ctx context.Context) (BiDirectionStreamClient[Req, Resp], error) {
+	return p(ctx)
+}
+
+type streamClientStub[Req any, Resp any] struct {
+	send func(Req) error
+	recv func() (Resp, error)
+}
+
+func (c *streamClientStub[Req, Resp]) Send(request Req) error { return c.send(request) }
+func (c *streamClientStub[Req, Resp]) Recv() (Resp, error)    { return c.recv() }
+func (c *streamClientStub[Req, Resp]) CloseSend() error       { return nil }
+
+func waitForStreamCancellation(ctx context.Context, release <-chan struct{}) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-release:
+		return io.EOF
+	}
+}
+
+func waitForStreamSignal(t *testing.T, signal <-chan struct{}, failure string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(5 * time.Second):
+		t.Fatal(failure)
+	}
 }
 
 func (p *mockStreamClientProvider) Get(

--- a/service/history/replication/stream_receiver_test.go
+++ b/service/history/replication/stream_receiver_test.go
@@ -1,6 +1,7 @@
 package replication
 
 import (
+	"context"
 	"math/rand"
 	"testing"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"go.temporal.io/server/api/adminservice/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
@@ -128,6 +130,64 @@ func (s *streamReceiverSuite) SetupTest() {
 
 func (s *streamReceiverSuite) TearDownTest() {
 	s.controller.Finish()
+}
+
+func TestStreamReceiverStopCancelsTransport(t *testing.T) {
+	t.Parallel()
+
+	controller := gomock.NewController(t)
+	metadata := cluster.NewMockMetadata(controller)
+	metadata.EXPECT().ClusterNameForFailoverVersion(true, int64(1)).Return("source")
+	metadata.EXPECT().GetAllClusterInfo().Return(map[string]cluster.ClusterInformation{
+		"source": {InitialFailoverVersion: 1},
+	})
+	toolbox := ProcessToolBox{
+		ClusterMetadata: metadata,
+		Config:          tests.NewDynamicConfig(),
+		MetricsHandler:  metrics.NoopMetricsHandler,
+		Logger:          log.NewTestLogger(),
+	}
+	receiver := NewStreamReceiver(toolbox, nil, NewClusterShardKey(2, 1), NewClusterShardKey(1, 1))
+	highPriorityTracker := NewMockExecutableTaskTracker(controller)
+	lowPriorityTracker := NewMockExecutableTaskTracker(controller)
+	receiver.highPriorityTaskTracker = highPriorityTracker
+	receiver.lowPriorityTaskTracker = lowPriorityTracker
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	provider := streamClientProviderFunc[*adminservice.StreamWorkflowReplicationMessagesRequest, *adminservice.StreamWorkflowReplicationMessagesResponse](
+		func(ctx context.Context) (BiDirectionStreamClient[*adminservice.StreamWorkflowReplicationMessagesRequest, *adminservice.StreamWorkflowReplicationMessagesResponse], error) {
+			return &streamClientStub[*adminservice.StreamWorkflowReplicationMessagesRequest, *adminservice.StreamWorkflowReplicationMessagesResponse]{
+				send: func(*adminservice.StreamWorkflowReplicationMessagesRequest) error {
+					t.Error("idle receiver unexpectedly sent an ACK")
+					return nil
+				},
+				recv: func() (*adminservice.StreamWorkflowReplicationMessagesResponse, error) {
+					close(entered)
+					return nil, waitForStreamCancellation(ctx, release)
+				},
+			}, nil
+		})
+	stream := NewBiDirectionStream(provider, metrics.NoopMetricsHandler, log.NewTestLogger())
+	t.Cleanup(func() {
+		close(release)
+		stream.Close()
+	})
+	receiver.stream = stream
+	receiver.status = common.DaemonStatusStarted
+	highPriorityTracker.EXPECT().Cancel()
+	lowPriorityTracker.EXPECT().Cancel()
+	result := make(chan error, 1)
+	go func() { result <- receiver.processMessages(stream) }()
+	waitForStreamSignal(t, entered, "receiver did not wait for a transport response")
+	receiver.Stop()
+	select {
+	case err := <-result:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("receiver message loop did not return after Stop")
+	}
+	require.False(t, stream.IsValid())
+	require.False(t, receiver.IsValid())
 }
 
 func (s *streamReceiverSuite) TestAckMessage_Noop() {


### PR DESCRIPTION
## Summary

Cancel a replication transport when it closes so blocked stream I/O and receive delivery can release their resources.

## Problem

The transport creates its RPC with `context.Background()`. `Close` then waits for the mutex held during client initialization or `Send` and only calls `CloseSend`. A blocked RPC can prevent shutdown from progressing.

The receive loop can also block while delivering into its full 512-response channel. If its consumer has stopped, the producer has no way to exit. Repeated stream shutdowns or reconnects can leave these goroutines and transport resources alive.

## Approach

Give each transport a cancellation context. `Close` cancels before acquiring the mutex, allowing context-aware client initialization and I/O to return. The Send-error path also cancels the transport.

Make receive delivery observe cancellation, including when the buffer is full. Keep `Send` and `CloseSend` serialized, and keep the receive loop as its channel's only closer. Active response order, EOF/error handling, and the full-channel counter retain their existing behavior.

## Validation

- The new full-buffer regression fails before the fix without draining the channel to unblock the producer.
- Focused tests cover blocked initialization, Send and Recv; full-buffer delivery; repeated and pre-initialization Close; Send-error cancellation; and the receiver's Stop/message-loop path.
- The complete replication package passes. Focused tests also pass with the race detector across three repetitions.
- Changed-package repository lint passes.

```sh
go test -tags test_dep ./service/history/replication -count=1
go test -race -tags test_dep ./service/history/replication -run 'TestBiDirectionStream|TestStreamReceiverStopCancelsTransport' -count=3
```

## Risks, rollout, and scope

Intentional close can discard a pending receive error. A response racing cancellation may still be delivered, and buffered responses may drain afterward. Receiver Stop remains asynchronous; this change does not cancel unrelated task execution or scheduler submission.

Cancellation depends on the client honoring its context. A client that ignores cancellation or blocks indefinitely in `CloseSend` remains outside this guarantee.
