### PR TITLE
Back off failed search attribute cache refreshes

### DIFF
--- a/common/searchattribute/manager.go
+++ b/common/searchattribute/manager.go
@@ -23,7 +23,7 @@ const (
 	cacheRefreshTimeout               = 5 * time.Second
 	cacheRefreshInterval              = 60 * time.Second
 	cacheRefreshIfUnavailableInterval = 20 * time.Second
-	cacheRefreshColdInterval          = 1 * time.Second
+	cacheRefreshErrorInterval         = 1 * time.Second
 )
 
 type (
@@ -42,6 +42,8 @@ type (
 		searchAttributes map[string]NameTypeMap
 		dbVersion        int64
 		expireOn         time.Time
+		refreshErr       error
+		retryAfter       time.Time
 	}
 )
 
@@ -79,7 +81,6 @@ func (m *managerImpl) GetSearchAttributes(
 	result := NewNameTypeMap(nil)
 	saCache, err := m.refreshCache(forceRefreshCache, now)
 	if err != nil {
-		m.logger.Error("failed to refresh search attributes cache", tag.Error(err))
 		return result, err
 	}
 	if indexSearchAttributes, ok := saCache.searchAttributes[indexName]; ok {
@@ -88,23 +89,35 @@ func (m *managerImpl) GetSearchAttributes(
 	return result, nil
 }
 
-func (m *managerImpl) needRefreshCache(saCache cache, forceRefreshCache bool, now time.Time) bool {
-	return forceRefreshCache || saCache.expireOn.Before(now) || m.forceRefresh()
+// needRefreshCache also returns the shared error when an expired snapshot is in cooldown.
+func (m *managerImpl) needRefreshCache(saCache cache, forceRefreshCache bool, now time.Time) (bool, error) {
+	if forceRefreshCache || m.forceRefresh() {
+		return true, nil
+	}
+	// A failed forced refresh must not poison an otherwise usable snapshot.
+	if !saCache.expireOn.Before(now) {
+		return false, nil
+	}
+	if now.Before(saCache.retryAfter) {
+		return false, saCache.refreshErr
+	}
+	return true, nil
 }
 
 func (m *managerImpl) refreshCache(forceRefreshCache bool, now time.Time) (cache, error) {
 	//nolint:revive // cache value is always of type `cache`
 	saCache := m.cache.Load().(cache)
-	if !m.needRefreshCache(saCache, forceRefreshCache, now) {
-		return saCache, nil
+	if refresh, err := m.needRefreshCache(saCache, forceRefreshCache, now); !refresh {
+		return saCache, err
 	}
 
 	m.cacheUpdateMutex.Lock()
 	defer m.cacheUpdateMutex.Unlock()
 	//nolint:revive // cache value is always of type `cache`
 	saCache = m.cache.Load().(cache)
-	if !m.needRefreshCache(saCache, forceRefreshCache, now) {
-		return saCache, nil
+	now = m.timeSource.Now()
+	if refresh, err := m.needRefreshCache(saCache, forceRefreshCache, now); !refresh {
+		return saCache, err
 	}
 
 	return m.refreshCacheLocked(saCache, now)
@@ -121,6 +134,8 @@ func (m *managerImpl) refreshCacheLocked(saCache cache, now time.Time) (cache, e
 	}
 
 	clusterMetadata, err := m.clusterMetadataManager.GetCurrentClusterMetadata(ctx)
+	saCache.refreshErr = nil
+	saCache.retryAfter = time.Time{}
 	if err != nil {
 		switch err.(type) {
 		case *serviceerror.NotFound:
@@ -129,16 +144,19 @@ func (m *managerImpl) refreshCacheLocked(saCache cache, now time.Time) (cache, e
 			saCache.expireOn = now.Add(cacheRefreshInterval)
 			err = nil
 		case *serviceerror.Unavailable:
-			if saCache.dbVersion == 0 {
-				// If the cache is still cold, and persistence is Unavailable, retry more aggressively
-				// within cacheRefreshColdInterval.
-				saCache.expireOn = now.Add(time.Duration(rand.Int63n(int64(cacheRefreshColdInterval))))
-			} else {
+			if saCache.dbVersion != 0 {
 				// If persistence is Unavailable, but cache was loaded at least once, then ignore the error
 				// and use existing cache for cacheRefreshIfUnavailableInterval.
 				saCache.expireOn = now.Add(cacheRefreshIfUnavailableInterval)
 				err = nil
 			}
+		}
+		if err != nil {
+			// Share the failed attempt without marking cold or expired metadata fresh.
+			// Start the positive, jittered cooldown after I/O completes.
+			saCache.refreshErr = err
+			saCache.retryAfter = m.timeSource.Now().Add(cacheRefreshErrorInterval + time.Duration(rand.Int63n(int64(cacheRefreshErrorInterval))))
+			m.logger.Error("failed to refresh search attributes cache", tag.Error(err))
 		}
 		m.cache.Store(saCache)
 		return saCache, err
@@ -183,7 +201,10 @@ func (m *managerImpl) SaveSearchAttributes(
 		Version:         clusterMetadataResponse.Version,
 	})
 	// Flush local cache, even if there was an error, which is most likely version mismatch (=stale cache).
+	// Keep network operations outside the lock, but order invalidation after any older refresh publication.
+	m.cacheUpdateMutex.Lock()
 	m.cache.Store(cache{})
+	m.cacheUpdateMutex.Unlock()
 
 	return err
 }

--- a/common/searchattribute/manager_refresh_test.go
+++ b/common/searchattribute/manager_refresh_test.go
@@ -1,0 +1,279 @@
+package searchattribute
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/testing/testlogger"
+	"go.uber.org/mock/gomock"
+)
+
+func TestManagerRefreshErrorCooldown(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		warm bool
+		err  error
+	}{
+		{"cold resource exhausted", false, persistence.ErrPersistenceSystemLimitExceeded},
+		{"warm resource exhausted", true, persistence.ErrPersistenceSystemLimitExceeded},
+		{"cold unavailable", false, serviceerror.NewUnavailable("metadata unavailable")},
+		{"cold timeout", false, context.DeadlineExceeded},
+		{"warm timeout", true, context.DeadlineExceeded},
+		{"cold unexpected error", false, errors.New("metadata failure")},
+		{"warm unexpected error", true, errors.New("metadata failure")},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			m, metadata, timeSource, logs := newRefreshTestManager(t)
+			if test.warm {
+				metadata.EXPECT().GetCurrentClusterMetadata(gomock.Any()).Return(refreshTestMetadata(1, "Old"), nil)
+				_, err := m.GetSearchAttributes("index", false)
+				require.NoError(t, err)
+				timeSource.Advance(61 * time.Second)
+			}
+			metadata.EXPECT().GetCurrentClusterMetadata(gomock.Any()).DoAndReturn(
+				func(context.Context) (*persistence.GetClusterMetadataResponse, error) {
+					timeSource.Advance(10 * time.Second)
+					return nil, test.err
+				})
+			for range 20 {
+				attributes, err := m.GetSearchAttributes("index", false)
+				require.Equal(t, test.err, err)
+				require.Empty(t, attributes.Custom())
+			}
+			// Slow I/O must not consume the minimum retry interval.
+			timeSource.Advance(time.Second - time.Nanosecond)
+			_, err := m.GetSearchAttributes("index", false)
+			require.Equal(t, test.err, err)
+			require.EqualValues(t, 1, logs.MatchCount())
+
+			timeSource.Advance(time.Second)
+			metadata.EXPECT().GetCurrentClusterMetadata(gomock.Any()).Return(refreshTestMetadata(2, "New"), nil)
+			attributes, err := m.GetSearchAttributes("index", false)
+			require.NoError(t, err)
+			require.Contains(t, attributes.Custom(), "New")
+			timeSource.Advance(59 * time.Second)
+			_, err = m.GetSearchAttributes("index", false)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func newRefreshTestManager(t *testing.T) (*managerImpl, *persistence.MockClusterMetadataManager, *clock.EventTimeSource, *testlogger.Expectation) {
+	t.Helper()
+	metadata := persistence.NewMockClusterMetadataManager(gomock.NewController(t))
+	timeSource := clock.NewEventTimeSource()
+	logger := testlogger.NewTestLogger(t, testlogger.FailOnAnyUnexpectedError)
+	logs := logger.Expect(testlogger.Error, "failed to refresh search attributes cache")
+	return NewManager(timeSource, metadata, logger, func() bool { return false }), metadata, timeSource, logs
+}
+
+func refreshTestMetadata(version int64, field string) *persistence.GetClusterMetadataResponse {
+	return &persistence.GetClusterMetadataResponse{
+		Version: version,
+		ClusterMetadata: &persistencespb.ClusterMetadata{IndexSearchAttributes: map[string]*persistencespb.IndexSearchAttributes{
+			"index": {CustomSearchAttributes: map[string]enumspb.IndexedValueType{field: enumspb.INDEXED_VALUE_TYPE_KEYWORD}},
+		}},
+	}
+}
+
+func TestManagerConcurrentFailedRefresh(t *testing.T) {
+	m, metadata, timeSource, logs := newRefreshTestManager(t)
+	entered, release := make(chan struct{}), make(chan struct{})
+	releaseRefresh := sync.OnceFunc(func() { close(release) })
+	defer releaseRefresh()
+	refreshErr := persistence.ErrPersistenceSystemLimitExceeded
+	metadata.EXPECT().GetCurrentClusterMetadata(gomock.Any()).DoAndReturn(
+		func(context.Context) (*persistence.GetClusterMetadataResponse, error) {
+			close(entered)
+			<-release
+			return nil, refreshErr
+		})
+	const callers = 32
+	results := make(chan error, callers)
+	for range callers {
+		go func() {
+			_, err := m.GetSearchAttributes("index", false)
+			results <- err
+		}()
+	}
+	awaitRefreshTest(t, entered)
+	timeSource.Advance(10 * time.Second)
+	releaseRefresh()
+	for range callers {
+		require.Same(t, refreshErr, awaitRefreshTest(t, results))
+	}
+	require.EqualValues(t, 1, logs.MatchCount())
+}
+
+func TestManagerForceBypassesRefreshError(t *testing.T) {
+	m, metadata, _, logs := newRefreshTestManager(t)
+	refreshErr := persistence.ErrPersistenceSystemLimitExceeded
+	metadata.EXPECT().GetCurrentClusterMetadata(gomock.Any()).Return(nil, refreshErr).Times(3)
+	_, err := m.GetSearchAttributes("index", false)
+	require.Same(t, refreshErr, err)
+	_, err = m.GetSearchAttributes("index", true)
+	require.Same(t, refreshErr, err)
+	m.forceRefresh = func() bool { return true }
+	_, err = m.GetSearchAttributes("index", false)
+	require.Same(t, refreshErr, err)
+	m.forceRefresh = func() bool { return false }
+	_, err = m.GetSearchAttributes("index", false)
+	require.Same(t, refreshErr, err)
+	require.EqualValues(t, 3, logs.MatchCount())
+}
+
+func TestManagerFailedForcePreservesFreshCache(t *testing.T) {
+	m, metadata, timeSource, logs := newRefreshTestManager(t)
+	metadata.EXPECT().GetCurrentClusterMetadata(gomock.Any()).Return(refreshTestMetadata(1, "Old"), nil)
+	_, err := m.GetSearchAttributes("index", false)
+	require.NoError(t, err)
+	timeSource.Advance(59*time.Second + 500*time.Millisecond)
+	refreshErr := persistence.ErrPersistenceSystemLimitExceeded
+	metadata.EXPECT().GetCurrentClusterMetadata(gomock.Any()).Return(nil, refreshErr)
+	_, err = m.GetSearchAttributes("index", true)
+	require.Same(t, refreshErr, err)
+	attributes, err := m.GetSearchAttributes("index", false)
+	require.NoError(t, err)
+	require.Contains(t, attributes.Custom(), "Old")
+	// After the original TTL, ordinary callers share the failure until retry is due.
+	timeSource.Advance(500*time.Millisecond + time.Nanosecond)
+	_, err = m.GetSearchAttributes("index", false)
+	require.Same(t, refreshErr, err)
+	require.EqualValues(t, 1, logs.MatchCount())
+}
+
+func TestManagerRefreshClearsRetainedError(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		warm bool
+		err  error
+	}{
+		{"not found", false, serviceerror.NewNotFound("metadata not persisted")},
+		{"warm unavailable", true, serviceerror.NewUnavailable("metadata unavailable")},
+		{"unchanged version", true, nil},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			m, metadata, timeSource, logs := newRefreshTestManager(t)
+			if test.warm {
+				metadata.EXPECT().GetCurrentClusterMetadata(gomock.Any()).Return(refreshTestMetadata(1, "Old"), nil)
+				_, err := m.GetSearchAttributes("index", false)
+				require.NoError(t, err)
+				timeSource.Advance(61 * time.Second)
+			}
+			metadata.EXPECT().GetCurrentClusterMetadata(gomock.Any()).Return(nil, persistence.ErrPersistenceSystemLimitExceeded)
+			_, err := m.GetSearchAttributes("index", false)
+			require.Error(t, err)
+			metadata.EXPECT().GetCurrentClusterMetadata(gomock.Any()).Return(refreshTestMetadata(1, "Ignored"), test.err)
+			attributes, err := m.GetSearchAttributes("index", true)
+			require.NoError(t, err)
+			if test.warm {
+				require.Contains(t, attributes.Custom(), "Old")
+			} else {
+				require.Empty(t, attributes.Custom())
+			}
+			_, err = m.GetSearchAttributes("index", false)
+			require.NoError(t, err)
+			timeSource.Advance(19 * time.Second)
+			_, err = m.GetSearchAttributes("index", false)
+			require.NoError(t, err)
+			require.EqualValues(t, 1, logs.MatchCount())
+		})
+	}
+}
+
+func TestManagerSaveInvalidatesRefreshError(t *testing.T) {
+	for _, saveErr := range []error{nil, errors.New("write conflict")} {
+		t.Run(fmt.Sprint(saveErr), func(t *testing.T) {
+			m, metadata, _, _ := newRefreshTestManager(t)
+			metadata.EXPECT().GetCurrentClusterMetadata(gomock.Any()).Return(nil, persistence.ErrPersistenceSystemLimitExceeded)
+			_, err := m.GetSearchAttributes("index", false)
+			require.Error(t, err)
+			metadata.EXPECT().GetCurrentClusterMetadata(gomock.Any()).Return(refreshTestMetadata(1, "Old"), nil)
+			metadata.EXPECT().SaveClusterMetadata(gomock.Any(), gomock.Any()).Return(false, saveErr)
+			err = m.SaveSearchAttributes(t.Context(), "index", map[string]enumspb.IndexedValueType{"New": enumspb.INDEXED_VALUE_TYPE_KEYWORD})
+			require.Equal(t, saveErr, err)
+			metadata.EXPECT().GetCurrentClusterMetadata(gomock.Any()).Return(refreshTestMetadata(2, "New"), nil)
+			attributes, err := m.GetSearchAttributes("index", false)
+			require.NoError(t, err)
+			require.Contains(t, attributes.Custom(), "New")
+		})
+	}
+}
+
+func TestManagerSaveInvalidationFollowsRefresh(t *testing.T) {
+	m, metadata, _, _ := newRefreshTestManager(t)
+	entered, release, written := make(chan struct{}), make(chan struct{}), make(chan struct{})
+	releaseRefresh := sync.OnceFunc(func() { close(release) })
+	defer releaseRefresh()
+	metadata.EXPECT().GetCurrentClusterMetadata(gomock.Any()).DoAndReturn(
+		func(context.Context) (*persistence.GetClusterMetadataResponse, error) {
+			close(entered)
+			<-release
+			return refreshTestMetadata(1, "Old"), nil
+		})
+	refreshed := make(chan error, 1)
+	go func() {
+		_, err := m.GetSearchAttributes("index", false)
+		refreshed <- err
+	}()
+	awaitRefreshTest(t, entered)
+	metadata.EXPECT().GetCurrentClusterMetadata(gomock.Any()).Return(refreshTestMetadata(1, "Old"), nil)
+	metadata.EXPECT().SaveClusterMetadata(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(context.Context, *persistence.SaveClusterMetadataRequest) (bool, error) {
+			close(written)
+			return true, nil
+		})
+	saved := make(chan error, 1)
+	go func() {
+		saved <- m.SaveSearchAttributes(t.Context(), "index", map[string]enumspb.IndexedValueType{"New": enumspb.INDEXED_VALUE_TYPE_KEYWORD})
+	}()
+	// Save I/O completes while the previous refresh still owns the publication lock.
+	awaitRefreshTest(t, written)
+	select {
+	case err := <-saved:
+		t.Fatalf("Save returned before the in-flight refresh released publication: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	releaseRefresh()
+	require.NoError(t, awaitRefreshTest(t, refreshed))
+	require.NoError(t, awaitRefreshTest(t, saved))
+	metadata.EXPECT().GetCurrentClusterMetadata(gomock.Any()).Return(refreshTestMetadata(2, "New"), nil)
+	attributes, err := m.GetSearchAttributes("index", false)
+	require.NoError(t, err)
+	require.Contains(t, attributes.Custom(), "New")
+}
+
+func awaitRefreshTest[T any](t *testing.T, result <-chan T) T {
+	t.Helper()
+	select {
+	case value := <-result:
+		return value
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for cache test goroutine")
+		var zero T
+		return zero
+	}
+}
+
+func TestManagerColdUnavailablePreservesError(t *testing.T) {
+	m, metadata, _, logs := newRefreshTestManager(t)
+	refreshErr := serviceerror.NewUnavailable("metadata unavailable")
+	metadata.EXPECT().GetCurrentClusterMetadata(gomock.Any()).Return(nil, refreshErr)
+	for range 2 {
+		attributes, err := m.GetSearchAttributes("index", false)
+		require.Error(t, err)
+		require.Same(t, refreshErr, err)
+		require.Empty(t, attributes.Custom())
+	}
+	require.EqualValues(t, 1, logs.MatchCount())
+}


### PR DESCRIPTION
## Summary

Share failed search attribute cache refreshes for a short retry interval so concurrent readers do not each repeat the same rejected metadata operation.

## Problem

When the search attribute cache expires and `GetCurrentClusterMetadata` fails, for example with `ResourceExhausted`, the cache stays expired. The refresh mutex makes callers take turns, but each caller can still make another persistence request and write another error log. This adds work while persistence is already rejecting requests.

Cold-cache `Unavailable` has a separate problem: it advances the cache expiration without retaining the failure. The next ordinary caller can receive successful empty custom attributes even though metadata has never loaded.

## Approach

Store the refresh error with a retry deadline of one to less than two seconds after the attempt finishes. Ordinary readers whose cache is cold or expired receive that error during the interval. The next eligible reader retries under the existing mutex. Log once per failed persistence attempt.

A failed forced refresh still returns its error, but ordinary readers can use any previously loaded metadata until its original expiration. Explicit force, the dynamic force flag, and local save invalidation permit an immediate new refresh. `NotFound`, successful version checks, and the existing warm-cache `Unavailable` fallback keep their behavior.

Local save invalidation also acquires the refresh mutex after completing its persistence work, so an older in-flight refresh cannot overwrite the invalidation.

## Validation

- Reproduced both bugs on the original manager: ordinary readers made an unexpected additional metadata attempt after failure, and a second cold-cache reader received nil error after `Unavailable`.
- `go test -p 4 -tags test_dep ./common/searchattribute -count=1` passed.
- `go test -p 4 -race -tags test_dep ./common/searchattribute -count=3` passed.
- New tests cover cold and warm errors, retry timing after slow I/O, concurrent readers, forced refreshes, successful and accepted fallback results, and local save invalidation.
- These tests use mock persistence. The save-ordering test includes a bounded 20 ms observation while a refresh is blocked.
- Changed-package repository lint passed.

## Risks, rollout, and scope

The retry interval can delay recovery by its remaining duration. It applies per manager instance; forced reads and callers outside this manager have independent retry behavior. Saving search attributes may wait for an in-flight refresh before invalidating the local cache. The existing warm-cache `Unavailable` fallback can continue serving stale metadata across repeated failures.

No API, persistence schema, or configuration changes.

## References

[Related caller error-classification proposal](https://github.com/temporalio/temporal/pull/11777).
