### PR TITLE
Create DLQ queues only when enqueue reports them missing

### DIFF
--- a/common/persistence/tests/history_task_queue_manager_test_suite.go
+++ b/common/persistence/tests/history_task_queue_manager_test_suite.go
@@ -10,16 +10,22 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/client/history/historytest"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/definition"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/persistencetest"
 	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/service/history/api/deletedlqtasks/deletedlqtaskstest"
 	"go.temporal.io/server/service/history/api/getdlqtasks/getdlqtaskstest"
 	"go.temporal.io/server/service/history/api/listqueues/listqueuestest"
+	"go.temporal.io/server/service/history/queues"
 	"go.temporal.io/server/service/history/tasks"
+	"go.uber.org/mock/gomock"
 )
 
 type (
@@ -94,6 +100,10 @@ func RunHistoryTaskQueueManagerTestSuite(t *testing.T, queue persistence.QueueV2
 		t.Parallel()
 		testHistoryTaskQueueManagerEnqueueTasks(t, historyTaskQueueManager)
 	})
+	t.Run("DLQWriter", func(t *testing.T) {
+		t.Parallel()
+		testDLQWriter(t, historyTaskQueueManager)
+	})
 	t.Run("TestHistoryTaskQueueManagerEnqueueTasksErr", func(t *testing.T) {
 		t.Parallel()
 		testHistoryTaskQueueManagerEnqueueTasksErr(t, queue)
@@ -126,6 +136,42 @@ func RunHistoryTaskQueueManagerTestSuite(t *testing.T, queue persistence.QueueV2
 		t.Parallel()
 		historytest.TestClient(t, historyTaskQueueManager)
 	})
+}
+
+func testDLQWriter(t *testing.T, manager persistence.HistoryTaskQueueManager) {
+	t.Helper()
+
+	queueKey := persistencetest.GetQueueKey(t, persistencetest.WithQueueType(persistence.QueueTypeHistoryDLQ))
+	namespaceRegistry := namespace.NewMockRegistry(gomock.NewController(t))
+	namespaceRegistry.EXPECT().GetNamespaceByID(gomock.Any()).Return(&namespace.Namespace{}, nil).AnyTimes()
+	logger := log.NewTestLogger()
+	writer := queues.NewDLQWriter(manager, metrics.NoopMetricsHandler, logger, namespaceRegistry, chasm.NewRegistry(logger))
+	for taskID := int64(1); taskID <= 2; taskID++ {
+		require.NoError(t, writer.WriteTaskToDLQ(t.Context(), queueKey.SourceCluster, queueKey.TargetCluster,
+			7, &tasks.WorkflowTask{TaskID: taskID}, true))
+	}
+	response, err := manager.ReadTasks(t.Context(), &persistence.ReadTasksRequest{
+		QueueKey: queueKey, PageSize: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, response.Tasks, 2)
+	for i, task := range response.Tasks {
+		require.Equal(t, int64(i), task.MessageMetadata.ID)
+		require.Equal(t, int64(i+1), task.Task.GetTaskID())
+	}
+	_, err = manager.DeleteTasks(t.Context(), &persistence.DeleteTasksRequest{
+		QueueKey: queueKey, InclusiveMaxMessageMetadata: persistence.MessageMetadata{ID: 1},
+	})
+	require.NoError(t, err)
+	require.NoError(t, writer.WriteTaskToDLQ(t.Context(), queueKey.SourceCluster, queueKey.TargetCluster,
+		7, &tasks.WorkflowTask{TaskID: 3}, true))
+	response, err = manager.ReadTasks(t.Context(), &persistence.ReadTasksRequest{
+		QueueKey: queueKey, PageSize: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, response.Tasks, 1)
+	require.Equal(t, int64(2), response.Tasks[0].MessageMetadata.ID)
+	require.Equal(t, int64(3), response.Tasks[0].Task.GetTaskID())
 }
 
 func testHistoryTaskQueueManagerCreateQueueErr(t *testing.T, queue persistence.QueueV2) {

--- a/service/history/queues/dlq_writer.go
+++ b/service/history/queues/dlq_writer.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sync"
 
+	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
@@ -74,15 +75,6 @@ func (q *DLQWriter) WriteTaskToDLQ(
 		SourceCluster: sourceCluster,
 		TargetCluster: targetCluster,
 	}
-	_, err := q.dlqWriter.CreateQueue(ctx, &persistence.CreateQueueRequest{
-		QueueKey: queueKey,
-	})
-	if err != nil {
-		if !errors.Is(err, persistence.ErrQueueAlreadyExists) {
-			return fmt.Errorf("%w: %v", ErrCreateDLQ, err)
-		}
-	}
-
 	resp, err := func() (*persistence.EnqueueTaskResponse, error) {
 		// Acquire a process-level lock for this specific DLQ to prevent concurrent writes
 		// from multiple shards causing CAS conflicts in the persistence layer.
@@ -90,16 +82,29 @@ func (q *DLQWriter) WriteTaskToDLQ(
 		mu.Lock()
 		defer mu.Unlock()
 
-		return q.dlqWriter.EnqueueTask(ctx, &persistence.EnqueueTaskRequest{
+		request := &persistence.EnqueueTaskRequest{
 			QueueType:     queueKey.QueueType,
 			SourceCluster: queueKey.SourceCluster,
 			TargetCluster: queueKey.TargetCluster,
 			Task:          task,
 			SourceShardID: sourceShardID,
-		})
+		}
+		resp, err := q.dlqWriter.EnqueueTask(ctx, request)
+		if errors.As(err, new(*serviceerror.NotFound)) {
+			// A missing queue is reported before persistence inserts the task, so it is safe to retry.
+			_, err = q.dlqWriter.CreateQueue(ctx, &persistence.CreateQueueRequest{QueueKey: queueKey})
+			if err != nil && !errors.Is(err, persistence.ErrQueueAlreadyExists) {
+				return nil, fmt.Errorf("%w: %v", ErrCreateDLQ, err)
+			}
+			resp, err = q.dlqWriter.EnqueueTask(ctx, request)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrSendTaskToDLQ, err)
+		}
+		return resp, nil
 	}()
 	if err != nil {
-		return fmt.Errorf("%w: %v", ErrSendTaskToDLQ, err)
+		return err
 	}
 
 	nsMetricTag := metrics.NamespaceUnknownTag()

--- a/service/history/queues/dlq_writer_test.go
+++ b/service/history/queues/dlq_writer_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/log"
@@ -42,6 +43,112 @@ func (l *logRecorder) Warn(msg string, tags ...tag.Tag) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	l.records = append(l.records, logRecord{msg: msg, tags: tags})
+}
+
+func TestDLQWriter_CreateQueueOnDemand(t *testing.T) {
+	t.Parallel()
+
+	notFound := persistence.NewQueueNotFoundError(persistence.QueueTypeHistoryDLQ, "missing-queue")
+	unavailable := serviceerror.NewUnavailable("unavailable")
+	type writeAttempt struct {
+		enqueueErr error
+		createErr  error
+		retryErr   error
+		wantErr    error
+	}
+	for _, tc := range []struct {
+		name     string
+		attempts []writeAttempt
+	}{
+		{name: "existing queue", attempts: []writeAttempt{{}, {}}},
+		{name: "missing queue", attempts: []writeAttempt{{enqueueErr: notFound}, {}}},
+		{name: "concurrent creator", attempts: []writeAttempt{{enqueueErr: notFound, createErr: persistence.ErrQueueAlreadyExists}}},
+		{name: "create failure is retried on next write", attempts: []writeAttempt{
+			{enqueueErr: notFound, createErr: unavailable, wantErr: queues.ErrCreateDLQ},
+			{enqueueErr: notFound},
+		}},
+		{name: "queue disappears between writes", attempts: []writeAttempt{{enqueueErr: notFound}, {enqueueErr: notFound}}},
+		{name: "enqueue failure is not retried", attempts: []writeAttempt{{enqueueErr: unavailable, wantErr: queues.ErrSendTaskToDLQ}}},
+		{name: "retry failure", attempts: []writeAttempt{{enqueueErr: notFound, retryErr: unavailable, wantErr: queues.ErrSendTaskToDLQ}}},
+		{name: "retry is bounded", attempts: []writeAttempt{{enqueueErr: notFound, retryErr: notFound, wantErr: queues.ErrSendTaskToDLQ}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			queueWriter := persistence.NewMockHistoryTaskQueueManager(ctrl)
+			namespaceRegistry := namespace.NewMockRegistry(ctrl)
+			namespaceRegistry.EXPECT().GetNamespaceByID(gomock.Any()).Return(&namespace.Namespace{}, nil).AnyTimes()
+			metricsHandler := metricstest.NewCaptureHandler()
+			capture := metricsHandler.StartCapture()
+			logger := log.NewTestLogger()
+			writer := queues.NewDLQWriter(queueWriter, metricsHandler, logger, namespaceRegistry, chasm.NewRegistry(logger))
+			task := &tasks.WorkflowTask{}
+			queueKey := persistence.QueueKey{
+				QueueType: persistence.QueueTypeHistoryDLQ, Category: task.GetCategory(),
+				SourceCluster: "source_cluster", TargetCluster: "target_cluster",
+			}
+			request := &persistence.EnqueueTaskRequest{
+				QueueType: queueKey.QueueType, SourceCluster: queueKey.SourceCluster, TargetCluster: queueKey.TargetCluster,
+				Task: task, SourceShardID: 7,
+			}
+			response := &persistence.EnqueueTaskResponse{Metadata: persistence.MessageMetadata{ID: 42}}
+			var successfulWrites int
+			for _, attempt := range tc.attempts {
+				calls := []any{queueWriter.EXPECT().EnqueueTask(gomock.Any(), request).Return(response, attempt.enqueueErr)}
+				if errors.As(attempt.enqueueErr, new(*serviceerror.NotFound)) {
+					calls = append(calls, queueWriter.EXPECT().CreateQueue(gomock.Any(), &persistence.CreateQueueRequest{
+						QueueKey: queueKey,
+					}).Return(nil, attempt.createErr))
+					if attempt.createErr == nil || errors.Is(attempt.createErr, persistence.ErrQueueAlreadyExists) {
+						calls = append(calls, queueWriter.EXPECT().EnqueueTask(gomock.Any(), request).Return(response, attempt.retryErr))
+					}
+				}
+				gomock.InOrder(calls...)
+				err := writer.WriteTaskToDLQ(t.Context(), queueKey.SourceCluster, queueKey.TargetCluster, request.SourceShardID, task, true)
+				if attempt.wantErr != nil {
+					require.ErrorIs(t, err, attempt.wantErr)
+				} else {
+					require.NoError(t, err)
+					successfulWrites++
+				}
+			}
+			require.Len(t, capture.Snapshot()[metrics.DLQWrites.Name()], successfulWrites)
+		})
+	}
+}
+
+func TestDLQWriter_ConcurrentQueueCreation(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	queueWriter := persistence.NewMockHistoryTaskQueueManager(ctrl)
+	namespaceRegistry := namespace.NewMockRegistry(ctrl)
+	namespaceRegistry.EXPECT().GetNamespaceByID(gomock.Any()).Return(&namespace.Namespace{}, nil).AnyTimes()
+	logger := log.NewTestLogger()
+	writer := queues.NewDLQWriter(queueWriter, metrics.NoopMetricsHandler, logger, namespaceRegistry, chasm.NewRegistry(logger))
+	const numWrites = 50
+	var created atomic.Bool
+	queueWriter.EXPECT().CreateQueue(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(context.Context, *persistence.CreateQueueRequest) (*persistence.CreateQueueResponse, error) {
+			created.Store(true)
+			return &persistence.CreateQueueResponse{}, nil
+		},
+	)
+	queueWriter.EXPECT().EnqueueTask(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(context.Context, *persistence.EnqueueTaskRequest) (*persistence.EnqueueTaskResponse, error) {
+			if !created.Load() {
+				return nil, serviceerror.NewNotFound("queue not created")
+			}
+			return &persistence.EnqueueTaskResponse{}, nil
+		},
+	).Times(numWrites + 1)
+	var group errgroup.Group
+	for shardID := range numWrites {
+		group.Go(func() error {
+			return writer.WriteTaskToDLQ(t.Context(), "source", "target", shardID+1, &tasks.WorkflowTask{}, true)
+		})
+	}
+	require.NoError(t, group.Wait())
 }
 
 func TestDLQWriter_ErrGetNamespaceName(t *testing.T) {


### PR DESCRIPTION
## Summary

Create a DLQ queue only when enqueue reports it missing, avoiding repeated queue-creation requests for existing queues.

## Problem

Every DLQ write calls `CreateQueue` before `EnqueueTask`, including writes to queues that already exist. This adds persistence work to every write; Cassandra attempts a conditional metadata insert even though enqueue also checks the queue metadata.

## Approach

Attempt enqueue under the existing per-queue lock. If the queue is missing, create it and retry enqueue once. Accept `ErrQueueAlreadyExists` when another writer creates the queue first. Return other enqueue errors without introducing retries.

Cassandra and SQL report a missing queue before inserting a message, so this retry cannot duplicate a write that succeeded. The change adds no creation cache. A missing queue on a later write follows the same recovery path.

## Validation

- Native changed-code lint passed.
- Regression test fails on the original implementation because it calls `CreateQueue` for an existing queue.
- Queue and replication package tests passed.
- DLQ writer tests passed with `-race -count=10`, covering concurrent first writes, creation races, failed creation recovery, missing queues, bounded retries, and success metrics.
- Full SQLite and Cassandra QueueV2 suites passed, including a new DLQ writer test that verifies ordered readback and a write after purging all visible messages.

## Risks, rollout, and scope

The first write to a missing queue adds a failed enqueue attempt before creation. Existing-queue writes avoid the creation call. Queue identity, message IDs, per-process serialization, purge behavior, and schema stay the same.

This change does not address cross-process Cassandra message-ID contention or partition DLQs. It makes no measured throughput claim.
