### PR TITLE
Characterize scheduled cleanup across shard ownership changes

### DIFF
--- a/service/history/queues/queue_base.go
+++ b/service/history/queues/queue_base.go
@@ -375,6 +375,9 @@ func (p *queueBase) rangeCompleteTasks(
 	newExclusiveDeletionHighWatermark tasks.Key,
 ) error {
 	if p.category.Type() == tasks.CategoryTypeScheduled {
+		// Time-only cleanup is not fenced by shard ownership. A delayed request can
+		// cover a successor's tasks if its scheduling floor does not include this
+		// owner's unpersisted reader progress.
 		oldExclusiveDeletionHighWatermark.TaskID = 0
 		newExclusiveDeletionHighWatermark.TaskID = 0
 	}

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -378,6 +378,8 @@ func (s *ContextImpl) SetQueueState(
 	tasksCompleted int,
 	state *persistencespb.QueueState,
 ) error {
+	// A nil result can mean the update was batched in memory. It does not by
+	// itself make a scheduled cleanup boundary available to the next owner.
 	return s.updateShardInfo(tasksCompleted,
 		func() {
 			categoryID := category.ID()

--- a/service/history/shard/scheduled_cleanup_test.go
+++ b/service/history/shard/scheduled_cleanup_test.go
@@ -1,0 +1,181 @@
+package shard
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/cluster"
+	"go.temporal.io/server/common/definition"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/future"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/persistence"
+	persistencetests "go.temporal.io/server/common/persistence/persistence-tests"
+	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/common/persistence/sql"
+	"go.temporal.io/server/common/resolver"
+	historyi "go.temporal.io/server/service/history/interfaces"
+	"go.temporal.io/server/service/history/tasks"
+	historytests "go.temporal.io/server/service/history/tests"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// TestScheduledCleanupAfterOwnershipTransfer characterizes a delayed cleanup
+// deleting a successor-owned timer below an unpersisted predecessor frontier.
+// A future fix should preserve that row and keep it reachable to queue readers.
+// Engine callbacks control publication and polling; workflow execution is not run.
+func TestScheduledCleanupAfterOwnershipTransfer(t *testing.T) {
+	options := persistencetests.GetSQLiteMemoryTestClusterOption()
+	testCluster := sql.NewTestCluster(
+		options.SQLDBPluginName, options.DBName, options.DBUsername, options.DBPassword,
+		options.DBHost, options.DBPort, options.ConnectAttributes, options.SchemaDir, nil, log.NewNoopLogger(),
+	)
+	testCluster.SetupTestDatabase()
+	t.Cleanup(testCluster.TearDownTestDatabase)
+	serializer := serialization.NewSerializer()
+	persistenceConfig := testCluster.Config()
+	factory := sql.NewFactory(*persistenceConfig.DataStores[persistenceConfig.DefaultStore].SQL,
+		resolver.NewNoopResolver(), cluster.TestCurrentClusterName, log.NewNoopLogger(), metrics.NoopMetricsHandler, serializer)
+	t.Cleanup(factory.Close)
+	shardStore, err := factory.NewShardStore()
+	require.NoError(t, err)
+	shardManager := persistence.NewShardManager(shardStore, serializer)
+	t.Cleanup(shardManager.Close)
+	executionStore, err := factory.NewExecutionStore()
+	require.NoError(t, err)
+	executionManager := persistence.NewExecutionManager(executionStore, serializer, nil, log.NewNoopLogger(),
+		dynamicconfig.GetIntPropertyFn(4*1024*1024), dynamicconfig.GetBoolPropertyFn(false))
+	t.Cleanup(executionManager.Close)
+
+	for index, tc := range []struct {
+		name                 string
+		persistFrontier      bool
+		pollBeforeAssignment bool
+		survivesCleanup      bool
+	}{
+		{name: "unpersisted-frontier", survivesCleanup: false},
+		{name: "persisted-frontier", persistFrontier: true, survivesCleanup: true},
+		{name: "reader-poll-before-assignment", pollBeforeAssignment: true, survivesCleanup: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			now := time.Date(2020, 1, 1, 12, 0, 0, 0, time.UTC)
+			clockSource := clock.NewEventTimeSource().Update(now)
+			shardID := int32(index + 1)
+			_, err := shardManager.GetOrCreateShard(t.Context(), &persistence.GetOrCreateShardRequest{
+				ShardID:          shardID,
+				InitialShardInfo: &persistencespb.ShardInfo{ShardId: shardID, RangeId: 1},
+			})
+			require.NoError(t, err)
+
+			newOwner := func(onPublished func(*ContextTest)) *ContextTest {
+				ctrl := gomock.NewController(t)
+				cfg := historytests.NewDynamicConfig()
+				cfg.TimerProcessorMaxTimeShift = dynamicconfig.GetDurationPropertyFn(time.Second)
+				cfg.ShardUpdateMinInterval = dynamicconfig.GetDurationPropertyFn(0)
+				owner := NewTestContextWithTimeSource(ctrl, &persistencespb.ShardInfo{ShardId: shardID, RangeId: 1}, cfg, clockSource)
+				// The test helper only replaces the generator's clock; the production
+				// constructor supplies the same clock to the manager and generator.
+				owner.taskKeyManager.timeSource = clockSource
+				owner.persistenceShardManager = shardManager
+				owner.executionManager = executionManager
+				owner.state = contextStateAcquiring
+				owner.shardInfo = nil
+				owner.engineFuture = future.NewFuture[historyi.Engine]()
+				owner.Resource.ClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
+				owner.Resource.ClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
+				owner.Resource.NamespaceCache.EXPECT().GetNamespaceByID(historytests.NamespaceID).Return(historytests.LocalNamespaceEntry, nil).AnyTimes()
+				factory := NewMockEngineFactory(ctrl)
+				engine := historyi.NewMockEngine(ctrl)
+				owner.engineFactory = factory
+				factory.EXPECT().CreateEngine(owner.ContextImpl).Return(engine)
+				engine.EXPECT().Start()
+				engine.EXPECT().Stop()
+				called := false
+				engine.EXPECT().NotifyNewTasks(gomock.Any()).Do(func(_ map[tasks.Category][]tasks.Task) {
+					if !called {
+						called = true
+						require.True(t, owner.engineFuture.Ready())
+						require.Equal(t, contextStateAcquired, owner.state)
+						if onPublished != nil {
+							onPublished(owner)
+						}
+					}
+				}).AnyTimes()
+				t.Cleanup(owner.FinishStop)
+				owner.acquireShard()
+				require.Equal(t, contextStateAcquired, owner.state)
+				require.True(t, called)
+				return owner
+			}
+
+			predecessor := newOwner(nil)
+			predecessorRange := predecessor.GetRangeID()
+			highWatermark := predecessor.GetQueueExclusiveHighReadWatermark(tasks.CategoryTimer)
+			require.True(t, highWatermark.FireTime.After(now))
+			if tc.persistFrontier {
+				require.NoError(t, predecessor.SetQueueState(tasks.CategoryTimer, 0, &persistencespb.QueueState{
+					ExclusiveReaderHighWatermark: &persistencespb.TaskKey{FireTime: timestamppb.New(highWatermark.FireTime)},
+				}))
+			}
+			cleanup := &persistence.RangeCompleteHistoryTasksRequest{
+				ShardID:             shardID,
+				TaskCategory:        tasks.CategoryTimer,
+				InclusiveMinTaskKey: tasks.NewKey(now.Add(-time.Second), 0),
+				ExclusiveMaxTaskKey: highWatermark,
+			}
+			workflowKey := definition.NewWorkflowKey(historytests.NamespaceID.String(), historytests.WorkflowID, historytests.RunID)
+			timerTask := &tasks.WorkflowRunTimeoutTask{WorkflowKey: workflowKey, VisibilityTimestamp: now, Version: 1}
+			successor := newOwner(func(owner *ContextTest) {
+				if tc.pollBeforeAssignment {
+					owner.GetQueueExclusiveHighReadWatermark(tasks.CategoryTimer)
+				}
+				require.NoError(t, owner.AddTasks(t.Context(), &persistence.AddHistoryTasksRequest{
+					ShardID:     shardID,
+					NamespaceID: workflowKey.NamespaceID,
+					WorkflowID:  workflowKey.WorkflowID,
+					ArchetypeID: chasm.WorkflowArchetypeID,
+					Tasks:       map[tasks.Category][]tasks.Task{tasks.CategoryTimer: {timerTask}},
+				}))
+			})
+			require.Greater(t, successor.GetRangeID(), predecessorRange)
+			require.GreaterOrEqual(t, timerTask.TaskID, (predecessorRange+1)<<successor.config.RangeSizeBits)
+			require.Equal(t, !tc.survivesCleanup, timerTask.VisibilityTimestamp.Before(highWatermark.FireTime))
+
+			read := func() []tasks.Task {
+				response, err := executionManager.GetHistoryTasks(t.Context(), &persistence.GetHistoryTasksRequest{
+					ShardID:             shardID,
+					TaskCategory:        tasks.CategoryTimer,
+					InclusiveMinTaskKey: tasks.NewKey(now.Add(-time.Second), 0),
+					ExclusiveMaxTaskKey: tasks.NewKey(now.Add(10*time.Second), 0),
+					BatchSize:           10,
+				})
+				require.NoError(t, err)
+				return response.Tasks
+			}
+			require.Len(t, read(), 1)
+			require.NoError(t, executionManager.RangeCompleteHistoryTasks(t.Context(), cleanup))
+			if tc.survivesCleanup {
+				require.Len(t, read(), 1)
+			} else {
+				// This is the unsafe outcome being characterized, not the desired contract.
+				require.Empty(t, read())
+			}
+			t.Logf("predecessor_range=%d successor_range=%d cleanup_before=%s successor_key=(%s,%d) survives=%t", predecessorRange, successor.GetRangeID(), highWatermark.FireTime.Format(time.RFC3339Nano), timerTask.VisibilityTimestamp.Format(time.RFC3339Nano), timerTask.TaskID, tc.survivesCleanup)
+
+			// A stale normal task write is fenced even though range cleanup is not.
+			err = executionManager.AddHistoryTasks(t.Context(), &persistence.AddHistoryTasksRequest{
+				ShardID: shardID, RangeID: predecessorRange,
+				NamespaceID: workflowKey.NamespaceID, WorkflowID: workflowKey.WorkflowID,
+				ArchetypeID: chasm.WorkflowArchetypeID,
+				Tasks:       map[tasks.Category][]tasks.Task{tasks.CategoryTimer: {timerTask}},
+			})
+			require.ErrorAs(t, err, new(*persistence.ShardOwnershipLostError))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Characterize scheduled cleanup that deletes a task written by a successor shard owner, so the cleanup contract can be reviewed with a repeatable test.

## Problem

Scheduled cleanup selects a time range without the originating shard's ownership version. An owner can authorize cleanup through a boundary that exists only in memory. After ownership changes, the successor restores its scheduling floor from durable metadata and can assign a timer below that boundary before its first reader poll. A delayed cleanup from the predecessor then removes the new task even though ordinary writes from the predecessor are rejected.

The test acquires two real shard ownership ranges and uses the normal task-key assignment and persistence APIs. A timer written by the successor is visible before the predecessor's cleanup and absent afterward. Two controls retain the task: making the predecessor's reader frontier durable before transfer, or polling the successor's queue boundary before assigning the task.

## Approach

Add comments at scheduled range cleanup and batched queue-state persistence, plus a passing SQLite-backed characterization test. It records the unsafe outcome explicitly; a future fix must preserve the successor's task and keep it reachable to queue readers.

Two possible follow-ups, neither implemented nor validated here:

1. **Make the authorized cleanup frontier durable before deletion.** Require a completed, ownership-fenced shard update before issuing cleanup through that frontier. The successor can then restore a scheduling floor beyond the predecessor's cleanup range. Calling the current `SetQueueState` earlier is insufficient because it can return after an in-memory update. This option needs checks for write failures, batching cost, reader holes and the successor's restored read positions.
2. **Bound scheduled deletion by the originating owner's task-ID allocation range as well as time.** Successor task IDs belong to a later range. Carrying the predecessor's upper ID bound through cleanup could preserve those rows. Every store must enforce that predicate correctly, including before page limits and across retries; query cost and non-wrapping ID assumptions need validation.

A separate ownership read immediately before deletion leaves a check/write race. Advancing the successor's local time floor earlier narrows startup exposure but does not establish the predecessor's maximum authorized boundary.

## Validation

- The three-case characterization passed with native in-memory SQLite and separately with Cassandra 5.0.9 using a local test overlay.
- The SQLite characterization passed with the race detector in three repeated runs.
- Full shard-package tests passed (`go test -p 4 -tags test_dep ./service/history/shard -count=1 -timeout=5m`).
- Native changed-package lint passed with the repository configuration and fixes disabled.

The committed test needs no external datastore. It runs real shard acquisition, task-key assignment and persistence operations, with mocked engine callbacks controlling publication and polling. It does not run a complete History engine or reproduce end-to-end workflow loss. The Cassandra overlay is local corroboration and is not included in the diff.

## Risks, rollout, and scope

This is a problem-scoping draft containing comments and tests. The passing assertions describe the defect and do not certify either repair option. No production frequency, replica-failure behavior or complete recovery protocol is established by this test.
