### PR TITLE
Honor cancellation while replication senders are paused

### DIFF
--- a/service/history/replication/stream_sender_flow_controller.go
+++ b/service/history/replication/stream_sender_flow_controller.go
@@ -104,11 +104,25 @@ func (s *SenderFlowControllerImpl) Wait(ctx context.Context, priority enumsspb.T
 
 	state.mu.Lock()
 	if !state.resume {
+		// Lock before broadcasting so cancellation cannot race between checking
+		// ctx.Err and entering Wait. Other waiters must recheck their own context.
+		stop := context.AfterFunc(ctx, func() {
+			state.mu.Lock()
+			defer state.mu.Unlock()
+			state.cond.Broadcast()
+		})
 		state.waiters++
 		s.logger.Info("sender is paused", tag.TaskPriority(priority.String()))
-		state.cond.Wait()
-		s.logger.Info("sender is resumed", tag.TaskPriority(priority.String()))
+		for !state.resume && ctx.Err() == nil {
+			state.cond.Wait()
+		}
 		state.waiters--
+		stop()
+		if err := ctx.Err(); err != nil {
+			state.mu.Unlock()
+			return err
+		}
+		s.logger.Info("sender is resumed", tag.TaskPriority(priority.String()))
 	}
 	state.mu.Unlock()
 	return waitForRateLimiter(state.rateLimiter)

--- a/service/history/replication/stream_sender_flow_controller_test.go
+++ b/service/history/replication/stream_sender_flow_controller_test.go
@@ -2,16 +2,20 @@ package replication
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/quotas"
+	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/service/history/configs"
 	"go.uber.org/mock/gomock"
 )
