### PR TITLE
Checkpoint history scanner pages after branch work completes

### DIFF
--- a/service/worker/scanner/history/scavenger.go
+++ b/service/worker/scanner/history/scavenger.go
@@ -1,6 +1,7 @@
 package history
 
 import (
+	"bytes"
 	"context"
 	"sync"
 	"time"
@@ -14,7 +15,6 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common"
-	"go.temporal.io/server/common/collection"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
@@ -66,6 +66,7 @@ type (
 		workflowID  string
 		runID       string
 		branchToken []byte
+		completed   chan<- struct{}
 	}
 )
 
@@ -96,6 +97,7 @@ func NewScavenger(
 	logger log.Logger,
 	serializer serialization.Serializer,
 ) *Scavenger {
+	hbd.NextPageToken = bytes.Clone(hbd.NextPageToken)
 	return &Scavenger{
 		numShards:   numShards,
 		db:          db,
@@ -139,36 +141,68 @@ func (s *Scavenger) loadTasks(
 
 	defer close(reqCh)
 
-	iter := collection.NewPagingIteratorWithToken(s.getPaginationFn(ctx), s.hbd.NextPageToken)
-	for iter.HasNext() {
-		if err := s.rateLimiter.Wait(ctx); err != nil {
-			// context done
+	s.Lock()
+	pageToken := s.hbd.NextPageToken
+	s.Unlock()
+	for {
+		if err := ctx.Err(); err != nil {
 			return err
 		}
-
-		item, err := iter.Next()
+		resp, err := s.db.GetAllHistoryTreeBranches(ctx, &persistence.GetAllHistoryTreeBranchesRequest{
+			PageSize:      pageSize,
+			NextPageToken: bytes.Clone(pageToken),
+		})
 		if err != nil {
 			return err
 		}
+		nextPageToken := bytes.Clone(resp.NextPageToken)
+		s.Lock()
+		s.hbd.CurrentPage++
+		s.Unlock()
 
-		// Heartbeat to prevent heartbeat timeout.
+		// Buffer every possible completion so workers can finish even if dispatch
+		// is interrupted. A store may return more rows than the requested page size.
+		completed := make(chan struct{}, len(resp.Branches))
+		dispatched := 0
+		for _, item := range resp.Branches {
+			if err := s.rateLimiter.Wait(ctx); err != nil {
+				return err
+			}
+
+			s.heartbeat(ctx)
+			task := s.filterTask(item)
+			if task == nil {
+				continue
+			}
+			task.completed = completed
+			select {
+			case reqCh <- *task:
+				dispatched++
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+
+		for range dispatched {
+			select {
+			case <-completed:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		// An interrupted page must resume from its input until all outcomes are counted.
+		s.Lock()
+		s.hbd.NextPageToken = nextPageToken
+		s.Unlock()
 		s.heartbeat(ctx)
-
-		task := s.filterTask(item)
-		if task == nil {
-			continue
+		if len(nextPageToken) == 0 {
+			return nil
 		}
-
-		select {
-		case reqCh <- *task:
-			// noop
-
-		case <-ctx.Done():
-			return ctx.Err()
-		}
+		pageToken = nextPageToken
 	}
-
-	return nil
 }
 
 func (s *Scavenger) taskWorker(
@@ -190,6 +224,7 @@ func (s *Scavenger) taskWorker(
 
 			s.heartbeat(ctx)
 			s.handleErr(s.handleTask(ctx, task))
+			task.completed <- struct{}{}
 		}
 	}
 }
@@ -301,29 +336,6 @@ func (s *Scavenger) handleErr(
 
 	metrics.HistoryScavengerSuccessCount.With(s.metricsHandler).Record(1)
 	s.hbd.SuccessCount++
-}
-
-func (s *Scavenger) getPaginationFn(
-	ctx context.Context,
-) collection.PaginationFn[persistence.HistoryBranchDetail] {
-	return func(paginationToken []byte) ([]persistence.HistoryBranchDetail, []byte, error) {
-		req := &persistence.GetAllHistoryTreeBranchesRequest{
-			PageSize:      pageSize,
-			NextPageToken: paginationToken,
-		}
-		resp, err := s.db.GetAllHistoryTreeBranches(ctx, req)
-		if err != nil {
-			return nil, nil, err
-		}
-		paginateItems := resp.Branches
-
-		s.Lock()
-		s.hbd.CurrentPage++
-		s.hbd.NextPageToken = resp.NextPageToken
-		s.Unlock()
-
-		return paginateItems, resp.NextPageToken, nil
-	}
 }
 
 func (s *Scavenger) cleanUpWorkflowPastRetention(

--- a/service/worker/scanner/history/scavenger_checkpoint_test.go
+++ b/service/worker/scanner/history/scavenger_checkpoint_test.go
@@ -1,0 +1,266 @@
+package history
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/api/historyservice/v1"
+	"go.temporal.io/server/api/historyservicemock/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/common/primitives/timestamp"
+	"go.temporal.io/server/common/quotas"
+	"go.temporal.io/server/common/testing/await"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc"
+)
+
+func TestScavengerPageWaitsForBranchOutcomes(t *testing.T) {
+	t.Parallel()
+	for _, terminal := range []bool{false, true} {
+		t.Run(fmt.Sprintf("terminal=%v", terminal), func(t *testing.T) {
+			t.Parallel()
+			synctest.Test(t, func(t *testing.T) {
+				s, db, client := newCheckpointScavenger(t)
+				s.hbd = ScavengerHeartbeatDetails{CurrentPage: 7, NextPageToken: []byte("current")}
+				var next []byte
+				if !terminal {
+					next = []byte("next")
+				}
+				db.EXPECT().GetAllHistoryTreeBranches(gomock.Any(), &persistence.GetAllHistoryTreeBranchesRequest{
+					PageSize: pageSize, NextPageToken: []byte("current"),
+				}).Return(&persistence.GetAllHistoryTreeBranchesResponse{
+					Branches: checkpointBranches(3), NextPageToken: next,
+				}, nil)
+				if !terminal {
+					db.EXPECT().GetAllHistoryTreeBranches(gomock.Any(), &persistence.GetAllHistoryTreeBranchesRequest{
+						PageSize: pageSize, NextPageToken: next,
+					}).Return(&persistence.GetAllHistoryTreeBranchesResponse{}, nil)
+				}
+				entered, release := make(chan struct{}), make(chan struct{})
+				releaseWorker := sync.OnceFunc(func() { close(release) })
+				defer releaseWorker()
+				client.EXPECT().DescribeMutableState(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, req *historyservice.DescribeMutableStateRequest, _ ...grpc.CallOption) (*historyservice.DescribeMutableStateResponse, error) {
+						if req.Execution.RunId == "run-0" {
+							close(entered)
+							await.Rcv(t, release)
+						}
+						if req.Execution.RunId == "run-1" {
+							return nil, serviceerror.NewUnavailable("branch unavailable")
+						}
+						return nil, nil
+					}).Times(3)
+				done := make(chan ScavengerHeartbeatDetails, 1)
+				go func() {
+					details, _ := s.Run(t.Context())
+					done <- details
+				}()
+				await.Rcv(t, entered)
+				synctest.Wait()
+				s.Lock()
+				checkpoint := s.hbd
+				s.Unlock()
+				require.Equal(t, []byte("current"), checkpoint.NextPageToken)
+				require.Equal(t, 8, checkpoint.CurrentPage)
+				require.Equal(t, 1, checkpoint.SuccessCount)
+				require.Equal(t, 1, checkpoint.ErrorCount)
+				releaseWorker()
+				result := await.Rcv(t, done)
+				require.Empty(t, result.NextPageToken)
+				require.Equal(t, 2, result.SuccessCount)
+				require.Equal(t, 1, result.ErrorCount)
+			})
+		})
+	}
+}
+
+func newCheckpointScavenger(t *testing.T) (*Scavenger, *persistence.MockExecutionManager, *historyservicemock.MockHistoryServiceClient) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	db := persistence.NewMockExecutionManager(ctrl)
+	client := historyservicemock.NewMockHistoryServiceClient(ctrl)
+	s := NewScavenger(512, db, 100, client, nil, nil, ScavengerHeartbeatDetails{},
+		dynamicconfig.GetDurationPropertyFn(time.Hour), dynamicconfig.GetDurationPropertyFn(time.Second),
+		dynamicconfig.GetBoolPropertyFn(false), metrics.NoopMetricsHandler, log.NewNoopLogger(), serialization.NewSerializer())
+	s.isInTest = true
+	limiter := quotas.NewMockRateLimiter(ctrl)
+	limiter.EXPECT().Wait(gomock.Any()).Return(nil).AnyTimes()
+	s.rateLimiter = limiter
+	return s, db, client
+}
+
+func checkpointBranches(count int) []persistence.HistoryBranchDetail {
+	branches := make([]persistence.HistoryBranchDetail, count)
+	for i := range branches {
+		branches[i] = persistence.HistoryBranchDetail{
+			BranchInfo: &persistencespb.HistoryBranch{TreeId: "tree", BranchId: fmt.Sprintf("branch-%d", i)},
+			ForkTime:   timestamp.TimePtr(time.Now().Add(-2 * time.Hour)),
+			Info:       persistence.BuildHistoryGarbageCleanupInfo("namespace", "workflow", fmt.Sprintf("run-%d", i)),
+		}
+	}
+	return branches
+}
+
+func TestScavengerPageCancellation(t *testing.T) {
+	t.Parallel()
+	for _, count := range []int{2 * numWorker, 2*pageSize + numWorker + 1} {
+		t.Run(fmt.Sprintf("rows=%d", count), func(t *testing.T) {
+			t.Parallel()
+			synctest.Test(t, func(t *testing.T) {
+				s, db, client := newCheckpointScavenger(t)
+				s.hbd.NextPageToken = []byte("current")
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+				db.EXPECT().GetAllHistoryTreeBranches(gomock.Any(), gomock.Any()).Return(
+					&persistence.GetAllHistoryTreeBranchesResponse{Branches: checkpointBranches(count), NextPageToken: []byte("next")}, nil)
+				entered := make(chan struct{})
+				enter := sync.OnceFunc(func() { close(entered) })
+				client.EXPECT().DescribeMutableState(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, _ *historyservice.DescribeMutableStateRequest, _ ...grpc.CallOption) (*historyservice.DescribeMutableStateResponse, error) {
+						enter()
+						<-ctx.Done()
+						return nil, ctx.Err()
+					}).AnyTimes()
+				done := make(chan ScavengerHeartbeatDetails, 1)
+				go func() {
+					details, _ := s.Run(ctx)
+					done <- details
+				}()
+				await.Rcv(t, entered)
+				synctest.Wait()
+				cancel()
+				synctest.Wait()
+				result := await.Rcv(t, done)
+				require.Equal(t, []byte("current"), result.NextPageToken)
+				require.Positive(t, result.ErrorCount)
+				require.Zero(t, result.SuccessCount)
+			})
+		})
+	}
+}
+
+func TestScavengerPagePartialDispatch(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		s, db, client := newCheckpointScavenger(t)
+		s.hbd.NextPageToken = []byte("current")
+		entered, release, failed := make(chan struct{}), make(chan struct{}), make(chan struct{})
+		releaseWorker := sync.OnceFunc(func() { close(release) })
+		defer releaseWorker()
+		limiter := quotas.NewMockRateLimiter(gomock.NewController(t))
+		s.rateLimiter = limiter
+		gomock.InOrder(
+			limiter.EXPECT().Wait(gomock.Any()).Return(nil),
+			limiter.EXPECT().Wait(gomock.Any()).DoAndReturn(func(context.Context) error {
+				await.Rcv(t, entered)
+				close(failed)
+				return serviceerror.NewUnavailable("limiter unavailable")
+			}),
+		)
+		db.EXPECT().GetAllHistoryTreeBranches(gomock.Any(), gomock.Any()).Return(
+			&persistence.GetAllHistoryTreeBranchesResponse{Branches: checkpointBranches(2), NextPageToken: []byte("next")}, nil)
+		client.EXPECT().DescribeMutableState(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(context.Context, *historyservice.DescribeMutableStateRequest, ...grpc.CallOption) (*historyservice.DescribeMutableStateResponse, error) {
+				close(entered)
+				await.Rcv(t, release)
+				return nil, nil
+			})
+		done := make(chan ScavengerHeartbeatDetails, 1)
+		go func() {
+			details, _ := s.Run(t.Context())
+			done <- details
+		}()
+		await.Rcv(t, failed)
+		synctest.Wait()
+		select {
+		case <-done:
+			t.Fatal("Run returned before the dispatched branch finished")
+		default:
+		}
+		releaseWorker()
+		result := await.Rcv(t, done)
+		require.Equal(t, []byte("current"), result.NextPageToken)
+		require.Equal(t, 1, result.SuccessCount)
+	})
+}
+
+func TestScavengerPageOversizedResponse(t *testing.T) {
+	t.Parallel()
+	s, db, client := newCheckpointScavenger(t)
+	count := 2*pageSize + numWorker + 1
+	db.EXPECT().GetAllHistoryTreeBranches(gomock.Any(), gomock.Any()).Return(
+		&persistence.GetAllHistoryTreeBranchesResponse{Branches: checkpointBranches(count)}, nil)
+	client.EXPECT().DescribeMutableState(gomock.Any(), gomock.Any()).Return(nil, nil).Times(count)
+	result, err := s.Run(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, count, result.SuccessCount)
+	require.Empty(t, result.NextPageToken)
+}
+
+func TestScavengerPageEmptyResponses(t *testing.T) {
+	t.Parallel()
+	s, db, _ := newCheckpointScavenger(t)
+	gomock.InOrder(
+		db.EXPECT().GetAllHistoryTreeBranches(gomock.Any(), &persistence.GetAllHistoryTreeBranchesRequest{PageSize: pageSize}).Return(
+			&persistence.GetAllHistoryTreeBranchesResponse{NextPageToken: []byte("next")}, nil),
+		db.EXPECT().GetAllHistoryTreeBranches(gomock.Any(), &persistence.GetAllHistoryTreeBranchesRequest{PageSize: pageSize, NextPageToken: []byte("next")}).Return(
+			&persistence.GetAllHistoryTreeBranchesResponse{}, nil),
+	)
+	result, err := s.Run(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, ScavengerHeartbeatDetails{CurrentPage: 2}, result)
+}
+
+func TestScavengerPageTokenOwnership(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		s, db, client := newCheckpointScavenger(t)
+		s.hbd.NextPageToken = []byte("current")
+		next := []byte("next")
+		db.EXPECT().GetAllHistoryTreeBranches(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, req *persistence.GetAllHistoryTreeBranchesRequest) (*persistence.GetAllHistoryTreeBranchesResponse, error) {
+				req.NextPageToken[0] = 'X'
+				return &persistence.GetAllHistoryTreeBranchesResponse{Branches: checkpointBranches(1), NextPageToken: next}, nil
+			})
+		db.EXPECT().GetAllHistoryTreeBranches(gomock.Any(), &persistence.GetAllHistoryTreeBranchesRequest{PageSize: pageSize, NextPageToken: []byte("next")}).DoAndReturn(
+			func(_ context.Context, req *persistence.GetAllHistoryTreeBranchesRequest) (*persistence.GetAllHistoryTreeBranchesResponse, error) {
+				req.NextPageToken[0] = 'Z'
+				return nil, serviceerror.NewUnavailable("page unavailable")
+			})
+		entered, release := make(chan struct{}), make(chan struct{})
+		releaseWorker := sync.OnceFunc(func() { close(release) })
+		defer releaseWorker()
+		client.EXPECT().DescribeMutableState(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(context.Context, *historyservice.DescribeMutableStateRequest, ...grpc.CallOption) (*historyservice.DescribeMutableStateResponse, error) {
+				close(entered)
+				await.Rcv(t, release)
+				return nil, nil
+			})
+		done := make(chan ScavengerHeartbeatDetails, 1)
+		go func() {
+			details, _ := s.Run(t.Context())
+			done <- details
+		}()
+		await.Rcv(t, entered)
+		synctest.Wait()
+		s.Lock()
+		checkpoint := string(s.hbd.NextPageToken)
+		s.Unlock()
+		require.Equal(t, "current", checkpoint)
+		next[0] = 'Y'
+		releaseWorker()
+		result := await.Rcv(t, done)
+		require.Equal(t, []byte("next"), result.NextPageToken)
+	})
+}

