### PR TITLE
Fix SAA activity task validation routing

### DIFF
--- a/api/historyservice/v1/request_response.pb.go
+++ b/api/historyservice/v1/request_response.pb.go
@@ -2753,7 +2753,10 @@ type IsActivityTaskValidRequest struct {
 	Clock            *v18.VectorClock       `protobuf:"bytes,3,opt,name=clock,proto3" json:"clock,omitempty"`
 	ScheduledEventId int64                  `protobuf:"varint,4,opt,name=scheduled_event_id,json=scheduledEventId,proto3" json:"scheduled_event_id,omitempty"`
 	// Stamp represents the internal “version” of the activity options and can/will be changed with Activity API.
-	Stamp         int32 `protobuf:"varint,5,opt,name=stamp,proto3" json:"stamp,omitempty"`
+	Stamp int32 `protobuf:"varint,5,opt,name=stamp,proto3" json:"stamp,omitempty"`
+	// Reference to the Chasm component for standalone activity execution. When present, execution, clock, and
+	// scheduled_event_id are not used.
+	ComponentRef  []byte `protobuf:"bytes,6,opt,name=component_ref,json=componentRef,proto3" json:"component_ref,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2821,6 +2824,13 @@ func (x *IsActivityTaskValidRequest) GetStamp() int32 {
 		return x.Stamp
 	}
 	return 0
+}
+
+func (x *IsActivityTaskValidRequest) GetComponentRef() []byte {
+	if x != nil {
+		return x.ComponentRef
+	}
+	return nil
 }
 
 type IsActivityTaskValidResponse struct {
@@ -11022,13 +11032,14 @@ const file_temporal_server_api_historyservice_v1_request_response_proto_rawDesc 
 	"\"RespondActivityTaskCanceledRequest\x12!\n" +
 	"\fnamespace_id\x18\x01 \x01(\tR\vnamespaceId\x12j\n" +
 	"\x0ecancel_request\x18\x02 \x01(\v2C.temporal.api.workflowservice.v1.RespondActivityTaskCanceledRequestR\rcancelRequest:\x1f\x92\xc4\x03\x1b2\x19cancel_request.task_token\"%\n" +
-	"#RespondActivityTaskCanceledResponse\"\xaa\x02\n" +
+	"#RespondActivityTaskCanceledResponse\"\xba\x02\n" +
 	"\x1aIsActivityTaskValidRequest\x12!\n" +
 	"\fnamespace_id\x18\x01 \x01(\tR\vnamespaceId\x12G\n" +
 	"\texecution\x18\x02 \x01(\v2).temporal.api.common.v1.WorkflowExecutionR\texecution\x12?\n" +
 	"\x05clock\x18\x03 \x01(\v2).temporal.server.api.clock.v1.VectorClockR\x05clock\x12,\n" +
 	"\x12scheduled_event_id\x18\x04 \x01(\x03R\x10scheduledEventId\x12\x14\n" +
-	"\x05stamp\x18\x05 \x01(\x05R\x05stamp:\x1b\x92\xc4\x03\x17*\x15execution.workflow_id\"8\n" +
+	"\x05stamp\x18\x05 \x01(\x05R\x05stamp\x12#\n" +
+	"\rcomponent_ref\x18\x06 \x01(\fR\fcomponentRef:\x06\x92\xc4\x03\x02\b\x01\"8\n" +
 	"\x1bIsActivityTaskValidResponse\x12\x19\n" +
 	"\bis_valid\x18\x01 \x01(\bR\aisValid\"\xfb\x02\n" +
 	"\x1eSignalWorkflowExecutionRequest\x12!\n" +

--- a/api/historyservice/v1/service_grpc.pb.go
+++ b/api/historyservice/v1/service_grpc.pb.go
@@ -166,7 +166,7 @@ type HistoryServiceClient interface {
 	// PollActivityTaskQueue API call for completion. It fails with 'EntityNotExistsError' if the taskToken is not valid
 	// anymore due to activity timeout.
 	RespondActivityTaskCanceled(ctx context.Context, in *RespondActivityTaskCanceledRequest, opts ...grpc.CallOption) (*RespondActivityTaskCanceledResponse, error)
-	// IsActivityTaskValid is called by matching service checking whether the workflow task is valid.
+	// IsActivityTaskValid is called by matching service checking whether the activity task is valid.
 	IsActivityTaskValid(ctx context.Context, in *IsActivityTaskValidRequest, opts ...grpc.CallOption) (*IsActivityTaskValidResponse, error)
 	// SignalWorkflowExecution is used to send a signal event to running workflow execution.  This results in
 	// WorkflowExecutionSignaled event recorded in the history and a workflow task being created for the execution.
@@ -1184,7 +1184,7 @@ type HistoryServiceServer interface {
 	// PollActivityTaskQueue API call for completion. It fails with 'EntityNotExistsError' if the taskToken is not valid
 	// anymore due to activity timeout.
 	RespondActivityTaskCanceled(context.Context, *RespondActivityTaskCanceledRequest) (*RespondActivityTaskCanceledResponse, error)
-	// IsActivityTaskValid is called by matching service checking whether the workflow task is valid.
+	// IsActivityTaskValid is called by matching service checking whether the activity task is valid.
 	IsActivityTaskValid(context.Context, *IsActivityTaskValidRequest) (*IsActivityTaskValidResponse, error)
 	// SignalWorkflowExecution is used to send a signal event to running workflow execution.  This results in
 	// WorkflowExecutionSignaled event recorded in the history and a workflow task being created for the execution.

--- a/chasm/lib/activity/tasks.go
+++ b/chasm/lib/activity/tasks.go
@@ -49,8 +49,14 @@ func (h *activityDispatchTaskHandler) Validate(
 	_ chasm.TaskInvocation,
 	task *activitypb.ActivityDispatchTask,
 ) (bool, error) {
-	return (TransitionStarted.Possible(activity) &&
-		task.Stamp == activity.LastAttempt.Get(ctx).GetStamp()), nil
+	return activity.IsDispatchTaskValid(ctx, task.Stamp)
+}
+
+func (a *Activity) IsDispatchTaskValid(
+	ctx chasm.Context,
+	stamp int32,
+) (bool, error) {
+	return TransitionStarted.Possible(a) && stamp == a.LastAttempt.Get(ctx).GetStamp(), nil
 }
 
 func (h *activityDispatchTaskHandler) Execute(

--- a/chasm/lib/activity/tasks.go
+++ b/chasm/lib/activity/tasks.go
@@ -52,6 +52,8 @@ func (h *activityDispatchTaskHandler) Validate(
 	return activity.IsDispatchTaskValid(ctx, task.Stamp)
 }
 
+// IsDispatchTaskValid reports whether the attempt identified by stamp is still the activity's
+// current scheduled attempt.
 func (a *Activity) IsDispatchTaskValid(
 	ctx chasm.Context,
 	stamp int32,

--- a/chasm/lib/activity/tasks_test.go
+++ b/chasm/lib/activity/tasks_test.go
@@ -234,6 +234,71 @@ func TestActivityDispatchTaskHook(t *testing.T) {
 	})
 }
 
+func TestActivityIsDispatchTaskValid(t *testing.T) {
+	const currentStamp int32 = 42
+
+	testCases := []struct {
+		name   string
+		status activitypb.ActivityExecutionStatus
+		stamp  int32
+		valid  bool
+	}{
+		{
+			name:   "scheduled current attempt",
+			status: activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
+			stamp:  currentStamp,
+			valid:  true,
+		},
+		{
+			name:   "scheduled obsolete attempt",
+			status: activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
+			stamp:  currentStamp - 1,
+			valid:  false,
+		},
+		{
+			name:   "scheduled future attempt",
+			status: activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
+			stamp:  currentStamp + 1,
+			valid:  false,
+		},
+		{
+			name:   "started",
+			status: activitypb.ACTIVITY_EXECUTION_STATUS_STARTED,
+			stamp:  currentStamp,
+			valid:  false,
+		},
+		{
+			name:   "paused",
+			status: activitypb.ACTIVITY_EXECUTION_STATUS_PAUSED,
+			stamp:  currentStamp,
+			valid:  false,
+		},
+		{
+			name:   "completed",
+			status: activitypb.ACTIVITY_EXECUTION_STATUS_COMPLETED,
+			stamp:  currentStamp,
+			valid:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := &chasm.MockMutableContext{}
+			activity := &Activity{
+				ActivityState: &activitypb.ActivityState{Status: tc.status},
+				LastAttempt: chasm.NewDataField(ctx, &activitypb.ActivityAttemptState{
+					Stamp: currentStamp,
+				}),
+			}
+
+			valid, err := activity.IsDispatchTaskValid(ctx, tc.stamp)
+
+			require.NoError(t, err)
+			require.Equal(t, tc.valid, valid)
+		})
+	}
+}
+
 func TestScheduleToCloseTimeoutTaskValidateStamp(t *testing.T) {
 	handler := newScheduleToCloseTimeoutTaskHandler()
 

--- a/client/history/client.go
+++ b/client/history/client.go
@@ -254,6 +254,40 @@ func (c *clientImpl) RecordActivityTaskStarted(
 	return response, nil
 }
 
+func (c *clientImpl) IsActivityTaskValid(
+	ctx context.Context,
+	request *historyservice.IsActivityTaskValidRequest,
+	opts ...grpc.CallOption,
+) (*historyservice.IsActivityTaskValidResponse, error) {
+	var shardID int32
+	if len(request.GetComponentRef()) == 0 {
+		shardID = c.shardIDFromWorkflowID(request.GetNamespaceId(), request.GetExecution().GetWorkflowId())
+	} else {
+		componentRef, err := c.tokenSerializer.DeserializeChasmComponentRef(request.GetComponentRef())
+		if err != nil {
+			return nil, serviceerror.NewInvalidArgument("error deserializing component ref")
+		}
+		if componentRef.GetNamespaceId() == "" || componentRef.GetBusinessId() == "" {
+			return nil, serviceerror.NewInvalidArgument("component ref missing namespace ID or business ID")
+		}
+
+		shardID = c.shardIDFromWorkflowID(componentRef.GetNamespaceId(), componentRef.GetBusinessId())
+	}
+
+	var response *historyservice.IsActivityTaskValidResponse
+	op := func(ctx context.Context, client historyservice.HistoryServiceClient) error {
+		var err error
+		ctx, cancel := c.createContext(ctx)
+		defer cancel()
+		response, err = client.IsActivityTaskValid(ctx, request, opts...)
+		return err
+	}
+	if err := c.executeWithRedirect(ctx, shardID, op); err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
 func (c *clientImpl) StreamWorkflowReplicationMessages(
 	ctx context.Context,
 	opts ...grpc.CallOption,

--- a/client/history/client_gen.go
+++ b/client/history/client_gen.go
@@ -100,7 +100,7 @@ func (c *clientImpl) CompleteNexusOperationChasm(
 		return nil, serviceerror.NewInvalidArgument("error deserializing component ref")
 	}
 	shardID := c.shardIDFromWorkflowID(ref.GetNamespaceId(), ref.GetBusinessId())
-	
+
 	var response *historyservice.CompleteNexusOperationChasmResponse
 	op := func(ctx context.Context, client historyservice.HistoryServiceClient) error {
 		var err error
@@ -519,26 +519,6 @@ func (c *clientImpl) InvokeStateMachineMethod(
 	return response, nil
 }
 
-func (c *clientImpl) IsActivityTaskValid(
-	ctx context.Context,
-	request *historyservice.IsActivityTaskValidRequest,
-	opts ...grpc.CallOption,
-) (*historyservice.IsActivityTaskValidResponse, error) {
-	shardID := c.shardIDFromWorkflowID(request.GetNamespaceId(), request.GetExecution().GetWorkflowId())
-	var response *historyservice.IsActivityTaskValidResponse
-	op := func(ctx context.Context, client historyservice.HistoryServiceClient) error {
-		var err error
-		ctx, cancel := c.createContext(ctx)
-		defer cancel()
-		response, err = client.IsActivityTaskValid(ctx, request, opts...)
-		return err
-	}
-	if err := c.executeWithRedirect(ctx, shardID, op); err != nil {
-		return nil, err
-	}
-	return response, nil
-}
-
 func (c *clientImpl) IsWorkflowTaskValid(
 	ctx context.Context,
 	request *historyservice.IsWorkflowTaskValidRequest,
@@ -822,7 +802,7 @@ func (c *clientImpl) RecordActivityTaskHeartbeat(
 		businessID = taskToken.GetWorkflowId()
 	}
 	shardID := c.shardIDFromWorkflowID(namespaceID, businessID)
-	
+
 	var response *historyservice.RecordActivityTaskHeartbeatResponse
 	op := func(ctx context.Context, client historyservice.HistoryServiceClient) error {
 		var err error
@@ -1080,7 +1060,7 @@ func (c *clientImpl) RespondActivityTaskCanceled(
 		businessID = taskToken.GetWorkflowId()
 	}
 	shardID := c.shardIDFromWorkflowID(namespaceID, businessID)
-	
+
 	var response *historyservice.RespondActivityTaskCanceledResponse
 	op := func(ctx context.Context, client historyservice.HistoryServiceClient) error {
 		var err error
@@ -1118,7 +1098,7 @@ func (c *clientImpl) RespondActivityTaskCompleted(
 		businessID = taskToken.GetWorkflowId()
 	}
 	shardID := c.shardIDFromWorkflowID(namespaceID, businessID)
-	
+
 	var response *historyservice.RespondActivityTaskCompletedResponse
 	op := func(ctx context.Context, client historyservice.HistoryServiceClient) error {
 		var err error
@@ -1156,7 +1136,7 @@ func (c *clientImpl) RespondActivityTaskFailed(
 		businessID = taskToken.GetWorkflowId()
 	}
 	shardID := c.shardIDFromWorkflowID(namespaceID, businessID)
-	
+
 	var response *historyservice.RespondActivityTaskFailedResponse
 	op := func(ctx context.Context, client historyservice.HistoryServiceClient) error {
 		var err error
@@ -1194,7 +1174,7 @@ func (c *clientImpl) RespondWorkflowTaskCompleted(
 		businessID = taskToken.GetWorkflowId()
 	}
 	shardID := c.shardIDFromWorkflowID(namespaceID, businessID)
-	
+
 	var response *historyservice.RespondWorkflowTaskCompletedResponse
 	op := func(ctx context.Context, client historyservice.HistoryServiceClient) error {
 		var err error
@@ -1232,7 +1212,7 @@ func (c *clientImpl) RespondWorkflowTaskFailed(
 		businessID = taskToken.GetWorkflowId()
 	}
 	shardID := c.shardIDFromWorkflowID(namespaceID, businessID)
-	
+
 	var response *historyservice.RespondWorkflowTaskFailedResponse
 	op := func(ctx context.Context, client historyservice.HistoryServiceClient) error {
 		var err error

--- a/client/history/client_test.go
+++ b/client/history/client_test.go
@@ -7,8 +7,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/api/historyservice/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/client/history"
+	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/convert"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/membership"
@@ -153,6 +158,133 @@ func TestShardAgnosticConnectionStrategy(t *testing.T) {
 	}
 }
 
+func TestIsActivityTaskValidRouting(t *testing.T) {
+	const (
+		namespaceID    = "test-namespace-id"
+		businessID     = "test-activity-id"
+		workflowID     = "test-workflow-id"
+		numberOfShards = int32(128)
+	)
+	standaloneShardID := common.WorkflowIDToHistoryShard(namespaceID, businessID, numberOfShards)
+	workflowShardID := common.WorkflowIDToHistoryShard(namespaceID, workflowID, numberOfShards)
+	require.NotEqual(t, standaloneShardID, workflowShardID)
+
+	for _, tc := range []struct {
+		name       string
+		routingID  string
+		standalone bool
+	}{
+		{
+			name:       "standalone activity uses business ID",
+			routingID:  businessID,
+			standalone: true,
+		},
+		{
+			name:      "workflow activity uses workflow ID",
+			routingID: workflowID,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			expectedShardID := common.WorkflowIDToHistoryShard(namespaceID, tc.routingID, numberOfShards)
+
+			serviceResolver := membership.NewMockServiceResolver(ctrl)
+			serviceResolver.EXPECT().Lookup(convert.Int32ToString(expectedShardID)).Return(membership.NewHostInfoFromAddress("localhost"), nil)
+			serviceResolver.EXPECT().AddListener(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			serviceResolver.EXPECT().RemoveListener(gomock.Any()).Return(nil).AnyTimes()
+			serviceResolver.EXPECT().Members().Return(nil).AnyTimes()
+
+			listener := nettest.NewListener(nettest.NewPipe())
+			grpcServer := grpc.NewServer()
+			historyservice.RegisterHistoryServiceServer(grpcServer, &testHistoryService{})
+			errs := make(chan error)
+			go func() {
+				errs <- grpcServer.Serve(listener)
+			}()
+			defer func() {
+				grpcServer.Stop()
+				require.NoError(t, <-errs)
+			}()
+
+			request := &historyservice.IsActivityTaskValidRequest{NamespaceId: namespaceID}
+			if tc.standalone {
+				componentRef, err := (&persistencespb.ChasmComponentRef{
+					NamespaceId: namespaceID,
+					BusinessId:  businessID,
+				}).Marshal()
+				require.NoError(t, err)
+				request.ComponentRef = componentRef
+			} else {
+				request.Execution = &commonpb.WorkflowExecution{WorkflowId: workflowID}
+			}
+
+			client := history.NewClient(
+				dynamicconfig.NewNoopCollection(),
+				serviceResolver,
+				log.NewTestLogger(),
+				numberOfShards,
+				nettest.NewRPCFactory(listener),
+				time.Second,
+			)
+			response, err := client.IsActivityTaskValid(context.Background(), request)
+			require.NoError(t, err)
+			require.True(t, response.GetIsValid())
+		})
+	}
+}
+
+func TestIsActivityTaskValidInvalidComponentRef(t *testing.T) {
+	missingBusinessIDRef, err := (&persistencespb.ChasmComponentRef{NamespaceId: "test-namespace-id"}).Marshal()
+	require.NoError(t, err)
+	missingNamespaceIDRef, err := (&persistencespb.ChasmComponentRef{BusinessId: "test-activity-id"}).Marshal()
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name         string
+		componentRef []byte
+		errMessage   string
+	}{
+		{
+			name:         "malformed",
+			componentRef: []byte("not-a-component-ref"),
+			errMessage:   "error deserializing component ref",
+		},
+		{
+			name:         "missing business ID",
+			componentRef: missingBusinessIDRef,
+			errMessage:   "component ref missing namespace ID or business ID",
+		},
+		{
+			name:         "missing namespace ID",
+			componentRef: missingNamespaceIDRef,
+			errMessage:   "component ref missing namespace ID or business ID",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			serviceResolver := membership.NewMockServiceResolver(ctrl)
+			serviceResolver.EXPECT().AddListener(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			serviceResolver.EXPECT().RemoveListener(gomock.Any()).Return(nil).AnyTimes()
+			serviceResolver.EXPECT().Members().Return(nil).AnyTimes()
+
+			client := history.NewClient(
+				dynamicconfig.NewNoopCollection(),
+				serviceResolver,
+				log.NewTestLogger(),
+				1,
+				nil,
+				time.Second,
+			)
+			_, err := client.IsActivityTaskValid(context.Background(), &historyservice.IsActivityTaskValidRequest{
+				ComponentRef: tc.componentRef,
+			})
+
+			require.ErrorAs(t, err, new(*serviceerror.InvalidArgument))
+			require.ErrorContains(t, err, tc.errMessage)
+		})
+	}
+}
+
 func (s *testHistoryService) GetDLQTasks(
 	context.Context,
 	*historyservice.GetDLQTasksRequest,
@@ -165,6 +297,13 @@ func (s *testHistoryService) DeleteDLQTasks(
 	*historyservice.DeleteDLQTasksRequest,
 ) (*historyservice.DeleteDLQTasksResponse, error) {
 	return &historyservice.DeleteDLQTasksResponse{}, nil
+}
+
+func (s *testHistoryService) IsActivityTaskValid(
+	context.Context,
+	*historyservice.IsActivityTaskValidRequest,
+) (*historyservice.IsActivityTaskValidResponse, error) {
+	return &historyservice.IsActivityTaskValidResponse{IsValid: true}, nil
 }
 
 func (t *testRPCFactory) CreateHistoryGRPCConnection(rpcAddress string) *grpc.ClientConn {

--- a/cmd/tools/genrpcwrappers/main.go
+++ b/cmd/tools/genrpcwrappers/main.go
@@ -297,8 +297,10 @@ func makeGetHistoryClient(reqType reflect.Type, routingOptions *historyservice.R
 		namespaceID = %s
 		businessID = taskToken.GetWorkflowId()
 	}
-	shardID := c.shardIDFromWorkflowID(namespaceID, businessID)
-	`, toGetter(routingOptions.TaskToken), toGetter(namespaceIdField))
+	shardID := c.shardIDFromWorkflowID(namespaceID, businessID)`,
+			toGetter(routingOptions.TaskToken),
+			toGetter(namespaceIdField),
+		) + "\n"
 	}
 	if routingOptions.ChasmComponentRef != "" {
 		verifyFieldExists(t, routingOptions.ChasmComponentRef)
@@ -306,8 +308,9 @@ func makeGetHistoryClient(reqType reflect.Type, routingOptions *historyservice.R
 	if err != nil {
 		return nil, serviceerror.NewInvalidArgument("error deserializing component ref")
 	}
-	shardID := c.shardIDFromWorkflowID(ref.GetNamespaceId(), ref.GetBusinessId())
-	`, toGetter(routingOptions.ChasmComponentRef))
+	shardID := c.shardIDFromWorkflowID(ref.GetNamespaceId(), ref.GetBusinessId())`,
+			toGetter(routingOptions.ChasmComponentRef),
+		) + "\n"
 	}
 	if routingOptions.TaskInfos != "" {
 		verifyFieldExists(t, routingOptions.TaskInfos)

--- a/proto/internal/temporal/server/api/historyservice/v1/request_response.proto
+++ b/proto/internal/temporal/server/api/historyservice/v1/request_response.proto
@@ -477,7 +477,7 @@ message RespondActivityTaskCanceledRequest {
 message RespondActivityTaskCanceledResponse {}
 
 message IsActivityTaskValidRequest {
-  option (routing).workflow_id = "execution.workflow_id";
+  option (routing).custom = true;
 
   string namespace_id = 1;
   temporal.api.common.v1.WorkflowExecution execution = 2;
@@ -485,6 +485,9 @@ message IsActivityTaskValidRequest {
   int64 scheduled_event_id = 4;
   // Stamp represents the internal “version” of the activity options and can/will be changed with Activity API.
   int32 stamp = 5;
+  // Reference to the Chasm component for standalone activity execution. When present, execution, clock, and
+  // scheduled_event_id are not used.
+  bytes component_ref = 6;
 }
 
 message IsActivityTaskValidResponse {

--- a/proto/internal/temporal/server/api/historyservice/v1/service.proto
+++ b/proto/internal/temporal/server/api/historyservice/v1/service.proto
@@ -111,7 +111,7 @@ service HistoryService {
     option (temporal.server.api.common.v1.api_category).category = API_CATEGORY_STANDARD;
   }
 
-  // IsActivityTaskValid is called by matching service checking whether the workflow task is valid.
+  // IsActivityTaskValid is called by matching service checking whether the activity task is valid.
   rpc IsActivityTaskValid(IsActivityTaskValidRequest) returns (IsActivityTaskValidResponse) {
     option (temporal.server.api.common.v1.api_category).category = API_CATEGORY_STANDARD;
   }

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -245,6 +245,18 @@ func (h *Handler) IsActivityTaskValid(ctx context.Context, request *historyservi
 	if namespaceID == "" {
 		return nil, h.convertError(errNamespaceNotSet)
 	}
+	if componentRefBytes := request.GetComponentRef(); len(componentRefBytes) > 0 {
+		isValid, err := chasm.ReadComponent(
+			ctx,
+			componentRefBytes,
+			(*activity.Activity).IsDispatchTaskValid,
+			request.GetStamp(),
+		)
+		if err != nil {
+			return nil, h.convertError(err)
+		}
+		return &historyservice.IsActivityTaskValidResponse{IsValid: isValid}, nil
+	}
 	workflowID := request.Execution.WorkflowId
 
 	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)

--- a/service/history/handler_test.go
+++ b/service/history/handler_test.go
@@ -107,10 +107,12 @@ func TestIsActivityTaskValidStandaloneActivity(t *testing.T) {
 	engine.EXPECT().ReadComponent(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 		func(
 			_ context.Context,
-			_ chasm.ComponentRef,
+			componentRef chasm.ComponentRef,
 			readFn func(chasm.Context, chasm.Component) error,
 			_ ...chasm.TransitionOption,
 		) error {
+			require.Equal(t, namespaceID, componentRef.NamespaceID)
+			require.Equal(t, businessID, componentRef.BusinessID)
 			return readFn(activityCtx, standaloneActivity)
 		},
 	)

--- a/service/history/handler_test.go
+++ b/service/history/handler_test.go
@@ -16,6 +16,8 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	tokenspb "go.temporal.io/server/api/token/v1"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/lib/activity"
+	"go.temporal.io/server/chasm/lib/activity/gen/activitypb/v1"
 	chasmtests "go.temporal.io/server/chasm/lib/tests"
 	"go.temporal.io/server/common/contextutil"
 	"go.temporal.io/server/common/log"
@@ -81,6 +83,58 @@ func TestDescribeHistoryHost(t *testing.T) {
 		ShardId: 2,
 	})
 	assert.NoError(t, err)
+}
+
+func TestIsActivityTaskValidStandaloneActivity(t *testing.T) {
+	const (
+		namespaceID = "test-namespace-id"
+		businessID  = "test-activity-id"
+		stamp       = int32(42)
+	)
+
+	controller := gomock.NewController(t)
+	shardController := shard.NewMockController(controller)
+	engine := chasm.NewMockEngine(controller)
+	activityCtx := &chasm.MockMutableContext{}
+	standaloneActivity := &activity.Activity{
+		ActivityState: &activitypb.ActivityState{
+			Status: activitypb.ACTIVITY_EXECUTION_STATUS_SCHEDULED,
+		},
+		LastAttempt: chasm.NewDataField(activityCtx, &activitypb.ActivityAttemptState{
+			Stamp: stamp,
+		}),
+	}
+	engine.EXPECT().ReadComponent(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(
+			_ context.Context,
+			_ chasm.ComponentRef,
+			readFn func(chasm.Context, chasm.Component) error,
+			_ ...chasm.TransitionOption,
+		) error {
+			return readFn(activityCtx, standaloneActivity)
+		},
+	)
+
+	componentRef, err := (&persistencespb.ChasmComponentRef{
+		NamespaceId: namespaceID,
+		BusinessId:  businessID,
+		ArchetypeId: activity.ArchetypeID,
+	}).Marshal()
+	require.NoError(t, err)
+
+	handler := &Handler{controller: shardController}
+	response, err := handler.IsActivityTaskValid(
+		chasm.NewEngineContext(context.Background(), engine),
+		&historyservice.IsActivityTaskValidRequest{
+			NamespaceId:  namespaceID,
+			Execution:    &commonpb.WorkflowExecution{},
+			Stamp:        stamp,
+			ComponentRef: componentRef,
+		},
+	)
+
+	require.NoError(t, err)
+	require.True(t, response.GetIsValid())
 }
 
 // fakeNexusCompletionHandler is a CHASM component that records whether its completion

--- a/service/matching/task_validation.go
+++ b/service/matching/task_validation.go
@@ -91,7 +91,9 @@ func (v *taskValidatorImpl) preValidate(
 		// if cannot find the namespace entry, treat task as active
 		return v.preValidateActive(task)
 	}
-	// CONSIDER(fretz12): A RoutingKey-aware resolver must use component_ref.business_id for standalone activities.
+	// CONSIDER(fretz12): Standalone activities have no workflow ID, so this routing key is always
+	// empty and resolves to the namespace-level active cluster. Per-key routing needs
+	// component_ref.business_id here.
 	if v.clusterMetadata.GetCurrentClusterName() == namespaceEntry.ActiveClusterName(namespace.RoutingKey{ID: task.Data.WorkflowId}) {
 		return v.preValidateActive(task)
 	}

--- a/service/matching/task_validation.go
+++ b/service/matching/task_validation.go
@@ -91,6 +91,7 @@ func (v *taskValidatorImpl) preValidate(
 		// if cannot find the namespace entry, treat task as active
 		return v.preValidateActive(task)
 	}
+	// CONSIDER(fretz12): A RoutingKey-aware resolver must use component_ref.business_id for standalone activities.
 	if v.clusterMetadata.GetCurrentClusterName() == namespaceEntry.ActiveClusterName(namespace.RoutingKey{ID: task.Data.WorkflowId}) {
 		return v.preValidateActive(task)
 	}
@@ -176,6 +177,7 @@ func (v *taskValidatorImpl) isTaskValid(
 			Clock:            task.Data.Clock,
 			ScheduledEventId: task.Data.ScheduledEventId,
 			Stamp:            task.Data.GetStamp(),
+			ComponentRef:     task.Data.GetComponentRef(),
 		})
 		switch err.(type) {
 		case nil:

--- a/service/matching/task_validation.go
+++ b/service/matching/task_validation.go
@@ -91,9 +91,9 @@ func (v *taskValidatorImpl) preValidate(
 		// if cannot find the namespace entry, treat task as active
 		return v.preValidateActive(task)
 	}
-	// CONSIDER(fretz12): Standalone activities have no workflow ID, so this routing key is always
-	// empty and resolves to the namespace-level active cluster. Per-key routing needs
-	// component_ref.business_id here.
+	// CONSIDER(fretz12): Standalone activities have no workflow ID, so this uses the empty routing key.
+	// Before enabling a RoutingKey-aware resolver, use component_ref.business_id here; otherwise Matching
+	// can route a task as active on a non-owning cluster, executing it twice and repeating external side effects.
 	if v.clusterMetadata.GetCurrentClusterName() == namespaceEntry.ActiveClusterName(namespace.RoutingKey{ID: task.Data.WorkflowId}) {
 		return v.preValidateActive(task)
 	}

--- a/service/matching/task_validation_test.go
+++ b/service/matching/task_validation_test.go
@@ -203,6 +203,28 @@ func (s *taskValidatorSuite) TestIsTaskValid_ActivityTask_Valid() {
 	s.True(valid)
 }
 
+func (s *taskValidatorSuite) TestIsTaskValid_StandaloneActivityTask_Valid() {
+	const componentRef = "standalone-activity-component-ref"
+
+	s.task.Data.WorkflowId = ""
+	s.task.Data.RunId = ""
+	s.task.Data.ScheduledEventId = 0
+	s.task.Data.ComponentRef = []byte(componentRef)
+
+	s.historyClient.EXPECT().IsActivityTaskValid(gomock.Any(), &historyservice.IsActivityTaskValidRequest{
+		NamespaceId:  s.namespaceID,
+		Execution:    &commonpb.WorkflowExecution{},
+		Clock:        s.task.Data.Clock,
+		Stamp:        s.task.Data.GetStamp(),
+		ComponentRef: []byte(componentRef),
+	}).Return(&historyservice.IsActivityTaskValidResponse{IsValid: true}, nil)
+
+	valid, err := s.taskValidator.isTaskValid(s.task, enumspb.TASK_QUEUE_TYPE_ACTIVITY)
+
+	s.Require().NoError(err)
+	s.True(valid)
+}
+
 func (s *taskValidatorSuite) TestIsTaskValid_ActivityTask_NotFound() {
 	taskType := enumspb.TASK_QUEUE_TYPE_ACTIVITY
 


### PR DESCRIPTION
## What changed?
Added SAA support to IsActivityTaskValid by carrying the CHASM component reference from Matching to History, routing the History client by the component business ID, and validating the current SAA dispatch attempt through CHASM.

## Why?
Standalone activities do not have workflow execution fields. On standby clusters, Matching previously sent an empty workflow ID to IsActivityTaskValid, causing History routing/validation failures and preventing standby backlog from being validated correctly.

Using the component reference identifies the SAA execution and lets History determine whether that exact dispatch attempt is still scheduled and current.

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)

