### PR TITLE
Report history scanner enumeration failures

### DIFF
--- a/service/worker/scanner/history/scavenger.go
+++ b/service/worker/scanner/history/scavenger.go
@@ -119,17 +119,21 @@ func NewScavenger(
 func (s *Scavenger) Run(ctx context.Context) (ScavengerHeartbeatDetails, error) {
 	reqCh := make(chan taskDetail, pageSize)
 
-	go s.loadTasks(ctx, reqCh)
 	for range numWorker {
 		s.Add(1)
 		go s.taskWorker(ctx, reqCh)
 	}
 
+	err := s.loadTasks(ctx, reqCh)
+	// Drain dispatched work before reporting enumeration failure.
 	s.Wait()
 
 	s.Lock()
 	defer s.Unlock()
-	return s.hbd, nil
+	if err == nil {
+		err = ctx.Err()
+	}
+	return s.hbd, err
 }
 
 func (s *Scavenger) loadTasks(

--- a/service/worker/scanner/history/scavenger_run_test.go
+++ b/service/worker/scanner/history/scavenger_run_test.go
@@ -1,0 +1,245 @@
+package history
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/api/historyservice/v1"
+	"go.temporal.io/server/api/historyservicemock/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/common/primitives/timestamp"
+	"go.temporal.io/server/common/quotas"
+	"go.temporal.io/server/common/testing/await"
+	"go.uber.org/mock/gomock"
+)
+
+func TestScavengerRunEnumerationFailure(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	s, db, _ := newScavengerRunTest(ctrl)
+	failure := errors.New("history enumeration failed")
+	db.EXPECT().GetAllHistoryTreeBranches(gomock.Any(), gomock.Any()).Return(nil, failure)
+
+	details, err := s.Run(t.Context())
+
+	require.ErrorIs(t, err, failure)
+	require.Equal(t, ScavengerHeartbeatDetails{}, details)
+}
+
+func TestScavengerRunEmptyContinuation(t *testing.T) {
+	t.Parallel()
+	for _, fail := range []bool{false, true} {
+		name := "success"
+		if fail {
+			name = "failure"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			s, db, _ := newScavengerRunTest(ctrl)
+			var failure error
+			if fail {
+				failure = errors.New("next history page unavailable")
+			}
+			db.EXPECT().GetAllHistoryTreeBranches(gomock.Any(), &persistence.GetAllHistoryTreeBranchesRequest{PageSize: pageSize}).Return(
+				&persistence.GetAllHistoryTreeBranchesResponse{NextPageToken: []byte("next")}, nil)
+			db.EXPECT().GetAllHistoryTreeBranches(gomock.Any(), &persistence.GetAllHistoryTreeBranchesRequest{PageSize: pageSize, NextPageToken: []byte("next")}).Return(
+				&persistence.GetAllHistoryTreeBranchesResponse{}, failure)
+
+			details, err := s.Run(t.Context())
+
+			if fail {
+				require.ErrorIs(t, err, failure)
+				require.Equal(t, 1, details.CurrentPage)
+				require.Equal(t, []byte("next"), details.NextPageToken)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, 2, details.CurrentPage)
+				require.Empty(t, details.NextPageToken)
+			}
+		})
+	}
+}
+
+func TestScavengerRunDrainsAfterLoaderFailure(t *testing.T) {
+	t.Parallel()
+	for _, cancelWhileDraining := range []bool{false, true} {
+		name := "live context"
+		if cancelWhileDraining {
+			name = "canceled context"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			synctest.Test(t, func(t *testing.T) {
+				ctrl := gomock.NewController(t)
+				s, db, client := newScavengerRunTest(ctrl)
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+				entered, failed, release := make(chan struct{}), make(chan struct{}), make(chan struct{})
+				releaseWorker := sync.OnceFunc(func() { close(release) })
+				defer releaseWorker()
+				failure := errors.New("rate limiter failed")
+				limiter := quotas.NewMockRateLimiter(ctrl)
+				s.rateLimiter = limiter
+				gomock.InOrder(
+					limiter.EXPECT().Wait(gomock.Any()).Return(nil),
+					limiter.EXPECT().Wait(gomock.Any()).DoAndReturn(func(context.Context) error {
+						await.Rcv(t, entered)
+						close(failed)
+						return failure
+					}),
+				)
+				db.EXPECT().GetAllHistoryTreeBranches(gomock.Any(), gomock.Any()).Return(
+					&persistence.GetAllHistoryTreeBranchesResponse{Branches: []persistence.HistoryBranchDetail{scavengerRunTestBranch(), scavengerRunTestBranch()}}, nil)
+				client.EXPECT().DescribeMutableState(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, _ *historyservice.DescribeMutableStateRequest, _ ...any) (*historyservice.DescribeMutableStateResponse, error) {
+						close(entered)
+						select {
+						case <-release:
+							return &historyservice.DescribeMutableStateResponse{}, nil
+						case <-ctx.Done():
+							return nil, ctx.Err()
+						}
+					})
+				done := make(chan scavengerRunResult, 1)
+				go func() {
+					details, err := s.Run(ctx)
+					done <- scavengerRunResult{details, err}
+				}()
+				await.Rcv(t, failed)
+				synctest.Wait()
+				select {
+				case got := <-done:
+					t.Fatalf("Run returned before the dispatched branch finished: %+v", got)
+				default:
+				}
+				if cancelWhileDraining {
+					cancel()
+				} else {
+					releaseWorker()
+				}
+				got := await.Rcv(t, done)
+				require.ErrorIs(t, got.err, failure)
+				if cancelWhileDraining {
+					require.Equal(t, 1, got.details.ErrorCount)
+					require.Zero(t, got.details.SuccessCount)
+				} else {
+					require.Equal(t, 1, got.details.SuccessCount)
+					require.Zero(t, got.details.ErrorCount)
+				}
+			})
+		})
+	}
+}
+
+func TestScavengerRunCancellationJoinsLoader(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		s, db, _ := newScavengerRunTest(ctrl)
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		entered, canceled, release := make(chan struct{}), make(chan struct{}), make(chan struct{})
+		releaseLoader := sync.OnceFunc(func() { close(release) })
+		defer releaseLoader()
+		db.EXPECT().GetAllHistoryTreeBranches(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, _ *persistence.GetAllHistoryTreeBranchesRequest) (*persistence.GetAllHistoryTreeBranchesResponse, error) {
+				close(entered)
+				await.Rcv(t, ctx.Done())
+				close(canceled)
+				await.Rcv(t, release)
+				return nil, ctx.Err()
+			})
+		done := make(chan error, 1)
+		go func() { _, err := s.Run(ctx); done <- err }()
+		await.Rcv(t, entered)
+		cancel()
+		await.Rcv(t, canceled)
+		synctest.Wait()
+		select {
+		case err := <-done:
+			t.Fatalf("Run returned before its loader exited: %v", err)
+		default:
+		}
+		releaseLoader()
+		require.ErrorIs(t, await.Rcv(t, done), context.Canceled)
+	})
+}
+
+func TestScavengerRunCancellationWhileWorkerDrains(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		s, db, client := newScavengerRunTest(ctrl)
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		entered := make(chan struct{})
+		db.EXPECT().GetAllHistoryTreeBranches(gomock.Any(), gomock.Any()).Return(
+			&persistence.GetAllHistoryTreeBranchesResponse{Branches: []persistence.HistoryBranchDetail{scavengerRunTestBranch()}}, nil)
+		client.EXPECT().DescribeMutableState(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, _ *historyservice.DescribeMutableStateRequest, _ ...any) (*historyservice.DescribeMutableStateResponse, error) {
+				close(entered)
+				await.Rcv(t, ctx.Done())
+				return nil, ctx.Err()
+			})
+		done := make(chan scavengerRunResult, 1)
+		go func() {
+			details, err := s.Run(ctx)
+			done <- scavengerRunResult{details, err}
+		}()
+		await.Rcv(t, entered)
+		synctest.Wait()
+		cancel()
+		got := await.Rcv(t, done)
+		require.ErrorIs(t, got.err, context.Canceled)
+		require.Equal(t, 1, got.details.ErrorCount)
+	})
+}
+
+func TestScavengerRunBranchFailureIsNonfatal(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	s, db, client := newScavengerRunTest(ctrl)
+	db.EXPECT().GetAllHistoryTreeBranches(gomock.Any(), gomock.Any()).Return(
+		&persistence.GetAllHistoryTreeBranchesResponse{Branches: []persistence.HistoryBranchDetail{scavengerRunTestBranch()}}, nil)
+	client.EXPECT().DescribeMutableState(gomock.Any(), gomock.Any()).Return(nil, errors.New("branch unavailable"))
+
+	details, err := s.Run(t.Context())
+
+	require.NoError(t, err)
+	require.Equal(t, 1, details.ErrorCount)
+	require.Zero(t, details.SuccessCount)
+}
+
+type scavengerRunResult struct {
+	details ScavengerHeartbeatDetails
+	err     error
+}
+
+func newScavengerRunTest(ctrl *gomock.Controller) (*Scavenger, *persistence.MockExecutionManager, *historyservicemock.MockHistoryServiceClient) {
+	db := persistence.NewMockExecutionManager(ctrl)
+	client := historyservicemock.NewMockHistoryServiceClient(ctrl)
+	s := NewScavenger(512, db, 100, client, nil, nil, ScavengerHeartbeatDetails{},
+		dynamicconfig.GetDurationPropertyFn(time.Hour), dynamicconfig.GetDurationPropertyFn(time.Second),
+		dynamicconfig.GetBoolPropertyFn(false), metrics.NoopMetricsHandler, log.NewNoopLogger(), serialization.NewSerializer())
+	s.isInTest = true
+	return s, db, client
+}
+
+func scavengerRunTestBranch() persistence.HistoryBranchDetail {
+	return persistence.HistoryBranchDetail{
+		BranchInfo: &persistencespb.HistoryBranch{TreeId: treeID1, BranchId: branchID1},
+		ForkTime:   timestamp.TimePtr(time.Now().Add(-2 * time.Hour)),
+		Info:       persistence.BuildHistoryGarbageCleanupInfo("namespaceID", "workflowID", "runID"),
+	}
+}

