### PR TITLE
Characterize delayed queue inserts below retired boundaries

### DIFF
--- a/common/persistence/cassandra/queue_store.go
+++ b/common/persistence/cassandra/queue_store.go
@@ -92,6 +92,8 @@ func (q *QueueStore) tryEnqueue(
 	messageID int64,
 	blob *commonpb.DataBlob,
 ) (int64, error) {
+	// IF NOT EXISTS detects an occupied ID, but does not fence a delayed producer after cleanup
+	// removes that ID. Such an insert can succeed behind the main queue's acknowledged read cursor.
 	query := q.session.Query(templateEnqueueMessageQuery, queueType, messageID, blob.Data, blob.EncodingType.String()).WithContext(ctx)
 	previous := make(map[string]any)
 	applied, err := query.MapScanCAS(previous)

--- a/common/persistence/cassandra/queue_v2_store.go
+++ b/common/persistence/cassandra/queue_v2_store.go
@@ -128,6 +128,9 @@ func (s *queueV2Store) EnqueueMessage(
 	} else {
 		nextMessageID = lastMessageID + 1
 	}
+	// Retaining the maximum physical ID prevents fresh allocations from going backwards, but does not
+	// fence this earlier allocation: cleanup can remove nextMessageID before the conditional insert,
+	// allowing it to succeed below the queue's minimum readable ID.
 	err = s.tryInsert(ctx, request.QueueType, request.QueueName, request.Blob, nextMessageID)
 	if err != nil {
 		return nil, err

--- a/common/persistence/tests/cassandra_delayed_queue_writer_test.go
+++ b/common/persistence/tests/cassandra_delayed_queue_writer_test.go
@@ -1,0 +1,159 @@
+package tests
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/cassandra"
+	persistencetests "go.temporal.io/server/common/persistence/persistence-tests"
+	"go.temporal.io/server/common/persistence/serialization"
+)
+
+// TestCassandraDelayedQueueWriterCharacterization documents the current publication gap, not the desired contract.
+// A future fix should prevent an acknowledged insert from newly appearing behind the retired read boundary.
+func TestCassandraDelayedQueueWriterCharacterization(t *testing.T) {
+	cluster := persistencetests.NewTestClusterForCassandra(&persistencetests.TestBaseOptions{}, log.NewNoopLogger())
+	cluster.SetupTestDatabase()
+	t.Cleanup(cluster.TearDownTestDatabase)
+
+	t.Run("QueueV2", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		session := &blockingSession{
+			Session:          cluster.GetSession(),
+			queryToBlockOn:   cassandra.TemplateEnqueueMessageQuery,
+			queryStarted:     make(chan struct{}, 1),
+			queryCanContinue: make(chan struct{}),
+		}
+		resume := sync.OnceFunc(func() { close(session.queryCanContinue) })
+		defer resume()
+		delayed := newQueueV2Store(session)
+		active := newQueueV2Store(cluster.GetSession())
+		queueType := persistence.QueueTypeHistoryNormal
+		queueName := t.Name()
+		_, err := active.CreateQueue(ctx, &persistence.InternalCreateQueueRequest{QueueType: queueType, QueueName: queueName})
+		require.NoError(t, err)
+		blob := &commonpb.DataBlob{EncodingType: enumspb.ENCODING_TYPE_PROTO3, Data: []byte("delayed")}
+		type result struct {
+			response *persistence.InternalEnqueueMessageResponse
+			err      error
+		}
+		results := make(chan result, 1)
+		go func() {
+			response, err := delayed.EnqueueMessage(ctx, &persistence.InternalEnqueueMessageRequest{QueueType: queueType, QueueName: queueName, Blob: blob})
+			results <- result{response, err}
+		}()
+		select {
+		case <-session.queryStarted:
+		case <-ctx.Done():
+			t.Fatal("delayed writer did not reach insert")
+		}
+		for range 2 {
+			_, err := active.EnqueueMessage(ctx, &persistence.InternalEnqueueMessageRequest{
+				QueueType: queueType, QueueName: queueName,
+				Blob: &commonpb.DataBlob{EncodingType: enumspb.ENCODING_TYPE_PROTO3, Data: []byte("active")},
+			})
+			require.NoError(t, err)
+		}
+		consumed, err := active.ReadMessages(ctx, &persistence.InternalReadMessagesRequest{QueueType: queueType, QueueName: queueName, PageSize: 10})
+		require.NoError(t, err)
+		require.Len(t, consumed.Messages, 2)
+		_, err = active.RangeDeleteMessages(ctx, &persistence.InternalRangeDeleteMessagesRequest{
+			QueueType: queueType, QueueName: queueName,
+			InclusiveMaxMessageMetadata: persistence.MessageMetadata{ID: persistence.FirstQueueMessageID},
+		})
+		require.NoError(t, err)
+		q, err := cassandra.GetQueue(ctx, cluster.GetSession(), queueName, queueType)
+		require.NoError(t, err)
+		require.Equal(t, int64(persistence.FirstQueueMessageID+1), q.Metadata.Partitions[0].MinMessageId)
+		resume()
+		var res result
+		select {
+		case res = <-results:
+		case <-ctx.Done():
+			t.Fatal("delayed writer did not finish")
+		}
+		require.NoError(t, res.err)
+		require.NotNil(t, res.response)
+		require.Equal(t, int64(persistence.FirstQueueMessageID), res.response.Metadata.ID)
+		var payload []byte
+		err = cluster.GetSession().Query("SELECT message_payload FROM queue_messages WHERE queue_type = ? AND queue_name = ? AND queue_partition = ? AND message_id = ?",
+			queueType, queueName, 0, res.response.Metadata.ID).WithContext(ctx).Scan(&payload)
+		require.NoError(t, err)
+		require.Equal(t, blob.Data, payload)
+		read, err := active.ReadMessages(ctx, &persistence.InternalReadMessagesRequest{QueueType: queueType, QueueName: queueName, PageSize: 10})
+		require.NoError(t, err)
+		t.Logf("delayed enqueue returned success: ID=%d, stored payload=%q, minimum readable ID=%d, visible messages=%v", res.response.Metadata.ID, payload, q.Metadata.Partitions[0].MinMessageId, read.Messages)
+		require.Less(t, res.response.Metadata.ID, q.Metadata.Partitions[0].MinMessageId)
+		require.Len(t, read.Messages, 1)
+		require.Equal(t, int64(persistence.FirstQueueMessageID+1), read.Messages[0].MetaData.ID)
+		require.Equal(t, []byte("active"), read.Messages[0].Data.Data)
+	})
+
+	t.Run("LegacyQueue", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		session := &blockingSession{
+			Session:          cluster.GetSession(),
+			queryToBlockOn:   "INSERT INTO queue (queue_type, message_id, message_payload, message_encoding) VALUES(?, ?, ?, ?) IF NOT EXISTS",
+			queryStarted:     make(chan struct{}, 1),
+			queryCanContinue: make(chan struct{}),
+		}
+		resume := sync.OnceFunc(func() { close(session.queryCanContinue) })
+		defer resume()
+		queueType := persistence.NamespaceReplicationQueueType
+		delayed, err := cassandra.NewQueueStore(queueType, session, log.NewNoopLogger())
+		require.NoError(t, err)
+		active, err := cassandra.NewQueueStore(queueType, cluster.GetSession(), log.NewNoopLogger())
+		require.NoError(t, err)
+		serializer := serialization.NewSerializer()
+		metadataBlob, err := serializer.QueueMetadataToBlob(&persistencespb.QueueMetadata{ClusterAckLevels: map[string]int64{}})
+		require.NoError(t, err)
+		require.NoError(t, active.Init(ctx, metadataBlob))
+		blob := &commonpb.DataBlob{EncodingType: enumspb.ENCODING_TYPE_PROTO3, Data: []byte("delayed")}
+		results := make(chan error, 1)
+		go func() { results <- delayed.EnqueueMessage(ctx, blob) }()
+		select {
+		case <-session.queryStarted:
+		case <-ctx.Done():
+			t.Fatal("delayed writer did not reach insert")
+		}
+		for range 2 {
+			require.NoError(t, active.EnqueueMessage(ctx, &commonpb.DataBlob{EncodingType: enumspb.ENCODING_TYPE_PROTO3, Data: []byte("active")}))
+		}
+		consumed, err := active.ReadMessages(ctx, persistence.EmptyQueueMessageID, 10)
+		require.NoError(t, err)
+		require.Len(t, consumed, 2)
+		lastRead := consumed[1].ID
+		metadata, err := active.GetAckLevels(ctx)
+		require.NoError(t, err)
+		metadata.Blob, err = serializer.QueueMetadataToBlob(&persistencespb.QueueMetadata{ClusterAckLevels: map[string]int64{"reader": lastRead}})
+		require.NoError(t, err)
+		require.NoError(t, active.UpdateAckLevel(ctx, metadata))
+		require.NoError(t, active.DeleteMessagesBefore(ctx, lastRead))
+		resume()
+		select {
+		case err = <-results:
+		case <-ctx.Done():
+			t.Fatal("delayed writer did not finish")
+		}
+		require.NoError(t, err)
+		var payload []byte
+		err = cluster.GetSession().Query("SELECT message_payload FROM queue WHERE queue_type = ? AND message_id = ?", queueType, persistence.FirstQueueMessageID).WithContext(ctx).Scan(&payload)
+		require.NoError(t, err)
+		require.Equal(t, blob.Data, payload)
+		read, err := active.ReadMessages(ctx, lastRead, 10)
+		require.NoError(t, err)
+		t.Logf("delayed enqueue returned success: ID=%d, stored payload=%q, acknowledged/read cursor=%d, visible messages=%v", persistence.FirstQueueMessageID, payload, lastRead, read)
+		require.Equal(t, int64(persistence.FirstQueueMessageID+1), lastRead)
+		require.Empty(t, read, "the delayed payload exists physically, but is behind the acknowledged cursor")
+	})
+}

