### PR TITLE
Fence uncertain Matching task writes before advancing readers

### DIFF
--- a/common/persistence/tests/task_write_fence_test.go
+++ b/common/persistence/tests/task_write_fence_test.go
@@ -1,0 +1,93 @@
+package tests
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	enumspb "go.temporal.io/api/enums/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/serialization"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestCassandraTaskWriteFence(t *testing.T) {
+	testData, tearDown := setUpCassandraTest(t)
+	defer tearDown()
+	store, err := testData.Factory.NewTaskStore()
+	require.NoError(t, err)
+	manager := persistence.NewTaskManager(store, serialization.NewSerializer())
+
+	for _, updateMetadata := range []bool{true, false} {
+		for _, commitBeforeFence := range []bool{true, false} {
+			name := "commit_after_fence"
+			if commitBeforeFence {
+				name = "commit_before_fence"
+			}
+			if updateMetadata {
+				name += "_with_metadata"
+			}
+			t.Run(name, func(t *testing.T) {
+				ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+				defer cancel()
+				info := &persistencespb.TaskQueueInfo{
+					NamespaceId: uuid.NewString(), Name: uuid.NewString(),
+					TaskType: enumspb.TASK_QUEUE_TYPE_WORKFLOW, Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
+					LastUpdateTime: timestamppb.Now(),
+				}
+				_, err := manager.CreateTaskQueue(ctx, &persistence.CreateTaskQueueRequest{RangeID: 1, TaskQueueInfo: info})
+				require.NoError(t, err)
+
+				// Delay a write carrying the old range ID until before or after the
+				// lease update. Both outcomes must be safe for subsequent task reads.
+				release := make(chan struct{})
+				releaseWrite := sync.OnceFunc(func() { close(release) })
+				result := make(chan error, 1)
+				done := make(chan struct{})
+				t.Cleanup(func() {
+					releaseWrite()
+					<-done
+				})
+				go func() {
+					defer close(done)
+					<-release
+					_, err := manager.CreateTasks(ctx, &persistence.CreateTasksRequest{
+						TaskQueueInfo:  &persistence.PersistedTaskQueueInfo{RangeID: 1, Data: info},
+						Tasks:          []*persistencespb.AllocatedTaskInfo{{TaskId: 1, Data: &persistencespb.TaskInfo{CreateTime: timestamppb.Now()}}},
+						UpdateMetadata: updateMetadata,
+					})
+					result <- err
+				}()
+
+				read := func() []*persistencespb.AllocatedTaskInfo {
+					response, err := manager.GetTasks(ctx, &persistence.GetTasksRequest{
+						NamespaceID: info.NamespaceId, TaskQueue: info.Name, TaskType: info.TaskType,
+						InclusiveMinTaskID: 1, ExclusiveMaxTaskID: 2, PageSize: 10,
+					})
+					require.NoError(t, err)
+					return response.Tasks
+				}
+				require.Empty(t, read())
+				if commitBeforeFence {
+					releaseWrite()
+					require.NoError(t, <-result)
+				}
+				_, err = manager.UpdateTaskQueue(ctx, &persistence.UpdateTaskQueueRequest{
+					PrevRangeID: 1, RangeID: 2, TaskQueueInfo: info,
+				})
+				require.NoError(t, err)
+				if commitBeforeFence {
+					require.Len(t, read(), 1)
+				} else {
+					releaseWrite()
+					require.ErrorAs(t, <-result, new(*persistence.ConditionFailedError))
+					require.Empty(t, read())
+				}
+			})
+		}
+	}
+}

--- a/service/matching/db.go
+++ b/service/matching/db.go
@@ -44,10 +44,11 @@ type (
 
 		// mutable
 		sync.Mutex
-		rangeID       int64
-		subqueues     []*dbSubqueue
-		otherHasTasks bool
-		scaleState    *persistencespb.PartitionScaleState
+		rangeID          int64
+		subqueues        []*dbSubqueue
+		otherHasTasks    bool
+		scaleState       *persistencespb.PartitionScaleState
+		unknownTaskWrite bool
 
 		// used to avoid unnecessary metadata writes:
 		lastChange time.Time // updated when metadata is changed in memory
@@ -164,6 +165,15 @@ func (db *taskQueueDB) RenewLease(
 			return taskQueueState{}, err
 		}
 	}