--- a/service/worker/scanner/workflow_enumeration_test.go
+++ b/service/worker/scanner/workflow_enumeration_test.go
@@ -1,0 +1,98 @@
+package scanner
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
+	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/serialization"
+	"go.uber.org/mock/gomock"
+)
+
+func TestHistoryScannerRetriesEnumerationFromHeartbeat(t *testing.T) {
+	t.Parallel()
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	controller := gomock.NewController(t)
+	db := persistence.NewMockExecutionManager(controller)
+	scannerCtx := scannerContext{
+		cfg: &Config{
+			Persistence:                   &config.Persistence{NumHistoryShards: 512},
+			PersistenceMaxQPS:             dynamicconfig.GetIntPropertyFn(100),
+			HistoryScannerDataMinAge:      dynamicconfig.GetDurationPropertyFn(time.Hour),
+			HistoryScannerVerifyRetention: dynamicconfig.GetBoolPropertyFn(false),
+			ExecutionDataDurationBuffer:   dynamicconfig.GetDurationPropertyFn(time.Second),
+		},
+		executionManager: db,
+		logger:           log.NewNoopLogger(),
+		metricsHandler:   metrics.NoopMetricsHandler,
+		serializer:       serialization.NewSerializer(),
+	}
+	env.SetWorkerOptions(worker.Options{BackgroundActivityContext: context.WithValue(t.Context(), scannerContextKey, scannerCtx)})
+	env.SetTestTimeout(5 * time.Second)
+	env.RegisterActivityWithOptions(HistoryScavengerActivity, activity.RegisterOptions{Name: historyScavengerActivityName})
+
+	// Bound the test's retries without changing the scanner's retry policy.
+	opts := activityOptions
+	retry := activityRetryPolicy
+	retry.MaximumAttempts = 2
+	retry.InitialInterval = time.Millisecond
+	retry.MaximumInterval = time.Millisecond
+	opts.RetryPolicy = &retry
+	opts.StartToCloseTimeout = 2 * time.Second
+	opts.HeartbeatTimeout = time.Second
+	testWorkflow := func(ctx workflow.Context) error {
+		return workflow.ExecuteActivity(workflow.WithActivityOptions(ctx, opts), historyScavengerActivityName).Get(ctx, nil)
+	}
+	env.RegisterWorkflow(testWorkflow)
+	type observation struct {
+		attempt      int32
+		token        string
+		hasHeartbeat bool
+	}
+	var mu sync.Mutex
+	var observed []observation
+	failure := errors.New("next history page unavailable")
+	db.EXPECT().GetAllHistoryTreeBranches(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, req *persistence.GetAllHistoryTreeBranchesRequest) (*persistence.GetAllHistoryTreeBranchesResponse, error) {
+			attempt := activity.GetInfo(ctx).Attempt
+			mu.Lock()
+			observed = append(observed, observation{attempt, string(req.NextPageToken), activity.HasHeartbeatDetails(ctx)})
+			mu.Unlock()
+			switch string(req.NextPageToken) {
+			case "":
+				// The loader heartbeats even when cleanup metadata is invalid.
+				return &persistence.GetAllHistoryTreeBranchesResponse{
+					Branches:      []persistence.HistoryBranchDetail{{Info: "invalid-cleanup-info"}},
+					NextPageToken: []byte("next"),
+				}, nil
+			case "next":
+				if attempt == 1 {
+					return nil, failure
+				}
+				return &persistence.GetAllHistoryTreeBranchesResponse{}, nil
+			default:
+				return nil, failure
+			}
+		}).AnyTimes()
+
+	env.ExecuteWorkflow(testWorkflow)
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	mu.Lock()
+	defer mu.Unlock()
+	// Retry recovery uses SDK-carried heartbeat details, never the failed result.
+	require.Equal(t, []observation{{1, "", false}, {1, "next", false}, {2, "next", true}}, observed)
+}