--- a/common/persistence/tests/cassandra_queue_metadata_gap_test.go
+++ b/common/persistence/tests/cassandra_queue_metadata_gap_test.go
@@ -1,0 +1,113 @@
+package tests
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/cassandra"
+	persistencetests "go.temporal.io/server/common/persistence/persistence-tests"
+)
+
+// TestCassandraDelayedWriterBeforeRetirementMetadataCharacterization demonstrates why checking metadata after
+// insertion alone would not fence retirement: cleanup may have deleted the row without updating metadata yet.
+func TestCassandraDelayedWriterBeforeRetirementMetadataCharacterization(t *testing.T) {
+	cluster := persistencetests.NewTestClusterForCassandra(&persistencetests.TestBaseOptions{}, log.NewNoopLogger())
+	cluster.SetupTestDatabase()
+	t.Cleanup(cluster.TearDownTestDatabase)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	writerSession := &blockingSession{
+		Session: cluster.GetSession(), queryToBlockOn: cassandra.TemplateEnqueueMessageQuery,
+		queryStarted: make(chan struct{}, 1), queryCanContinue: make(chan struct{}),
+	}
+	cleanerSession := &blockingSession{
+		Session: cluster.GetSession(), queryToBlockOn: cassandra.TemplateUpdateQueueMetadataQuery,
+		queryStarted: make(chan struct{}, 1), queryCanContinue: make(chan struct{}),
+	}
+	resumeWriter := sync.OnceFunc(func() { close(writerSession.queryCanContinue) })
+	defer resumeWriter()
+	resumeCleaner := sync.OnceFunc(func() { close(cleanerSession.queryCanContinue) })
+	defer resumeCleaner()
+	delayed := newQueueV2Store(writerSession)
+	cleaner := newQueueV2Store(cleanerSession)
+	active := newQueueV2Store(cluster.GetSession())
+	queueType := persistence.QueueTypeHistoryNormal
+	queueName := t.Name()
+	_, err := active.CreateQueue(ctx, &persistence.InternalCreateQueueRequest{QueueType: queueType, QueueName: queueName})
+	require.NoError(t, err)
+	results := make(chan error, 1)
+	go func() {
+		_, err := delayed.EnqueueMessage(ctx, &persistence.InternalEnqueueMessageRequest{
+			QueueType: queueType, QueueName: queueName,
+			Blob: &commonpb.DataBlob{EncodingType: enumspb.ENCODING_TYPE_PROTO3, Data: []byte("delayed")},
+		})
+		results <- err
+	}()
+	select {
+	case <-writerSession.queryStarted:
+	case <-ctx.Done():
+		t.Fatal("delayed writer did not reach insert")
+	}
+	for range 2 {
+		_, err := active.EnqueueMessage(ctx, &persistence.InternalEnqueueMessageRequest{
+			QueueType: queueType, QueueName: queueName,
+			Blob: &commonpb.DataBlob{EncodingType: enumspb.ENCODING_TYPE_PROTO3, Data: []byte("active")},
+		})
+		require.NoError(t, err)
+	}
+	consumed, err := active.ReadMessages(ctx, &persistence.InternalReadMessagesRequest{QueueType: queueType, QueueName: queueName, PageSize: 10})
+	require.NoError(t, err)
+	require.Len(t, consumed.Messages, 2)
+	deletes := make(chan error, 1)
+	go func() {
+		_, err := cleaner.RangeDeleteMessages(ctx, &persistence.InternalRangeDeleteMessagesRequest{
+			QueueType: queueType, QueueName: queueName,
+			InclusiveMaxMessageMetadata: persistence.MessageMetadata{ID: 0},
+		})
+		deletes <- err
+	}()
+	select {
+	case <-cleanerSession.queryStarted:
+	case <-ctx.Done():
+		t.Fatal("cleaner did not reach metadata update")
+	}
+	resumeWriter()
+	select {
+	case err = <-results:
+		require.NoError(t, err)
+	case <-ctx.Done():
+		t.Fatal("delayed writer did not finish")
+	}
+	q, err := cassandra.GetQueue(ctx, cluster.GetSession(), queueName, queueType)
+	require.NoError(t, err)
+	require.Zero(t, q.Metadata.Partitions[0].MinMessageId)
+	beforeRetirement, err := active.ReadMessages(ctx, &persistence.InternalReadMessagesRequest{QueueType: queueType, QueueName: queueName, PageSize: 10})
+	require.NoError(t, err)
+	require.Len(t, beforeRetirement.Messages, 2)
+	require.Equal(t, int64(persistence.FirstQueueMessageID), beforeRetirement.Messages[0].MetaData.ID)
+	require.Equal(t, []byte("delayed"), beforeRetirement.Messages[0].Data.Data)
+	t.Logf("delayed enqueue returned success after physical deletion; subsequent metadata read still permits ID 0, version=%d", q.Version)
+	resumeCleaner()
+	select {
+	case err = <-deletes:
+		require.NoError(t, err)
+	case <-ctx.Done():
+		t.Fatal("cleaner did not finish")
+	}
+	read, err := active.ReadMessages(ctx, &persistence.InternalReadMessagesRequest{QueueType: queueType, QueueName: queueName, PageSize: 10})
+	require.NoError(t, err)
+	t.Logf("after metadata commit, visible messages=%v", read.Messages)
+	q, err = cassandra.GetQueue(ctx, cluster.GetSession(), queueName, queueType)
+	require.NoError(t, err)
+	require.Equal(t, int64(persistence.FirstQueueMessageID+1), q.Metadata.Partitions[0].MinMessageId)
+	require.Len(t, read.Messages, 1)
+	require.Equal(t, int64(persistence.FirstQueueMessageID+1), read.Messages[0].MetaData.ID)
+	require.Equal(t, []byte("active"), read.Messages[0].Data.Data)
+}


