### PR TITLE
Preserve unreplayed tasks during legacy DLQ merge

### DIFF
--- a/service/frontend/admin_handler.go
+++ b/service/frontend/admin_handler.go
@@ -1261,7 +1261,7 @@ func (adh *AdminHandler) MergeDLQMessages(
 		}
 
 		return &adminservice.MergeDLQMessagesResponse{
-			NextPageToken: request.GetNextPageToken(),
+			NextPageToken: resp.GetNextPageToken(),
 		}, nil
 	case enumsspb.DEAD_LETTER_QUEUE_TYPE_NAMESPACE:
 		token, err := adh.namespaceDLQHandler.Merge(

--- a/service/frontend/admin_handler_dlq_test.go
+++ b/service/frontend/admin_handler_dlq_test.go
@@ -1,0 +1,56 @@
+package frontend
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/api/adminservice/v1"
+	enumsspb "go.temporal.io/server/api/enums/v1"
+	"go.temporal.io/server/api/historyservice/v1"
+	"go.temporal.io/server/api/historyservicemock/v1"
+	"go.temporal.io/server/common/log"
+	"go.uber.org/mock/gomock"
+)
+
+func TestMergeDLQMessagesHistoryContinuation(t *testing.T) {
+	t.Parallel()
+	for _, scenario := range []struct {
+		name          string
+		input, output []byte
+	}{
+		{name: "first page", output: []byte("next page")},
+		{name: "middle page", input: []byte("previous page"), output: []byte("next page")},
+		{name: "last page", input: []byte("previous page")},
+	} {
+		t.Run(scenario.name, func(t *testing.T) {
+			t.Parallel()
+			history := historyservicemock.NewMockHistoryServiceClient(gomock.NewController(t))
+			handler := &AdminHandler{historyClient: history, logger: log.NewNoopLogger()}
+			request := &adminservice.MergeDLQMessagesRequest{
+				Type:    enumsspb.DEAD_LETTER_QUEUE_TYPE_REPLICATION,
+				ShardId: 1, SourceCluster: "source", InclusiveEndMessageId: 100,
+				MaximumPageSize: 2, NextPageToken: scenario.input,
+			}
+			history.EXPECT().MergeDLQMessages(gomock.Any(), &historyservice.MergeDLQMessagesRequest{
+				Type: request.Type, ShardId: request.ShardId, SourceCluster: request.SourceCluster,
+				InclusiveEndMessageId: request.InclusiveEndMessageId,
+				MaximumPageSize:       request.MaximumPageSize, NextPageToken: scenario.input,
+			}).Return(&historyservice.MergeDLQMessagesResponse{NextPageToken: scenario.output}, nil)
+			response, err := handler.MergeDLQMessages(t.Context(), request)
+			require.NoError(t, err)
+			require.Equal(t, scenario.output, response.NextPageToken)
+		})
+	}
+}
+
+func TestMergeDLQMessagesHistoryError(t *testing.T) {
+	t.Parallel()
+	history := historyservicemock.NewMockHistoryServiceClient(gomock.NewController(t))
+	handler := &AdminHandler{historyClient: history, logger: log.NewNoopLogger()}
+	failure := serviceerror.NewUnavailable("history unavailable")
+	history.EXPECT().MergeDLQMessages(gomock.Any(), gomock.Any()).Return(nil, failure)
+	response, err := handler.MergeDLQMessages(t.Context(), &adminservice.MergeDLQMessagesRequest{Type: enumsspb.DEAD_LETTER_QUEUE_TYPE_REPLICATION})
+	require.ErrorIs(t, err, failure)
+	require.Nil(t, response)
+}

--- a/service/history/replication/dlq_handler.go
+++ b/service/history/replication/dlq_handler.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sync"
 
