### PR TITLE
Initialize dynamic quota buckets when first enabled

### DIFF
--- a/common/quotas/dynamic_rate_limiter_impl.go
+++ b/common/quotas/dynamic_rate_limiter_impl.go
@@ -2,6 +2,8 @@ package quotas
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -18,7 +20,9 @@ type (
 		refreshInterval time.Duration
 
 		refreshTimer *time.Timer
-		rateLimiter  *RateLimiterImpl
+		rateLimiter  atomic.Pointer[RateLimiterImpl]
+		refreshMu    sync.Mutex
+		initialized  bool // guarded by refreshMu
 	}
 )
 
@@ -29,13 +33,15 @@ func NewDynamicRateLimiter(
 	rateBurstFn RateBurst,
 	refreshInterval time.Duration,
 ) *DynamicRateLimiterImpl {
+	initialRate, initialBurst := rateBurstFn.Rate(), rateBurstFn.Burst()
 	rateLimiter := &DynamicRateLimiterImpl{
 		rateBurstFn:     rateBurstFn,
 		refreshInterval: refreshInterval,
 
 		refreshTimer: time.NewTimer(refreshInterval),
-		rateLimiter:  NewRateLimiter(rateBurstFn.Rate(), rateBurstFn.Burst()),
+		initialized:  initialRate != 0 || initialBurst != 0,
 	}
+	rateLimiter.rateLimiter.Store(NewRateLimiter(initialRate, initialBurst))
 	return rateLimiter
 }
 