### PR DESCRIPTION
## Summary

Characterize Cassandra queue inserts that succeed below a retired read boundary, so a publication contract can be agreed before changing the protocol.

## Problem

QueueStore and QueueV2 select the next ID from the current physical maximum, then insert with `IF NOT EXISTS`. A producer can pause after selecting ID 0. Another producer writes IDs 0 and 1; a reader processes them; cleanup removes ID 0 while retaining ID 1. When the delayed producer resumes, its insert succeeds because ID 0 is absent. Its new payload is behind the acknowledged cursor or QueueV2 minimum readable ID.

QueueV2 also has a gap between physical deletion and the metadata update. A delayed insert can succeed during that gap, and a subsequent metadata read still permits its ID. Cleanup then advances the minimum past it. Checking metadata after insertion alone would therefore miss this interleaving.

## Approach

Add comments at the allocation/insertion gap and deterministic Cassandra characterization tests for both queues and the QueueV2 metadata-update gap. The tests assert the current adverse outcome and explicitly identify the future desired contract: an acknowledged insert must not newly publish its payload behind a retired boundary.

Two possible next steps need evaluation:

1. **Validate the physical maximum after insertion in a bounded scope.** QueueV2 retains its maximum row; under suitable consistency, a greater maximum could detect a recreated lower ID. This needs a defined uncertain-outcome error, proof for supported consistency settings, and tests for healthy writers overtaking one another. An error may follow an already consumed insertion, so retries can duplicate payloads or repeatedly fail. Legacy main-queue retention is caller-owned; legacy DLQ deletion does not preserve the same anchor.
2. **Prototype a QueueV2 publication/retirement marker.** Limit the experiment to one QueueV2 message partition, with participating writers and cleanup using one agreed protocol. Its initialization, atomic operations, retention, failure recovery and mixed-version behavior require design and testing before extending it to other queues. This is an option, not an established requirement.