@@ -158,4 +162,137 @@ func (s *senderFlowControllerSuite) TestPauseToResume() {
 
 	s.Equal(0, state.waiters)
 	s.True(state.resume)
+}
+
+func TestSenderFlowControllerWaitCancellation(t *testing.T) {
+	t.Parallel()
+	for _, priority := range []enumsspb.TaskPriority{enumsspb.TASK_PRIORITY_HIGH, enumsspb.TASK_PRIORITY_LOW} {
+		for _, mode := range []string{"cancel", "already_canceled", "deadline", "cancel_before_resume"} {
+			t.Run(priority.String()+"/"+mode, func(t *testing.T) {
+				t.Parallel()
+				synctest.Test(t, func(t *testing.T) {
+					flow := NewSenderFlowController(&configs.Config{
+						ReplicationStreamSenderHighPriorityQPS: func() int { return 10 },
+						ReplicationStreamSenderLowPriorityQPS:  func() int { return 5 },
+					}, log.NewTestLogger())
+					state := flow.flowControlStates[priority]
+					limiter := quotas.NewMockRateLimiter(gomock.NewController(t))
+					state.rateLimiter = limiter
+					rateLimitCalls := 0
+					limiter.EXPECT().Wait(gomock.Any()).DoAndReturn(func(context.Context) error {
+						rateLimitCalls++
+						return nil
+					}).AnyTimes()
+					flow.setState(state, enumsspb.REPLICATION_FLOW_CONTROL_COMMAND_PAUSE)
+					defer flow.setState(state, enumsspb.REPLICATION_FLOW_CONTROL_COMMAND_RESUME)
+
+					ctx, cancel := context.WithCancel(t.Context())
+					wantErr := context.Canceled
+					switch mode {
+					case "deadline":
+						cancel()
+						ctx, cancel = context.WithTimeout(t.Context(), time.Second)
+						wantErr = context.DeadlineExceeded
+					case "already_canceled":
+						cancel()
+					default:
+					}
+					defer cancel()
+					result := make(chan error, 1)
+					go func() { result <- flow.Wait(ctx, priority) }()
+					synctest.Wait()
+					if mode != "already_canceled" {
+						requireFlowControlState(t, state, 1, false)
+					}
+
+					switch mode {
+					case "cancel":
+						cancel()
+					case "deadline":
+						await.Rcv(t, ctx.Done())
+					case "cancel_before_resume":
+						// Make both events visible before the waiter can reacquire the mutex.
+						state.mu.Lock()
+						cancel()
+						state.resume = true
+						state.cond.Broadcast()
+						state.mu.Unlock()
+					default:
+					}
+					synctest.Wait()
+					select {
+					case err := <-result:
+						require.ErrorIs(t, err, wantErr)
+					default:
+						t.Fatal("canceled paused waiter requires RESUME to return")
+					}
+					require.Zero(t, rateLimitCalls)
+					requireFlowControlState(t, state, 0, mode == "cancel_before_resume")
+				})
+			})
+		}
+	}
+}
+
+func TestSenderFlowControllerCancelDoesNotResumeOtherWaiter(t *testing.T) {
+	t.Parallel()
+	for _, priority := range []enumsspb.TaskPriority{enumsspb.TASK_PRIORITY_HIGH, enumsspb.TASK_PRIORITY_LOW} {
+		t.Run(priority.String(), func(t *testing.T) {
+			t.Parallel()
+			synctest.Test(t, func(t *testing.T) {
+				flow := NewSenderFlowController(&configs.Config{
+					ReplicationStreamSenderHighPriorityQPS: func() int { return 10 },
+					ReplicationStreamSenderLowPriorityQPS:  func() int { return 5 },
+				}, log.NewTestLogger())
+				state := flow.flowControlStates[priority]
+				limiter := quotas.NewMockRateLimiter(gomock.NewController(t))
+				state.rateLimiter = limiter
+				rateErr := errors.New("rate limiter failed after resume")
+				limiter.EXPECT().Wait(gomock.Any()).Return(rateErr)
+				flow.setState(state, enumsspb.REPLICATION_FLOW_CONTROL_COMMAND_PAUSE)
+				defer flow.setState(state, enumsspb.REPLICATION_FLOW_CONTROL_COMMAND_RESUME)
+
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+				canceledResult, liveResult := make(chan error, 1), make(chan error, 1)
+				go func() { canceledResult <- flow.Wait(ctx, priority) }()
+				go func() { liveResult <- flow.Wait(t.Context(), priority) }()
+				synctest.Wait()
+				requireFlowControlState(t, state, 2, false)
+
+				cancel()
+				synctest.Wait()
+				select {
+				case err := <-canceledResult:
+					require.ErrorIs(t, err, context.Canceled)
+				default:
+					t.Fatal("canceled waiter did not return")
+				}
+				select {
+				case err := <-liveResult:
+					t.Fatalf("live waiter bypassed PAUSE: %v", err)
+				default:
+				}
+				requireFlowControlState(t, state, 1, false)
+
+				flow.setState(state, enumsspb.REPLICATION_FLOW_CONTROL_COMMAND_RESUME)
+				synctest.Wait()
+				select {
+				case err := <-liveResult:
+					require.ErrorIs(t, err, rateErr)
+				default:
+					t.Fatal("live waiter did not return after RESUME")
+				}
+				requireFlowControlState(t, state, 0, true)
+			})
+		})
+	}
+}
+
+func requireFlowControlState(t *testing.T, state *flowControlState, waiters int, resume bool) {
+	t.Helper()
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	require.Equal(t, waiters, state.waiters)
+	require.Equal(t, resume, state.resume)
 }


### PR DESCRIPTION
## Summary

Make paused replication sender waits return their caller's context error so canceled streams can release their waiting goroutines without a receiver RESUME command.

## Problem

The sender waits on a condition variable while its priority is paused, without checking its context. The rate-limiter timeout starts after that pause, so it cannot release the wait when the stream ends.

## Approach

Register a context callback that locks the condition mutex and broadcasts. Each awakened waiter rechecks its own context and the shared pause state. A canceled waiter exits before rate limiting; live waiters remain paused until RESUME. Stop the callback registration when the paused wait ends.

## Validation

- Observed all eight new cancellation cases fail on the original implementation and pass after the fix.
- The controller suite and full replication package pass with `-tags test_dep`.
- Deterministic concurrency tests cover both priorities, cancellation, already-canceled contexts, deadline expiry, cancellation published before RESUME, and sibling isolation with limiter error propagation after RESUME.
- The controller suite passed 50 repetitions with `-race -tags test_dep`.
- Native `make lint-code-fast GOLANGCI_LINT_FIX=false` passed.

## Risks, rollout, and scope

Cancellation broadcasts can wake other same-priority waiters, which recheck the pause predicate before proceeding. Rate-limiter selection and timeout behavior remain unchanged. The enclosing sender's handling of deadline errors and its Stop lifecycle are outside this change.