--- a/service/worker/scanner/workflow_checkpoint_test.go
+++ b/service/worker/scanner/workflow_checkpoint_test.go
@@ -1,0 +1,132 @@
+package scanner
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/converter"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/worker"
+	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/service/worker/scanner/history"
+	"go.uber.org/mock/gomock"
+)
+
+func TestHistoryScavengerCheckpointReplaysUnfinishedPage(t *testing.T) {
+	t.Parallel()
+	db := persistence.NewMockExecutionManager(gomock.NewController(t))
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	env := newCheckpointActivityEnvironment(ctx, db)
+	env.SetHeartbeatDetails(history.ScavengerHeartbeatDetails{
+		CurrentPage: 7, ErrorCount: 3, NextPageToken: []byte("current"),
+	})
+	var captured history.ScavengerHeartbeatDetails
+	var captureErr error
+	var first sync.Once
+	env.SetOnActivityHeartbeatListener(func(_ *activity.Info, values converter.EncodedValues) {
+		first.Do(func() {
+			captureErr = values.Get(&captured)
+			cancel()
+		})
+	})
+	rows := []persistence.HistoryBranchDetail{{Info: "invalid-first"}, {Info: "invalid-second"}}
+	db.EXPECT().GetAllHistoryTreeBranches(gomock.Any(), &persistence.GetAllHistoryTreeBranchesRequest{
+		PageSize: 100, NextPageToken: []byte("current"),
+	}).Return(&persistence.GetAllHistoryTreeBranchesResponse{Branches: rows, NextPageToken: []byte("next")}, nil)
+	_, _ = env.ExecuteActivity(historyScavengerActivityName)
+	require.NoError(t, captureErr)
+	require.Equal(t, history.ScavengerHeartbeatDetails{
+		CurrentPage: 8, ErrorCount: 3, NextPageToken: []byte("current"),
+	}, captured)
+
+	// Recovery uses the SDK heartbeat, not the activity's returned result.
+	retryEnv := newCheckpointActivityEnvironment(t.Context(), db)
+	retryEnv.SetHeartbeatDetails(captured)
+	gomock.InOrder(
+		db.EXPECT().GetAllHistoryTreeBranches(gomock.Any(), &persistence.GetAllHistoryTreeBranchesRequest{
+			PageSize: 100, NextPageToken: []byte("current"),
+		}).Return(&persistence.GetAllHistoryTreeBranchesResponse{Branches: rows, NextPageToken: []byte("next")}, nil),
+		db.EXPECT().GetAllHistoryTreeBranches(gomock.Any(), &persistence.GetAllHistoryTreeBranchesRequest{
+			PageSize: 100, NextPageToken: []byte("next"),
+		}).Return(&persistence.GetAllHistoryTreeBranchesResponse{}, nil),
+	)
+	result, err := retryEnv.ExecuteActivity(historyScavengerActivityName)
+	require.NoError(t, err)
+	var final history.ScavengerHeartbeatDetails
+	require.NoError(t, result.Get(&final))
+	require.Equal(t, history.ScavengerHeartbeatDetails{CurrentPage: 10, ErrorCount: 5}, final)
+}
+
+func TestHistoryScavengerCheckpointEmptyPage(t *testing.T) {
+	t.Parallel()
+	for _, terminal := range []bool{false, true} {
+		t.Run(fmt.Sprintf("terminal=%v", terminal), func(t *testing.T) {
+			t.Parallel()
+			db := persistence.NewMockExecutionManager(gomock.NewController(t))
+			env := newCheckpointActivityEnvironment(t.Context(), db)
+			env.SetHeartbeatDetails(history.ScavengerHeartbeatDetails{CurrentPage: 7, NextPageToken: []byte("current")})
+			var captured history.ScavengerHeartbeatDetails
+			var captureErr error
+			var first sync.Once
+			env.SetOnActivityHeartbeatListener(func(_ *activity.Info, values converter.EncodedValues) {
+				first.Do(func() { captureErr = values.Get(&captured) })
+			})
+			var next []byte
+			if !terminal {
+				next = []byte("next")
+				db.EXPECT().GetAllHistoryTreeBranches(gomock.Any(), &persistence.GetAllHistoryTreeBranchesRequest{
+					PageSize: 100, NextPageToken: next,
+				}).Return(&persistence.GetAllHistoryTreeBranchesResponse{}, nil)
+			}
+			db.EXPECT().GetAllHistoryTreeBranches(gomock.Any(), &persistence.GetAllHistoryTreeBranchesRequest{
+				PageSize: 100, NextPageToken: []byte("current"),
+			}).Return(&persistence.GetAllHistoryTreeBranchesResponse{NextPageToken: next}, nil)
+			_, err := env.ExecuteActivity(historyScavengerActivityName)
+			require.NoError(t, err)
+			require.NoError(t, captureErr)
+			require.Equal(t, history.ScavengerHeartbeatDetails{CurrentPage: 8, NextPageToken: next}, captured)
+
+			retryEnv := newCheckpointActivityEnvironment(t.Context(), db)
+			retryEnv.SetHeartbeatDetails(captured)
+			db.EXPECT().GetAllHistoryTreeBranches(gomock.Any(), &persistence.GetAllHistoryTreeBranchesRequest{
+				PageSize: 100, NextPageToken: next,
+			}).Return(&persistence.GetAllHistoryTreeBranchesResponse{}, nil)
+			result, err := retryEnv.ExecuteActivity(historyScavengerActivityName)
+			require.NoError(t, err)
+			var final history.ScavengerHeartbeatDetails
+			require.NoError(t, result.Get(&final))
+			require.Equal(t, history.ScavengerHeartbeatDetails{CurrentPage: 9}, final)
+		})
+	}
+}
+
+func newCheckpointActivityEnvironment(ctx context.Context, db persistence.ExecutionManager) *testsuite.TestActivityEnvironment {
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestActivityEnvironment()
+	env.RegisterActivityWithOptions(HistoryScavengerActivity, activity.RegisterOptions{Name: historyScavengerActivityName})
+	env.SetWorkerOptions(worker.Options{BackgroundActivityContext: context.WithValue(ctx, scannerContextKey, scannerContext{
+		cfg: &Config{
+			Persistence:                   &config.Persistence{NumHistoryShards: 512},
+			PersistenceMaxQPS:             dynamicconfig.GetIntPropertyFn(100),
+			HistoryScannerDataMinAge:      dynamicconfig.GetDurationPropertyFn(time.Hour),
+			HistoryScannerVerifyRetention: dynamicconfig.GetBoolPropertyFn(false),
+			ExecutionDataDurationBuffer:   dynamicconfig.GetDurationPropertyFn(time.Second),
+		},
+		executionManager: db,
+		logger:           log.NewNoopLogger(),
+		metricsHandler:   metrics.NoopMetricsHandler,
+		serializer:       serialization.NewSerializer(),
+	})})
+	return env
+}