The namespace queue retry wrapper retries `Unavailable` and `ConditionFailedError`; the History task queue manager has no corresponding wrapper, and DLQWriter wraps enqueue failures under `ErrSendTaskToDLQ`. A proposed error change needs caller-level validation. Process-local producer locks do not coordinate different processes with cleanup.

## Validation

- All three characterization scenarios and the existing Cassandra QueuePersistence/QueueV2Persistence suites passed on Cassandra 5.0.9 (`go test -p 4 -tags test_dep`, 13.177s).
- Native changed-package lint passed with no reported new issues; `git diff --check` passed.
- All three scenarios passed with the race detector across three repetitions (12.372s), with no race reports.

The tests use real Cassandra conditional inserts, reads, deletes and metadata updates, with channel gates immediately before the selected driver query. They do not pause an already submitted Cassandra operation.

## Risks, rollout, and scope

This draft changes comments and tests only. The passing tests document a defect; they do not validate either repair option. Evidence is limited to the persistence boundary and does not establish production frequency, end-to-end workflow loss, or a distributed consistency proof. Legacy main queue is covered; legacy DLQ retirement is outside this reproduction.

## References

- [QueueV2 caching proposal](https://github.com/temporalio/temporal/pull/11179) changes metadata lookup cost, with the same ID allocation/insertion sequence.
- [DLQ queue creation optimization](https://github.com/temporalio/temporal/pull/12006) preserves process-local serialization and explicitly leaves cross-process message-ID contention out of scope.
- [Legacy replication DLQ merge fix](https://github.com/temporalio/temporal/pull/12007) concerns a separate task store and retirement protocol; it does not change QueueStore or QueueV2 publication.
