### PR TITLE
Avoid rewriting namespace tombstones during repeated deletion

### DIFF
--- a/service/worker/deletenamespace/activities.go
+++ b/service/worker/deletenamespace/activities.go
@@ -159,6 +159,11 @@ func (a *localActivities) MarkNamespaceDeletedActivity(ctx context.Context, nsNa
 		return err
 	}
 
+	// A previous reclaim workflow may remove this namespace after the read.
+	// Avoid writing its deleted state back and recreating it in persistence.
+	if ns.Namespace.Info.State == enumspb.NAMESPACE_STATE_DELETED {
+		return nil
+	}
 	ns.Namespace.Info.State = enumspb.NAMESPACE_STATE_DELETED
 
 	updateRequest := &persistence.UpdateNamespaceRequest{

--- a/service/worker/deletenamespace/mark_namespace_deleted_test.go
+++ b/service/worker/deletenamespace/mark_namespace_deleted_test.go
@@ -1,0 +1,52 @@
+package deletenamespace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	enumspb "go.temporal.io/api/enums/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/persistence"
+	"go.uber.org/mock/gomock"
+)
+
+func TestMarkNamespaceDeletedActivity(t *testing.T) {
+	for _, state := range []enumspb.NamespaceState{
+		enumspb.NAMESPACE_STATE_REGISTERED,
+		enumspb.NAMESPACE_STATE_DEPRECATED,
+		enumspb.NAMESPACE_STATE_DELETED,
+	} {
+		t.Run(state.String(), func(t *testing.T) {
+			metadataManager := persistence.NewMockMetadataManager(gomock.NewController(t))
+			a := &localActivities{metadataManager: metadataManager, logger: log.NewTestLogger()}
+			ns := &persistencespb.NamespaceDetail{
+				Info: &persistencespb.NamespaceInfo{Id: "namespace-id", Name: "namespace", State: state},
+			}
+			metadataRead := metadataManager.EXPECT().GetMetadata(gomock.Any()).Return(
+				&persistence.GetMetadataResponse{NotificationVersion: 42}, nil,
+			)
+			namespaceRead := metadataManager.EXPECT().GetNamespace(gomock.Any(), &persistence.GetNamespaceRequest{
+				Name: "namespace",
+			}).Return(&persistence.GetNamespaceResponse{
+				Namespace: ns, IsGlobalNamespace: true,
+			}, nil).After(metadataRead)
+
+			if state != enumspb.NAMESPACE_STATE_DELETED {
+				metadataManager.EXPECT().UpdateNamespace(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, request *persistence.UpdateNamespaceRequest) error {
+						require.Equal(t, enumspb.NAMESPACE_STATE_DELETED, request.Namespace.Info.State)
+						require.Equal(t, "namespace-id", request.Namespace.Info.Id)
+						require.Equal(t, "namespace", request.Namespace.Info.Name)
+						require.Equal(t, int64(42), request.NotificationVersion)
+						require.True(t, request.IsGlobalNamespace)
+						return nil
+					},
+				).After(namespaceRead)
+			}
+
+			require.NoError(t, a.MarkNamespaceDeletedActivity(context.Background(), "namespace"))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Skip the namespace state update when a repeated deletion finds the namespace already deleted, preventing that activity from recreating a tombstone removed by an earlier reclaim workflow.

## Problem

A repeated `DeleteNamespace` request can run while the earlier asynchronous reclaim workflow is still active. `MarkNamespaceDeletedActivity` writes `DELETED` even if it reads that state from persistence. In Cassandra, physical deletion does not advance the notification version, so a reclaim between the activity's read and update allows the stale update to recreate the name row while its ID mapping remains absent.

## Approach

Return success when the persisted namespace state is already `DELETED`. The activity performs no write in that case. Registered and deprecated namespaces still transition to deleted using the existing notification-version check.

## Validation

- Native changed-code lint passed.
- Unit regression covers registered, deprecated and already-deleted namespaces, preserves metadata-before-namespace read ordering, and checks ID, name, global status and notification version on state transitions.
- A temporary native Cassandra 5.0.9 regression invokes the actual activity and physically deletes the namespace after its read. It failed before the change because name lookup still succeeded after reclaim, then passed three times after the change and three times with the race detector.
- All deletion-worker package tests, their race-enabled runs, and the full Cassandra metadata persistence suite passed.

## Risks, rollout, and scope

This change prevents the repeated-deletion activity from resurrecting an already-deleted namespace. It does not make Cassandra's separate name and ID mutations atomic or repair existing inconsistent rows. A complete persistence-level fix needs an ownership and recovery protocol across those mappings. No schema migration is required for this change. The native interleaving fixture was run separately; the permanent unit regression guards the no-write behavior without adding a database dependency to the worker unit suite.