### PR DESCRIPTION
## Summary

Return history scanner enumeration failures so incomplete scans retry instead of completing successfully.

## Problem

The scanner starts its page loader in a goroutine and discards its error. A failed first or later page can therefore produce a successful activity result. Cancellation can also return before the loader finishes.

## Approach

Start the existing branch workers, run the loader, and wait for all workers before returning its error. A loader failure lets dispatched work finish with its existing context. If loading succeeds but the context ends while workers finish, return the context error. Branch errors retain their existing counted, nonfatal behavior.

## Validation

- Reproduced discarded enumeration/cancellation errors and missing activity retry on the original code.
- Added deterministic lifecycle tests for initial and later page failures, empty continuation pages, worker draining, loader shutdown, cancellation, and nonfatal branch failures.
- Added a test through the real activity wrapper that verifies an enumeration failure retries using SDK-carried heartbeat details.
- Passed both scanner packages and the focused regression tests.
- Passed the focused lifecycle and activity retry tests three times with the race detector.
- Passed native `make lint-code-fast GOLANGCI_LINT_FIX=false`.
- Both scanner packages passed with the race detector when combined with the separate page-checkpoint change.

## Risks, rollout, and scope

Persistent enumeration failures now follow the existing activity retry policy. Shutdown still depends on downstream calls finishing or honoring cancellation. Heartbeat timing is unchanged; interrupted scans can still skip unfinished branches or replay prior work. This change does not alter persistence behavior, branch concurrency, or retry configuration.

## References

- [Companion page-checkpoint fix](https://github.com/temporalio/temporal/pull/12002); either change can land independently.
