### PR TITLE
Characterize SQL cluster metadata pagination repeating its first page

### DIFF
--- a/common/persistence/sql/cluster_metadata.go
+++ b/common/persistence/sql/cluster_metadata.go
@@ -50,6 +50,9 @@ func (s *sqlClusterMetadataManager) ListClusterMetadata(
 
 	resp := &p.InternalListClusterMetadataResponse{ClusterMetadata: clusterMetadata}
 	if len(rows) >= request.PageSize {
+		// The SQL list projections currently omit cluster_name, so this field is
+		// empty and a full page produces a token that restarts at the first page.
+		// See TestSQLiteClusterMetadataPaginationRepeatsFirstPage for characterization.
 		nextPageToken, err := gobSerialize(rows[len(rows)-1].ClusterName)
 		if err != nil {
 			return nil, serviceerror.NewInternalf("error serializing page token: %v", err)

--- a/common/persistence/tests/cluster_metadata_pagination_test.go
+++ b/common/persistence/tests/cluster_metadata_pagination_test.go
@@ -1,0 +1,72 @@
+package tests
+
+import (
+	"bytes"
+	"encoding/gob"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/common/persistence/sql"
+	"go.temporal.io/server/common/resolver"
+)
+
+func TestSQLiteClusterMetadataPaginationRepeatsFirstPage(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	logger := log.NewNoopLogger()
+	serializer := serialization.NewSerializer()
+	factory := sql.NewFactory(
+		*NewSQLiteMemoryConfig(), resolver.NewNoopResolver(), testSQLiteClusterName,
+		logger, metrics.NoopMetricsHandler, serializer,
+	)
+	t.Cleanup(factory.Close)
+	store, err := factory.NewClusterMetadataStore()
+	require.NoError(t, err)
+	manager := persistence.NewClusterMetadataManagerImpl(store, serializer, testSQLiteClusterName, logger)
+	for index, name := range []string{"cluster-a", "cluster-b"} {
+		applied, err := manager.SaveClusterMetadata(ctx, &persistence.SaveClusterMetadataRequest{
+			ClusterMetadata: &persistencespb.ClusterMetadata{
+				ClusterName:              name,
+				ClusterId:                uuid.NewString(),
+				HistoryShardCount:        4,
+				ClusterAddress:           name + ":7233",
+				FailoverVersionIncrement: 10,
+				InitialFailoverVersion:   int64(index + 1),
+				IsGlobalNamespaceEnabled: true,
+				IsConnectionEnabled:      true,
+			},
+		})
+		require.NoError(t, err)
+		require.True(t, applied)
+	}
+	secondCluster, err := manager.GetClusterMetadata(ctx, &persistence.GetClusterMetadataRequest{ClusterName: "cluster-b"})
+	require.NoError(t, err)
+	require.Equal(t, "cluster-b", secondCluster.GetClusterName())
+
+	first, err := manager.ListClusterMetadata(ctx, &persistence.ListClusterMetadataRequest{PageSize: 1})
+	require.NoError(t, err)
+	require.Len(t, first.ClusterMetadata, 1)
+	require.Equal(t, "cluster-a", first.ClusterMetadata[0].GetClusterName())
+	require.NotEmpty(t, first.NextPageToken)
+	var cursor string
+	require.NoError(t, gob.NewDecoder(bytes.NewReader(first.NextPageToken)).Decode(&cursor))
+	require.Empty(t, cursor)
+
+	// Characterize the current defect with bounded reads. A corrected traversal
+	// must return cluster-b next and then terminate; no data changes between pages.
+	for range 2 {
+		next, err := manager.ListClusterMetadata(ctx, &persistence.ListClusterMetadataRequest{
+			PageSize: 1, NextPageToken: first.NextPageToken,
+		})
+		require.NoError(t, err)
+		require.Len(t, next.ClusterMetadata, 1)
+		require.Equal(t, "cluster-a", next.ClusterMetadata[0].GetClusterName())
+		require.Equal(t, first.NextPageToken, next.NextPageToken)
+	}
+}


### PR DESCRIPTION
## Summary

Document and reproduce SQL cluster metadata pagination repeating its first page so a follow-up fix can restore forward progress without changing cluster lifecycle semantics.

## Problem

The MySQL, PostgreSQL, and SQLite list queries select `data`, `data_encoding`, and `version`, but omit `cluster_name`. `ListClusterMetadata` builds the continuation token from the returned row's `ClusterName`, which remains empty. The serialized empty string is a nonempty token; the next request decodes it and chooses the initial query again.

With two unchanged clusters and page size 1, every page returns the first cluster. A client following these tokens cannot reach later clusters or finish its traversal. The background cluster cache refresher and startup metadata loader use page size 100, so a full first page can prevent their scans from completing while reads continue to succeed. Errors or context cancellation can interrupt the scan.

The existing shared persistence suite checks that both pages contain one row, but does not check their identities or progress. This SQL defect does not require concurrent writes or cluster rename.

## Approach

Add a comment where the SQL store produces the cursor and a bounded native SQLite characterization. The test persists two distinct valid cluster records, verifies the second by point read, and demonstrates that the continuation token decodes to an empty cursor and returns the first cluster repeatedly. Its passing assertions document the current defect; a repair should replace them with forward-progress and termination assertions.

Two contained follow-up options are:

1. **Project the physical key in all three list queries.** Include `cluster_name` in the list-specific SELECT projection so the current store can encode the last row's actual ordering key. This is the smaller option and preserves the existing token format and point-read behavior.
2. **Derive the cursor from the last persisted payload.** Decode that row's cluster metadata before token construction and encode its nonempty cluster name. This preserves the current projections, but couples pagination to payload decoding and relies on the payload name matching the physical key. That invariant and malformed-payload behavior would need explicit validation.

Neither option is implemented or validated here.

## Validation

- Native in-memory SQLite characterization: passed.
- Existing SQLite cluster metadata persistence suite plus characterization: passed, including all seven existing suite cases.
- `git diff --check`: passed.
- Native changed-package lint reported no issues.

MySQL and PostgreSQL share the source-level projection defect; they were not exercised against running databases. The test uses bounded page reads and does not start an indefinitely repeating loader or refresher.

## Risks, rollout, and scope

This changes comments and tests only. The characterization intentionally asserts the current broken outcome and must change alongside a repair. Cluster mutation consistency, Cassandra pagination, cache eviction confirmation, and namespace rename are outside this candidate.

## References

- [#2331](https://github.com/temporalio/temporal/pull/2331) fixed token forwarding by the cluster refresher.
- [#5608](https://github.com/temporalio/temporal/pull/5608) fixed token forwarding by a startup caller.
- [#12012](https://github.com/temporalio/temporal/pull/12012) concerns namespaces renamed across a page cursor and does not cover this SQL projection defect.