@@ -79,54 +85,68 @@ func NewDefaultRateLimiter(
 // token is available or not
 func (d *DynamicRateLimiterImpl) Allow() bool {
 	d.maybeRefresh()
-	return d.rateLimiter.Allow()
+	return d.rateLimiter.Load().Allow()
 }
 
 // AllowN immediately returns with true or false indicating if n rate limit
 // token is available or not
 func (d *DynamicRateLimiterImpl) AllowN(now time.Time, numToken int) bool {
 	d.maybeRefresh()
-	return d.rateLimiter.AllowN(now, numToken)
+	return d.rateLimiter.Load().AllowN(now, numToken)
 }
 
 // Reserve reserves a rate limit token
 func (d *DynamicRateLimiterImpl) Reserve() Reservation {
 	d.maybeRefresh()
-	return d.rateLimiter.Reserve()
+	return d.rateLimiter.Load().Reserve()
 }
 
 // ReserveN reserves n rate limit token
 func (d *DynamicRateLimiterImpl) ReserveN(now time.Time, numToken int) Reservation {
 	d.maybeRefresh()
-	return d.rateLimiter.ReserveN(now, numToken)
+	return d.rateLimiter.Load().ReserveN(now, numToken)
 }
 
 // Wait waits up till deadline for a rate limit token
 func (d *DynamicRateLimiterImpl) Wait(ctx context.Context) error {
 	d.maybeRefresh()
-	return d.rateLimiter.Wait(ctx)
+	return d.rateLimiter.Load().Wait(ctx)
 }
 
 // WaitN waits up till deadline for n rate limit token
 func (d *DynamicRateLimiterImpl) WaitN(ctx context.Context, numToken int) error {
 	d.maybeRefresh()
-	return d.rateLimiter.WaitN(ctx, numToken)
+	return d.rateLimiter.Load().WaitN(ctx, numToken)
 }
 
 // Rate returns the rate per second for this rate limiter
 func (d *DynamicRateLimiterImpl) Rate() float64 {
 	d.maybeRefresh()
-	return d.rateLimiter.Rate()
+	return d.rateLimiter.Load().Rate()
 }
 
 // Burst returns the burst for this rate limiter
 func (d *DynamicRateLimiterImpl) Burst() int {
 	d.maybeRefresh()
-	return d.rateLimiter.Burst()
+	return d.rateLimiter.Load().Burst()
 }
 
 func (d *DynamicRateLimiterImpl) Refresh() {
-	d.rateLimiter.SetRateBurst(d.rateBurstFn.Rate(), d.rateBurstFn.Burst())
+	d.refreshMu.Lock()
+	defer d.refreshMu.Unlock()
+
+	newRate, newBurst := d.rateBurstFn.Rate(), d.rateBurstFn.Burst()
+	if !d.initialized && (newRate != 0 || newBurst != 0) {
+		d.initialized = true
+		if newRate > 0 && newBurst > 0 {
+			// A bucket created at (0, 0) has neither tokens nor positive-token
+			// reservations. Give its first usable configuration the usual initial
+			// burst, without resetting tokens or debt on later pause/resume cycles.
+			d.rateLimiter.Store(NewRateLimiter(newRate, newBurst))
+			return
+		}
+	}
+	d.rateLimiter.Load().SetRateBurst(newRate, newBurst)
 }
 
 func (d *DynamicRateLimiterImpl) maybeRefresh() {
@@ -141,10 +161,10 @@ func (d *DynamicRateLimiterImpl) maybeRefresh() {
 }
 
 func (d *DynamicRateLimiterImpl) TokensAt(t time.Time) int {
-	return d.rateLimiter.TokensAt(t)
+	return d.rateLimiter.Load().TokensAt(t)
 }
 
 // RecycleToken returns a token to the rate limiter
 func (d *DynamicRateLimiterImpl) RecycleToken() {
-	d.rateLimiter.RecycleToken()
+	d.rateLimiter.Load().RecycleToken()
 }

--- a/common/quotas/dynamic_rate_limiter_impl_test.go
+++ b/common/quotas/dynamic_rate_limiter_impl_test.go
@@ -1,12 +1,163 @@
 package quotas_test
 
 import (
+	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/server/common/quotas"
 )
+
+func TestDynamicRateLimiterInitialZeroQuota(t *testing.T) {
+	t.Parallel()
+
+	rateBurst := quotas.NewMutableRateBurst(0, 0)
+	limiter := quotas.NewDynamicRateLimiter(rateBurst, time.Hour)
+	now := time.Now()
+	require.False(t, limiter.AllowN(now, 1))
+	require.False(t, limiter.ReserveN(now, 1).OK())
+	limiter.Refresh()
+	require.False(t, limiter.AllowN(now.Add(time.Hour), 1))
+
+	rateBurst.SetRPS(1)
+	rateBurst.SetBurst(2)
+	limiter.Refresh()
+	require.True(t, limiter.AllowN(now, 2))
+	require.False(t, limiter.AllowN(now, 1))
+	limiter.Refresh()
+	require.False(t, limiter.AllowN(now, 1))
+}
+
+func TestDynamicRateLimiterPausePreservesReservations(t *testing.T) {
+	t.Parallel()
+
+	for _, initialRate := range []float64{0, 1} {
+		t.Run(fmt.Sprintf("initial_rate_%g", initialRate), func(t *testing.T) {
+			t.Parallel()
+
+			rateBurst := quotas.NewMutableRateBurst(initialRate, int(initialRate)*2)
+			limiter := quotas.NewDynamicRateLimiter(rateBurst, time.Hour)
+			rateBurst.SetRPS(1)
+			rateBurst.SetBurst(2)
+			limiter.Refresh()
+			now := time.Now()
+			require.True(t, limiter.AllowN(now, 2))
+			reservation := limiter.ReserveN(now, 1)
+			require.True(t, reservation.OK())
+
+			rateBurst.SetRPS(0)
+			rateBurst.SetBurst(0)
+			limiter.Refresh()
+			require.False(t, limiter.AllowN(now, 1))
+			rateBurst.SetRPS(1)
+			rateBurst.SetBurst(2)
+			limiter.Refresh()
+			require.False(t, limiter.AllowN(now, 1))
+			require.Greater(t, limiter.ReserveN(now, 1).DelayFrom(now), time.Second)
+		})
+	}
+}
+
+func TestDynamicRateLimiterZeroRateWithBurstDoesNotReinitialize(t *testing.T) {
+	t.Parallel()
+
+	rateBurst := quotas.NewMutableRateBurst(0, 1)
+	limiter := quotas.NewDynamicRateLimiter(rateBurst, time.Hour)
+	now := time.Now()
+	require.True(t, limiter.AllowN(now, 1))
+	rateBurst.SetRPS(1)
+	rateBurst.SetBurst(2)
+	limiter.Refresh()
+	require.False(t, limiter.AllowN(now, 1))
+}
+
+func TestDynamicRateLimiterZeroRateReservationDoesNotReinitialize(t *testing.T) {
+	t.Parallel()
+
+	rateBurst := quotas.NewMutableRateBurst(0, 0)
+	limiter := quotas.NewDynamicRateLimiter(rateBurst, time.Hour)
+	now := time.Now()
+	rateBurst.SetBurst(1)
+	limiter.Refresh()
+	require.True(t, limiter.ReserveN(now, 1).OK())
+
+	rateBurst.SetRPS(1)
+	rateBurst.SetBurst(2)
+	limiter.Refresh()
+	require.False(t, limiter.AllowN(now, 1))
+	require.Greater(t, limiter.ReserveN(now, 1).DelayFrom(now), time.Second)
+}
+
+func TestDynamicRateLimiterInitialZeroQuotaRefreshOnRequest(t *testing.T) {
+	t.Parallel()
+
+	rateBurst := quotas.NewMutableRateBurst(0, 0)
+	limiter := quotas.NewDynamicRateLimiter(rateBurst, 0)
+	now := time.Now()
+	require.False(t, limiter.AllowN(now, 1))
+	rateBurst.SetRPS(1)
+	rateBurst.SetBurst(2)
+	require.True(t, limiter.AllowN(now, 2))
+	require.False(t, limiter.AllowN(now, 1))
+}
+
+func TestDynamicRateLimiterInitialZeroQuotaConcurrentRefresh(t *testing.T) {
+	t.Parallel()
+
+	rateBurst := quotas.NewMutableRateBurst(0, 0)
+	limiter := quotas.NewDynamicRateLimiter(rateBurst, time.Hour)
+	rateBurst.SetRPS(1)
+	rateBurst.SetBurst(8)
+	now := time.Now()
+	var allowed atomic.Int32
+	var wg sync.WaitGroup
+	for range 64 {
+		wg.Go(func() {
+			limiter.Refresh()
+			if limiter.AllowN(now, 1) {
+				allowed.Add(1)
+			}
+		})
+	}
+	wg.Wait()
+	require.EqualValues(t, 8, allowed.Load())
+}
+
+func TestDynamicRateLimiterInitialZeroQuotaPriorityIsolation(t *testing.T) {
+	t.Parallel()
+
+	rateBurst := quotas.NewMutableRateBurst(0, 0)
+	high := quotas.NewDynamicRateLimiter(rateBurst, time.Hour)
+	low := quotas.NewDynamicRateLimiter(rateBurst, time.Hour)
+	limiter := quotas.NewPriorityRateLimiter(
+		func(request quotas.Request) int { return int(request.CallerSegment) },
+		map[int]quotas.RequestRateLimiter{
+			0: quotas.NewRequestRateLimiterAdapter(high),
+			1: quotas.NewRequestRateLimiterAdapter(low),
+		},
+	)
+	highRequest := quotas.NewRequest("test-api", 1, "test-namespace", "", 0, "")
+	lowRequest := quotas.NewRequest("test-api", 1, "test-namespace", "", 1, "")
+	now := time.Now()
+	rateBurst.SetRPS(1)
+	rateBurst.SetBurst(2)
+	low.Refresh()
+	require.True(t, limiter.Allow(now, lowRequest))
+	require.True(t, limiter.Allow(now, lowRequest))
+	require.False(t, limiter.Allow(now, lowRequest))
+
+	// The higher priority remains idle until after the lower priority has spent its burst.
+	high.Refresh()
+	require.True(t, limiter.Allow(now, highRequest))
+	require.True(t, limiter.Allow(now, highRequest))
+	require.False(t, limiter.Allow(now, highRequest))
+	low.Refresh()
+	require.False(t, limiter.Allow(now, lowRequest))
+	require.Greater(t, low.ReserveN(now, 1).DelayFrom(now), 2*time.Second)
+}
 
 func TestDynamicRateLimiterRateAndBurstRefreshAfterInterval(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

Initialize a dynamic limiter's unused zero-quota bucket when it first receives positive rate and burst, allowing its first request to use the configured burst.

## Problem

A dynamic limiter constructed with zero rate and burst has no tokens. When a request later refreshes it to a positive quota, the rate and burst change but the bucket remains empty. The first request is rejected until new tokens accumulate. This can affect an idle persistence priority even while another priority is making progress.

## Approach

Track whether the limiter has observed a configuration other than `(0, 0)`. When its first such configuration has positive rate and burst, replace the unused bucket with a normally initialized one. Serialize refreshes and publish the bucket atomically so concurrent requests cannot create multiple initial bursts.

A zero quota continues to reject positive-token requests. Once the limiter has left `(0, 0)`, updates retain existing token and reservation accounting, including subsequent pauses. A zero-rate bucket with a nonzero burst can already hold reservations, so it is never replaced by this initialization path. Each priority retains its own bucket.

## Validation

- The constructor-zero regression fails before the fix and passes afterward.
- `go test -p 4 -tags test_dep ./common/quotas ./common/persistence/client`
- `go test -p 4 -tags test_dep -race ./common/quotas -run 'TestDynamicRateLimiter' -count=1`
- Tests cover immediate and request-triggered initialization, concurrent refreshes, explicit zero, repeated refresh, pause/resume reservation debt, and an idle higher priority alongside an active lower priority.
- `gofmt` and `git diff --check`
- Native `make lint-code-fast GOLANGCI_LINT_FIX=false` passed.

## Risks, rollout, and scope

The change applies to all dynamic limiters constructed at zero rate and burst, including callers outside persistence. Their first positive configuration now receives the same initial burst as a limiter constructed with that configuration. Subsequent transitions retain existing behavior. Quota allocation and the refresh interval are unchanged; a configuration change is still observed through the existing refresh mechanism. No configuration or storage migration is required.