+	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/api/adminservice/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
@@ -161,7 +162,7 @@ func (r *dlqHandlerImpl) MergeMessages(
 	pageToken []byte,
 ) ([]byte, error) {
 
-	replicationTasks, _, ackLevel, token, err := r.readMessagesWithAckLevel(
+	replicationTasks, taskInfos, _, token, err := r.readMessagesWithAckLevel(
 		ctx,
 		sourceCluster,
 		lastMessageID,
@@ -170,6 +171,28 @@ func (r *dlqHandlerImpl) MergeMessages(
 	)
 	if err != nil {
 		return nil, err
+	}
+
+	// Remote shards may return tasks out of order or omit them after a fetch error.
+	// Require every persisted ID before replaying or retiring any part of the page.
+	if len(replicationTasks) != len(taskInfos) {
+		return nil, serviceerror.NewUnavailable("Incomplete DLQ replication task response")
+	}
+	pendingTaskIDs := make(map[int64]struct{}, len(taskInfos))
+	for _, taskInfo := range taskInfos {
+		pendingTaskIDs[taskInfo.GetTaskId()] = struct{}{}
+	}
+	for _, task := range replicationTasks {
+		if task == nil {
+			return nil, serviceerror.NewUnavailable("Missing DLQ replication task")
+		}
+		if _, ok := pendingTaskIDs[task.GetSourceTaskId()]; !ok {
+			return nil, serviceerror.NewUnavailable("Unexpected DLQ replication task ID")
+		}
+		delete(pendingTaskIDs, task.GetSourceTaskId())
+	}
+	if len(taskInfos) == 0 {
+		return token, nil
 	}
 
 	taskExecutor, err := r.getOrCreateTaskExecutor(sourceCluster)
@@ -187,28 +210,24 @@ func (r *dlqHandlerImpl) MergeMessages(
 		}
 	}
 
-	err = r.shard.GetExecutionManager().RangeDeleteReplicationTaskFromDLQ(
-		ctx,
-		&persistence.RangeDeleteReplicationTaskFromDLQRequest{
-			RangeCompleteHistoryTasksRequest: persistence.RangeCompleteHistoryTasksRequest{
-				ShardID:             r.shard.GetShardID(),
-				TaskCategory:        tasks.CategoryReplication,
-				InclusiveMinTaskKey: tasks.NewImmediateKey(ackLevel + 1),
-				ExclusiveMaxTaskKey: tasks.NewImmediateKey(lastMessageID + 1),
+	// Writers can insert older task IDs while this page is being replayed. Delete
+	// only this page's entries and leave the range acknowledgment unchanged so
+	// those late entries remain readable on a subsequent traversal.
+	for _, taskInfo := range taskInfos {
+		err = r.shard.GetExecutionManager().DeleteReplicationTaskFromDLQ(
+			ctx,
+			&persistence.DeleteReplicationTaskFromDLQRequest{
+				CompleteHistoryTaskRequest: persistence.CompleteHistoryTaskRequest{
+					ShardID:      r.shard.GetShardID(),
+					TaskCategory: tasks.CategoryReplication,
+					TaskKey:      tasks.NewImmediateKey(taskInfo.GetTaskId()),
+				},
+				SourceClusterName: sourceCluster,
 			},
-			SourceClusterName: sourceCluster,
-		},
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	if err = r.shard.UpdateReplicatorDLQAckLevel(
-		sourceCluster,
-		lastMessageID,
-	); err != nil {
-		r.logger.Error("Failed to purge history replication message", tag.Error(err))
-		// The update ack level should not block the call. Ignore the error.
+		)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return token, nil
 }

--- a/service/history/replication/dlq_handler_merge_test.go
+++ b/service/history/replication/dlq_handler_merge_test.go
@@ -1,0 +1,223 @@
+package replication
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/api/adminservice/v1"
+	"go.temporal.io/server/api/adminservicemock/v1"
+	replicationspb "go.temporal.io/server/api/replication/v1"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/persistence"
+	historyi "go.temporal.io/server/service/history/interfaces"
+	"go.temporal.io/server/service/history/tasks"
+	"go.uber.org/mock/gomock"
+)
+
+func newMergeTestHandler(t *testing.T) (*dlqHandlerImpl, *persistence.MockExecutionManager, *adminservicemock.MockAdminServiceClient, *MockTaskExecutor) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	shard := historyi.NewMockShardContext(ctrl)
+	manager := persistence.NewMockExecutionManager(ctrl)
+	admin := adminservicemock.NewMockAdminServiceClient(ctrl)
+	executor := NewMockTaskExecutor(ctrl)
+	shard.EXPECT().GetReplicatorDLQAckLevel("source").Return(int64(-1)).AnyTimes()
+	shard.EXPECT().GetShardID().Return(int32(1)).AnyTimes()
+	shard.EXPECT().GetExecutionManager().Return(manager).AnyTimes()
+	shard.EXPECT().GetRemoteAdminClient("source").Return(admin, nil).AnyTimes()
+	return &dlqHandlerImpl{
+		shard:         shard,
+		taskExecutors: map[string]TaskExecutor{"source": executor},
+		logger:        log.NewNoopLogger(),
+	}, manager, admin, executor
+}
+
+func TestMergeMessagesPreservesUnreplayedEntries(t *testing.T) {
+	t.Parallel()
+	handler, manager, admin, executor := newMergeTestHandler(t)
+	var mu sync.Mutex
+	entries := map[int64]bool{10: true, 30: true, 50: true}
+	manager.EXPECT().GetReplicationTasksFromDLQ(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, request *persistence.GetReplicationTasksFromDLQRequest) (*persistence.GetHistoryTasksResponse, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			after := request.InclusiveMinTaskKey.TaskID - 1
+			if len(request.NextPageToken) > 0 {
+				var err error
+				after, err = strconv.ParseInt(string(request.NextPageToken), 10, 64)
+				require.NoError(t, err)
+			}
+			ids := make([]int64, 0, len(entries))
+			for id := range entries {
+				if id > after && id < request.ExclusiveMaxTaskKey.TaskID {
+					ids = append(ids, id)
+				}
+			}
+			slices.Sort(ids)
+			response := &persistence.GetHistoryTasksResponse{}
+			if len(ids) > request.BatchSize {
+				ids = ids[:request.BatchSize]
+				response.NextPageToken = []byte(strconv.FormatInt(ids[len(ids)-1], 10))
+			}
+			for _, id := range ids {
+				response.Tasks = append(response.Tasks, &tasks.HistoryReplicationTask{TaskID: id})
+			}
+			return response, nil
+		}).AnyTimes()
+	admin.EXPECT().GetDLQReplicationMessages(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, request *adminservice.GetDLQReplicationMessagesRequest, _ ...any) (*adminservice.GetDLQReplicationMessagesResponse, error) {
+			response := &adminservice.GetDLQReplicationMessagesResponse{}
+			// Source shards can finish their fetches in a different order.
+			for _, info := range slices.Backward(request.TaskInfos) {
+				response.ReplicationTasks = append(response.ReplicationTasks, &replicationspb.ReplicationTask{SourceTaskId: info.TaskId})
+			}
+			return response, nil
+		}).AnyTimes()
+
+	appendEntry := make(chan struct{})
+	appended := make(chan struct{})
+	go func() {
+		defer close(appended)
+		select {
+		case <-appendEntry:
+			mu.Lock()
+			entries[20] = true
+			mu.Unlock()
+		case <-t.Context().Done():
+		}
+	}()
+	var once sync.Once
+	var replayed []int64
+	executor.EXPECT().Execute(gomock.Any(), gomock.Any(), true).DoAndReturn(
+		func(ctx context.Context, task *replicationspb.ReplicationTask, _ bool) error {
+			once.Do(func() { close(appendEntry) })
+			select {
+			case <-appended:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+			replayed = append(replayed, task.SourceTaskId)
+			return nil
+		}).AnyTimes()
+	manager.EXPECT().DeleteReplicationTaskFromDLQ(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, request *persistence.DeleteReplicationTaskFromDLQRequest) error {
+			require.Equal(t, int32(1), request.ShardID)
+			require.Equal(t, "source", request.SourceClusterName)
+			require.Equal(t, tasks.CategoryReplication, request.TaskCategory)
+			require.Contains(t, replayed, request.TaskKey.TaskID)
+			mu.Lock()
+			defer mu.Unlock()
+			delete(entries, request.TaskKey.TaskID)
+			return nil
+		}).AnyTimes()
+
+	token, err := handler.MergeMessages(t.Context(), "source", 100, 2, nil)
+	require.NoError(t, err)
+	require.Equal(t, []byte("30"), token)
+	require.Equal(t, map[int64]bool{20: true, 50: true}, entries)
+	require.ElementsMatch(t, []int64{10, 30}, replayed)
+
+	token, err = handler.MergeMessages(t.Context(), "source", 100, 2, token)
+	require.NoError(t, err)
+	require.Empty(t, token)
+	require.Equal(t, map[int64]bool{20: true}, entries)
+
+	// A late insertion below the previous page remains visible to a fresh traversal.
+	token, err = handler.MergeMessages(t.Context(), "source", 100, 2, nil)
+	require.NoError(t, err)
+	require.Empty(t, token)
+	require.Empty(t, entries)
+	require.ElementsMatch(t, []int64{10, 30, 50, 20}, replayed)
+}
+
+func TestMergeMessagesDoesNotRetireOnFailure(t *testing.T) {
+	t.Parallel()
+	for _, scenario := range []string{"read", "remote", "replay", "missing", "duplicate", "unknown", "nil"} {
+		t.Run(scenario, func(t *testing.T) {
+			t.Parallel()
+			handler, manager, admin, executor := newMergeTestHandler(t)
+			failure := errors.New("injected failure")
+			response := &persistence.GetHistoryTasksResponse{Tasks: []tasks.Task{
+				&tasks.HistoryReplicationTask{TaskID: 10},
+				&tasks.HistoryReplicationTask{TaskID: 30},
+			}}
+			if scenario == "read" {
+				manager.EXPECT().GetReplicationTasksFromDLQ(gomock.Any(), gomock.Any()).Return(nil, failure)
+			} else {
+				manager.EXPECT().GetReplicationTasksFromDLQ(gomock.Any(), gomock.Any()).Return(response, nil)
+				remoteTasks := []*replicationspb.ReplicationTask{{SourceTaskId: 10}, {SourceTaskId: 30}}
+				switch scenario {
+				case "missing":
+					remoteTasks = remoteTasks[:1]
+				case "duplicate":
+					remoteTasks[1].SourceTaskId = 10
+				case "unknown":
+					remoteTasks[1].SourceTaskId = 100
+				case "nil":
+					remoteTasks[1] = nil
+				default:
+				}
+				if scenario == "remote" {
+					admin.EXPECT().GetDLQReplicationMessages(gomock.Any(), gomock.Any()).Return(nil, failure)
+				} else {
+					admin.EXPECT().GetDLQReplicationMessages(gomock.Any(), gomock.Any()).Return(&adminservice.GetDLQReplicationMessagesResponse{ReplicationTasks: remoteTasks}, nil)
+					if scenario == "replay" {
+						gomock.InOrder(
+							executor.EXPECT().Execute(gomock.Any(), remoteTasks[0], true).Return(nil),
+							executor.EXPECT().Execute(gomock.Any(), remoteTasks[1], true).Return(failure),
+						)
+					}
+				}
+			}
+			token, err := handler.MergeMessages(t.Context(), "source", 100, 2, nil)
+			require.Error(t, err)
+			require.Nil(t, token)
+		})
+	}
+}
+
+func TestMergeMessagesEmptyPage(t *testing.T) {
+	t.Parallel()
+	for _, token := range [][]byte{nil, []byte("next page")} {
+		t.Run(string(token), func(t *testing.T) {
+			t.Parallel()
+			handler, manager, _, _ := newMergeTestHandler(t)
+			manager.EXPECT().GetReplicationTasksFromDLQ(gomock.Any(), gomock.Any()).Return(&persistence.GetHistoryTasksResponse{NextPageToken: token}, nil)
+			actual, err := handler.MergeMessages(t.Context(), "source", 100, 2, nil)
+			require.NoError(t, err)
+			require.Equal(t, token, actual)
+		})
+	}
+}
+
+func TestMergeMessagesDeleteFailure(t *testing.T) {
+	t.Parallel()
+	handler, manager, admin, executor := newMergeTestHandler(t)
+	failure := errors.New("delete failed")
+	manager.EXPECT().GetReplicationTasksFromDLQ(gomock.Any(), gomock.Any()).Return(&persistence.GetHistoryTasksResponse{
+		Tasks:         []tasks.Task{&tasks.HistoryReplicationTask{TaskID: 10}, &tasks.HistoryReplicationTask{TaskID: 30}},
+		NextPageToken: []byte("next page"),
+	}, nil)
+	remoteTasks := []*replicationspb.ReplicationTask{{SourceTaskId: 10}, {SourceTaskId: 30}}
+	admin.EXPECT().GetDLQReplicationMessages(gomock.Any(), gomock.Any()).Return(&adminservice.GetDLQReplicationMessagesResponse{ReplicationTasks: remoteTasks}, nil)
+	gomock.InOrder(
+		executor.EXPECT().Execute(gomock.Any(), remoteTasks[0], true).Return(nil),
+		executor.EXPECT().Execute(gomock.Any(), remoteTasks[1], true).Return(nil),
+		manager.EXPECT().DeleteReplicationTaskFromDLQ(gomock.Any(), &persistence.DeleteReplicationTaskFromDLQRequest{
+			CompleteHistoryTaskRequest: persistence.CompleteHistoryTaskRequest{ShardID: 1, TaskCategory: tasks.CategoryReplication, TaskKey: tasks.NewImmediateKey(10)},
+			SourceClusterName:          "source",
+		}).Return(nil),
+		manager.EXPECT().DeleteReplicationTaskFromDLQ(gomock.Any(), &persistence.DeleteReplicationTaskFromDLQRequest{
+			CompleteHistoryTaskRequest: persistence.CompleteHistoryTaskRequest{ShardID: 1, TaskCategory: tasks.CategoryReplication, TaskKey: tasks.NewImmediateKey(30)},
+			SourceClusterName:          "source",
+		}).Return(failure),
+	)
+	token, err := handler.MergeMessages(t.Context(), "source", 100, 2, nil)
+	require.ErrorIs(t, err, failure)
+	require.Nil(t, token)
+}

--- a/service/history/replication/dlq_handler_test.go
+++ b/service/history/replication/dlq_handler_test.go
@@ -213,7 +213,7 @@ func (s *dlqHandlerSuite) TestMergeMessages() {
 	namespaceID := uuid.NewString()
 	workflowID := uuid.NewString()
 	runID := uuid.NewString()
-	taskID := int64(12345)
+	taskID := int64(123)
 	version := int64(2333)
 	firstEventID := int64(144)
 	nextEventID := int64(233)
@@ -272,17 +272,14 @@ func (s *dlqHandlerSuite) TestMergeMessages() {
 			ReplicationTasks: []*replicationspb.ReplicationTask{remoteTask},
 		}, nil)
 	s.taskExecutor.EXPECT().Execute(gomock.Any(), remoteTask, true).Return(nil)
-	s.executionManager.EXPECT().RangeDeleteReplicationTaskFromDLQ(gomock.Any(), &persistence.RangeDeleteReplicationTaskFromDLQRequest{
-		RangeCompleteHistoryTasksRequest: persistence.RangeCompleteHistoryTasksRequest{
-			ShardID:             s.mockShard.GetShardID(),
-			TaskCategory:        tasks.CategoryReplication,
-			InclusiveMinTaskKey: tasks.NewImmediateKey(persistence.EmptyQueueMessageID + 1),
-			ExclusiveMaxTaskKey: tasks.NewImmediateKey(lastMessageID + 1),
+	s.executionManager.EXPECT().DeleteReplicationTaskFromDLQ(gomock.Any(), &persistence.DeleteReplicationTaskFromDLQRequest{
+		CompleteHistoryTaskRequest: persistence.CompleteHistoryTaskRequest{
+			ShardID:      s.mockShard.GetShardID(),
+			TaskCategory: tasks.CategoryReplication,
+			TaskKey:      tasks.NewImmediateKey(taskID),
 		},
 		SourceClusterName: s.sourceCluster,
 	}).Return(nil)
-
-	s.shardManager.EXPECT().UpdateShard(gomock.Any(), gomock.Any()).Return(nil)
 
 	token, err := s.replicationMessageHandler.MergeMessages(ctx, s.sourceCluster, lastMessageID, pageSize, pageToken)
 	s.NoError(err)


### PR DESCRIPTION
## Summary

Retire only fully replayed legacy replication DLQ pages and return History's continuation token from Frontend.

## Problem

History reads one page but deletes and acknowledges the entire requested range. A multi-page merge can therefore discard tasks that were never replayed. Frontend also returns the input token, causing clients to stop after the first page or repeat a token.

A page's highest task ID is insufficient as a safe retirement boundary: concurrent writers can insert lower IDs. Remote task fetches can also return reordered or incomplete results when requests span source shards.

## Approach

Match the remote response against the persisted page's task IDs before replay. After every task in the page succeeds, delete those exact entries individually. Leave the range acknowledgment unchanged so concurrent late entries remain readable in a subsequent traversal. Return History's next-page token through Frontend.

Incomplete, duplicate, unknown, or nil remote task results fail before replay or deletion. Empty pages do not retire messages. Replay errors preserve the page for retry; delete errors can cause already applied tasks to replay again.

## Validation

- Native changed-code lint passed.
- Full `service/history/replication` and `service/frontend` package tests passed with `go test -p 4 -tags test_dep`.
- Focused DLQ regression and existing DLQ handler tests passed with `-race`.
- Regression tests failed on the previous implementation and passed after the change.
- Coverage includes multiple pages, reordered replies, concurrent lower-ID insertion, terminal and nonterminal empty pages, remote/read/replay failures, incomplete task replies, deletion failure, and Frontend continuation/error propagation.

## Risks, rollout, and scope

Legacy merges now issue one delete per replayed task, and merge no longer advances the DLQ acknowledgment gauge. Entries inserted behind a continuation token require a fresh traversal. Missing or irrecoverable remote tasks remain in the DLQ for retry or explicit purge.

The change uses existing persistence APIs and needs no schema migration. It does not alter explicit purge, QueueV2, or recover tasks already lost or hidden by earlier range acknowledgments. Cassandra integration was not run locally.
