### PR TITLE
Hold the base workflow lock while forking reset history

### DIFF
--- a/service/history/ndc/resetter.go
+++ b/service/history/ndc/resetter.go
@@ -86,7 +86,7 @@ func (r *resetterImpl) resetWorkflow(
 	incomingFirstEventVersion int64,
 ) (historyi.MutableState, error) {
 
-	baseBranchToken, err := r.getBaseBranchToken(
+	resetBranchToken, newBaseBranchToken, err := r.getResetBranchTokens(
 		ctx,
 		baseLastEventID,
 		baseLastEventVersion,
@@ -94,11 +94,6 @@ func (r *resetterImpl) resetWorkflow(
 		incomingFirstEventVersion,
 	)
 
-	if err != nil {
-		return nil, err
-	}
-
-	resetBranchToken, newBaseBranchToken, err := r.getResetBranchToken(ctx, baseBranchToken, baseLastEventID)
 	if err != nil {
 		return nil, err
 	}
@@ -138,13 +133,13 @@ func (r *resetterImpl) resetWorkflow(
 	return rebuildMutableState, nil
 }
 
-func (r *resetterImpl) getBaseBranchToken(
+func (r *resetterImpl) getResetBranchTokens(
 	ctx context.Context,
 	baseLastEventID int64,
 	baseLastEventVersion int64,
 	incomingFirstEventID int64,
 	incomingFirstEventVersion int64,
-) (baseBranchToken []byte, retError error) {
+) (resetBranchToken, baseBranchToken []byte, retError error) {
 
 	baseWorkflow, err := r.transactionMgr.LoadWorkflow(
 		ctx,
@@ -168,7 +163,7 @@ func (r *resetterImpl) getBaseBranchToken(
 			// the base event and incoming event are from different branch
 			// only re-replicate the gap on the incoming branch
 			// the base branch event will eventually arrived
-			return nil, serviceerrors.NewRetryReplication(
+			return nil, nil, serviceerrors.NewRetryReplication(
 				resendOnResetWorkflowMessage,
 				r.namespaceID.String(),
 				r.workflowID,
@@ -182,11 +177,13 @@ func (r *resetterImpl) getBaseBranchToken(
 
 		baseVersionHistory, err := versionhistory.GetVersionHistory(baseVersionHistories, index)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return baseVersionHistory.GetBranchToken(), nil
+		// Publish the new branch while the base workflow is locked so retention
+		// cleanup cannot retire its history before the new reference exists.
+		return r.getResetBranchToken(ctx, baseVersionHistory.GetBranchToken(), baseLastEventID)
 	case *serviceerror.NotFound:
-		return nil, serviceerrors.NewRetryReplication(
+		return nil, nil, serviceerrors.NewRetryReplication(
 			resendOnResetWorkflowMessage,
 			r.namespaceID.String(),
 			r.workflowID,
@@ -197,7 +194,7 @@ func (r *resetterImpl) getBaseBranchToken(
 			incomingFirstEventVersion,
 		)
 	default:
-		return nil, err
+		return nil, nil, err
 	}
 }
 

--- a/service/history/ndc/resetter_test.go
+++ b/service/history/ndc/resetter_test.go
@@ -2,6 +2,7 @@ package ndc
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/definition"
+	"go.temporal.io/server/common/locks"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
@@ -108,6 +110,77 @@ func (s *resetterSuite) SetupTest() {
 func (s *resetterSuite) TearDownTest() {
 	s.controller.Finish()
 	s.mockShard.StopForTest()
+}
+
+func (s *resetterSuite) TestResetWorkflow_HoldsBaseLeaseDuringFork() {
+	for _, forkFails := range []bool{false, true} {
+		name := "fork succeeds"
+		if forkFails {
+			name = "fork fails"
+		}
+		s.Run(name, func() {
+			r := require.New(s.T())
+			ctx := s.T().Context()
+			baseContext := workflow.NewContext(
+				s.mockShard.GetConfig(), definition.NewWorkflowKey(s.namespaceID.String(), s.workflowID, s.baseRunID),
+				chasm.WorkflowArchetypeID, s.logger, s.mockShard.GetThrottledLogger(), s.mockShard.GetMetricsHandler(), nil, testhooks.TestHooks{},
+			)
+			r.NoError(baseContext.Lock(ctx, locks.PriorityLow))
+			var releaseCount int
+			var releaseErr error
+			release := func(err error) {
+				releaseCount++
+				releaseErr = err
+				baseContext.Unlock()
+			}
+			baseState := historyi.NewMockMutableState(s.controller)
+			baseState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
+				VersionHistories: versionhistory.NewVersionHistories(versionhistory.NewVersionHistory(
+					[]byte("base"), []*historyspb.VersionHistoryItem{versionhistory.NewVersionHistoryItem(100, 1)},
+				)),
+			})
+			baseWorkflow := NewMockWorkflow(s.controller)
+			baseWorkflow.EXPECT().GetMutableState().Return(baseState)
+			baseWorkflow.EXPECT().GetReleaseFn().Return(release)
+			s.mockTransactionMgr.EXPECT().LoadWorkflow(ctx, s.namespaceID, s.workflowID, s.baseRunID, chasm.WorkflowArchetypeID).Return(baseWorkflow, nil)
+			forkErr := errors.New("fork failed")
+			rebuildErr := errors.New("stop after fork")
+			s.mockExecManager.EXPECT().ForkHistoryBranch(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(context.Context, *persistence.ForkHistoryBranchRequest) (*persistence.ForkHistoryBranchResponse, error) {
+					// A competing history cleanup uses the same workflow lock.
+					waitCtx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+					defer cancel()
+					lockErr := baseContext.Lock(waitCtx, locks.PriorityLow)
+					if lockErr == nil {
+						baseContext.Unlock()
+					}
+					r.ErrorIs(lockErr, context.DeadlineExceeded)
+					if forkFails {
+						return nil, forkErr
+					}
+					return &persistence.ForkHistoryBranchResponse{NewBranchToken: []byte("reset")}, nil
+				})
+			if !forkFails {
+				s.mockStateBuilder.EXPECT().Rebuild(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+					func(context.Context, time.Time, definition.WorkflowKey, []byte, int64, *int64, definition.WorkflowKey, []byte, string) (historyi.MutableState, RebuildStats, error) {
+						r.Equal(1, releaseCount)
+						return nil, RebuildStats{}, rebuildErr
+					})
+			}
+			_, err := s.workflowResetter.resetWorkflow(ctx, time.Now(), 90, 1, 91, 1)
+			r.Equal(1, releaseCount)
+			if forkFails {
+				r.ErrorIs(err, forkErr)
+				r.ErrorIs(releaseErr, forkErr)
+			} else {
+				r.ErrorIs(err, rebuildErr)
+				r.NoError(releaseErr)
+			}
+			// The lease is available again after either fork outcome.
+			r.NoError(baseContext.Lock(ctx, locks.PriorityLow))
+			baseContext.Unlock()
+		})
+	}
 }
 
 func (s *resetterSuite) TestResetWorkflow_NoError() {


### PR DESCRIPTION
## Summary

Hold the base workflow lock until a replicated reset publishes its history branch, closing the gap where retention cleanup can run between lookup and fork.

## Problem

The replicated-reset path loads the base workflow to select a history branch, then releases its workflow-cache lock before calling `ForkHistoryBranch`. Retention cleanup acquires that same lock and can delete the base history during the gap, before the reset branch exists as a reference.

## Approach

Select and fork the branch within the existing base-workflow lease. Release the lease after the fork succeeds or fails, before rebuilding the reset workflow. Preserve the existing retry response for missing history and the storage layer's rewritten branch tokens.

## Validation

- Native changed-code lint passed.
- A regression using the real workflow-context lock failed before the change: a competing lock acquisition succeeded during the fork. Both successful and failed fork cases pass after the change.
- The regression verifies one release, fork-error propagation to the release function, and release before rebuilding.
- The full NDC package passed; the resetter suite passed ten repetitions with the race detector.
- Existing reset tests continue to cover rewritten base tokens and retry behavior.

## Risks, rollout, and scope

The base workflow lock is held across one additional persistence call. Fork errors now reach the lease release function, which follows the existing cache error handling.

This closes the same-owner retention-cleanup gap in replicated resets. It does not add storage-level fencing across shard ownership changes or administrative force deletion. The regression establishes lock ordering; it does not reproduce a complete workflow with missing history or establish production frequency. No schema or API migration is required.