+	if db.unknownTaskWrite {
+		// The range-ID update fences pending writes from the previous lease. Only
+		// now is it safe for readers to skip IDs that those writes did not create.
+		maxReadLevel := rangeIDToTaskIDBlock(db.rangeID, db.config.RangeSize).start - 1
+		for _, s := range db.subqueues {
+			s.maxReadLevel = maxReadLevel
+		}
+		db.unknownTaskWrite = false
+	}
 	return taskQueueState{
 		rangeID:       db.rangeID,
 		ackLevel:      db.subqueues[subqueueZero].AckLevel, // TODO(pri): cleanup, only used by old backlog manager
@@ -269,7 +279,7 @@ func (db *taskQueueDB) OldUpdateState(
 
 	// Reset approximateBacklogCount to fix the count divergence issue
 	maxReadLevel := db.getMaxReadLevelLocked(subqueueZero)
-	if ackLevel == maxReadLevel {
+	if ackLevel == maxReadLevel && !db.unknownTaskWrite {
 		db.subqueues[subqueueZero].ApproximateBacklogCount = 0
 		db.subqueues[subqueueZero].oldestTime = time.Time{} // zero time means no backlog
 	}
@@ -354,7 +364,7 @@ func (db *taskQueueDB) updateAckLevelAndBacklogStats(subqueue subqueueIndex, new
 		dbQueue.AckLevel = newAckLevel
 	}
 
-	if newAckLevel == db.getMaxReadLevelLocked(subqueue) {
+	if newAckLevel == db.getMaxReadLevelLocked(subqueue) && !db.unknownTaskWrite {
 		// Reset approximateBacklogCount to fix the count divergence issue
 		if dbQueue.ApproximateBacklogCount != 0 || !dbQueue.oldestTime.Equal(oldestTime) {
 			db.lastChange = time.Now()
@@ -531,6 +541,9 @@ func (db *taskQueueDB) CreateTasks(
 	if len(reqs) == 0 {
 		return createTasksResponse{}, nil
 	}
+	if db.unknownTaskWrite {
+		return createTasksResponse{}, errShutdown
+	}
 
 	updates := make(map[subqueueIndex]subqueueCreateTasksResponse)
 	allTasks := make([]*persistencespb.AllocatedTaskInfo, len(reqs))
@@ -574,9 +587,13 @@ func (db *taskQueueDB) CreateTasks(
 
 	// Update the maxReadLevel after the writes are completed, but before we send the response,
 	// so that taskReader is guaranteed to see the new read level when SpoolTask wakes it up.
-	// Do this even if the write fails, we won't reuse the task ids.
-	for sq, update := range updates {
-		db.subqueues[sq].maxReadLevel = update.maxReadLevelAfter
+	// A write with an unknown outcome may still commit, so keep its IDs unreadable
+	// until RenewLease fences the previous range ID.
+	db.unknownTaskWrite = err != nil && !writeDefinitelyFailed(err)
+	if !db.unknownTaskWrite {
+		for sq, update := range updates {
+			db.subqueues[sq].maxReadLevel = update.maxReadLevelAfter
+		}
 	}
 
 	if err == nil {

--- a/service/matching/pri_task_writer.go
+++ b/service/matching/pri_task_writer.go
@@ -125,6 +125,23 @@ func (w *priTaskWriter) appendTasks(reqs []*writeTaskRequest) error {
 	resp, err := w.db.CreateTasks(w.backlogMgr.tqCtx, reqs)
 	if err != nil {
 		w.backlogMgr.signalIfFatal(err)
+		if !writeDefinitelyFailed(err) {
+			state, leaseErr := w.renewLeaseWithRetry(persistenceOperationRetryPolicy, common.IsPersistenceTransientError)
+			if leaseErr != nil {
+				if !w.backlogMgr.signalIfFatal(leaseErr) {
+					w.backlogMgr.pqMgr.UnloadFromPartitionManager(unloadCauseOtherError)
+				}
+			} else {
+				w.taskIDBlock = rangeIDToTaskIDBlock(state.rangeID, w.config.RangeSize)
+				// The write may not have committed, so readers must reload from
+				// persistence instead of adding these tasks directly to memory.
+				w.backlogMgr.subqueueLock.Lock()
+				for _, reader := range w.backlogMgr.subqueues {
+					reader.SignalTaskLoading()
+				}
+				w.backlogMgr.subqueueLock.Unlock()
+			}
+		}
 		w.logger.Error("Persistent store operation failure",
 			tag.StoreOperationCreateTask,
 			tag.Error(err),

--- a/service/matching/task_write_recovery_test.go
+++ b/service/matching/task_write_recovery_test.go
@@ -1,0 +1,194 @@
+package matching
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/testing/testlogger"
+	"go.temporal.io/server/common/tqid"
+	"go.uber.org/mock/gomock"
+)
+
+type delayedTaskWriter struct {
+	persistence.TaskManager
+	pending      *persistence.CreateTasksRequest
+	beforeUpdate func()
+	updateErr    error
+}
+
+func (s *delayedTaskWriter) CreateTasks(_ context.Context, request *persistence.CreateTasksRequest) (*persistence.CreateTasksResponse, error) {
+	s.pending = request
+	return nil, serviceerror.NewUnavailable("write outcome unknown")
+}
+
+func TestTaskWriteRecovery(t *testing.T) {
+	for _, commitBeforeFence := range []bool{true, false} {
+		name := "commit_after_fence"
+		if commitBeforeFence {
+			name = "commit_before_fence"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctx := t.Context()
+			logger := testlogger.NewTestLogger(t, testlogger.FailOnAnyUnexpectedError)
+			store := &delayedTaskWriter{TaskManager: newTestTaskManager(logger)}
+			family, err := tqid.NewTaskQueueFamily("namespace", "queue")
+			require.NoError(t, err)
+			partition := family.TaskQueue(enumspb.TASK_QUEUE_TYPE_WORKFLOW).NormalPartition(0)
+			queue := UnversionedQueueKey(partition)
+			config := newTaskQueueConfig(partition.TaskQueue(), NewConfig(dynamicconfig.NewNoopCollection()), "namespace")
+			pq := NewMockphysicalTaskQueueManager(gomock.NewController(t))
+			pq.EXPECT().QueueKey().Return(queue).AnyTimes()
+			manager := newBacklogManager(ctx, pq, config, store, logger, logger, nil, metrics.NoopMetricsHandler)
+			require.NoError(t, manager.taskWriter.initReadWriteState())
+			db := manager.db
+
+			_, err = db.CreateTasks(ctx, []*writeTaskRequest{{taskInfo: &persistencespb.TaskInfo{}, fairLevel: fairLevel{id: 1}}})
+			require.Error(t, err)
+			pending := store.pending
+
+			// An empty read while the write is still pending must not acknowledge its ID.
+			batch, err := manager.taskReader.getTaskBatch(ctx)
+			require.NoError(t, err)
+			require.Empty(t, batch.tasks)
+			manager.taskAckManager.setReadLevelAfterGap(batch.readLevel)
+			require.Zero(t, manager.taskAckManager.getAckLevel())
+			require.NoError(t, db.OldUpdateState(ctx, manager.taskAckManager.getAckLevel()))
+			db.updateAckLevelAndBacklogStats(subqueueZero, 0, 0, time.Time{})
+			require.Equal(t, int64(1), db.getTotalApproximateBacklogCount())
+
+			// A later append cannot make the unresolved range readable.
+			_, err = db.CreateTasks(ctx, []*writeTaskRequest{{taskInfo: &persistencespb.TaskInfo{}, fairLevel: fairLevel{id: 2}}})
+			require.Error(t, err)
+			require.Same(t, pending, store.pending)
+
+			if commitBeforeFence {
+				_, err = store.TaskManager.CreateTasks(ctx, pending)
+				require.NoError(t, err)
+			}
+			state, err := db.RenewLease(ctx)
+			require.NoError(t, err)
+			require.Equal(t, int64(2), state.rangeID)
+			if !commitBeforeFence {
+				_, err = store.TaskManager.CreateTasks(ctx, pending)
+				require.ErrorAs(t, err, new(*persistence.ConditionFailedError))
+			}
+
+			batch, err = manager.taskReader.getTaskBatch(ctx)
+			require.NoError(t, err)
+			if commitBeforeFence {
+				require.Len(t, batch.tasks, 1)
+				require.Equal(t, int64(1), batch.tasks[0].TaskId)
+			} else {
+				require.Empty(t, batch.tasks)
+				manager.taskAckManager.setReadLevelAfterGap(batch.readLevel)
+				require.NoError(t, db.OldUpdateState(ctx, manager.taskAckManager.getAckLevel()))
+				require.Zero(t, db.getTotalApproximateBacklogCount())
+			}
+		})
+	}
+}
+
+func (s *delayedTaskWriter) UpdateTaskQueue(ctx context.Context, request *persistence.UpdateTaskQueueRequest) (*persistence.UpdateTaskQueueResponse, error) {
+	if s.beforeUpdate != nil {
+		s.beforeUpdate()
+	}
+	if s.updateErr != nil {
+		return nil, s.updateErr
+	}
+	return s.TaskManager.UpdateTaskQueue(ctx, request)
+}
+
+func TestTaskWriterRecoversUnknownWrite(t *testing.T) {
+	for _, priority := range []bool{false, true} {
+		name := "classic"
+		if priority {
+			name = "priority"
+		}
+		t.Run(name, func(t *testing.T) {
+			for _, fenceErr := range []error{nil, serviceerror.NewInternal("fence failed"), &persistence.ConditionFailedError{Msg: "ownership lost"}} {
+				caseName := "recovered"
+				if fenceErr != nil {
+					caseName = fenceErr.Error()
+				}
+				t.Run(caseName, func(t *testing.T) {
+					ctx := t.Context()
+					logger := testlogger.NewTestLogger(t, testlogger.FailOnAnyUnexpectedError)
+					logger.Expect(testlogger.Error, "Persistent store operation failure")
+					store := &delayedTaskWriter{TaskManager: newTestTaskManager(logger)}
+					family, err := tqid.NewTaskQueueFamily("namespace", "queue")
+					require.NoError(t, err)
+					partition := family.TaskQueue(enumspb.TASK_QUEUE_TYPE_WORKFLOW).NormalPartition(0)
+					queue := UnversionedQueueKey(partition)
+					config := newTaskQueueConfig(partition.TaskQueue(), NewConfig(dynamicconfig.NewNoopCollection()), "namespace")
+					pq := NewMockphysicalTaskQueueManager(gomock.NewController(t))
+					pq.EXPECT().QueueKey().Return(queue).AnyTimes()
+
+					var db *taskQueueDB
+					var assign, appendTasks func([]*writeTaskRequest) error
+					var notify <-chan struct{}
+					if priority {
+						manager := newPriBacklogManager(ctx, pq, config, store, logger, logger, nil, metrics.NoopMetricsHandler, false)
+						db = manager.db
+						state, err := db.RenewLease(ctx)
+						require.NoError(t, err)
+						manager.taskWriter.taskIDBlock = rangeIDToTaskIDBlock(state.rangeID, config.RangeSize)
+						reader := newPriTaskReader(manager, subqueueZero, 0)
+						manager.subqueues = []*priTaskReader{reader}
+						assign, appendTasks = manager.taskWriter.assignTaskIDs, manager.taskWriter.appendTasks
+						notify = reader.notifyC
+					} else {
+						manager := newBacklogManager(ctx, pq, config, store, logger, logger, nil, metrics.NoopMetricsHandler)
+						require.NoError(t, manager.taskWriter.initReadWriteState())
+						db = manager.db
+						assign, appendTasks = manager.taskWriter.assignTaskIDs, manager.taskWriter.appendTasks
+						notify = manager.taskReader.notifyC
+					}
+					store.updateErr = fenceErr
+					if fenceErr != nil {
+						cause := unloadCauseOtherError
+						if _, ok := fenceErr.(*persistence.ConditionFailedError); ok {
+							cause = unloadCauseConflict
+						}
+						pq.EXPECT().UnloadFromPartitionManager(cause)
+					}
+					var commitErr error
+					store.beforeUpdate = func() {
+						_, commitErr = store.TaskManager.CreateTasks(ctx, store.pending)
+					}
+					requests := []*writeTaskRequest{{taskInfo: &persistencespb.TaskInfo{}}}
+					require.NoError(t, assign(requests))
+					err = appendTasks(requests)
+					require.ErrorAs(t, err, new(*serviceerror.Unavailable))
+					require.NoError(t, commitErr)
+					if fenceErr != nil {
+						require.Zero(t, db.GetMaxReadLevel(subqueueZero))
+						require.True(t, db.unknownTaskWrite)
+						return
+					}
+
+					// Recovery and reader notification happen without another append.
+					require.Equal(t, int64(2), db.RangeID())
+					require.Len(t, notify, 1)
+					require.False(t, db.unknownTaskWrite)
+					response, err := db.GetTasks(ctx, subqueueZero, 1, db.GetMaxReadLevel(subqueueZero)+1, 10)
+					require.NoError(t, err)
+					require.Len(t, response.Tasks, 1)
+					require.Equal(t, requests[0].id, response.Tasks[0].TaskId)
+					next := []*writeTaskRequest{{taskInfo: &persistencespb.TaskInfo{}}}
+					require.NoError(t, assign(next))
+					require.Equal(t, rangeIDToTaskIDBlock(2, config.RangeSize).start, next[0].id)
+					db.store = store.TaskManager
+					require.NoError(t, appendTasks(next))
+				})
+			}
+		})
+	}
+}

--- a/service/matching/task_writer.go
+++ b/service/matching/task_writer.go
@@ -141,6 +141,19 @@ func (w *taskWriter) appendTasks(reqs []*writeTaskRequest) error {
 	_, err := w.db.CreateTasks(w.backlogMgr.tqCtx, reqs)
 	if err != nil {
 		w.backlogMgr.signalIfFatal(err)
+		if !writeDefinitelyFailed(err) {
+			// Recover even if no further appends arrive. The new lease fences the
+			// uncertain write before its task IDs become readable.
+			state, leaseErr := w.renewLeaseWithRetry(persistenceOperationRetryPolicy, common.IsPersistenceTransientError)
+			if leaseErr != nil {
+				if !w.backlogMgr.signalIfFatal(leaseErr) {
+					w.backlogMgr.pqMgr.UnloadFromPartitionManager(unloadCauseOtherError)
+				}
+			} else {
+				w.taskIDBlock = rangeIDToTaskIDBlock(state.rangeID, w.config.RangeSize)
+				w.backlogMgr.taskReader.Signal()
+			}
+		}
 		w.logger.Error("Persistent store operation failure",
 			tag.StoreOperationCreateTask,
 			tag.Error(err),


### PR DESCRIPTION
## Summary

Fence uncertain non-fair Matching task writes before advancing the readable task-ID boundary, so a delayed write cannot land behind the reader and acknowledgment positions.

## Problem

`CreateTasks` currently advances `maxReadLevel` even when persistence returns an error with an unknown commit outcome. An empty read can then advance the acknowledgment position past a task that commits later. A subsequent successful append can expose the same gap, so leaving the boundary unchanged for only the failed call is insufficient.

## Approach

Keep the uncertain range closed and reject further writes until the writer renews its lease. The successful range-ID update fences the previous write before readers can cross its IDs. Both classic and priority writers perform this recovery immediately, allocate from the new block, and wake their readers. If recovery fails, the queue unloads with the uncertain range still closed.

Preserve the approximate backlog count while those IDs are hidden. Definite persistence rejections keep their existing accounting and ID-consumption behavior. Fair task writers are outside this change.

## Validation

- Native changed-code lint passed.
- The new regression fails on the base code because an empty read acknowledges a still-pending task. It passes after the change, including both commit orders and conservative backlog accounting.
- Both writer variants pass recovery, reader notification, fresh-ID allocation, and failed-fence tests; repeated 20 times with the race detector.
- Native Cassandra tests pass commit-before-fence and fence-before-commit cases, with metadata updates on and off; repeated three times with the race detector.
- All classic, priority, and fair backlog suites pass.
- The full Matching package was run twice. Existing priority approximate-backlog assertions failed, including `TestLesserNumberOfPollersThanTasksNoDBErrors`. An overlay using the unchanged production files from the base commit reproduced these failures. The first full run also hit the existing fake-time `TestPerKeyRateLimit` timing bound.

## Risks, rollout, and scope

An uncertain write now incurs a lease renewal using the existing 30-second retry policy and consumes the remainder of its task-ID block. The original append still fails, so caller retries can produce duplicate logical tasks as before.

The Cassandra test gates the old write before it enters the native store. It exercises the real range-ID compare-and-set and task reads on one Cassandra node; it does not inject replica failures or pause an already-accepted Paxos proposal. SQL fencing was checked in the existing transaction and task-queue lock implementation, without a new SQL integration run. No schema change or migration is required.