### PR DESCRIPTION
## Summary

Checkpoint each history scanner page after its branch outcomes are recorded so a retry cannot skip unfinished work from that page.

## Problem

The scanner saves a fetched page's continuation before its workers finish. If an attempt times out, an accepted heartbeat can resume at the next page and omit unfinished branches.

## Approach

Keep the page's input cursor in heartbeats while its rows are filtered and processed by the existing worker pool. After every outcome is counted, heartbeat the continuation and fetch the next page. Empty pages use the same boundary. Completion notifications remain buffered if cancellation or partial dispatch interrupts the loader.

Branch errors remain counted and nonfatal. Copy pagination tokens so persistence request and response buffers cannot change the checkpoint.

## Validation

The new page-barrier regression failed against the original implementation for terminal and nonterminal pages, then passed with this change. Tests cover out-of-order completion, cancellation with queued tasks, partial dispatch, oversized responses, token ownership, empty pages, and SDK heartbeat capture and replay.

Both scanner packages also passed with the race detector when combined with the separate enumeration-error change.

```sh
go test -p 4 -tags test_dep ./service/worker/scanner/history ./service/worker/scanner -count=1 -timeout=5m
go test -p 4 -tags test_dep -race ./service/worker/scanner/history ./service/worker/scanner -count=1 -timeout=5m
make lint-code-fast GOLANGCI_LINT_FIX=false
```

## Risks, rollout, and scope

A slow branch now delays the next page and may expose the existing heartbeat timeout. Replayed pages can repeat branch attempts and counters. Existing unsafe checkpoints are not repaired, and a terminal nil cursor retains its existing restart-from-beginning behavior. The heartbeat schema and retry policy are unchanged. Loader error propagation is a separate change.

## References

- [Companion enumeration-error fix](https://github.com/temporalio/temporal/pull/12003); either change can land independently.
- [Scanner pagination and checkpoints](https://github.com/temporalio/temporal/blob/951c5516e9e7b3066e7e069adda9565cfd68844c/service/worker/scanner/history/scavenger.go#L306-L329)
- [Activity heartbeat recovery](https://github.com/temporalio/temporal/blob/951c5516e9e7b3066e7e069adda9565cfd68844c/service/worker/scanner/workflow.go#L107-L145)
