### PR TITLE
Confirm omitted namespaces before evicting registry entries

### DIFF
--- a/common/namespace/nsregistry/registry.go
+++ b/common/namespace/nsregistry/registry.go
@@ -604,8 +604,27 @@ func (r *registry) refreshNamespaces(ctx context.Context) (err error) {
 	var deletedEntries []*namespace.Namespace
 	for _, ns := range r.GetAllNamespaces() {
 		if _, namespaceExistsDb := namespaceIDsDb[ns.ID()]; !namespaceExistsDb {
-			deletedEntries = append(deletedEntries, ns)
-			continue
+			// A concurrent rename can move a namespace behind the pagination cursor.
+			// Confirm physical deletion by ID before removing a cached namespace.
+			response, err := r.persistence.GetNamespace(ctx, &persistence.GetNamespaceRequest{ID: ns.ID().String()})
+			var notFound *serviceerror.NamespaceNotFound
+			if errors.As(err, &notFound) {
+				deletedEntries = append(deletedEntries, ns)
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			current, err := namespace.FromPersistentState(
+				response.Namespace,
+				r.replicationResolverFactory(response.Namespace),
+				namespace.WithGlobalFlag(response.IsGlobalNamespace),
+				namespace.WithNotificationVersion(response.NotificationVersion),
+			)
+			if err != nil {
+				return err
+			}
+			namespacesDb = append(namespacesDb, current)
 		}
 		newNameToID[ns.Name()] = ns.ID()
 		newIDToNamespace[ns.ID()] = ns
@@ -614,8 +633,8 @@ func (r *registry) refreshNamespaces(ctx context.Context) (err error) {
 	var stateChanged []*namespace.Namespace
 	for _, aNamespace := range namespacesDb {
 		oldNS := r.updateIDToNamespace(newIDToNamespace, aNamespace.ID(), aNamespace)
-		// If namespace was renamed, remove entry for the old name
-		if oldNS != nil && oldNS.Name() != aNamespace.Name() {
+		// Remove a renamed namespace's old name only if it has not been reused.
+		if oldNS != nil && oldNS.Name() != aNamespace.Name() && newNameToID[oldNS.Name()] == aNamespace.ID() {
 			delete(newNameToID, oldNS.Name())
 		}
 		newNameToID[aNamespace.Name()] = aNamespace.ID()

--- a/common/namespace/nsregistry/registry_refresh_test.go
+++ b/common/namespace/nsregistry/registry_refresh_test.go
@@ -1,0 +1,160 @@
+package nsregistry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/persistence"
+	"go.uber.org/mock/gomock"
+)
+
+func TestRefreshNamespacesRevalidatesOmittedID(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name            string
+		state           enumspb.NamespaceState
+		err             error
+		conversionError bool
+		reuseOldName    bool
+	}{
+		{name: "renamed", state: enumspb.NAMESPACE_STATE_REGISTERED},
+		{name: "old name reused", state: enumspb.NAMESPACE_STATE_REGISTERED, reuseOldName: true},
+		{name: "deprecated", state: enumspb.NAMESPACE_STATE_DEPRECATED},
+		{name: "soft deleted", state: enumspb.NAMESPACE_STATE_DELETED},
+		{name: "physically deleted", err: serviceerror.NewNamespaceNotFound("omitted")},
+		{name: "wrapped not found", err: fmt.Errorf("lookup: %w", serviceerror.NewNamespaceNotFound("omitted"))},
+		{name: "unavailable", err: serviceerror.NewUnavailable("rename in progress")},
+		{name: "cancelled", err: context.Canceled},
+		{name: "conversion error", conversionError: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			store := NewMockPersistence(gomock.NewController(t))
+			reg := NewRegistry(
+				store, true, "active", dynamicconfig.GetDurationPropertyFn(time.Hour),
+				dynamicconfig.GetBoolPropertyFn(false), metrics.NoopMetricsHandler, log.NewNoopLogger(),
+				namespace.NewDefaultReplicationResolverFactory(), DefaultNamespaceStateChanged,
+			)
+			omitted := &persistence.GetNamespaceResponse{
+				Namespace: &persistencespb.NamespaceDetail{
+					Info: &persistencespb.NamespaceInfo{
+						Id: namespace.NewID().String(), Name: "z-namespace", State: enumspb.NAMESPACE_STATE_REGISTERED,
+					},
+					Config:            &persistencespb.NamespaceConfig{},
+					ReplicationConfig: &persistencespb.NamespaceReplicationConfig{},
+				},
+				NotificationVersion: 1,
+			}
+			store.EXPECT().ListNamespaces(ctx, gomock.Any()).Return(&persistence.ListNamespacesResponse{
+				Namespaces: []*persistence.GetNamespaceResponse{omitted},
+			}, nil)
+			require.NoError(t, reg.refreshNamespaces(ctx))
+			oldEntries := reg.GetAllNamespaces()
+			var changed []*namespace.Namespace
+			var deleted []bool
+			reg.RegisterStateChangeCallback("test", func(ns *namespace.Namespace, removed bool) {
+				changed = append(changed, ns)
+				deleted = append(deleted, removed)
+			})
+			changed, deleted = nil, nil // Discard registration's catch-up callback.
+			var scanned []*persistence.GetNamespaceResponse
+			var replacementID namespace.ID
+			if tc.reuseOldName {
+				replacementID = namespace.NewID()
+				scanned = []*persistence.GetNamespaceResponse{{
+					Namespace: &persistencespb.NamespaceDetail{
+						Info: &persistencespb.NamespaceInfo{
+							Id: replacementID.String(), Name: "z-namespace", State: enumspb.NAMESPACE_STATE_REGISTERED,
+						},
+						Config: &persistencespb.NamespaceConfig{}, ReplicationConfig: &persistencespb.NamespaceReplicationConfig{},
+					},
+					NotificationVersion: 8,
+				}}
+			}
+
+			store.EXPECT().ListNamespaces(ctx, &persistence.ListNamespacesRequest{
+				PageSize: CacheRefreshPageSize, IncludeDeleted: true,
+			}).Return(&persistence.ListNamespacesResponse{NextPageToken: []byte("after-m")}, nil)
+			store.EXPECT().ListNamespaces(ctx, &persistence.ListNamespacesRequest{
+				PageSize: CacheRefreshPageSize, IncludeDeleted: true, NextPageToken: []byte("after-m"),
+			}).Return(&persistence.ListNamespacesResponse{Namespaces: scanned}, nil)
+			renamed := &persistence.GetNamespaceResponse{
+				Namespace: &persistencespb.NamespaceDetail{
+					Info: &persistencespb.NamespaceInfo{
+						Id: omitted.Namespace.Info.Id, Name: "a-namespace", State: tc.state,
+					},
+					Config: omitted.Namespace.Config, ReplicationConfig: omitted.Namespace.ReplicationConfig,
+				},
+				IsGlobalNamespace: true, NotificationVersion: 7,
+			}
+			store.EXPECT().GetNamespace(ctx, &persistence.GetNamespaceRequest{ID: omitted.Namespace.Info.Id}).
+				Return(renamed, tc.err)
+			if tc.conversionError {
+				reg.replicationResolverFactory = func(*persistencespb.NamespaceDetail) namespace.ReplicationResolver {
+					return nil
+				}
+			}
+			var notFound *serviceerror.NamespaceNotFound
+			lookupFailed := tc.err != nil && !errors.As(tc.err, &notFound)
+			if lookupFailed || tc.conversionError {
+				reg.stateChangedDuringReadthrough = oldEntries
+			}
+
+			err := reg.refreshNamespaces(ctx)
+			if lookupFailed || tc.conversionError {
+				if tc.conversionError {
+					require.ErrorAs(t, err, new(*serviceerror.InvalidArgument))
+				} else {
+					require.ErrorIs(t, err, tc.err)
+				}
+				require.Equal(t, oldEntries, reg.GetAllNamespaces())
+				require.Equal(t, oldEntries, reg.stateChangedDuringReadthrough)
+				require.Empty(t, changed)
+				return
+			}
+			require.NoError(t, err)
+			if tc.reuseOldName {
+				require.Len(t, changed, 2)
+				require.Equal(t, []bool{false, false}, deleted)
+				require.Len(t, reg.GetAllNamespaces(), 2)
+				replacement, err := reg.getNamespace("z-namespace")
+				require.NoError(t, err)
+				require.Equal(t, replacementID, replacement.ID())
+				renamed, err := reg.getNamespace("a-namespace")
+				require.NoError(t, err)
+				require.Equal(t, namespace.ID(omitted.Namespace.Info.Id), renamed.ID())
+				return
+			}
+			require.Len(t, changed, 1)
+			if tc.err != nil {
+				require.Equal(t, []bool{true}, deleted)
+				require.Equal(t, oldEntries[0], changed[0])
+				require.Empty(t, reg.GetAllNamespaces())
+				return
+			}
+			require.Equal(t, []bool{false}, deleted)
+			require.Equal(t, namespace.Name("a-namespace"), changed[0].Name())
+			require.Equal(t, tc.state, changed[0].State())
+			require.True(t, changed[0].IsGlobalNamespace())
+			require.Equal(t, int64(7), changed[0].NotificationVersion())
+			require.Equal(t, changed, reg.GetAllNamespaces())
+			_, err = reg.getNamespace("z-namespace")
+			require.ErrorAs(t, err, new(*serviceerror.NamespaceNotFound))
+			entry, err := reg.getNamespace("a-namespace")
+			require.NoError(t, err)
+			require.Equal(t, changed[0], entry)
+		})
+	}
+}

--- a/common/namespace/nsregistry/registry_test.go
+++ b/common/namespace/nsregistry/registry_test.go
@@ -628,6 +628,9 @@ func (s *registrySuite) TestRemoveDeletedNamespace() {
 			namespaceRecord2},
 		NextPageToken: nil,
 	}, nil)
+	s.regPersistence.EXPECT().GetNamespace(gomock.Any(), &persistence.GetNamespaceRequest{
+		ID: namespaceRecord1.Namespace.Info.Id,
+	}).Return(nil, serviceerror.NewNamespaceNotFound(namespaceRecord1.Namespace.Info.Id))
 
 	// load namespaces
 	s.registry.Start()

--- a/common/namespace/nsregistry/registry_watch_test.go
+++ b/common/namespace/nsregistry/registry_watch_test.go
@@ -1235,6 +1235,8 @@ func (s *registryWatchSuite) TestWatchNamespaceDeletedDuringRefresh() {
 
 	ns2ID := namespace.NewID()
 	ns2Record := s.newNamespaceResponse(ns2ID, "namespace-2", cluster.TestCurrentClusterName, 2)
+	s.regPersistence.EXPECT().GetNamespace(gomock.Any(), &persistence.GetNamespaceRequest{ID: ns2ID.String()}).
+		Return(nil, serviceerror.NewNamespaceNotFound(ns2ID.String()))
 
 	watchCh1 := make(chan *persistence.NamespaceWatchEvent, 1)
 	watchCh2 := make(chan *persistence.NamespaceWatchEvent, 1)

--- a/common/persistence/tests/namespace_registry_test.go
+++ b/common/persistence/tests/namespace_registry_test.go
@@ -1,0 +1,121 @@
+package tests
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/namespace/nsregistry"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/cassandra"
+	persistencetests "go.temporal.io/server/common/persistence/persistence-tests"
+	"go.temporal.io/server/common/persistence/serialization"
+)
+
+type renamingNamespacePersistence struct {
+	persistence.MetadataManager
+	renameOnNextPage atomic.Bool
+}
+
+func (p *renamingNamespacePersistence) ListNamespaces(
+	ctx context.Context,
+	request *persistence.ListNamespacesRequest,
+) (*persistence.ListNamespacesResponse, error) {
+	pageRequest := *request
+	pageRequest.PageSize = 1
+	response, err := p.MetadataManager.ListNamespaces(ctx, &pageRequest)
+	if err != nil {
+		return nil, err
+	}
+	if len(request.NextPageToken) == 0 && p.renameOnNextPage.Swap(false) {
+		err = p.RenameNamespace(ctx, &persistence.RenameNamespaceRequest{
+			PreviousName: "z-namespace",
+			NewName:      "a-namespace",
+		})
+	}
+	return response, err
+}
+
+func TestCassandraNamespaceRegistryRenameDuringPagination(t *testing.T) {
+	t.Parallel()
+	cluster := persistencetests.NewTestClusterForCassandra(&persistencetests.TestBaseOptions{}, log.NewNoopLogger())
+	cluster.SetupTestDatabase()
+	t.Cleanup(cluster.TearDownTestDatabase)
+	store, err := cassandra.NewMetadataStore("active", cluster.GetSession(), log.NewNoopLogger())
+	require.NoError(t, err)
+	manager := persistence.NewMetadataManagerImpl(store, serialization.NewSerializer(), log.NewNoopLogger(), "active")
+	ctx := context.Background()
+	var renamedID namespace.ID
+	for _, name := range []string{"m-namespace", "z-namespace"} {
+		id := namespace.NewID()
+		_, err := manager.CreateNamespace(ctx, &persistence.CreateNamespaceRequest{
+			Namespace: &persistencespb.NamespaceDetail{
+				Info: &persistencespb.NamespaceInfo{
+					Id: id.String(), Name: name, State: enumspb.NAMESPACE_STATE_REGISTERED,
+				},
+				Config:            &persistencespb.NamespaceConfig{},
+				ReplicationConfig: &persistencespb.NamespaceReplicationConfig{},
+			},
+		})
+		require.NoError(t, err)
+		renamedID = id
+	}
+	regPersistence := &renamingNamespacePersistence{MetadataManager: manager}
+	registry := nsregistry.NewRegistry(
+		regPersistence, true, "active", dynamicconfig.GetDurationPropertyFn(10*time.Millisecond),
+		dynamicconfig.GetBoolPropertyFn(false), metrics.NoopMetricsHandler, log.NewNoopLogger(),
+		namespace.NewDefaultReplicationResolverFactory(), nsregistry.DefaultNamespaceStateChanged,
+	)
+	registry.Start()
+	t.Cleanup(registry.Stop)
+	type change struct {
+		ns      *namespace.Namespace
+		deleted bool
+	}
+	changes := make(chan change, 1)
+	registry.RegisterStateChangeCallback("rename", func(ns *namespace.Namespace, deleted bool) {
+		if ns.ID() == renamedID && (deleted || ns.Name() == "a-namespace") {
+			select {
+			case changes <- change{ns: ns, deleted: deleted}:
+			default:
+			}
+		}
+	})
+	regPersistence.renameOnNextPage.Store(true)
+	select {
+	case changed := <-changes:
+		persisted, err := manager.GetNamespace(ctx, &persistence.GetNamespaceRequest{ID: renamedID.String()})
+		require.NoError(t, err)
+		require.Equal(t, "a-namespace", persisted.Namespace.Info.Name)
+		require.False(t, changed.deleted, "a rename across the page cursor must not be reported as physical deletion")
+		require.Equal(t, namespace.Name("a-namespace"), changed.ns.Name())
+	case <-time.After(5 * time.Second):
+		t.Fatal("namespace rename was not observed")
+	}
+	entries := registry.GetAllNamespaces()
+	require.Len(t, entries, 2)
+	entry, err := registry.GetNamespace("a-namespace")
+	require.NoError(t, err)
+	require.Equal(t, renamedID, entry.ID())
+	_, err = registry.GetNamespace("z-namespace")
+	require.ErrorAs(t, err, new(*serviceerror.NamespaceNotFound))
+
+	require.NoError(t, manager.DeleteNamespace(ctx, &persistence.DeleteNamespaceRequest{ID: renamedID.String()}))
+	select {
+	case changed := <-changes:
+		require.True(t, changed.deleted)
+		require.Equal(t, renamedID, changed.ns.ID())
+	case <-time.After(5 * time.Second):
+		t.Fatal("physical namespace deletion was not observed")
+	}
+	require.Len(t, registry.GetAllNamespaces(), 1)
+}


### PR DESCRIPTION
## Summary

Verify cached namespaces omitted from a refresh by ID before evicting them, preventing a concurrent rename from being reported as physical deletion.

## Problem

Cassandra lists namespaces in name order, with separate reads for each page. A rename from beyond the current cursor to before it can leave a live namespace out of the completed scan. The registry currently removes that cached ID and invokes deletion callbacks.

## Approach

Look up each omitted cached ID before reconciling the refresh. A namespace that still exists goes through the existing name, state, and callback reconciliation. `NamespaceNotFound` confirms physical deletion. Other lookup or conversion errors abort the refresh before swapping the cache or delivering callbacks. When reconciling a rename, remove its old-name mapping only if that mapping still belongs to the same namespace; a newly created namespace can already have reused the name.

## Validation

- Native changed-code lint passed.
- Reproduced the false deletion callback against Cassandra 5.0.9 using a real metadata-manager rename between list pages; the regression passes with this change and also checks subsequent physical deletion.
- Unit coverage checks rename, deprecated and soft-deleted states, notification version and global flag, confirmed absence, wrapped absence errors, transient errors, cancellation, conversion failures, and both cache-only name lookups when a new namespace reuses the renamed namespace's old name.
- Full registry package passes with and without the race detector.
- Existing Cassandra metadata suite passes; the new Cassandra regression passes three times with the race detector.

## Risks, rollout, and scope

Each omitted cached ID adds one persistence read, including actual deletions. Complete scans add no reads. A failed verification delays the whole refresh until its existing retry path succeeds, preserving the prior cache and queued callbacks. This does not give paginated namespace listing a consistent snapshot or change Cassandra's rename and deletion protocols.
