### PR TITLE
Don't check partition counts if scaler is disabled

### DIFF
--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -144,6 +144,7 @@ type (
 		FairnessPassDither            dynamicconfig.BoolPropertyFnWithTaskQueueFilter
 		PartitionScaleAllowedDrift    dynamicconfig.TypedPropertyFnWithTaskQueueFilter[dynamicconfig.PartitionScaleAllowedDrift]
 		PartitionScaleManagerSettings dynamicconfig.TypedPropertyFnWithTaskQueueFilter[dynamicconfig.PartitionScaleManagerSettings]
+		PartitionScalerSettings       dynamicconfig.TypedPropertyFnWithTaskQueueFilter[dynamicconfig.SimplePartitionScalerSettings]
 
 		LogAllReqErrors dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	}
@@ -239,6 +240,7 @@ type (
 		FairnessPassDither            func() bool
 		PartitionScaleAllowedDrift    func() dynamicconfig.PartitionScaleAllowedDrift
 		PartitionScaleManagerSettings func() dynamicconfig.PartitionScaleManagerSettings
+		PartitionScalerSettings       func() dynamicconfig.SimplePartitionScalerSettings
 
 		loadCause loadCause
 	}
@@ -393,6 +395,7 @@ func NewConfig(
 		FairnessPassDither:            dynamicconfig.MatchingFairnessPassDither.Get(dc),
 		PartitionScaleAllowedDrift:    dynamicconfig.MatchingPartitionScaleAllowedDrift.Get(dc),
 		PartitionScaleManagerSettings: dynamicconfig.MatchingPartitionScaleManager.Get(dc),
+		PartitionScalerSettings:       dynamicconfig.MatchingPartitionScaler.Get(dc),
 
 		LogAllReqErrors: dynamicconfig.LogAllReqErrors.Get(dc),
 
@@ -581,6 +584,9 @@ func newTaskQueueConfig(tq *tqid.TaskQueue, config *Config, ns namespace.Name) *
 		},
 		PartitionScaleManagerSettings: func() dynamicconfig.PartitionScaleManagerSettings {
 			return config.PartitionScaleManagerSettings(ns.String(), taskQueueName, taskType)
+		},
+		PartitionScalerSettings: func() dynamicconfig.SimplePartitionScalerSettings {
+			return config.PartitionScalerSettings(ns.String(), taskQueueName, taskType)
 		},
 		MaxVersionsInTaskQueue: func() int { return config.MaxVersionsInTaskQueue(ns.String()) },
 	}

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -356,14 +356,19 @@ func (pm *taskQueuePartitionManagerImpl) StartScaleManager(scaleState *persisten
 }
 
 func (pm *taskQueuePartitionManagerImpl) checkPartitionCounts(ctx context.Context, forWrite bool) error {
-	if !pm.config.PartitionScalerSettings().Enabled {
-		return nil
-	}
-
 	normal, ok := pm.partition.(*tqid.NormalPartition)
 	if !ok {
 		return nil // only normal partitions do dynamic scaling
 	}
+
+	// The scaler may have been disabled after it wrote scale state. That state is
+	// republished to ephemeral data on every task queue load, so it would keep
+	// rejecting RPCs with no scaler left to correct it.
+	// TODO: clear the published scale info in scaleManager instead.
+	if !pm.config.PartitionScalerSettings().Enabled {
+		return nil
+	}
+
 	id := normal.PartitionId()
 
 	// userDataManager must be initialized here already so we can just ask it for scale info

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -356,6 +356,10 @@ func (pm *taskQueuePartitionManagerImpl) StartScaleManager(scaleState *persisten
 }
 
 func (pm *taskQueuePartitionManagerImpl) checkPartitionCounts(ctx context.Context, forWrite bool) error {
+	if !pm.config.PartitionScalerSettings().Enabled {
+		return nil
+	}
+
 	normal, ok := pm.partition.(*tqid.NormalPartition)
 	if !ok {
 		return nil // only normal partitions do dynamic scaling

--- a/service/matching/validate_partition_counts_test.go
+++ b/service/matching/validate_partition_counts_test.go
@@ -31,7 +31,7 @@ func TestCheckPartitionCountsScalerEnablement(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			partition := tqid.UnsafeTaskQueueFamily(namespaceID, taskQueueName).
 				TaskQueue(enumspb.TASK_QUEUE_TYPE_WORKFLOW).
-				NormalPartition(8)
+				NormalPartition(10)
 			pm := &taskQueuePartitionManagerImpl{
 				partition: partition,
 				userDataManager: &mockUserDataManager{

--- a/service/matching/validate_partition_counts_test.go
+++ b/service/matching/validate_partition_counts_test.go
@@ -1,15 +1,58 @@
 package matching
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	taskqueuespb "go.temporal.io/server/api/taskqueue/v1"
 	"go.temporal.io/server/client/matching"
 	"go.temporal.io/server/common/dynamicconfig"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
+	"go.temporal.io/server/common/tqid"
 )
+
+func TestCheckPartitionCountsScalerEnablement(t *testing.T) {
+	t.Parallel()
+
+	var stale *serviceerrors.StalePartitionCounts
+	tests := []struct {
+		name     string
+		enabled  bool
+		expected any
+	}{
+		{name: "disabled", enabled: false, expected: nil},
+		{name: "enabled", enabled: true, expected: &stale},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			partition := tqid.UnsafeTaskQueueFamily(namespaceID, taskQueueName).
+				TaskQueue(enumspb.TASK_QUEUE_TYPE_WORKFLOW).
+				NormalPartition(8)
+			pm := &taskQueuePartitionManagerImpl{
+				partition: partition,
+				userDataManager: &mockUserDataManager{
+					scaleInfo: &taskqueuespb.PartitionScaleInfo{Read: 8, Write: 4},
+				},
+				config: &taskQueueConfig{
+					PartitionScalerSettings: func() dynamicconfig.SimplePartitionScalerSettings {
+						return dynamicconfig.SimplePartitionScalerSettings{Enabled: tc.enabled}
+					},
+				},
+			}
+
+			err := pm.checkPartitionCounts(context.Background(), true)
+			if tc.expected == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorAs(t, err, tc.expected)
+			}
+		})
+	}
+}
 
 func TestValidatePartitionCounts(t *testing.T) {
 	t.Parallel()

--- a/service/matching/validate_partition_counts_test.go
+++ b/service/matching/validate_partition_counts_test.go
@@ -19,12 +19,11 @@ func TestCheckPartitionCountsScalerEnablement(t *testing.T) {
 
 	var stale *serviceerrors.StalePartitionCounts
 	tests := []struct {
-		name     string
-		enabled  bool
-		expected any
+		name    string
+		enabled bool
 	}{
-		{name: "disabled", enabled: false, expected: nil},
-		{name: "enabled", enabled: true, expected: &stale},
+		{name: "disabled", enabled: false},
+		{name: "enabled", enabled: true},
 	}
 
 	for _, tc := range tests {
@@ -45,10 +44,10 @@ func TestCheckPartitionCountsScalerEnablement(t *testing.T) {
 			}
 
 			err := pm.checkPartitionCounts(context.Background(), true)
-			if tc.expected == nil {
-				require.NoError(t, err)
+			if tc.enabled {
+				require.ErrorAs(t, err, &stale)
 			} else {
-				require.ErrorAs(t, err, tc.expected)
+				require.NoError(t, err)
 			}
 		})
 	}


### PR DESCRIPTION
## What changed?
Don't check partition counts if scaler is disabled.

## Why?
Mitigation for issue where scaler ran and then was disabled, leaving stale scaleInfo that rejects calls.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes RPC acceptance on task queue partitions when scaling is disabled; low blast radius but affects matching load-balancing and error paths for stale scale metadata.
> 
> **Overview**
> Fixes a case where **partition count checks** kept rejecting add/poll RPCs after the **partition scaler was turned off**, because stale `PartitionScaleInfo` was still published on each task queue load.
> 
> **`checkPartitionCounts`** now returns immediately when `PartitionScalerSettings().Enabled` is false, so validation only runs while dynamic scaling is active. Matching config is extended to expose **`PartitionScalerSettings`** from `MatchingPartitionScaler` at the global and per–task-queue levels.
> 
> A unit test covers enabled vs disabled scaler behavior with mock scale info that would otherwise trigger `StalePartitionCounts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e714ec9c899b4375b7131da9aab0bd26830cb512. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->