### PR TITLE
Merge support for `NexusHandler`-variant callbacks

### DIFF
--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -326,19 +326,9 @@ func (a *Activity) addCompletionCallbacks(
 	registrationTime := timestamppb.New(ctx.Now(a))
 
 	for idx, cb := range completionCallbacks {
-		chasmCB := &callbackspb.Callback{
-			Links: cb.GetLinks(),
-		}
-		switch variant := cb.Variant.(type) {
-		case *commonpb.Callback_Nexus_:
-			chasmCB.Variant = &callbackspb.Callback_Nexus_{
-				Nexus: &callbackspb.Callback_Nexus{
-					Url:    variant.Nexus.GetUrl(),
-					Header: variant.Nexus.GetHeader(),
-				},
-			}
-		default:
-			return serviceerror.NewInvalidArgumentf("unsupported callback variant: %T", variant)
+		chasmCB, err := callback.FromAPICallback(cb)
+		if err != nil {
+			return err
 		}
 
 		// requestID (unique per API call) + idx (position within the request) ensures unique,idempotent callback IDs.

--- a/chasm/lib/activity/activity.go
+++ b/chasm/lib/activity/activity.go
@@ -17,7 +17,6 @@ import (
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/activity/gen/activitypb/v1"
 	"go.temporal.io/server/chasm/lib/callback"
-	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/contextutil"
 	"go.temporal.io/server/common/metrics"
@@ -331,9 +330,9 @@ func (a *Activity) addCompletionCallbacks(
 			return err
 		}
 
-		// requestID (unique per API call) + idx (position within the request) ensures unique,idempotent callback IDs.
+		// requestID (unique per API call) + idx (position within the request) ensures unique, idempotent callback IDs.
 		id := fmt.Sprintf("%s-%d", requestID, idx)
-		callbackObj := callback.NewCallback(requestID, registrationTime, &callbackspb.CallbackState{}, chasmCB)
+		callbackObj := callback.NewCallback(requestID, registrationTime, chasmCB)
 		a.Callbacks[id] = chasm.NewComponentField(ctx, callbackObj)
 	}
 	return nil

--- a/chasm/lib/activity/config.go
+++ b/chasm/lib/activity/config.go
@@ -3,6 +3,7 @@ package activity
 import (
 	"go.temporal.io/server/chasm/lib/callback"
 	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/callbacks"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/retrypolicy"
 )
@@ -40,6 +41,14 @@ var (
 		`Allows attaching completion callbacks to standalone activity executions.`,
 	)
 
+	EnabledCallbackKinds = dynamicconfig.NewNamespaceTypedSettingWithConverter(
+		"activity.enabledCallbackKinds",
+		callbacks.ConvertEnabledKinds,
+		[]callbacks.Kind{callbacks.KindNexus},
+		`The list of completion callback kinds that may be attached to a standalone activity execution.
+Only consulted when activity.enableCallbacks is set.`,
+	)
+
 	EnableStandaloneActivityOperatorCommands = dynamicconfig.NewNamespaceBoolSetting(
 		"history.enableStandaloneActivityOperatorCommands",
 		false,
@@ -52,6 +61,7 @@ type Config struct {
 	BlobSizeLimitWarn                         dynamicconfig.IntPropertyFnWithNamespaceFilter
 	BreakdownMetricsByTaskQueue               dynamicconfig.TypedPropertyFnWithTaskQueueFilter[bool]
 	EnableCallbacks                           dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	EnabledCallbackKinds                      dynamicconfig.TypedPropertyFnWithNamespaceFilter[[]callbacks.Kind]
 	Enabled                                   dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	EnableStandaloneActivityOperatorCommands  dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	LongPollBuffer                            dynamicconfig.DurationPropertyFnWithNamespaceFilter
@@ -73,6 +83,7 @@ func ConfigProvider(dc *dynamicconfig.Collection) *Config {
 		BreakdownMetricsByTaskQueue:               dynamicconfig.MetricsBreakdownByTaskQueue.Get(dc),
 		DefaultActivityRetryPolicy:                dynamicconfig.DefaultActivityRetryPolicy.Get(dc),
 		EnableCallbacks:                           EnableCallbacks.Get(dc),
+		EnabledCallbackKinds:                      EnabledCallbackKinds.Get(dc),
 		Enabled:                                   Enabled.Get(dc),
 		EnableStandaloneActivityOperatorCommands:  EnableStandaloneActivityOperatorCommands.Get(dc),
 		LongPollBuffer:                            LongPollBuffer.Get(dc),

--- a/chasm/lib/activity/frontend.go
+++ b/chasm/lib/activity/frontend.go
@@ -418,7 +418,10 @@ func (h *frontendHandler) validateAndPopulateStartRequest(
 		if !h.config.EnableCallbacks(req.GetNamespace()) {
 			return nil, serviceerror.NewInvalidArgument("completion callbacks are not enabled for this namespace")
 		}
-		if err := h.callbackValidator.Validate(ctx, req.GetNamespace(), cbs); err != nil {
+		opts := callbacks.ValidatorOptions{
+			EnabledKinds: h.config.EnabledCallbackKinds(req.GetNamespace()),
+		}
+		if err := h.callbackValidator.Validate(ctx, req.GetNamespace(), cbs, opts); err != nil {
 			return nil, err
 		}
 	}

--- a/chasm/lib/activity/responses.go
+++ b/chasm/lib/activity/responses.go
@@ -4,15 +4,12 @@ import (
 	"fmt"
 
 	apiactivitypb "go.temporal.io/api/activity/v1" //nolint:importas
-	callbackpb "go.temporal.io/api/callback/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
-	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/activity/gen/activitypb/v1"
-	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -205,42 +202,16 @@ func (a *Activity) buildCallbackInfos(ctx chasm.Context) ([]*apiactivitypb.Callb
 	for _, field := range a.Callbacks {
 		cb := field.Get(ctx)
 
-		cbSpec, err := cb.ToAPICallback()
+		cbInfo, err := cb.ToAPICallbackInfo(ctx)
 		if err != nil {
 			return nil, err
-		}
-
-		var state enumspb.CallbackState
-		switch cb.Status {
-		case callbackspb.CALLBACK_STATUS_UNSPECIFIED:
-			return nil, serviceerror.NewInternal("callback with UNSPECIFIED state")
-		case callbackspb.CALLBACK_STATUS_STANDBY:
-			state = enumspb.CALLBACK_STATE_STANDBY
-		case callbackspb.CALLBACK_STATUS_SCHEDULED:
-			state = enumspb.CALLBACK_STATE_SCHEDULED
-		case callbackspb.CALLBACK_STATUS_BACKING_OFF:
-			state = enumspb.CALLBACK_STATE_BACKING_OFF
-		case callbackspb.CALLBACK_STATUS_FAILED:
-			state = enumspb.CALLBACK_STATE_FAILED
-		case callbackspb.CALLBACK_STATUS_SUCCEEDED:
-			state = enumspb.CALLBACK_STATE_SUCCEEDED
-		default:
-			return nil, serviceerror.NewInternalf("unknown callback state: %v", cb.Status)
 		}
 
 		cbInfos = append(cbInfos, &apiactivitypb.CallbackInfo{
 			Trigger: &apiactivitypb.CallbackInfo_Trigger{
 				Variant: &apiactivitypb.CallbackInfo_Trigger_ActivityClosed{},
 			},
-			Info: &callbackpb.CallbackInfo{
-				Callback:                cbSpec,
-				RegistrationTime:        cb.RegistrationTime,
-				State:                   state,
-				Attempt:                 cb.Attempt,
-				LastAttemptCompleteTime: cb.LastAttemptCompleteTime,
-				LastAttemptFailure:      cb.LastAttemptFailure,
-				NextAttemptScheduleTime: cb.NextAttemptScheduleTime,
-			},
+			Info: cbInfo,
 		})
 	}
 	return cbInfos, nil

--- a/chasm/lib/activity/validator_test.go
+++ b/chasm/lib/activity/validator_test.go
@@ -2,7 +2,6 @@ package activity
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 	"time"
 
@@ -22,6 +21,7 @@ import (
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/retrypolicy"
+	test "go.temporal.io/server/common/testing"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
@@ -534,18 +534,7 @@ func TestRequestIDGeneratedWhenMissing(t *testing.T) {
 // the request's own links and those embedded in its completion callbacks reach the link
 // validator. Link shape and limit semantics are covered in common/links.
 func TestValidateAndPopulateStartRequest_CombinesRequestAndCallbackLinks(t *testing.T) {
-	callbackValidator, err := callbacks.NewValidator(callbacks.ValidatorConfig{
-		MaxCallbacksPerExecution: func(string) int { return 2000 },
-		URLMaxLength:             func(string) int { return 1000 },
-		HeaderMaxSize:            func(string) int { return 2000 },
-		EndpointRules: func(string) callbacks.AddressMatchRules {
-			return callbacks.AddressMatchRules{
-				Rules: []callbacks.AddressMatchRule{
-					{Regexp: regexp.MustCompile(`.*`), AllowInsecure: true},
-				},
-			}
-		},
-	})
+	callbackValidator, err := callbacks.NewValidator(test.NewCallbacksValidatorConfig())
 	require.NoError(t, err)
 
 	h := &frontendHandler{
@@ -554,6 +543,9 @@ func TestValidateAndPopulateStartRequest_CombinesRequestAndCallbackLinks(t *test
 			BlobSizeLimitWarn:          defaultBlobSizeLimitWarn,
 			DefaultActivityRetryPolicy: getDefaultRetrySettings,
 			EnableCallbacks:            func(string) bool { return true },
+			EnabledCallbackKinds: func(string) []callbacks.Kind {
+				return []callbacks.Kind{callbacks.KindNexus}
+			},
 			MaxIDLengthLimit:           func() int { return defaultMaxIDLengthLimit },
 			MaxUserMetadataDetailsSize: defaultMaxUserMetadataDetailsSize,
 			MaxUserMetadataSummarySize: defaultMaxUserMetadataSummarySize,
@@ -580,8 +572,10 @@ func TestValidateAndPopulateStartRequest_CombinesRequestAndCallbackLinks(t *test
 			},
 		}},
 		CompletionCallbacks: []*commonpb.Callback{{
-			Variant: &commonpb.Callback_Internal_{
-				Internal: &commonpb.Callback_Internal{},
+			Variant: &commonpb.Callback_Nexus_{
+				Nexus: &commonpb.Callback_Nexus{
+					Url: "http://localhost/cb",
+				},
 			},
 			Links: []*commonpb.Link{{
 				Variant: &commonpb.Link_BatchJob_{

--- a/chasm/lib/callback/component.go
+++ b/chasm/lib/callback/component.go
@@ -80,9 +80,11 @@ func (c *Callback) loadInvocationArgs(
 	ctx chasm.Context,
 	_ chasm.NoValue,
 ) (invocable, error) {
-	// Only Nexus-variant callbacks are supported for now.
-	callback := c.GetCallback().GetNexus()
-	if callback == nil {
+	// Reject unknown/unsupported callback variants.
+	switch c.GetCallback().GetVariant().(type) {
+	case *callbackspb.Callback_Nexus_, *callbackspb.Callback_NexusHandler_:
+		// OK
+	default:
 		return nil, queueserrors.NewUnprocessableTaskError(
 			fmt.Sprintf("unprocessable callback variant: %T", c.GetCallback().GetVariant()),
 		)
@@ -95,6 +97,21 @@ func (c *Callback) loadInvocationArgs(
 		return nil, err
 	}
 
+	// NexusHandler callbacks, deliver the result by invoking a Nexus handler.
+	if nexusHandler := c.GetCallback().GetNexusHandler(); nexusHandler != nil {
+		return invocableNexusHandler{
+			callback:            nexusHandler,
+			completion:          completion,
+			completionSourceTag: c.CompletionSource.Fqn(),
+			businessID:          ctx.ExecutionKey().BusinessID,
+			runID:               ctx.ExecutionKey().RunID,
+			requestID:           c.RequestId,
+			attempt:             c.Attempt,
+		}, nil
+	}
+
+	// Nexus callbacks deliver results by also invoking a Nexus handler, but using HTTP.
+	callback := c.GetCallback().GetNexus()
 	if callback.GetUrl() == chasm.NexusCompletionHandlerURL {
 		return invocableInternal{
 			callback:   callback,
@@ -107,7 +124,7 @@ func (c *Callback) loadInvocationArgs(
 		callback:            callback,
 		completion:          completion,
 		completionSourceTag: c.CompletionSource.Fqn(),
-		workflowID:          ctx.ExecutionKey().BusinessID,
+		businessID:          ctx.ExecutionKey().BusinessID,
 		runID:               ctx.ExecutionKey().RunID,
 		attempt:             c.Attempt,
 	}, nil
@@ -262,9 +279,6 @@ func FromAPICallback(cb *commonpb.Callback) (*callbackspb.Callback, error) {
 		}
 		return res, nil
 	case *commonpb.Callback_NexusHandler_:
-		// Conversion is implemented ahead of the rest of the feature, but is currently
-		// unreachable. If somehow this gets persisted, executing the callback will
-		// fail with an UnprocessableTaskError and retried until it is DLQ'd.
 		res.Variant = &callbackspb.Callback_NexusHandler_{
 			NexusHandler: &callbackspb.Callback_NexusHandler{
 				TaskQueueName: variant.NexusHandler.GetTaskQueueName(),

--- a/chasm/lib/callback/component.go
+++ b/chasm/lib/callback/component.go
@@ -5,7 +5,9 @@ import (
 	"maps"
 	"time"
 
+	callbackpb "go.temporal.io/api/callback/v1"
 	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/chasm"
 	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
@@ -37,7 +39,6 @@ type Callback struct {
 func NewCallback(
 	requestID string,
 	registrationTime *timestamppb.Timestamp,
-	state *callbackspb.CallbackState,
 	cb *callbackspb.Callback,
 ) *Callback {
 	return &Callback{
@@ -87,6 +88,7 @@ func (c *Callback) loadInvocationArgs(
 		)
 	}
 
+	// Get the parent CHASM object's Nexus result to be delivered.
 	target := c.CompletionSource.Get(ctx)
 	completion, err := target.GetNexusCompletion(ctx, c.RequestId)
 	if err != nil {
@@ -174,6 +176,74 @@ func (c *Callback) ToAPICallback() (*commonpb.Callback, error) {
 	default:
 		return nil, serviceerror.NewInternalf("unsupported CHASM callback type: %T", variant)
 	}
+}
+
+// APIState converts the CHASM callback status to the API CallbackState enum along with the relevant
+// circuit breaker's blocking status.
+func (c *Callback) APIState(ctx chasm.Context) (enumspb.CallbackState, string, error) {
+	state, err := c.apiStatus()
+	if err != nil {
+		return enumspb.CALLBACK_STATE_UNSPECIFIED, "", err
+	}
+
+	// The circuit breaker is only relevant for scheduled callbacks.
+	if state != enumspb.CALLBACK_STATE_SCHEDULED {
+		return state, "", nil
+	}
+
+	cbCtx := callbackContextFromChasm(ctx)
+	destination, err := callbackDestination(c.GetCallback())
+	if err != nil {
+		return enumspb.CALLBACK_STATE_UNSPECIFIED, "", err
+	}
+	if !cbCtx.destinationBlocked(ctx.ExecutionKey().NamespaceID, destination) {
+		return state, "", nil
+	}
+	return enumspb.CALLBACK_STATE_BLOCKED, "The circuit breaker is open.", nil
+}
+
+func (c *Callback) apiStatus() (enumspb.CallbackState, error) {
+	switch c.Status {
+	case callbackspb.CALLBACK_STATUS_STANDBY:
+		return enumspb.CALLBACK_STATE_STANDBY, nil
+	case callbackspb.CALLBACK_STATUS_SCHEDULED:
+		return enumspb.CALLBACK_STATE_SCHEDULED, nil
+	case callbackspb.CALLBACK_STATUS_BACKING_OFF:
+		return enumspb.CALLBACK_STATE_BACKING_OFF, nil
+	case callbackspb.CALLBACK_STATUS_FAILED:
+		return enumspb.CALLBACK_STATE_FAILED, nil
+	case callbackspb.CALLBACK_STATUS_SUCCEEDED:
+		return enumspb.CALLBACK_STATE_SUCCEEDED, nil
+	case callbackspb.CALLBACK_STATUS_UNSPECIFIED:
+		return enumspb.CALLBACK_STATE_UNSPECIFIED, serviceerror.NewInternal("callback with UNSPECIFIED state")
+	default:
+		return enumspb.CALLBACK_STATE_UNSPECIFIED, serviceerror.NewInternalf("unknown callback state: %v", c.Status)
+	}
+}
+
+// ToAPICallbackInfo returns the API CallbackInfo based on the current state of the CHASM component.
+func (c *Callback) ToAPICallbackInfo(ctx chasm.Context) (*callbackpb.CallbackInfo, error) {
+	apiCb, err := c.ToAPICallback()
+	if err != nil {
+		return nil, err
+	}
+	apiState, blockedReason, err := c.APIState(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	info := &callbackpb.CallbackInfo{
+		Callback:                apiCb,
+		RegistrationTime:        common.CloneProto(c.RegistrationTime),
+		State:                   apiState,
+		BlockedReason:           blockedReason,
+		RequestId:               c.RequestId,
+		Attempt:                 c.Attempt,
+		LastAttemptCompleteTime: common.CloneProto(c.LastAttemptCompleteTime),
+		LastAttemptFailure:      common.CloneProto(c.LastAttemptFailure),
+		NextAttemptScheduleTime: common.CloneProto(c.NextAttemptScheduleTime),
+	}
+	return info, nil
 }
 
 // FromAPICallback converts an API callback into a CHASM callback proto.

--- a/chasm/lib/callback/component.go
+++ b/chasm/lib/callback/component.go
@@ -3,13 +3,13 @@ package callback
 import (
 	"fmt"
 	"maps"
-	"slices"
 	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/chasm"
 	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/nexus/nexusrpc"
 	queueserrors "go.temporal.io/server/service/history/queues/errors"
@@ -79,21 +79,21 @@ func (c *Callback) loadInvocationArgs(
 	ctx chasm.Context,
 	_ chasm.NoValue,
 ) (invocable, error) {
-	target := c.CompletionSource.Get(ctx)
+	// Only Nexus-variant callbacks are supported for now.
+	callback := c.GetCallback().GetNexus()
+	if callback == nil {
+		return nil, queueserrors.NewUnprocessableTaskError(
+			fmt.Sprintf("unprocessable callback variant: %T", c.GetCallback().GetVariant()),
+		)
+	}
 
+	target := c.CompletionSource.Get(ctx)
 	completion, err := target.GetNexusCompletion(ctx, c.RequestId)
 	if err != nil {
 		return nil, err
 	}
 
-	callback := c.GetCallback().GetNexus()
-	if callback == nil {
-		return nil, queueserrors.NewUnprocessableTaskError(
-			fmt.Sprintf("unprocessable callback variant: %v", callback),
-		)
-	}
-
-	if callback.Url == chasm.NexusCompletionHandlerURL {
+	if callback.GetUrl() == chasm.NexusCompletionHandlerURL {
 		return invocableInternal{
 			callback:   callback,
 			attempt:    c.Attempt,
@@ -149,11 +149,11 @@ func (c *Callback) ToAPICallback() (*commonpb.Callback, error) {
 	// Convert CHASM callback proto to API callback proto
 	chasmCB := c.GetCallback()
 	res := &commonpb.Callback{
-		Links: slices.Clone(chasmCB.GetLinks()),
+		Links: common.CloneProtoSlice(chasmCB.GetLinks()),
 	}
 
-	// CHASM currently only supports Nexus callbacks
-	if variant, ok := chasmCB.Variant.(*callbackspb.Callback_Nexus_); ok {
+	switch variant := chasmCB.GetVariant().(type) {
+	case *callbackspb.Callback_Nexus_:
 		res.Variant = &commonpb.Callback_Nexus_{
 			Nexus: &commonpb.Callback_Nexus{
 				Url:    variant.Nexus.GetUrl(),
@@ -161,10 +161,52 @@ func (c *Callback) ToAPICallback() (*commonpb.Callback, error) {
 			},
 		}
 		return res, nil
+	case *callbackspb.Callback_NexusHandler_:
+		res.Variant = &commonpb.Callback_NexusHandler_{
+			NexusHandler: &commonpb.Callback_NexusHandler{
+				TaskQueueName: variant.NexusHandler.GetTaskQueueName(),
+				Service:       variant.NexusHandler.GetService(),
+				Operation:     variant.NexusHandler.GetOperation(),
+				SourceContext: common.CloneProto(variant.NexusHandler.GetSourceContext()),
+			},
+		}
+		return res, nil
+	default:
+		return nil, serviceerror.NewInternalf("unsupported CHASM callback type: %T", variant)
+	}
+}
+
+// FromAPICallback converts an API callback into a CHASM callback proto.
+func FromAPICallback(cb *commonpb.Callback) (*callbackspb.Callback, error) {
+	res := &callbackspb.Callback{
+		Links: common.CloneProtoSlice(cb.GetLinks()),
 	}
 
-	// This should not happen as CHASM only supports Nexus callbacks currently
-	return nil, serviceerror.NewInternal("unsupported CHASM callback type")
+	switch variant := cb.GetVariant().(type) {
+	case *commonpb.Callback_Nexus_:
+		res.Variant = &callbackspb.Callback_Nexus_{
+			Nexus: &callbackspb.Callback_Nexus{
+				Url:    variant.Nexus.GetUrl(),
+				Header: maps.Clone(variant.Nexus.GetHeader()),
+			},
+		}
+		return res, nil
+	case *commonpb.Callback_NexusHandler_:
+		// Conversion is implemented ahead of the rest of the feature, but is currently
+		// unreachable. If somehow this gets persisted, executing the callback will
+		// fail with an UnprocessableTaskError and retried until it is DLQ'd.
+		res.Variant = &callbackspb.Callback_NexusHandler_{
+			NexusHandler: &callbackspb.Callback_NexusHandler{
+				TaskQueueName: variant.NexusHandler.GetTaskQueueName(),
+				Service:       variant.NexusHandler.GetService(),
+				Operation:     variant.NexusHandler.GetOperation(),
+				SourceContext: common.CloneProto(variant.NexusHandler.GetSourceContext()),
+			},
+		}
+		return res, nil
+	default:
+		return nil, serviceerror.NewInvalidArgumentf("unsupported callback variant: %T", variant)
+	}
 }
 
 // ScheduleStandbyCallbacks transitions all STANDBY callbacks to SCHEDULED state,

--- a/chasm/lib/callback/component_test.go
+++ b/chasm/lib/callback/component_test.go
@@ -1,0 +1,154 @@
+package callback
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/chasm"
+	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
+	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/testing/protorequire"
+	queueserrors "go.temporal.io/server/service/history/queues/errors"
+)
+
+func TestFromAPICallback(t *testing.T) {
+	// Set of API Callback variants to test.
+	apiCallbackVariants := map[string]struct {
+		callback *commonpb.Callback
+		// Whether CHASM can persist this variant. Persistable variants must round trip.
+		persistable bool
+	}{
+		"nexus": {
+			callback: &commonpb.Callback{
+				Variant: &commonpb.Callback_Nexus_{
+					Nexus: &commonpb.Callback_Nexus{
+						Url:    "http://localhost:8080/cb",
+						Header: map[string]string{"key": "value"},
+					},
+				},
+			},
+			persistable: true,
+		},
+		"nexus handler": {
+			callback: &commonpb.Callback{
+				Variant: &commonpb.Callback_NexusHandler_{
+					NexusHandler: &commonpb.Callback_NexusHandler{
+						TaskQueueName: "completions-task-queue",
+						Service:       "HTTPAdapter",
+						Operation:     "DeliverAsWebhook",
+						SourceContext: &commonpb.Payload{Data: []byte("...")},
+					},
+				},
+			},
+			persistable: true,
+		},
+		"internal": {
+			callback: &commonpb.Callback{
+				Variant: &commonpb.Callback_Internal_{Internal: &commonpb.Callback_Internal{}},
+			},
+			// Not defined in the CHASM callback proto.
+			persistable: false,
+		},
+		"unset": {callback: &commonpb.Callback{}},
+	}
+
+	t.Run("RoundTripped", func(t *testing.T) {
+		for name, tc := range apiCallbackVariants {
+			t.Run(name, func(t *testing.T) {
+				got, err := FromAPICallback(tc.callback)
+
+				// Error case, for invalid or unknown API callbacks.
+				if !tc.persistable {
+					var invalidArgErr *serviceerror.InvalidArgument
+					require.ErrorAs(t, err, &invalidArgErr)
+					require.ErrorContains(t, err, "unsupported callback variant")
+					return
+				}
+				require.NoError(t, err)
+
+				// Verify round-tripping the proto produces the same result.
+				chasmComponent := &Callback{
+					CallbackState: &callbackspb.CallbackState{
+						Callback: got,
+					},
+				}
+				roundTripped, err := chasmComponent.ToAPICallback()
+				require.NoError(t, err)
+				protorequire.ProtoEqual(t, tc.callback, roundTripped)
+			})
+		}
+	})
+
+	t.Run("LinksPersistedForVariants", func(t *testing.T) {
+		links := []*commonpb.Link{
+			{
+				Variant: &commonpb.Link_WorkflowEvent_{
+					WorkflowEvent: &commonpb.Link_WorkflowEvent{Namespace: "ns", WorkflowId: "wf-id"},
+				},
+			},
+			{
+				Variant: &commonpb.Link_Callback_{
+					Callback: &commonpb.Link_Callback{
+						Execution: &commonpb.Execution{
+							Type:       enumspb.EXECUTION_TYPE_NEXUS_OPERATION,
+							BusinessId: "nexus-operation-id",
+							RunId:      "run-id",
+						},
+						RequestId: "request-id",
+					},
+				},
+			},
+		}
+
+		for name, tc := range apiCallbackVariants {
+			// This test only applies to callbacks that can be converted.
+			if !tc.persistable {
+				continue
+			}
+
+			t.Run(name, func(t *testing.T) {
+				cbWithLinks := common.CloneProto(tc.callback)
+				cbWithLinks.Links = links
+
+				got, err := FromAPICallback(cbWithLinks)
+				require.NoError(t, err)
+
+				// Verify links were converted in the process.
+				gotLinks := got.GetLinks()
+				require.Len(t, gotLinks, 2)
+				require.NotNil(t, gotLinks[0].GetWorkflowEvent())
+				require.NotNil(t, gotLinks[1].GetCallback())
+
+				// Verify that a deep copy was used. (Different references.)
+				require.NotSame(t, links[0], gotLinks[0])
+				require.NotSame(t, links[1], gotLinks[1])
+			})
+		}
+	})
+}
+
+// Asserts that CHASM Callbacks do not support the new NexusHandler callback variant.
+func TestNexusHandlerCallbacksNotSupported(t *testing.T) {
+	apiCb := &commonpb.Callback{
+		Variant: &commonpb.Callback_NexusHandler_{
+			NexusHandler: &commonpb.Callback_NexusHandler{},
+		},
+	}
+	chasmCB, err := FromAPICallback(apiCb)
+	require.NoError(t, err)
+
+	cb := &Callback{
+		CallbackState: &callbackspb.CallbackState{
+			Callback: chasmCB,
+		},
+	}
+	_, err = cb.loadInvocationArgs(&chasm.MockMutableContext{}, nil)
+
+	var unprocessableErr *queueserrors.UnprocessableTaskError
+	require.ErrorAs(t, err, &unprocessableErr)
+	require.ErrorContains(t, err, "unprocessable callback variant")
+	require.ErrorContains(t, err, "Callback_NexusHandler_")
+}

--- a/chasm/lib/callback/component_test.go
+++ b/chasm/lib/callback/component_test.go
@@ -2,16 +2,23 @@ package callback
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	callbackpb "go.temporal.io/api/callback/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/chasm"
 	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
 	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/definition"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/testing/protorequire"
 	queueserrors "go.temporal.io/server/service/history/queues/errors"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestFromAPICallback(t *testing.T) {
@@ -151,4 +158,270 @@ func TestNexusHandlerCallbacksNotSupported(t *testing.T) {
 	require.ErrorAs(t, err, &unprocessableErr)
 	require.ErrorContains(t, err, "unprocessable callback variant")
 	require.ErrorContains(t, err, "Callback_NexusHandler_")
+}
+
+const (
+	testNamespaceID = "test-namespace-id"
+	testCallbackURL = "http://callback.example.com:8080/path?query=string"
+	// testDestination is what the outbound queue keys the callback's rate limiter and circuit
+	// breaker by the scheme and host of the callback URL. See [callbackDestination].
+	testDestination = "http://callback.example.com:8080"
+)
+
+// blockedQuery is one question the component asked the injected DestinationBlockedFn.
+type blockedQuery struct {
+	namespaceID string
+	destination string
+}
+
+// destinationBlockedStub is a fake for the History Service's outbound queue's circuit breakers.
+// It keeps track of the blocked/unblocked state.
+type destinationBlockedStub struct {
+	blocked bool
+	queries []blockedQuery
+}
+
+func (s *destinationBlockedStub) fn(namespaceID string, destination string) bool {
+	s.queries = append(s.queries, blockedQuery{namespaceID: namespaceID, destination: destination})
+	return s.blocked
+}
+
+func newTestContext(t *testing.T, lib *Library) chasm.Context {
+	t.Helper()
+
+	logger := log.NewTestLogger()
+	registry := chasm.NewRegistry(logger)
+	require.NoError(t, registry.Register(lib))
+
+	backend := &chasm.MockNodeBackend{
+		HandleGetWorkflowKey: func() definition.WorkflowKey {
+			return definition.NewWorkflowKey(testNamespaceID, "business-id", "run-id")
+		},
+	}
+	node := chasm.NewEmptyTree(
+		registry,
+		clock.NewEventTimeSource(),
+		backend,
+		chasm.DefaultPathEncoder,
+		logger,
+		metrics.NoopMetricsHandler,
+	)
+	return chasm.NewContext(t.Context(), node)
+}
+
+// newTestLibrary builds the library the way fx does, sans task handlers.
+func newTestLibrary(destinationBlocked DestinationBlockedFn) *Library {
+	return newLibrary(libraryParams{DestinationBlocked: destinationBlocked})
+}
+
+func newTestCallback(status callbackspb.CallbackStatus, variant *callbackspb.Callback) *Callback {
+	return &Callback{
+		CallbackState: &callbackspb.CallbackState{
+			Status:   status,
+			Callback: variant,
+		},
+	}
+}
+
+func nexusVariant(url string) *callbackspb.Callback {
+	return &callbackspb.Callback{
+		Variant: &callbackspb.Callback_Nexus_{Nexus: &callbackspb.Callback_Nexus{Url: url}},
+	}
+}
+
+// Only a SCHEDULED callback can be held back by an open circuit breaker. Tt is the one state in
+// which a delivery is waiting on the outbound queue. Every other state reports as itself and must
+// not consult the breaker at all.
+func TestAPIStateCircuitBreaker(t *testing.T) {
+	cases := []struct {
+		name      string
+		status    callbackspb.CallbackStatus
+		wantState enumspb.CallbackState
+		// blockable is true for the states an open breaker can turn into BLOCKED.
+		blockable bool
+	}{
+		{
+			name:      "standby",
+			status:    callbackspb.CALLBACK_STATUS_STANDBY,
+			wantState: enumspb.CALLBACK_STATE_STANDBY,
+		},
+		{
+			name:      "scheduled",
+			status:    callbackspb.CALLBACK_STATUS_SCHEDULED,
+			wantState: enumspb.CALLBACK_STATE_SCHEDULED,
+			blockable: true,
+		},
+		{
+			name:      "backing off",
+			status:    callbackspb.CALLBACK_STATUS_BACKING_OFF,
+			wantState: enumspb.CALLBACK_STATE_BACKING_OFF,
+		},
+		{
+			name:      "succeeded",
+			status:    callbackspb.CALLBACK_STATUS_SUCCEEDED,
+			wantState: enumspb.CALLBACK_STATE_SUCCEEDED,
+		},
+		{
+			name:      "failed",
+			status:    callbackspb.CALLBACK_STATUS_FAILED,
+			wantState: enumspb.CALLBACK_STATE_FAILED,
+		},
+	}
+
+	for _, tc := range cases {
+		for _, blocked := range []bool{false, true} {
+			name := tc.name
+			if blocked {
+				name += " with an open breaker"
+			}
+
+			t.Run(name, func(t *testing.T) {
+				stub := &destinationBlockedStub{blocked: blocked}
+				ctx := newTestContext(t, newTestLibrary(stub.fn))
+				cb := newTestCallback(tc.status, nexusVariant(testCallbackURL))
+
+				state, blockedReason, err := cb.APIState(ctx)
+				require.NoError(t, err)
+
+				if blocked && tc.blockable {
+					require.Equal(t, enumspb.CALLBACK_STATE_BLOCKED, state)
+					require.Equal(t, "The circuit breaker is open.", blockedReason)
+				} else {
+					require.Equal(t, tc.wantState, state)
+					require.Empty(t, blockedReason)
+				}
+
+				if tc.blockable {
+					require.Equal(t,
+						[]blockedQuery{{namespaceID: testNamespaceID, destination: testDestination}},
+						stub.queries)
+				} else {
+					require.Empty(t, stub.queries, "the breaker is only relevant to a scheduled callback")
+				}
+			})
+		}
+	}
+}
+
+func TestAPIStateQueriesCallbackDestination(t *testing.T) {
+	cases := []struct {
+		name            string
+		variant         *callbackspb.Callback
+		wantDestination string
+	}{
+		{
+			name:            "nexus",
+			variant:         nexusVariant(testCallbackURL),
+			wantDestination: testDestination,
+		},
+		{
+			name: "nexus handler",
+			variant: &callbackspb.Callback{
+				Variant: &callbackspb.Callback_NexusHandler_{
+					NexusHandler: &callbackspb.Callback_NexusHandler{TaskQueueName: "completions-task-queue"},
+				},
+			},
+			wantDestination: "nexus-handler://completions-task-queue",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stub := &destinationBlockedStub{}
+			ctx := newTestContext(t, newTestLibrary(stub.fn))
+			cb := newTestCallback(callbackspb.CALLBACK_STATUS_SCHEDULED, tc.variant)
+
+			_, _, err := cb.APIState(ctx)
+
+			// Confirm that calling APIState results in looking up the
+			// circuit breaker status for the given destination.
+			wantQuery := blockedQuery{
+				namespaceID: testNamespaceID,
+				destination: tc.wantDestination,
+			}
+			require.NoError(t, err)
+			require.Equal(t,
+				[]blockedQuery{wantQuery},
+				stub.queries)
+		})
+	}
+
+	// Assert that a failure computing the callback's destination will be surfaced from APIState.
+	t.Run("InvalidDestination", func(t *testing.T) {
+		stub := &destinationBlockedStub{blocked: true}
+		ctx := newTestContext(t, newTestLibrary(stub.fn))
+		cb := newTestCallback(callbackspb.CALLBACK_STATUS_SCHEDULED, nexusVariant("http://invalid url/path"))
+
+		state, blockedReason, err := cb.APIState(ctx)
+		require.ErrorContains(t, err, "failed to parse URL:")
+		require.Equal(t, enumspb.CALLBACK_STATE_UNSPECIFIED, state)
+		require.Empty(t, blockedReason)
+		require.Empty(t, stub.queries)
+	})
+}
+
+// Only the history service runs the outbound queue, so elsewhere the library is built without a
+// DestinationBlockedFn. Those processes must still be able to describe a callback.
+func TestAPIStateWithoutInjectedDestinationBlocked(t *testing.T) {
+	for name, lib := range map[string]*Library{
+		"no fn provided": newTestLibrary(nil),
+		"nil library":    NewNilLibrary(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx := newTestContext(t, lib)
+			cb := newTestCallback(callbackspb.CALLBACK_STATUS_SCHEDULED, nexusVariant(testCallbackURL))
+
+			state, blockedReason, err := cb.APIState(ctx)
+			require.NoError(t, err)
+			require.Equal(t, enumspb.CALLBACK_STATE_SCHEDULED, state)
+			require.Empty(t, blockedReason)
+		})
+	}
+}
+
+// ToAPICallbackInfo surfaces the blocked state and its reason alongside the rest of the callback's
+// state, which is what Describe returns to a caller.
+func TestToAPICallbackInfoReportsBlocked(t *testing.T) {
+	registrationTime := timestamppb.New(time.Now())
+
+	for _, blocked := range []bool{false, true} {
+		name := "scheduled"
+		if blocked {
+			name = "blocked by an open breaker"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			stub := &destinationBlockedStub{blocked: blocked}
+			ctx := newTestContext(t, newTestLibrary(stub.fn))
+
+			cb := newTestCallback(callbackspb.CALLBACK_STATUS_SCHEDULED, nexusVariant(testCallbackURL))
+			cb.RequestId = "request-id"
+			cb.RegistrationTime = registrationTime
+			cb.Attempt = 7
+
+			info, err := cb.ToAPICallbackInfo(ctx)
+			require.NoError(t, err)
+
+			wantState := enumspb.CALLBACK_STATE_SCHEDULED
+			wantReason := ""
+			if blocked {
+				wantState = enumspb.CALLBACK_STATE_BLOCKED
+				wantReason = "The circuit breaker is open."
+			}
+			want := &callbackpb.CallbackInfo{
+				Callback: &commonpb.Callback{
+					Variant: &commonpb.Callback_Nexus_{
+						Nexus: &commonpb.Callback_Nexus{Url: testCallbackURL},
+					},
+				},
+				RegistrationTime: registrationTime,
+				State:            wantState,
+				BlockedReason:    wantReason,
+				RequestId:        "request-id",
+				Attempt:          7,
+			}
+
+			protorequire.ProtoEqual(t, want, info)
+		})
+	}
 }

--- a/chasm/lib/callback/component_test.go
+++ b/chasm/lib/callback/component_test.go
@@ -135,29 +135,53 @@ func TestFromAPICallback(t *testing.T) {
 			})
 		}
 	})
+
+	// Confirm a malformed CHASM Callback fails to be converted into the api proto.
+	t.Run("UnsupportedVariant", func(t *testing.T) {
+		cb := &Callback{CallbackState: &callbackspb.CallbackState{
+			Callback: &callbackspb.Callback{},
+		}}
+		_, err := cb.ToAPICallback()
+		var internalErr *serviceerror.Internal
+		require.ErrorAs(t, err, &internalErr)
+		require.ErrorContains(t, err, "unsupported CHASM callback type")
+	})
 }
 
-// Asserts that CHASM Callbacks do not support the new NexusHandler callback variant.
-func TestNexusHandlerCallbacksNotSupported(t *testing.T) {
-	apiCb := &commonpb.Callback{
-		Variant: &commonpb.Callback_NexusHandler_{
-			NexusHandler: &commonpb.Callback_NexusHandler{},
-		},
-	}
-	chasmCB, err := FromAPICallback(apiCb)
-	require.NoError(t, err)
-
+// A callback whose variant this server doesn't know how to invoke can still be persisted (by a server that
+// does, or by a future version), so its invocation task has to be rejected rather than crash.
+func TestLoadInvocationArgsUnsupportedVariant(t *testing.T) {
 	cb := &Callback{
 		CallbackState: &callbackspb.CallbackState{
-			Callback: chasmCB,
+			Callback: &callbackspb.Callback{},
 		},
 	}
-	_, err = cb.loadInvocationArgs(&chasm.MockMutableContext{}, nil)
+	_, err := cb.loadInvocationArgs(&chasm.MockMutableContext{}, nil)
 
 	var unprocessableErr *queueserrors.UnprocessableTaskError
 	require.ErrorAs(t, err, &unprocessableErr)
 	require.ErrorContains(t, err, "unprocessable callback variant")
-	require.ErrorContains(t, err, "Callback_NexusHandler_")
+}
+
+// Confirm the request ID passed to NewCallback is persisited, and set in ToAPICallbackInfo.
+func TestToAPICallbackInfoCarriesTheRequestID(t *testing.T) {
+	ctx := &chasm.MockContext{}
+
+	cb := NewCallback(
+		"callback-request-id",
+		timestamppb.New(time.Unix(1, 0)),
+		&callbackspb.Callback{Variant: &callbackspb.Callback_NexusHandler_{
+			NexusHandler: &callbackspb.Callback_NexusHandler{
+				TaskQueueName: "completions-task-queue",
+				Service:       "HTTPAdapter",
+				Operation:     "DeliverAsWebhook",
+			},
+		}},
+	)
+
+	info, err := cb.ToAPICallbackInfo(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "callback-request-id", info.GetRequestId())
 }
 
 const (

--- a/chasm/lib/callback/config.go
+++ b/chasm/lib/callback/config.go
@@ -14,6 +14,18 @@ var MaxPerExecution = dynamicconfig.NewNamespaceIntSetting(
 	`MaxPerExecution is the maximum number of callbacks that can be attached to an execution (workflow or standalone activity).`,
 )
 
+// TODO(chrsmith): This just caps the size of an individual source context payload.
+// We also need to wire through an aggregate max size, for all callbacks in an execution.
+// (We expect that users will want fewer NexusHandler callbacks with larger payloads than the
+// full 2k execution callbacks, with a much smaller per-callback payload size.)
+
+var NexusHandlerSourceContextMaxSize = dynamicconfig.NewNamespaceIntSetting(
+	"callback.nexusHandler.sourceContext.maxSize",
+	1024*1024,
+	`The maximum allowed size, in bytes, of the opaque source context attached to a single NexusHandler
+completion callback. The server carries this payload to the callback's handler untouched.`,
+)
+
 var RequestTimeout = dynamicconfig.NewDestinationDurationSetting(
 	"callback.request.timeout",
 	time.Second*10,

--- a/chasm/lib/callback/gen/callbackpb/v1/message.pb.go
+++ b/chasm/lib/callback/gen/callbackpb/v1/message.pb.go
@@ -126,6 +126,10 @@ type CallbackState struct {
 	// https://github.com/temporalio/temporal/pull/8473#discussion_r2427348436
 	NextAttemptScheduleTime *timestamppb.Timestamp `protobuf:"bytes,8,opt,name=next_attempt_schedule_time,json=nextAttemptScheduleTime,proto3" json:"next_attempt_schedule_time,omitempty"`
 	// Request ID that added the callback.
+	//
+	// TODO(temporal/issues/11958): This field is overloaded. It is used for _both_, the outgoing
+	// request ID (to serve as an idempotency key). As well as the source request ID, to identify
+	// when the callback was added (for buffered workflow event scenarios).
 	RequestId     string `protobuf:"bytes,9,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -222,6 +226,7 @@ type Callback struct {
 	// Types that are valid to be assigned to Variant:
 	//
 	//	*Callback_Nexus_
+	//	*Callback_NexusHandler_
 	Variant       isCallback_Variant `protobuf_oneof:"variant"`
 	Links         []*v11.Link        `protobuf:"bytes,100,rep,name=links,proto3" json:"links,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -274,6 +279,15 @@ func (x *Callback) GetNexus() *Callback_Nexus {
 	return nil
 }
 
+func (x *Callback) GetNexusHandler() *Callback_NexusHandler {
+	if x != nil {
+		if x, ok := x.Variant.(*Callback_NexusHandler_); ok {
+			return x.NexusHandler
+		}
+	}
+	return nil
+}
+
 func (x *Callback) GetLinks() []*v11.Link {
 	if x != nil {
 		return x.Links
@@ -289,7 +303,13 @@ type Callback_Nexus_ struct {
 	Nexus *Callback_Nexus `protobuf:"bytes,2,opt,name=nexus,proto3,oneof"`
 }
 
+type Callback_NexusHandler_ struct {
+	NexusHandler *Callback_NexusHandler `protobuf:"bytes,4,opt,name=nexus_handler,json=nexusHandler,proto3,oneof"`
+}
+
 func (*Callback_Nexus_) isCallback_Variant() {}
+
+func (*Callback_NexusHandler_) isCallback_Variant() {}
 
 // Trigger for when the workflow is closed.
 type CallbackState_WorkflowClosed struct {
@@ -384,6 +404,79 @@ func (x *Callback_Nexus) GetHeader() map[string]string {
 	return nil
 }
 
+// Forked from temporal.api.common.v1.Callback.NexusHandler in the api repo, with abbreviated comments.
+type Callback_NexusHandler struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Nexus task queue the Temporal worker is listening on.
+	TaskQueueName string `protobuf:"bytes,1,opt,name=task_queue_name,json=taskQueueName,proto3" json:"task_queue_name,omitempty"`
+	// Target Nexus service.
+	Service string `protobuf:"bytes,2,opt,name=service,proto3" json:"service,omitempty"`
+	// Target operation.
+	Operation string `protobuf:"bytes,3,opt,name=operation,proto3" json:"operation,omitempty"`
+	// Arbitrary user-supplied data from the source operation's callsite.
+	SourceContext *v11.Payload `protobuf:"bytes,4,opt,name=source_context,json=sourceContext,proto3" json:"source_context,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Callback_NexusHandler) Reset() {
+	*x = Callback_NexusHandler{}
+	mi := &file_temporal_server_chasm_lib_callback_proto_v1_message_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Callback_NexusHandler) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Callback_NexusHandler) ProtoMessage() {}
+
+func (x *Callback_NexusHandler) ProtoReflect() protoreflect.Message {
+	mi := &file_temporal_server_chasm_lib_callback_proto_v1_message_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Callback_NexusHandler.ProtoReflect.Descriptor instead.
+func (*Callback_NexusHandler) Descriptor() ([]byte, []int) {
+	return file_temporal_server_chasm_lib_callback_proto_v1_message_proto_rawDescGZIP(), []int{1, 1}
+}
+
+func (x *Callback_NexusHandler) GetTaskQueueName() string {
+	if x != nil {
+		return x.TaskQueueName
+	}
+	return ""
+}
+
+func (x *Callback_NexusHandler) GetService() string {
+	if x != nil {
+		return x.Service
+	}
+	return ""
+}
+
+func (x *Callback_NexusHandler) GetOperation() string {
+	if x != nil {
+		return x.Operation
+	}
+	return ""
+}
+
+func (x *Callback_NexusHandler) GetSourceContext() *v11.Payload {
+	if x != nil {
+		return x.SourceContext
+	}
+	return nil
+}
+
 var File_temporal_server_chasm_lib_callback_proto_v1_message_proto protoreflect.FileDescriptor
 
 const file_temporal_server_chasm_lib_callback_proto_v1_message_proto_rawDesc = "" +
@@ -399,16 +492,22 @@ const file_temporal_server_chasm_lib_callback_proto_v1_message_proto_rawDesc = "
 	"\x1anext_attempt_schedule_time\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\x17nextAttemptScheduleTime\x12\x1d\n" +
 	"\n" +
 	"request_id\x18\t \x01(\tR\trequestId\x1a\x10\n" +
-	"\x0eWorkflowClosed\"\xde\x02\n" +
+	"\x0eWorkflowClosed\"\x83\x05\n" +
 	"\bCallback\x12T\n" +
-	"\x05nexus\x18\x02 \x01(\v2<.temporal.server.chasm.lib.callbacks.proto.v1.Callback.NexusH\x00R\x05nexus\x122\n" +
+	"\x05nexus\x18\x02 \x01(\v2<.temporal.server.chasm.lib.callbacks.proto.v1.Callback.NexusH\x00R\x05nexus\x12j\n" +
+	"\rnexus_handler\x18\x04 \x01(\v2C.temporal.server.chasm.lib.callbacks.proto.v1.Callback.NexusHandlerH\x00R\fnexusHandler\x122\n" +
 	"\x05links\x18d \x03(\v2\x1c.temporal.api.common.v1.LinkR\x05links\x1a\xb6\x01\n" +
 	"\x05Nexus\x12\x10\n" +
 	"\x03url\x18\x01 \x01(\tR\x03url\x12`\n" +
 	"\x06header\x18\x02 \x03(\v2H.temporal.server.chasm.lib.callbacks.proto.v1.Callback.Nexus.HeaderEntryR\x06header\x1a9\n" +
 	"\vHeaderEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\t\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a\xb6\x01\n" +
+	"\fNexusHandler\x12&\n" +
+	"\x0ftask_queue_name\x18\x01 \x01(\tR\rtaskQueueName\x12\x18\n" +
+	"\aservice\x18\x02 \x01(\tR\aservice\x12\x1c\n" +
+	"\toperation\x18\x03 \x01(\tR\toperation\x12F\n" +
+	"\x0esource_context\x18\x04 \x01(\v2\x1f.temporal.api.common.v1.PayloadR\rsourceContextB\t\n" +
 	"\avariantJ\x04\b\x01\x10\x02*\xc9\x01\n" +
 	"\x0eCallbackStatus\x12\x1f\n" +
 	"\x1bCALLBACK_STATUS_UNSPECIFIED\x10\x00\x12\x1b\n" +
@@ -431,33 +530,37 @@ func file_temporal_server_chasm_lib_callback_proto_v1_message_proto_rawDescGZIP(
 }
 
 var file_temporal_server_chasm_lib_callback_proto_v1_message_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_temporal_server_chasm_lib_callback_proto_v1_message_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_temporal_server_chasm_lib_callback_proto_v1_message_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_temporal_server_chasm_lib_callback_proto_v1_message_proto_goTypes = []any{
 	(CallbackStatus)(0),                  // 0: temporal.server.chasm.lib.callbacks.proto.v1.CallbackStatus
 	(*CallbackState)(nil),                // 1: temporal.server.chasm.lib.callbacks.proto.v1.CallbackState
 	(*Callback)(nil),                     // 2: temporal.server.chasm.lib.callbacks.proto.v1.Callback
 	(*CallbackState_WorkflowClosed)(nil), // 3: temporal.server.chasm.lib.callbacks.proto.v1.CallbackState.WorkflowClosed
 	(*Callback_Nexus)(nil),               // 4: temporal.server.chasm.lib.callbacks.proto.v1.Callback.Nexus
-	nil,                                  // 5: temporal.server.chasm.lib.callbacks.proto.v1.Callback.Nexus.HeaderEntry
-	(*timestamppb.Timestamp)(nil),        // 6: google.protobuf.Timestamp
-	(*v1.Failure)(nil),                   // 7: temporal.api.failure.v1.Failure
-	(*v11.Link)(nil),                     // 8: temporal.api.common.v1.Link
+	(*Callback_NexusHandler)(nil),        // 5: temporal.server.chasm.lib.callbacks.proto.v1.Callback.NexusHandler
+	nil,                                  // 6: temporal.server.chasm.lib.callbacks.proto.v1.Callback.Nexus.HeaderEntry
+	(*timestamppb.Timestamp)(nil),        // 7: google.protobuf.Timestamp
+	(*v1.Failure)(nil),                   // 8: temporal.api.failure.v1.Failure
+	(*v11.Link)(nil),                     // 9: temporal.api.common.v1.Link
+	(*v11.Payload)(nil),                  // 10: temporal.api.common.v1.Payload
 }
 var file_temporal_server_chasm_lib_callback_proto_v1_message_proto_depIdxs = []int32{
-	2, // 0: temporal.server.chasm.lib.callbacks.proto.v1.CallbackState.callback:type_name -> temporal.server.chasm.lib.callbacks.proto.v1.Callback
-	6, // 1: temporal.server.chasm.lib.callbacks.proto.v1.CallbackState.registration_time:type_name -> google.protobuf.Timestamp
-	0, // 2: temporal.server.chasm.lib.callbacks.proto.v1.CallbackState.status:type_name -> temporal.server.chasm.lib.callbacks.proto.v1.CallbackStatus
-	6, // 3: temporal.server.chasm.lib.callbacks.proto.v1.CallbackState.last_attempt_complete_time:type_name -> google.protobuf.Timestamp
-	7, // 4: temporal.server.chasm.lib.callbacks.proto.v1.CallbackState.last_attempt_failure:type_name -> temporal.api.failure.v1.Failure
-	6, // 5: temporal.server.chasm.lib.callbacks.proto.v1.CallbackState.next_attempt_schedule_time:type_name -> google.protobuf.Timestamp
-	4, // 6: temporal.server.chasm.lib.callbacks.proto.v1.Callback.nexus:type_name -> temporal.server.chasm.lib.callbacks.proto.v1.Callback.Nexus
-	8, // 7: temporal.server.chasm.lib.callbacks.proto.v1.Callback.links:type_name -> temporal.api.common.v1.Link
-	5, // 8: temporal.server.chasm.lib.callbacks.proto.v1.Callback.Nexus.header:type_name -> temporal.server.chasm.lib.callbacks.proto.v1.Callback.Nexus.HeaderEntry
-	9, // [9:9] is the sub-list for method output_type
-	9, // [9:9] is the sub-list for method input_type
-	9, // [9:9] is the sub-list for extension type_name
-	9, // [9:9] is the sub-list for extension extendee
-	0, // [0:9] is the sub-list for field type_name
+	2,  // 0: temporal.server.chasm.lib.callbacks.proto.v1.CallbackState.callback:type_name -> temporal.server.chasm.lib.callbacks.proto.v1.Callback
+	7,  // 1: temporal.server.chasm.lib.callbacks.proto.v1.CallbackState.registration_time:type_name -> google.protobuf.Timestamp
+	0,  // 2: temporal.server.chasm.lib.callbacks.proto.v1.CallbackState.status:type_name -> temporal.server.chasm.lib.callbacks.proto.v1.CallbackStatus
+	7,  // 3: temporal.server.chasm.lib.callbacks.proto.v1.CallbackState.last_attempt_complete_time:type_name -> google.protobuf.Timestamp
+	8,  // 4: temporal.server.chasm.lib.callbacks.proto.v1.CallbackState.last_attempt_failure:type_name -> temporal.api.failure.v1.Failure
+	7,  // 5: temporal.server.chasm.lib.callbacks.proto.v1.CallbackState.next_attempt_schedule_time:type_name -> google.protobuf.Timestamp
+	4,  // 6: temporal.server.chasm.lib.callbacks.proto.v1.Callback.nexus:type_name -> temporal.server.chasm.lib.callbacks.proto.v1.Callback.Nexus
+	5,  // 7: temporal.server.chasm.lib.callbacks.proto.v1.Callback.nexus_handler:type_name -> temporal.server.chasm.lib.callbacks.proto.v1.Callback.NexusHandler
+	9,  // 8: temporal.server.chasm.lib.callbacks.proto.v1.Callback.links:type_name -> temporal.api.common.v1.Link
+	6,  // 9: temporal.server.chasm.lib.callbacks.proto.v1.Callback.Nexus.header:type_name -> temporal.server.chasm.lib.callbacks.proto.v1.Callback.Nexus.HeaderEntry
+	10, // 10: temporal.server.chasm.lib.callbacks.proto.v1.Callback.NexusHandler.source_context:type_name -> temporal.api.common.v1.Payload
+	11, // [11:11] is the sub-list for method output_type
+	11, // [11:11] is the sub-list for method input_type
+	11, // [11:11] is the sub-list for extension type_name
+	11, // [11:11] is the sub-list for extension extendee
+	0,  // [0:11] is the sub-list for field type_name
 }
 
 func init() { file_temporal_server_chasm_lib_callback_proto_v1_message_proto_init() }
@@ -467,6 +570,7 @@ func file_temporal_server_chasm_lib_callback_proto_v1_message_proto_init() {
 	}
 	file_temporal_server_chasm_lib_callback_proto_v1_message_proto_msgTypes[1].OneofWrappers = []any{
 		(*Callback_Nexus_)(nil),
+		(*Callback_NexusHandler_)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -474,7 +578,7 @@ func file_temporal_server_chasm_lib_callback_proto_v1_message_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_temporal_server_chasm_lib_callback_proto_v1_message_proto_rawDesc), len(file_temporal_server_chasm_lib_callback_proto_v1_message_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   5,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/chasm/lib/callback/invocable_internal.go
+++ b/chasm/lib/callback/invocable_internal.go
@@ -20,7 +20,6 @@ import (
 	"go.temporal.io/server/common/namespace"
 	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/nexus/nexusrpc"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -110,13 +109,8 @@ func (c invocableInternal) Invoke(
 	// RPC to History for cross-shard completion delivery.
 	_, err = h.historyClient.CompleteNexusOperationChasm(ctx, request)
 	if err != nil {
-		// GetRPCStatus, not status.Code: the internode interceptor returns serviceerror
-		// types, which expose Status() rather than GRPCStatus(), so status.Code reports
-		// Unknown for all of them. IsRetryableRPCError below reads the code the same way.
-		outcome = outcomeTag(errorOutcomePrefix + codes.Unknown.String())
-		if st, ok := common.GetRPCStatus(err); ok {
-			outcome = outcomeTag(errorOutcomePrefix + st.Code().String())
-		}
+		// Set the outcome tag based on the gRPC error received (if applicable).
+		outcome = grpcErrorOutcome(err)
 		if ctx.Err() != nil {
 			outcome = outcomeRequestTimeout
 		}
@@ -160,17 +154,10 @@ func (c invocableInternal) getHistoryRequest(
 			Completion: completion,
 		}
 	} else {
-		failure, err := nexusrpc.DefaultFailureConverter().ErrorToFailure(c.completion.Error)
+		// Convert the nexus.OperationError into a failurepb.Failure.
+		apiFailure, err := commonnexus.OperationErrorToTemporalFailure(c.completion.Error)
 		if err != nil {
-			return nil, fmt.Errorf("failed to convert error to failure: %w", err)
-		}
-		// Unwrap the operation error, the handler on the other side is expecting to receive the underlying cause.
-		if failure.Cause != nil {
-			failure = *failure.Cause
-		}
-		apiFailure, err := commonnexus.NexusFailureToTemporalFailure(failure)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert failure type: %w", err)
+			return nil, err
 		}
 
 		req = &historyservice.CompleteNexusOperationChasmRequest{

--- a/chasm/lib/callback/invocable_nexushandler.go
+++ b/chasm/lib/callback/invocable_nexushandler.go
@@ -1,0 +1,294 @@
+package callback
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	nexuspb "go.temporal.io/api/nexus/v1"
+	"go.temporal.io/api/notificationservice/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	"go.temporal.io/server/api/matchingservice/v1"
+	"go.temporal.io/server/chasm"
+	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
+	commonnexus "go.temporal.io/server/common/nexus"
+	"go.temporal.io/server/common/nexus/nexusrpc"
+	"go.temporal.io/server/common/payload"
+	queueserrors "go.temporal.io/server/service/history/queues/errors"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// invocableNexusHandler is an invocable that delivers a completion to a Temporal worker by dispatching a Nexus
+// StartOperation task to the worker's task queue via MatchingService.DispatchNexusTask.
+//
+// Unlike invocableOutbound, which POSTs the completion to an arbitrary address, NexusHandler callbacks target a
+// Nexus service registered on a worker polling within the source operation's own namespace. This is faster
+// and more efficient than round tripping through the frontend's Nexus HTTP endpoint.
+type invocableNexusHandler struct {
+	callback   *callbackspb.Callback_NexusHandler
+	completion nexusrpc.CompleteOperationOptions
+
+	// completionSourceTag is the fully qualified name of the CHASM component that produced this
+	// completion, e.g. "workflow.workflow" or "activity.activity".
+	completionSourceTag string
+	businessID, runID   string
+
+	// requestID is sent as the Nexus request ID so that a redelivery of this callback is idempotent from
+	// the handler's perspective.
+	requestID string
+	attempt   int32
+}
+
+// buildOnCompleteRequest builds the input delivered to the worker's completion handler from the source
+// operation's outcome and the context the callback was registered with.
+func (n invocableNexusHandler) buildOnCompleteRequest() (*notificationservice.OnCompleteRequest, error) {
+	onCompReq := &notificationservice.OnCompleteRequest{
+		SourceContext: n.callback.GetSourceContext(),
+	}
+
+	if n.completion.Error != nil {
+		failure, err := commonnexus.OperationErrorToTemporalFailure(n.completion.Error)
+		if err != nil {
+			return nil, err
+		}
+		onCompReq.Result = &notificationservice.OnCompleteRequest_Failure{Failure: failure}
+		return onCompReq, nil
+	}
+
+	var result *commonpb.Payload
+	switch typed := n.completion.Result.(type) {
+	case nil:
+		// No payload present.
+	case *commonpb.Payload:
+		result = typed
+	default:
+		return nil, fmt.Errorf("invalid result, expected a payload, got: %T", n.completion.Result)
+	}
+
+	// A successful operation may legitimately have no result. The success variant always carries a
+	// payload on the wire, and a payload with no encoding fails the handler's data converter, so
+	// send the same binary/null representation of "no value" that the Nexus HTTP path produces.
+	if result == nil {
+		var err error
+		if result, err = payload.Encode(nil); err != nil {
+			return nil, fmt.Errorf("failed to encode empty NexusHandler callback result: %w", err)
+		}
+	}
+
+	onCompReq.Result = &notificationservice.OnCompleteRequest_Success{Success: result}
+	return onCompReq, nil
+}
+
+func (n invocableNexusHandler) buildDispatchRequest(
+	ns *namespace.Namespace,
+	scheduledTime time.Time,
+) (*matchingservice.DispatchNexusTaskRequest, error) {
+	taskQueueName := n.callback.GetTaskQueueName()
+	if taskQueueName == "" {
+		return nil, errors.New("NexusHandler callback is missing a task queue name")
+	}
+
+	onComplete, err := n.buildOnCompleteRequest()
+	if err != nil {
+		return nil, err
+	}
+	// The handler is a lang-SDK Nexus operation, so encode the input with the standard Temporal payload
+	// format (json/protobuf) that its data converter decodes back into an OnCompleteRequest.
+	//
+	// TODO(temporalio/temporal/issues/11891): Mark the Payload as a "system payload" to avoid the payload
+	// being decoded on the client-side by mistake.
+	input, err := payload.Encode(onComplete)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode NexusHandler callback input: %w", err)
+	}
+
+	req := &matchingservice.DispatchNexusTaskRequest{
+		NamespaceId: ns.ID().String(),
+		// The delivery lands on whatever version the task queue currently routes to by default:
+		// DispatchNexusTaskRequest carries no versioning directive, so matching decides, and it
+		// applies the task queue's assignment rules to every Nexus task alike.
+		//
+		// There is no way to pin a callback to the version that registered it, which is what a
+		// pinned workflow gets for its own activities. Wiring that through would mean carrying the
+		// version on the callback and adding a directive to this request; until then, a handler
+		// receiving completions has to stay compatible across the versions it is rolled through.
+		TaskQueue: &taskqueuepb.TaskQueue{
+			Name: taskQueueName,
+			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
+		},
+		Request: &nexuspb.Request{
+			ScheduledTime: timestamppb.New(scheduledTime),
+			Variant: &nexuspb.Request_StartOperation{
+				StartOperation: &nexuspb.StartOperationRequest{
+					Service:   n.callback.GetService(),
+					Operation: n.callback.GetOperation(),
+					RequestId: n.requestID,
+					Payload:   input,
+					// TODO(temporal/issues/11889): These links will be wrong. Backlinks to the source of the Nexus completion
+					// should be to the *callback attached* to the completion's source. Not the completion directly.
+					// e.g. a Link_Callback to "SANO xxx callback yyy", and not "SANO xxx".
+					Links: commonnexus.ConvertLinksToProto(n.completion.Links),
+				},
+			},
+			Capabilities: &nexuspb.Request_Capabilities{
+				TemporalFailureResponses: true,
+			},
+		},
+	}
+	return req, nil
+}
+
+func (n invocableNexusHandler) Invoke(
+	ctx context.Context,
+	ns *namespace.Namespace,
+	h *invocationTaskHandler,
+	task *callbackspb.InvocationTask,
+	taskAttr chasm.TaskAttributes,
+) invocationResult {
+	logger := log.With(h.logger,
+		tag.WorkflowNamespace(ns.Name().String()),
+		tag.Operation("DispatchNexusHandlerCallback"),
+		tag.WorkflowID(n.businessID),
+		tag.WorkflowRunID(n.runID),
+		tag.NexusCompletionSource(n.completionSourceTag),
+		tag.NewStringTag("task-queue", n.callback.GetTaskQueueName()),
+		tag.Attempt(n.attempt),
+	)
+
+	// nolint:forbidigo // Wall-clock RPC measurement, not component state; Invoke has no chasm.Context.
+	startTime := time.Now()
+
+	result, outcome := n.dispatch(ctx, startTime, logger, h, ns)
+
+	// Record metrics.
+	tags := []metrics.Tag{
+		metrics.NamespaceTag(ns.Name().String()),
+		metrics.DestinationTag(taskAttr.Destination),
+		metrics.OutcomeTag(string(outcome)),
+		metrics.NexusCompletionSourceTag(n.completionSourceTag),
+	}
+	NexusHandlerRequestCounter.With(h.metricsHandler).Record(1, tags...)
+	NexusHandlerRequestLatencyHistogram.With(h.metricsHandler).Record(time.Since(startTime), tags...)
+
+	return result
+}
+
+// dispatch hands the completion to matching and returns the invocationResult together with the value
+// of the metrics outcome tag to record for this attempt.
+func (n invocableNexusHandler) dispatch(
+	ctx context.Context,
+	startTime time.Time,
+	logger log.Logger,
+	h *invocationTaskHandler,
+	ns *namespace.Namespace,
+) (invocationResult, outcomeTag) {
+	// Build the DispatchNexusTaskRequest for the Matching Service.
+	dispatchReq, err := n.buildDispatchRequest(ns, startTime)
+	if err != nil {
+		logger.Error("Failed to build NexusHandler callback request", tag.Error(err))
+		return invocationResultFail{err}, outcomeRequestBuildError
+	}
+
+	// Send it to the worker.
+	resp, rpcErr := h.matchingClient.DispatchNexusTask(ctx, dispatchReq)
+	if rpcErr != nil {
+		// The task never reached a worker, so this is a problem between history and matching.
+		// Every other dispatch error is internal to Temporal and not something the namespace's users can
+		// fix, so only a reference ID to the logged error is surfaced to them.
+		handlerErr := commonnexus.ConvertGRPCError(rpcErr, false)
+		retryable := isRetryableCallError(handlerErr)
+		logger = log.With(logger, tag.Bool("retryable", retryable))
+		userFacingErr := logInternalError(logger, "NexusHandler callback dispatch failed", rpcErr)
+
+		// Derive the outcome metric based on the gRPC error received.
+		outcome := grpcErrorOutcome(rpcErr)
+		if ctx.Err() != nil {
+			outcome = outcomeRequestTimeout
+		}
+
+		if retryable {
+			return invocationResultRetry{userFacingErr}, outcome
+		}
+		return invocationResultFail{userFacingErr}, outcome
+	}
+
+	// The RPC succeeded, so whatever the worker had to say is in the response.
+	dispatchResult := commonnexus.ClassifyStartOperationDispatch(resp)
+	outcome := dispatchResult.OutcomeTag().Value
+	// Collapse "sync_success" and "async_success" into outcomeSuccess for clarity.
+	// The Nexus handler code in the Frontend service is interested in that detail, but here
+	// the sync/async aspect is not relevant.
+	if dispatchResult.Outcome.Succeeded() {
+		outcome = string(outcomeSuccess)
+	}
+	return n.classifyDispatchResult(logger, dispatchResult), outcomeTag(outcome)
+}
+
+// classifyDispatchResult inspects the response from the Nexus handler to determine how to handle
+// the NexusHandler callback: delivered, worth another attempt, or permanently failed.
+func (n invocableNexusHandler) classifyDispatchResult(
+	logger log.Logger,
+	result commonnexus.DispatchResult,
+) invocationResult {
+	if result.Outcome.Succeeded() {
+		// Both flavors of success count as delivered. An async start means the worker accepted the
+		// completion and started an operation to process it; either way the callback is done, it does
+		// not wait for that operation to finish.
+		return invocationResultOK{}
+	}
+
+	// Every remaining outcome carries an error: what the worker reported, or one that
+	// DispatchResultToError synthesizes when nothing usable came back.
+	err := commonnexus.DispatchResultToError(result)
+
+	switch result.Outcome {
+	case commonnexus.DispatchOutcomeOperationFailure:
+		// The worker received the completion and answered with a failure of its own: an operation that
+		// resolved as failed or canceled. That is the handler's verdict on this completion rather than
+		// a delivery problem, and redelivering would collect the same verdict, so the callback fails
+		// permanently.
+		logger.Error("NexusHandler callback resulted in an operation error", tag.Error(err))
+		return invocationResultFail{err}
+
+	case commonnexus.DispatchOutcomeHandlerFailure,
+		commonnexus.DispatchOutcomeRequestTimeout,
+		commonnexus.DispatchOutcomeUnrecognized:
+		// The completion was never handled: the worker refused the task with a Nexus handler error,
+		// nobody answered it before matching gave up, or this build cannot read the response. Only a
+		// handler error says whether another attempt is worthwhile, and the latter two reach us as
+		// handler errors synthesized above, so all three ask the same question.
+		handlerErr, ok := errors.AsType[*nexus.HandlerError](err)
+		retryable := ok && handlerErr.Retryable()
+		logger.Error("NexusHandler callback resulted in a handler error", tag.Error(err), tag.Bool("retryable", retryable))
+		if retryable {
+			return invocationResultRetry{err}
+		}
+		return invocationResultFail{err}
+
+	default:
+		// An outcome this build does not know about and that Succeeded() did not vouch for. Treat it
+		// like an unreadable response and keep retrying, in the hope the mismatch is transient.
+		logger.Error("NexusHandler callback got an unhandled dispatch outcome",
+			tag.NewStringTag("dispatch-outcome", string(result.Outcome)), tag.Error(err))
+		return invocationResultRetry{err}
+	}
+}
+
+func (n invocableNexusHandler) WrapError(result invocationResult, err error) error {
+	// A DestinationDownError counts against the outbound queue's circuit breaker for this task
+	// queue, which holds back every callback targeting it. Note that this means a single broken
+	// Nexus handler (e.g. always timing out) would open the circuit breaker and block every
+	// Nexus handler on the same task queue for delivering NexusHandler callbacks.
+	if retry, ok := result.(invocationResultRetry); ok {
+		return queueserrors.NewDestinationDownError(retry.err.Error(), err)
+	}
+	return err
+}

--- a/chasm/lib/callback/invocable_nexushandler_test.go
+++ b/chasm/lib/callback/invocable_nexushandler_test.go
@@ -1,0 +1,727 @@
+package callback
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	failurepb "go.temporal.io/api/failure/v1"
+	nexuspb "go.temporal.io/api/nexus/v1"
+	"go.temporal.io/api/notificationservice/v1"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/api/matchingservice/v1"
+	"go.temporal.io/server/api/matchingservicemock/v1"
+	"go.temporal.io/server/chasm"
+	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
+	"go.temporal.io/server/common/backoff"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
+	commonnexus "go.temporal.io/server/common/nexus"
+	"go.temporal.io/server/common/nexus/nexusrpc"
+	"go.temporal.io/server/common/payload"
+	test "go.temporal.io/server/common/testing"
+	"go.temporal.io/server/common/testing/protorequire"
+	queueserrors "go.temporal.io/server/service/history/queues/errors"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const (
+	testNexusHandlerTaskQueue   = "completions-task-queue"
+	testNexusHandlerService     = "HTTPAdapter"
+	testNexusHandlerOperation   = "DeliverAsWebhook"
+	testNexusHandlerDestination = "nexus-handler://completions-task-queue"
+)
+
+func newNexusHandlerCallback(t *testing.T) *Callback {
+	t.Helper()
+
+	return &Callback{
+		CallbackState: &callbackspb.CallbackState{
+			RequestId:        "request-id",
+			RegistrationTime: timestamppb.New(time.Now()),
+			Callback: &callbackspb.Callback{
+				Variant: &callbackspb.Callback_NexusHandler_{
+					NexusHandler: &callbackspb.Callback_NexusHandler{
+						TaskQueueName: testNexusHandlerTaskQueue,
+						Service:       testNexusHandlerService,
+						Operation:     testNexusHandlerOperation,
+						SourceContext: &commonpb.Payload{Data: []byte("source-context")},
+					},
+				},
+			},
+			Status:  callbackspb.CALLBACK_STATUS_SCHEDULED,
+			Attempt: 0,
+		},
+	}
+}
+
+// startOperationResponse builds the response matching returns when a worker handled the Nexus task and
+// replied with the given StartOperation response.
+func startOperationResponse(start *nexuspb.StartOperationResponse) *matchingservice.DispatchNexusTaskResponse {
+	return &matchingservice.DispatchNexusTaskResponse{
+		Outcome: &matchingservice.DispatchNexusTaskResponse_Response{
+			Response: &nexuspb.Response{
+				Variant: &nexuspb.Response_StartOperation{StartOperation: start},
+			},
+		},
+	}
+}
+
+func syncSuccessResponse() *matchingservice.DispatchNexusTaskResponse {
+	return startOperationResponse(&nexuspb.StartOperationResponse{
+		Variant: &nexuspb.StartOperationResponse_SyncSuccess{
+			SyncSuccess: &nexuspb.StartOperationResponse_Sync{},
+		},
+	})
+}
+
+// handlerFailureResponse builds the response matching returns when a worker fails the Nexus task itself,
+// i.e. responds with RespondNexusTaskFailed.
+func handlerFailureResponse(errType string) *matchingservice.DispatchNexusTaskResponse {
+	return &matchingservice.DispatchNexusTaskResponse{
+		Outcome: &matchingservice.DispatchNexusTaskResponse_Failure{
+			Failure: &failurepb.Failure{
+				Message: "handler error (" + errType + "): worker said no",
+				FailureInfo: &failurepb.Failure_NexusHandlerFailureInfo{
+					NexusHandlerFailureInfo: &failurepb.NexusHandlerFailureInfo{
+						Type: errType,
+					},
+				},
+			},
+		},
+	}
+}
+
+// requireNilPayload asserts the payload is the binary/null representation of "no value", which is
+// what a worker's data converter decodes into a nil result.
+func requireNilPayload(t *testing.T, p *commonpb.Payload) {
+	t.Helper()
+
+	expected, err := payload.Encode(nil)
+	require.NoError(t, err)
+	protorequire.ProtoEqual(t, expected, p)
+}
+
+// wrappedOperationError builds the completion error a CHASM source component produces when its
+// operation fails: the source's own Temporal failure is carried as the error's cause, and the
+// enclosing nexus.OperationError is marked as a redundant wrapper so that consumers within the server
+// unwrap it. See nexusrpc.MarkAsWrapperError, and Operation.getNexusCompletion in the nexusoperation
+// library for the real thing.
+func wrappedOperationError(
+	t *testing.T,
+	state nexus.OperationState,
+	message string,
+	cause *failurepb.Failure,
+) *nexus.OperationError {
+	t.Helper()
+
+	nexusFailure, err := commonnexus.TemporalFailureToNexusFailure(cause)
+	require.NoError(t, err)
+
+	opErr := &nexus.OperationError{
+		State:   state,
+		Message: message,
+		Cause:   &nexus.FailureError{Failure: nexusFailure},
+	}
+	require.NoError(t, nexusrpc.MarkAsWrapperError(nexusrpc.DefaultFailureConverter(), opErr))
+	return opErr
+}
+
+// requireTerminalFailure asserts the callback permanently failed, recording a non-retryable failure
+// whose message contains want.
+func requireTerminalFailure(t *testing.T, cb *Callback, want string) {
+	t.Helper()
+
+	require.Equal(t, callbackspb.CALLBACK_STATUS_FAILED, cb.Status)
+	require.Contains(t, cb.LastAttemptFailure.GetMessage(), want)
+	require.True(t, cb.LastAttemptFailure.GetApplicationFailureInfo().GetNonRetryable())
+}
+
+// TestExecuteInvocationTaskNexusHandler_Outcomes runs the invocation task end-to-end against a CHASM tree with a
+// mocked matching client, covering how each dispatch outcome maps onto the callback's state.
+func TestExecuteInvocationTaskNexusHandler_Outcomes(t *testing.T) {
+	cases := []struct {
+		name        string
+		response    *matchingservice.DispatchNexusTaskResponse
+		responseErr error
+		// Outcome tag for the NexusHandler-specific metrics.
+		expectedOutcome outcomeTag
+		// Outcome tag for the aggregate InvocationEventCounter, InvocationAttemptsHistogram which
+		// is just one of outcomeEvent{ Success, RetryableError, NonRetryableError }.
+		expectedEventOutcome coarseOutcomeTag
+		assertOutcome        func(*testing.T, *Callback, error)
+	}{
+		{
+			name:                 "sync-success",
+			response:             syncSuccessResponse(),
+			expectedOutcome:      outcomeSuccess,
+			expectedEventOutcome: outcomeEventSuccess,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				require.NoError(t, err)
+				require.Equal(t, callbackspb.CALLBACK_STATUS_SUCCEEDED, cb.Status)
+			},
+		},
+		{
+			// The handler accepted the completion and started an operation to process it. Delivery is
+			// done as far as the callback is concerned; it doesn't wait for that operation.
+			name: "async-success",
+			response: startOperationResponse(&nexuspb.StartOperationResponse{
+				Variant: &nexuspb.StartOperationResponse_AsyncSuccess{
+					AsyncSuccess: &nexuspb.StartOperationResponse_Async{OperationToken: "operation-token"},
+				},
+			}),
+			expectedOutcome:      outcomeSuccess,
+			expectedEventOutcome: outcomeEventSuccess,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				require.NoError(t, err)
+				require.Equal(t, callbackspb.CALLBACK_STATUS_SUCCEEDED, cb.Status)
+			},
+		},
+		{
+			// The worker ran the completion handler and the operation failed. That verdict is
+			// deterministic, so the callback fails permanently rather than retrying.
+			name: "operation-failed",
+			response: startOperationResponse(&nexuspb.StartOperationResponse{
+				Variant: &nexuspb.StartOperationResponse_Failure{
+					Failure: &failurepb.Failure{
+						Message: "handler rejected the completion",
+						FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+							ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{},
+						},
+					},
+				},
+			}),
+			expectedOutcome:      outcomeFailure,
+			expectedEventOutcome: outcomeEventNonRetryableError,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				require.NoError(t, err)
+				requireTerminalFailure(t, cb, "handler rejected the completion")
+			},
+		},
+		{
+			// Older workers report a failed operation with the deprecated OperationError variant. It
+			// is just as deterministic as the Failure variant, so it must not be retried either.
+			name: "deprecated-operation-error",
+			response: startOperationResponse(&nexuspb.StartOperationResponse{
+				//nolint:staticcheck // Deprecated, still sent by older workers.
+				Variant: &nexuspb.StartOperationResponse_OperationError{
+					OperationError: &nexuspb.UnsuccessfulOperationError{
+						OperationState: string(nexus.OperationStateFailed),
+						Failure:        &nexuspb.Failure{Message: "handler rejected the completion"},
+					},
+				},
+			}),
+			expectedOutcome:      outcomeLegacyFailure,
+			expectedEventOutcome: outcomeEventNonRetryableError,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				require.NoError(t, err)
+				requireTerminalFailure(t, cb, "handler rejected the completion")
+			},
+		},
+		{
+			// Older workers report a handler error with the deprecated HandlerError outcome. Its type
+			// still decides whether the delivery is worth retrying.
+			name: "deprecated-non-retryable-handler-error",
+			response: &matchingservice.DispatchNexusTaskResponse{
+				//nolint:staticcheck // Deprecated, still sent by older workers.
+				Outcome: &matchingservice.DispatchNexusTaskResponse_HandlerError{
+					HandlerError: &nexuspb.HandlerError{
+						ErrorType: "BAD_REQUEST",
+						Failure:   &nexuspb.Failure{Message: "worker said no"},
+					},
+				},
+			},
+			expectedOutcome:      outcomeTag("handler_error:BAD_REQUEST"),
+			expectedEventOutcome: outcomeEventNonRetryableError,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				require.NoError(t, err)
+				requireTerminalFailure(t, cb, "BAD_REQUEST")
+			},
+		},
+		{
+			// A worker can fail the task with something other than a handler error, e.g. an
+			// application error. RespondNexusTaskFailed rejects a failure carrying no handler failure
+			// info, so this shouldn't be reachable outside of tests; it is treated like a response this
+			// build cannot interpret and kept retrying. There is no handler error type to report,
+			// hence the UNKNOWN suffix.
+			name: "non-handler-task-failure",
+			response: &matchingservice.DispatchNexusTaskResponse{
+				Outcome: &matchingservice.DispatchNexusTaskResponse_Failure{
+					Failure: &failurepb.Failure{
+						Message: "worker rejected the task",
+						FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+							ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{Type: "SomeError"},
+						},
+					},
+				},
+			},
+			expectedOutcome:      outcomeTag("handler_error:UNKNOWN"),
+			expectedEventOutcome: outcomeEventNonRetryableError,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				require.Equal(t, callbackspb.CALLBACK_STATUS_FAILED, cb.Status)
+				require.Contains(t, cb.LastAttemptFailure.GetMessage(), "worker rejected the task")
+				require.True(t, cb.LastAttemptFailure.GetApplicationFailureInfo().GetNonRetryable())
+			},
+		},
+		{
+			name:                 "retryable-handler-error",
+			response:             handlerFailureResponse("INTERNAL"),
+			expectedOutcome:      outcomeTag("handler_error:INTERNAL"),
+			expectedEventOutcome: outcomeEventRetryableError,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				// Retryable handler errors will trip the circuit breaker. So we expect this to have
+				// be a DestinationDownError and open the circuit breaker if it persists.
+				var destDown *queueserrors.DestinationDownError
+				require.ErrorAs(t, err, &destDown)
+				require.Equal(t, callbackspb.CALLBACK_STATUS_BACKING_OFF, cb.Status)
+
+				// The failure is recorded, but not as a terminal one: another attempt is scheduled.
+				require.Contains(t, cb.LastAttemptFailure.GetMessage(), "INTERNAL")
+				require.False(t, cb.LastAttemptFailure.GetApplicationFailureInfo().GetNonRetryable())
+				require.NotNil(t, cb.NextAttemptScheduleTime)
+			},
+		},
+		{
+			name:                 "non-retryable-handler-error",
+			response:             handlerFailureResponse("BAD_REQUEST"),
+			expectedOutcome:      outcomeTag("handler_error:BAD_REQUEST"),
+			expectedEventOutcome: outcomeEventNonRetryableError,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				require.NoError(t, err)
+				requireTerminalFailure(t, cb, "BAD_REQUEST")
+			},
+		},
+		{
+			// Nobody is polling the task queue (or the worker died holding the task), so matching gave
+			// up waiting. A worker may show up later, so keep retrying.
+			name: "no-poller",
+			response: &matchingservice.DispatchNexusTaskResponse{
+				Outcome: &matchingservice.DispatchNexusTaskResponse_RequestTimeout{
+					RequestTimeout: &matchingservice.DispatchNexusTaskResponse_Timeout{},
+				},
+			},
+			expectedOutcome:      outcomeTag("handler_timeout"),
+			expectedEventOutcome: outcomeEventRetryableError,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				var destDownErr *queueserrors.DestinationDownError
+				require.ErrorAs(t, err, &destDownErr)
+				require.Equal(t, callbackspb.CALLBACK_STATUS_BACKING_OFF, cb.Status)
+			},
+		},
+		{
+			name:                 "retryable-rpc-error",
+			responseErr:          status.Error(codes.Unavailable, "matching unavailable"),
+			expectedOutcome:      outcomeTag("error:Unavailable"),
+			expectedEventOutcome: outcomeEventRetryableError,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				var destDownErr *queueserrors.DestinationDownError
+				require.ErrorAs(t, err, &destDownErr)
+				require.Equal(t, callbackspb.CALLBACK_STATUS_BACKING_OFF, cb.Status)
+			},
+		},
+		{
+			// Matching rejections aren't something users can fix, so they are blinded.
+			name:                 "rejected-rpc-request",
+			responseErr:          fmt.Errorf("wrapped gRPC error: %w", status.Error(codes.InvalidArgument, "malformed task queue name")),
+			expectedOutcome:      outcomeTag("error:InvalidArgument"),
+			expectedEventOutcome: outcomeEventNonRetryableError,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				require.NoError(t, err)
+				requireTerminalFailure(t, cb, "internal error, reference-id:")
+			},
+		},
+		{
+			// A throttle shares the status code but is a property of the server's state rather than
+			// of our bytes, so it clears on its own and stays retryable.
+			name: "throttled-rpc-request",
+			responseErr: serviceerror.NewResourceExhausted(
+				enumspb.RESOURCE_EXHAUSTED_CAUSE_RPS_LIMIT, "namespace rps limit exceeded"),
+			expectedOutcome:      outcomeTag("error:ResourceExhausted"),
+			expectedEventOutcome: outcomeEventRetryableError,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				var destDownErr *queueserrors.DestinationDownError
+				require.ErrorAs(t, err, &destDownErr)
+				require.Equal(t, callbackspb.CALLBACK_STATUS_BACKING_OFF, cb.Status)
+			},
+		},
+		{
+			// Any other RPC failure describes the state of the server, so it is hidden behind a
+			// reference ID and only the shape is asserted.
+			name:                 "non-retryable-rpc-error",
+			responseErr:          status.Error(codes.NotFound, "namespace not found"),
+			expectedOutcome:      outcomeTag("error:NotFound"),
+			expectedEventOutcome: outcomeEventNonRetryableError,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				require.NoError(t, err)
+				require.NotContains(t, cb.LastAttemptFailure.GetMessage(), "namespace not found")
+				requireTerminalFailure(t, cb, "internal error, reference-id:")
+			},
+		},
+		{
+			// A response this server cannot interpret is considered retryable. (In hopes that it is
+			// due to some version mismatch, and can be addressed.) Nothing about it came from a
+			// Nexus handler, but the shared outcome tag has always labeled it as a handler error.
+			name:                 "unrecognized-outcome",
+			response:             &matchingservice.DispatchNexusTaskResponse{},
+			expectedOutcome:      outcomeTag("handler_error:EMPTY_OUTCOME"),
+			expectedEventOutcome: outcomeEventRetryableError,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				var destDownErr *queueserrors.DestinationDownError
+				require.ErrorAs(t, err, &destDownErr)
+				require.Equal(t, callbackspb.CALLBACK_STATUS_BACKING_OFF, cb.Status)
+				require.False(t, cb.LastAttemptFailure.GetApplicationFailureInfo().GetNonRetryable())
+			},
+		},
+		{
+			// A handler error type outside the Nexus spec is collapsed so a worker cannot introduce
+			// unbounded metric cardinality.
+			name:                 "handler-error-with-an-unknown-type",
+			response:             handlerFailureResponse("SOMETHING_MADE_UP"),
+			expectedOutcome:      outcomeTag("handler_error:UNKNOWN"),
+			expectedEventOutcome: outcomeEventRetryableError,
+			assertOutcome: func(t *testing.T, cb *Callback, err error) {
+				// The error is retryable by spec, so it gets wrapped as a DestinationDown to potentially
+				// open the circuit breaker as applicable.
+				var destDown *queueserrors.DestinationDownError
+				require.ErrorAs(t, err, &destDown)
+				require.Equal(t, callbackspb.CALLBACK_STATUS_BACKING_OFF, cb.Status)
+				require.Contains(t, cb.LastAttemptFailure.GetMessage(), "SOMETHING_MADE_UP")
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// The completion source, business ID, and run ID are all supplied by the
+			// CHASM Context.
+			const completionSrcTag = "activity.activity"
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			ns := test.NewNamespace(t)
+
+			metricsHandler := metrics.NewMockHandler(ctrl)
+			counter := metrics.NewMockCounterIface(ctrl)
+			timer := metrics.NewMockTimerIface(ctrl)
+
+			// NexusHandler-specific metrics that are emitted.
+			metricsHandler.EXPECT().Counter(NexusHandlerRequestCounter.Name()).Return(counter)
+			counter.EXPECT().Record(int64(1),
+				metrics.NamespaceTag(ns.Name().String()),
+				metrics.DestinationTag(testNexusHandlerDestination),
+				metrics.OutcomeTag(string(tc.expectedOutcome)),
+				metrics.NexusCompletionSourceTag(testCompletionSourceFqn),
+			)
+			metricsHandler.EXPECT().Timer(NexusHandlerRequestLatencyHistogram.Name()).Return(timer)
+			timer.EXPECT().Record(gomock.Any(),
+				metrics.NamespaceTag(ns.Name().String()),
+				metrics.DestinationTag(testNexusHandlerDestination),
+				metrics.OutcomeTag(string(tc.expectedOutcome)),
+				metrics.NexusCompletionSourceTag(testCompletionSourceFqn),
+			)
+
+			// Additional metrics, reported for all forms of completion callbacks.
+			// The outcomeTag for those metrics is based on the success/retryable/non-retryable
+			// nature of the result. Hence a differentoutcome tag on the testcase.
+			eventTags := []metrics.Tag{
+				metrics.NamespaceTag(ns.Name().String()),
+				metrics.DestinationTag(testNexusHandlerDestination),
+				metrics.OutcomeTag(string(tc.expectedEventOutcome)),
+			}
+			dispositionCounter := metrics.NewMockCounterIface(ctrl)
+			metricsHandler.EXPECT().Counter(InvocationEventCounter.Name()).Return(dispositionCounter)
+			dispositionCounter.EXPECT().Record(int64(1), eventTags)
+			if tc.expectedEventOutcome != outcomeEventRetryableError {
+				attemptHistogram := metrics.NewMockHistogramIface(ctrl)
+				metricsHandler.EXPECT().
+					Histogram(InvocationAttemptsHistogram.Name(), InvocationAttemptsHistogram.Unit()).
+					Return(attemptHistogram)
+				attemptHistogram.EXPECT().Record(int64(1), eventTags)
+			}
+
+			// Setup the mock Matching service to return the test's result.
+			matchingClient := matchingservicemock.NewMockMatchingServiceClient(ctrl)
+			matchingClient.EXPECT().DispatchNexusTask(gomock.Any(), gomock.Any()).
+				Return(tc.response, tc.responseErr)
+
+			nsRegistry := namespace.NewMockRegistry(ctrl)
+			nsRegistry.EXPECT().GetNamespaceByID(gomock.Any()).Return(ns, nil)
+
+			// Invoke the NexusHandler callback.
+			handler := &invocationTaskHandler{
+				config: &Config{
+					RequestTimeout: dynamicconfig.GetDurationPropertyFnFilteredByDestination(time.Second),
+					RetryPolicy: func() backoff.RetryPolicy {
+						return backoff.NewExponentialRetryPolicy(time.Second)
+					},
+				},
+				namespaceRegistry: nsRegistry,
+				metricsHandler:    metricsHandler,
+				logger:            log.NewTestLogger(),
+				matchingClient:    matchingClient,
+			}
+
+			callback := newNexusHandlerCallback(t)
+			engineCtx, callbackRef := newInvocationTaskTest(t, handler, callback, nexusrpc.CompleteOperationOptions{})
+
+			executeErr := handler.Execute(
+				engineCtx,
+				callbackRef,
+				chasm.TaskAttributes{Destination: testNexusHandlerDestination},
+				&callbackspb.InvocationTask{Attempt: 0},
+			)
+
+			readCallbackState(engineCtx, t, callbackRef, func(_ chasm.Context, c *Callback) {
+				t.Helper()
+				tc.assertOutcome(t, c, executeErr)
+			})
+		})
+	}
+}
+
+// TestExecuteInvocationTaskNexusHandler_DispatchedRequest covers what the worker actually receives: the task is
+// addressed to the callback's task queue, service, and operation, and its input carries the source
+// operation's outcome.
+func TestExecuteInvocationTaskNexusHandler_DispatchedRequest(t *testing.T) {
+	sourceURL, err := url.Parse("temporal:///namespaces/ns-name/operations/op-id/runs/run-id")
+	require.NoError(t, err)
+	sourceLink := nexus.Link{URL: sourceURL, Type: "temporal.api.common.v1.Link.NexusOperation"}
+
+	for _, tc := range []struct {
+		name       string
+		completion nexusrpc.CompleteOperationOptions
+		assertOn   func(*testing.T, *notificationservice.OnCompleteRequest)
+	}{
+		{
+			name: "successful-completion",
+			completion: nexusrpc.CompleteOperationOptions{
+				Result: &commonpb.Payload{Data: []byte("result-data")},
+				Links:  []nexus.Link{sourceLink},
+			},
+			assertOn: func(t *testing.T, req *notificationservice.OnCompleteRequest) {
+				require.Equal(t, []byte("result-data"), req.GetSuccess().GetData())
+				require.Nil(t, req.GetFailure())
+			},
+		},
+		{
+			// A successful operation without a result still reports success, carrying the
+			// binary/null representation of "no value".
+			name: "successful-completion-without-a-result",
+			completion: nexusrpc.CompleteOperationOptions{
+				Links: []nexus.Link{sourceLink},
+			},
+			assertOn: func(t *testing.T, req *notificationservice.OnCompleteRequest) {
+				require.IsType(t, &notificationservice.OnCompleteRequest_Success{}, req.GetResult())
+				requireNilPayload(t, req.GetSuccess())
+			},
+		},
+		{
+			// Completion sources report an absent result as a nil *commonpb.Payload rather than an
+			// untyped nil, which must be treated the same as no result at all.
+			name: "successful-completion-with-a-typed-nil-result",
+			completion: nexusrpc.CompleteOperationOptions{
+				Result: (*commonpb.Payload)(nil),
+				Links:  []nexus.Link{sourceLink},
+			},
+			assertOn: func(t *testing.T, req *notificationservice.OnCompleteRequest) {
+				require.IsType(t, &notificationservice.OnCompleteRequest_Success{}, req.GetResult())
+				requireNilPayload(t, req.GetSuccess())
+			},
+		},
+		{
+			// The completion of a failed source operation is a nexus.OperationError wrapping the
+			// source's own Temporal failure. Since the OnCompleteRequest carries a Temporal failure
+			// anyway, that wrapper is redundant, so the source marks it (see
+			// nexusrpc.MarkAsWrapperError) and the handler unwraps it: the worker is handed the
+			// failure the source operation actually failed with, not the "operation failed" wrapper.
+			name: "failed-completion-unwraps-the-operation-error",
+			completion: nexusrpc.CompleteOperationOptions{
+				Error: wrappedOperationError(t, nexus.OperationStateFailed, "operation failed", &failurepb.Failure{
+					Message: "widget exploded",
+					FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+						ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
+							Type:         "WidgetError",
+							NonRetryable: true,
+						},
+					},
+				}),
+				Links: []nexus.Link{sourceLink},
+			},
+			assertOn: func(t *testing.T, req *notificationservice.OnCompleteRequest) {
+				require.Nil(t, req.GetSuccess())
+
+				// What the worker sees is the source failure verbatim: its message, its application
+				// failure type, and no enclosing "operation failed" layer.
+				failure := req.GetFailure()
+				require.Equal(t, "widget exploded", failure.GetMessage())
+				require.Equal(t, "WidgetError", failure.GetApplicationFailureInfo().GetType())
+				require.True(t, failure.GetApplicationFailureInfo().GetNonRetryable())
+				require.Nil(t, failure.GetCause())
+			},
+		},
+		{
+			// A canceled source operation is delivered the same way, and unwrapping preserves the
+			// failure's Temporal type: the worker sees a canceled failure rather than an application
+			// failure that merely says "operation canceled".
+			name: "canceled-completion-unwraps-the-operation-error",
+			completion: nexusrpc.CompleteOperationOptions{
+				Error: wrappedOperationError(t, nexus.OperationStateCanceled, "operation canceled", &failurepb.Failure{
+					Message: "operation canceled by the caller",
+					FailureInfo: &failurepb.Failure_CanceledFailureInfo{
+						CanceledFailureInfo: &failurepb.CanceledFailureInfo{},
+					},
+				}),
+				Links: []nexus.Link{sourceLink},
+			},
+			assertOn: func(t *testing.T, req *notificationservice.OnCompleteRequest) {
+				failure := req.GetFailure()
+				require.Equal(t, "operation canceled by the caller", failure.GetMessage())
+				require.NotNil(t, failure.GetCanceledFailureInfo())
+			},
+		},
+		{
+			// An OperationError that was not marked as a wrapper is delivered as-is, since dropping a
+			// layer nobody said was redundant would lose the only thing that identifies the outcome as
+			// a failed operation. This is what an error originating outside the Temporal server looks
+			// like, e.g. relayed from a third-party Nexus handler.
+			//
+			// The worker gets the wrapper as a non-retryable ApplicationFailure of type
+			// "OperationError", and the handler's own failure hangs off it as the cause.
+			name: "failed-completion-keeps-an-unmarked-operation-error",
+			completion: nexusrpc.CompleteOperationOptions{
+				Error: &nexus.OperationError{
+					State:   nexus.OperationStateFailed,
+					Message: "operation failed",
+					Cause:   &nexus.FailureError{Failure: nexus.Failure{Message: "widget exploded"}},
+				},
+				Links: []nexus.Link{sourceLink},
+			},
+			assertOn: func(t *testing.T, req *notificationservice.OnCompleteRequest) {
+				failure := req.GetFailure()
+				require.Equal(t, "operation failed", failure.GetMessage())
+				require.Equal(t, "OperationError", failure.GetApplicationFailureInfo().GetType())
+				require.True(t, failure.GetApplicationFailureInfo().GetNonRetryable())
+				require.Equal(t, "widget exploded", failure.GetCause().GetMessage())
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			var dispatched *matchingservice.DispatchNexusTaskRequest
+			matchingClient := matchingservicemock.NewMockMatchingServiceClient(ctrl)
+			matchingClient.EXPECT().DispatchNexusTask(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, req *matchingservice.DispatchNexusTaskRequest, _ ...grpc.CallOption) (*matchingservice.DispatchNexusTaskResponse, error) {
+					dispatched = req
+					return syncSuccessResponse(), nil
+				})
+
+			ns := test.NewNamespace(t)
+			nsRegistry := namespace.NewMockRegistry(ctrl)
+			nsRegistry.EXPECT().GetNamespaceByID(gomock.Any()).Return(ns, nil)
+
+			handler := &invocationTaskHandler{
+				config: &Config{
+					RequestTimeout: dynamicconfig.GetDurationPropertyFnFilteredByDestination(time.Second),
+					RetryPolicy: func() backoff.RetryPolicy {
+						return backoff.NewExponentialRetryPolicy(time.Second)
+					},
+				},
+				namespaceRegistry: nsRegistry,
+				metricsHandler:    metrics.NoopMetricsHandler,
+				logger:            log.NewTestLogger(),
+				matchingClient:    matchingClient,
+			}
+
+			callback := newNexusHandlerCallback(t)
+			engineCtx, callbackRef := newInvocationTaskTest(t, handler, callback, tc.completion)
+			dispatchStart := time.Now()
+			require.NoError(t, handler.Execute(
+				engineCtx,
+				callbackRef,
+				chasm.TaskAttributes{Destination: testNexusHandlerDestination},
+				&callbackspb.InvocationTask{Attempt: 0},
+			))
+
+			require.NotNil(t, dispatched)
+			require.Equal(t, ns.ID().String(), dispatched.GetNamespaceId())
+			// The worker's poller measures task latencies against the scheduled time, so it has to
+			// reflect when this delivery attempt started.
+			require.WithinDuration(t, dispatchStart, dispatched.GetRequest().GetScheduledTime().AsTime(), time.Minute)
+			require.Equal(t, testNexusHandlerTaskQueue, dispatched.GetTaskQueue().GetName())
+			require.Equal(t, enumspb.TASK_QUEUE_KIND_NORMAL, dispatched.GetTaskQueue().GetKind())
+
+			start := dispatched.GetRequest().GetStartOperation()
+			require.Equal(t, testNexusHandlerService, start.GetService())
+			require.Equal(t, testNexusHandlerOperation, start.GetOperation())
+			// The callback's request ID doubles as the Nexus request ID, so a redelivery is idempotent
+			// from the handler's perspective.
+			require.Equal(t, "request-id", start.GetRequestId())
+			// The source operation is identified to the handler by the completion's links.
+			require.Len(t, start.GetLinks(), 1)
+			require.Equal(t, sourceLink.URL.String(), start.GetLinks()[0].GetUrl())
+
+			var onComplete notificationservice.OnCompleteRequest
+			require.NoError(t, payload.Decode(start.GetPayload(), &onComplete))
+			protorequire.ProtoEqual(t, &commonpb.Payload{Data: []byte("source-context")}, onComplete.GetSourceContext())
+			tc.assertOn(t, &onComplete)
+		})
+	}
+}
+
+// A NexusHandler callback that cannot be dispatched at all fails permanently, since no further attempt
+// would change the outcome.
+func TestInvocableNexusHandlerCannotDispatch(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		callback    *callbackspb.Callback_NexusHandler
+		completion  nexusrpc.CompleteOperationOptions
+		wantMessage string
+	}{
+		{
+			name:        "without a task queue",
+			callback:    &callbackspb.Callback_NexusHandler{Service: testNexusHandlerService},
+			wantMessage: "missing a task queue name",
+		},
+		{
+			name:        "with a result that isn't a payload",
+			callback:    &callbackspb.Callback_NexusHandler{TaskQueueName: testNexusHandlerTaskQueue, Service: testNexusHandlerService},
+			completion:  nexusrpc.CompleteOperationOptions{Result: "not-a-payload"},
+			wantMessage: "invalid result, expected a payload",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			handler := &invocationTaskHandler{
+				config:         &Config{},
+				metricsHandler: metrics.NoopMetricsHandler,
+				logger:         log.NewTestLogger(),
+				// Dispatch must not be attempted, so the mock is left without expectations.
+				matchingClient: matchingservicemock.NewMockMatchingServiceClient(ctrl),
+			}
+			invocable := invocableNexusHandler{callback: tc.callback, completion: tc.completion}
+
+			ns := test.NewNamespace(t)
+			result := invocable.Invoke(context.Background(), ns, handler, nil, chasm.TaskAttributes{})
+
+			require.IsType(t, invocationResultFail{}, result)
+			require.ErrorContains(t, result.error(), tc.wantMessage)
+		})
+	}
+}

--- a/chasm/lib/callback/invocable_nexushandler_test.go
+++ b/chasm/lib/callback/invocable_nexushandler_test.go
@@ -253,9 +253,9 @@ func TestExecuteInvocationTaskNexusHandler_Outcomes(t *testing.T) {
 		{
 			// A worker can fail the task with something other than a handler error, e.g. an
 			// application error. RespondNexusTaskFailed rejects a failure carrying no handler failure
-			// info, so this shouldn't be reachable outside of tests; it is treated like a response this
-			// build cannot interpret and kept retrying. There is no handler error type to report,
-			// hence the UNKNOWN suffix.
+			// info, so this shouldn't be reachable outside of tests. There is no nexus.HandlerError to
+			// ask about retryability, so the delivery fails permanently, and no handler error type to
+			// report, hence the UNKNOWN suffix.
 			name: "non-handler-task-failure",
 			response: &matchingservice.DispatchNexusTaskResponse{
 				Outcome: &matchingservice.DispatchNexusTaskResponse_Failure{

--- a/chasm/lib/callback/invocable_outbound.go
+++ b/chasm/lib/callback/invocable_outbound.go
@@ -27,7 +27,7 @@ type invocableOutbound struct {
 	// completionSourceTag is the fully qualified name of the CHASM component that produced this
 	// completion, e.g. "workflow.workflow" or "activity.activity".
 	completionSourceTag string
-	workflowID, runID   string
+	businessID, runID   string
 	attempt             int32
 }
 
@@ -50,7 +50,7 @@ func (n invocableOutbound) Invoke(
 			tag.WorkflowNamespace(ns.Name().String()),
 			tag.Operation("CompleteNexusOperation"),
 			tag.Destination(taskAttr.Destination),
-			tag.WorkflowID(n.workflowID),
+			tag.WorkflowID(n.businessID),
 			tag.WorkflowRunID(n.runID),
 			tag.NexusCompletionSource(n.completionSourceTag),
 			tag.AttemptStart(time.Now().UTC()),
@@ -68,18 +68,23 @@ func (n invocableOutbound) Invoke(
 		}),
 		Serializer: commonnexus.PayloadSerializer,
 	})
-	// Make the call and record metrics.
+
+	// nolint:forbidigo // Wall-clock RPC measurement, not component state; Invoke has no chasm.Context.
 	startTime := time.Now()
 
+	// Make the call.
 	n.completion.Header = n.callback.Header
 	err := client.CompleteOperation(ctx, n.callback.Url, n.completion)
 
-	namespaceTag := metrics.NamespaceTag(ns.Name().String())
-	destTag := metrics.DestinationTag(taskAttr.Destination)
-	outcomeMetricTag := metrics.OutcomeTag(string(outboundOutcome(ctx, err)))
-	completionSourceMetricTag := metrics.NexusCompletionSourceTag(n.completionSourceTag)
-	h.metricsHandler.Counter(RequestCounter.Name()).Record(1, namespaceTag, destTag, outcomeMetricTag, completionSourceMetricTag)
-	h.metricsHandler.Timer(RequestLatencyHistogram.Name()).Record(time.Since(startTime), namespaceTag, destTag, outcomeMetricTag, completionSourceMetricTag)
+	// Record metrics.
+	tags := []metrics.Tag{
+		metrics.NamespaceTag(ns.Name().String()),
+		metrics.DestinationTag(taskAttr.Destination),
+		metrics.OutcomeTag(string(outboundOutcome(ctx, err))),
+		metrics.NexusCompletionSourceTag(n.completionSourceTag),
+	}
+	h.metricsHandler.Counter(RequestCounter.Name()).Record(1, tags...)
+	h.metricsHandler.Timer(RequestLatencyHistogram.Name()).Record(time.Since(startTime), tags...)
 
 	if err != nil {
 		retryable := isRetryableCallError(err)
@@ -88,7 +93,7 @@ func (n invocableOutbound) Invoke(
 			tag.Error(err),
 			tag.WorkflowNamespace(ns.Name().String()),
 			tag.Destination(taskAttr.Destination),
-			tag.WorkflowID(n.workflowID),
+			tag.WorkflowID(n.businessID),
 			tag.WorkflowRunID(n.runID),
 			tag.NexusCompletionSource(n.completionSourceTag),
 			tag.Attempt(n.attempt),
@@ -120,8 +125,4 @@ func outboundOutcome(callCtx context.Context, callErr error) outcomeTag {
 		return outcomeUnknownError
 	}
 	return outcomeSuccess
-}
-
-func handlerErrorOutcome(handlerErr *nexus.HandlerError) outcomeTag {
-	return outcomeTag(handlerErrorOutcomePrefix + commonnexus.BoundHandlerErrorType(string(handlerErr.Type)))
 }

--- a/chasm/lib/callback/library.go
+++ b/chasm/lib/callback/library.go
@@ -2,10 +2,33 @@ package callback
 
 import (
 	"go.temporal.io/server/chasm"
+	"go.uber.org/fx"
 	"google.golang.org/grpc"
 )
 
+// InvocationTaskGroup is the outbound queue task group that callback invocation tasks are
+// scheduled under. The queue's per-destination rate limiters and circuit breakers are keyed by it.
 const InvocationTaskGroup = chasm.CallbackLibraryName + ".invoke"
+
+// DestinationBlockedFn reports whether the outbound queue is currently holding back callback
+// deliveries to the given destination, i.e. whether its circuit breaker is open.
+type DestinationBlockedFn func(namespaceID string, destination string) bool
+
+type ctxKeyCallbackContextType struct{}
+
+var ctxKeyCallbackContext = ctxKeyCallbackContextType{}
+
+// callbackContext holds the dependencies injected into the chasm.Context for use by Callback methods.
+type callbackContext struct {
+	destinationBlocked DestinationBlockedFn
+}
+
+// callbackContextFromChasm extracts the callbackContext from a chasm.Context.
+// Panics if the context value is missing, which indicates a library registration bug.
+func callbackContextFromChasm(ctx chasm.Context) *callbackContext {
+	//nolint:revive // unchecked-type-assertion: intentional panic on missing context value
+	return ctx.Value(ctxKeyCallbackContext).(*callbackContext)
+}
 
 type (
 	Library struct {
@@ -13,6 +36,8 @@ type (
 
 		InvocationTaskHandler *invocationTaskHandler
 		BackoffTaskHandler    *backoffTaskHandler
+
+		destinationBlocked DestinationBlockedFn
 	}
 )
 
@@ -22,13 +47,21 @@ func NewNilLibrary() *Library {
 	return &Library{}
 }
 
-func newLibrary(
-	InvocationTaskHandler *invocationTaskHandler,
-	BackoffTaskHandler *backoffTaskHandler,
-) *Library {
+type libraryParams struct {
+	fx.In
+
+	InvocationTaskHandler *invocationTaskHandler
+	BackoffTaskHandler    *backoffTaskHandler
+	// Only the history service runs the outbound queue, so only it provides this. Elsewhere it is
+	// absent and callbacks are simply never reported as blocked.
+	DestinationBlocked DestinationBlockedFn `optional:"true"`
+}
+
+func newLibrary(params libraryParams) *Library {
 	return &Library{
-		InvocationTaskHandler: InvocationTaskHandler,
-		BackoffTaskHandler:    BackoffTaskHandler,
+		InvocationTaskHandler: params.InvocationTaskHandler,
+		BackoffTaskHandler:    params.BackoffTaskHandler,
+		destinationBlocked:    params.DestinationBlocked,
 	}
 }
 
@@ -37,10 +70,20 @@ func (l *Library) Name() string {
 }
 
 func (l *Library) Components() []*chasm.RegistrableComponent {
+	destinationBlocked := l.destinationBlocked
+	if destinationBlocked == nil {
+		// Processes that don't run the outbound queue never report a destination as blocked.
+		destinationBlocked = func(string, string) bool { return false }
+	}
 	return []*chasm.RegistrableComponent{
 		chasm.NewRegistrableComponent[*Callback](
 			chasm.CallbackComponentName,
 			chasm.WithDetached(),
+			chasm.WithContextValues(map[any]any{
+				ctxKeyCallbackContext: &callbackContext{
+					destinationBlocked: destinationBlocked,
+				},
+			}),
 		),
 	}
 }

--- a/chasm/lib/callback/metrics.go
+++ b/chasm/lib/callback/metrics.go
@@ -1,6 +1,12 @@
 package callback
 
-import "go.temporal.io/server/common/metrics"
+import (
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/metrics"
+	commonnexus "go.temporal.io/server/common/nexus"
+	"google.golang.org/grpc/codes"
+)
 
 // CHASM callback metrics.
 // These are defined independently from HSM callbacks to avoid coupling between the two implementations.
@@ -25,7 +31,17 @@ var (
 		metrics.WithDescription("Latency histogram of internal (cross-shard) callback deliveries made by the history service."),
 	)
 
-	// Emitted for both the internal and outbound paths, once the transition has committed.
+	// NexusHandler-variant callback metrics.
+	NexusHandlerRequestCounter = metrics.NewCounterDef(
+		"callback_nexushandler_requests",
+		metrics.WithDescription("The number of NexusHandler callback deliveries made by the history service."),
+	)
+	NexusHandlerRequestLatencyHistogram = metrics.NewTimerDef(
+		"callback_nexushandler_latency",
+		metrics.WithDescription("Latency histogram of NexusHandler callback deliveries made by the history service."),
+	)
+
+	// Emitted for all forms of callbacks (internal, outbound, and NexusHandler-variant) once the transition has committed.
 	InvocationEventCounter = metrics.NewCounterDef(
 		"callback_invocation_events",
 		metrics.WithDescription("Committed callback invocation events. Per callback: (retryable-error)* (success | nonretryable-error)."),
@@ -36,32 +52,56 @@ var (
 	)
 )
 
-// outcomeTag is a value of the outcome tag carried by the metrics above.
-type outcomeTag string
+// coarseOutcomeTag is the more coarse outcome only used by the InvocationEventCounter and InvocationAttemptsHistogram metrics.
+type coarseOutcomeTag string
 
-// Invocation events; the terminal success event is outcomeSuccess below.
+// The tags specific to InvocationEventCounter, which tracks the summary callback invocation event.
 const (
-	outcomeRetryableError    outcomeTag = "retryable-error"
-	outcomeNonretryableError outcomeTag = "nonretryable-error"
+	outcomeEventSuccess           coarseOutcomeTag = "success"
+	outcomeEventRetryableError    coarseOutcomeTag = "retryable-error"
+	outcomeEventNonRetryableError coarseOutcomeTag = "nonretryable-error"
 )
 
-// Internal-path delivery outcomes decided before the RPC is issued. Failures after it are tagged by
-// gRPC status code, under errorOutcomePrefix.
+// outcomeTag is a value of the outcome tag carried by the metrics above.
+//
+// While CHASM Callback outcomes are distinct from the Frontend service's Nexus invocation outcomes,
+// the labels should match when applicable. See common/nexus.DispatchResult's metricOutcome.
+type outcomeTag string
+
+// Outcome tags used for more granular tracing, used by InternalRequestCounter or NexusHandlerRequestLatencyHistogram.
+// This list is not exhaustive, handlerErrorOutcome and grpcErrorOutcome are used to generate outcome tags too.
 const (
 	// outcomeUnknown is the sentinel Invoke starts from, so a path that returns without
 	// setting an outcome shows up as unknown rather than as a success.
-	outcomeUnknown           outcomeTag = "unknown"
-	outcomeSuccess           outcomeTag = "success"
-	outcomeMissingToken      outcomeTag = "missing-token"
-	outcomeTokenDecodeError  outcomeTag = "token-decode-error"
-	outcomeInvalidRef        outcomeTag = "invalid-ref"
-	outcomeRequestBuildError outcomeTag = "request-build-error"
-	outcomeRequestTimeout    outcomeTag = "request-timeout"
+	outcomeUnknown outcomeTag = "unknown"
 	// An outbound failure that is not a Nexus handler error, e.g. a transport failure.
 	outcomeUnknownError outcomeTag = "unknown-error"
+
+	outcomeFailure           outcomeTag = "failure"
+	outcomeLegacyFailure     outcomeTag = "operation_error" // Emitted for clients sending older, deprecated error formats.
+	outcomeInvalidRef        outcomeTag = "invalid-ref"
+	outcomeMissingToken      outcomeTag = "missing-token"
+	outcomeRequestBuildError outcomeTag = "request-build-error"
+	outcomeRequestTimeout    outcomeTag = "request-timeout"
+	outcomeSuccess           outcomeTag = "success"
+	outcomeTokenDecodeError  outcomeTag = "token-decode-error"
 )
 
-const (
-	handlerErrorOutcomePrefix = "handler-error:"
-	errorOutcomePrefix        = "error:"
-)
+// handlerErrorOutcome generates the outcomeTag for a received Nexus HandlerError.
+func handlerErrorOutcome(handlerErr *nexus.HandlerError) outcomeTag {
+	// Only emit outcome tags for the error types defined in the spec.
+	// All others will be labeled as "handler-error:UNKNOWN", to prevent
+	// the metric from having unbounded cardinality.
+	boundedErrType := commonnexus.BoundHandlerErrorType(string(handlerErr.Type))
+	return outcomeTag("handler-error:" + boundedErrType)
+}
+
+// grpcErrorOutcome returns an outcomeTag derived from an error implementing
+// Statsui()/GRPCStatus(). Otherwise defaults to "error:Unknown".
+func grpcErrorOutcome(err error) outcomeTag {
+	tagSuffix := codes.Unknown.String()
+	if st, ok := common.GetRPCStatus(err); ok {
+		tagSuffix = st.Code().String()
+	}
+	return outcomeTag("error:" + tagSuffix)
+}

--- a/chasm/lib/callback/metrics.go
+++ b/chasm/lib/callback/metrics.go
@@ -97,7 +97,7 @@ func handlerErrorOutcome(handlerErr *nexus.HandlerError) outcomeTag {
 }
 
 // grpcErrorOutcome returns an outcomeTag derived from an error implementing
-// Statsui()/GRPCStatus(). Otherwise defaults to "error:Unknown".
+// Stats()/GRPCStatus(). Otherwise defaults to "error:Unknown".
 func grpcErrorOutcome(err error) outcomeTag {
 	tagSuffix := codes.Unknown.String()
 	if st, ok := common.GetRPCStatus(err); ok {

--- a/chasm/lib/callback/metrics_test.go
+++ b/chasm/lib/callback/metrics_test.go
@@ -1,0 +1,42 @@
+package callback
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestGRPCErrorOutcome(t *testing.T) {
+	cases := []struct {
+		Name string
+		E    error
+		Want string
+	}{
+		{
+			"status.Error",
+			status.Error(codes.Unavailable, "matching unavailable"),
+			"error:Unavailable",
+		},
+		{
+			"NotAGRPCError",
+			fmt.Errorf("doesn't implement %w", errors.New("the gRPC interfaces")),
+			"error:Unknown",
+		},
+		{
+			"WrappedGRPCError",
+			fmt.Errorf("first: %w", fmt.Errorf("second: %w", status.Error(codes.Internal, "third"))),
+			"error:Internal",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			got := grpcErrorOutcome(tc.E)
+			require.EqualValues(t, tc.Want, got)
+		})
+	}
+}

--- a/chasm/lib/callback/proto/v1/message.proto
+++ b/chasm/lib/callback/proto/v1/message.proto
@@ -32,6 +32,10 @@ message CallbackState {
   google.protobuf.Timestamp next_attempt_schedule_time = 8;
 
   // Request ID that added the callback.
+  //
+  // TODO(temporal/issues/11958): This field is overloaded. It is used for _both_, the outgoing
+  // request ID (to serve as an idempotency key). As well as the source request ID, to identify
+  // when the callback was added (for buffered workflow event scenarios).
   string request_id = 9;
 }
 
@@ -61,9 +65,22 @@ message Callback {
     map<string, string> header = 2;
   }
 
+  // Forked from temporal.api.common.v1.Callback.NexusHandler in the api repo, with abbreviated comments.
+  message NexusHandler {
+    // Nexus task queue the Temporal worker is listening on.
+    string task_queue_name = 1;
+    // Target Nexus service.
+    string service = 2;
+    // Target operation.
+    string operation = 3;
+    // Arbitrary user-supplied data from the source operation's callsite.
+    temporal.api.common.v1.Payload source_context = 4;
+  }
+
   reserved 1; // For a generic callback mechanism to be added later.
   oneof variant {
     Nexus nexus = 2;
+    NexusHandler nexus_handler = 4;
   }
 
   repeated temporal.api.common.v1.Link links = 100;

--- a/chasm/lib/callback/statemachine.go
+++ b/chasm/lib/callback/statemachine.go
@@ -12,6 +12,30 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+// callbackDestination returns the "destination" the callback is targeting. On the outbound queue
+// this keys the per-(namespace, destination) rate limits and circuit breaking. It also picks the
+// queue. A task with an empty destination goes to the transfer queue instead, see taskCategory
+// in chasm/tree.go.
+func callbackDestination(cb *callbackspb.Callback) (string, error) {
+	switch variant := cb.GetVariant().(type) {
+	case *callbackspb.Callback_Nexus_:
+		u, err := url.Parse(variant.Nexus.GetUrl())
+		if err != nil {
+			return "", fmt.Errorf("failed to parse URL: %v: %w", cb, err)
+		}
+		return u.Scheme + "://" + u.Host, nil
+	case *callbackspb.Callback_NexusHandler_:
+		// Use a new "nexus-handler" scheme to avoid colliding with any other type of callback variant.
+		return "nexus-handler://" + variant.NexusHandler.GetTaskQueueName(), nil
+	default:
+		// Only reachable if a newer server persisted a variant this build doesn't know about.
+		// Returning an error would fail the whole transaction that completed the execution,
+		// which is worse. An empty destination is valid: the task lands on the transfer queue,
+		// which runs CHASM side-effect tasks just fine.
+		return "", nil
+	}
+}
+
 // EventScheduled is triggered when the callback is meant to be scheduled for the first time - when its Trigger
 // condition is met.
 type EventScheduled struct{}
@@ -20,11 +44,11 @@ var TransitionScheduled = chasm.NewTransition(
 	[]callbackspb.CallbackStatus{callbackspb.CALLBACK_STATUS_STANDBY},
 	callbackspb.CALLBACK_STATUS_SCHEDULED,
 	func(cb *Callback, ctx chasm.MutableContext, event EventScheduled) error {
-		u, err := url.Parse(cb.Callback.GetNexus().GetUrl())
+		destination, err := callbackDestination(cb.GetCallback())
 		if err != nil {
-			return fmt.Errorf("failed to parse URL: %v: %w", cb.Callback, err)
+			return err
 		}
-		ctx.AddTask(cb, chasm.TaskAttributes{Destination: u.Scheme + "://" + u.Host}, &callbackspb.InvocationTask{})
+		ctx.AddTask(cb, chasm.TaskAttributes{Destination: destination}, &callbackspb.InvocationTask{})
 		return nil
 	},
 )
@@ -37,13 +61,13 @@ var TransitionRescheduled = chasm.NewTransition(
 	callbackspb.CALLBACK_STATUS_SCHEDULED,
 	func(cb *Callback, ctx chasm.MutableContext, event EventRescheduled) error {
 		cb.NextAttemptScheduleTime = nil
-		u, err := url.Parse(cb.Callback.GetNexus().Url)
+		destination, err := callbackDestination(cb.GetCallback())
 		if err != nil {
-			return fmt.Errorf("failed to parse URL: %v: %w", cb.Callback, err)
+			return err
 		}
 		ctx.AddTask(
 			cb,
-			chasm.TaskAttributes{Destination: u.Scheme + "://" + u.Host},
+			chasm.TaskAttributes{Destination: destination},
 			&callbackspb.InvocationTask{Attempt: cb.Attempt},
 		)
 		return nil

--- a/chasm/lib/callback/statemachine_test.go
+++ b/chasm/lib/callback/statemachine_test.go
@@ -12,6 +12,78 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+func TestCallbackDestination(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		cb      *callbackspb.Callback
+		want    string
+		wantErr string
+	}{
+		{
+			name: "nexus",
+			cb: &callbackspb.Callback{Variant: &callbackspb.Callback_Nexus_{
+				Nexus: &callbackspb.Callback_Nexus{Url: "http://address:666/path/to/callback?query=string"},
+			}},
+			want: "http://address:666",
+		},
+		{
+			name: "nexus with invalid url",
+			cb: &callbackspb.Callback{Variant: &callbackspb.Callback_Nexus_{
+				Nexus: &callbackspb.Callback_Nexus{Url: "http://invalid url/path"},
+			}},
+			wantErr: "failed to parse URL:",
+		},
+		{
+			name: "nexus handler",
+			cb: &callbackspb.Callback{Variant: &callbackspb.Callback_NexusHandler_{
+				NexusHandler: &callbackspb.Callback_NexusHandler{TaskQueueName: "completions-task-queue"},
+			}},
+			want: "nexus-handler://completions-task-queue",
+		},
+		{
+			// A variant this server does not recognize, e.g. one persisted by a newer server.
+			name: "unrecognized variant",
+			cb:   &callbackspb.Callback{},
+			want: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := callbackDestination(tc.cb)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				require.Equal(t, tc.want, got)
+			} else {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// Scheduling a NexusHandler callback succeeds and routes its invocation task to the target task
+// queue. Invoking it is not implemented yet, so the invocation task itself fails; scheduling must
+// not, since it runs as part of the execution's close transaction.
+func TestTransitionScheduled_NexusHandler(t *testing.T) {
+	cb := &Callback{
+		CallbackState: &callbackspb.CallbackState{
+			Callback: &callbackspb.Callback{
+				Variant: &callbackspb.Callback_NexusHandler_{
+					NexusHandler: &callbackspb.Callback_NexusHandler{TaskQueueName: "completions-task-queue"},
+				},
+			},
+		},
+	}
+	cb.SetStateMachineState(callbackspb.CALLBACK_STATUS_STANDBY)
+
+	mctx := &chasm.MockMutableContext{}
+	require.NoError(t, TransitionScheduled.Apply(cb, mctx, EventScheduled{}))
+
+	require.Equal(t, callbackspb.CALLBACK_STATUS_SCHEDULED, cb.StateMachineState())
+	require.Len(t, mctx.Tasks, 1)
+	require.IsType(t, &callbackspb.InvocationTask{}, mctx.Tasks[0].Payload)
+	require.Equal(t, "nexus-handler://completions-task-queue", mctx.Tasks[0].Attributes.Destination)
+}
+
 func TestValidTransitions(t *testing.T) {
 	// Setup
 	currentTime := time.Now().UTC()

--- a/chasm/lib/callback/statemachine_test.go
+++ b/chasm/lib/callback/statemachine_test.go
@@ -60,9 +60,8 @@ func TestCallbackDestination(t *testing.T) {
 	}
 }
 
-// Scheduling a NexusHandler callback succeeds and routes its invocation task to the target task
-// queue. Invoking it is not implemented yet, so the invocation task itself fails; scheduling must
-// not, since it runs as part of the execution's close transaction.
+// Scheduling a NexusHandler callback routes its invocation task to the target task queue rather
+// than to a URL-derived destination.
 func TestTransitionScheduled_NexusHandler(t *testing.T) {
 	cb := &Callback{
 		CallbackState: &callbackspb.CallbackState{

--- a/chasm/lib/callback/tasks.go
+++ b/chasm/lib/callback/tasks.go
@@ -80,6 +80,7 @@ type invocationTaskHandlerOptions struct {
 	HTTPCallerProvider HTTPCallerProvider
 	HTTPTraceProvider  commonnexus.HTTPClientTraceProvider
 	HistoryClient      resource.HistoryClient
+	MatchingClient     resource.MatchingClient
 }
 
 type invocationTaskHandler struct {
@@ -91,6 +92,7 @@ type invocationTaskHandler struct {
 	httpCallerProvider HTTPCallerProvider
 	httpTraceProvider  commonnexus.HTTPClientTraceProvider
 	historyClient      resource.HistoryClient
+	matchingClient     resource.MatchingClient
 }
 
 func newInvocationTaskHandler(opts invocationTaskHandlerOptions) *invocationTaskHandler {
@@ -102,6 +104,7 @@ func newInvocationTaskHandler(opts invocationTaskHandlerOptions) *invocationTask
 		httpCallerProvider: opts.HTTPCallerProvider,
 		httpTraceProvider:  opts.HTTPTraceProvider,
 		historyClient:      opts.HistoryClient,
+		matchingClient:     opts.MatchingClient,
 	}
 }
 
@@ -160,14 +163,14 @@ func (h *invocationTaskHandler) recordInvocationEvent(
 	task *callbackspb.InvocationTask,
 	result invocationResult,
 ) {
-	var outcome outcomeTag
+	var outcome coarseOutcomeTag
 	switch result.(type) {
 	case invocationResultOK:
-		outcome = outcomeSuccess
+		outcome = outcomeEventSuccess
 	case invocationResultRetry:
-		outcome = outcomeRetryableError
+		outcome = outcomeEventRetryableError
 	case invocationResultFail:
-		outcome = outcomeNonretryableError
+		outcome = outcomeEventNonRetryableError
 	default:
 		// saveResult rejects anything else as an unprocessable task.
 		return
@@ -180,10 +183,9 @@ func (h *invocationTaskHandler) recordInvocationEvent(
 	}
 	h.metricsHandler.Counter(InvocationEventCounter.Name()).Record(1, tags...)
 
-	if outcome != outcomeRetryableError {
+	if outcome != outcomeEventRetryableError {
 		// Attempt is 0-based, so +1 is the count. Only terminal events have a final total.
-		h.metricsHandler.Histogram(InvocationAttemptsHistogram.Name(), InvocationAttemptsHistogram.Unit()).
-			Record(int64(task.GetAttempt())+1, tags...)
+		InvocationAttemptsHistogram.With(h.metricsHandler).Record(int64(task.GetAttempt())+1, tags...)
 	}
 }
 

--- a/chasm/lib/callback/tasks_test.go
+++ b/chasm/lib/callback/tasks_test.go
@@ -30,6 +30,7 @@ import (
 	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/nexus/nexusrpc"
 	"go.temporal.io/server/common/resource"
+	test "go.temporal.io/server/common/testing"
 	"go.temporal.io/server/service/history/queues/common"
 	queueserrors "go.temporal.io/server/service/history/queues/errors"
 	"go.uber.org/mock/gomock"
@@ -82,6 +83,78 @@ func (l *mockNexusCompletionGetterLibrary) Components() []*chasm.RegistrableComp
 	return []*chasm.RegistrableComponent{
 		chasm.NewRegistrableComponent[*mockNexusCompletionGetterComponent]("nexusCompletionGetter"),
 	}
+}
+
+// newInvocationTaskTest builds a CHASM tree holding cb underneath a completion source that returns the
+// given completion, and returns an engine context plus a ref to the callback to invoke task handlers with.
+func newInvocationTaskTest(
+	t *testing.T,
+	handler *invocationTaskHandler,
+	cb *Callback,
+	completion nexusrpc.CompleteOperationOptions,
+) (context.Context, chasm.ComponentRef) {
+	t.Helper()
+
+	chasmRegistry := chasm.NewRegistry(log.NewTestLogger())
+	require.NoError(t, chasmRegistry.Register(&Library{InvocationTaskHandler: handler}))
+	require.NoError(t, chasmRegistry.Register(&mockNexusCompletionGetterLibrary{}))
+
+	executionKey := chasm.ExecutionKey{
+		NamespaceID: "namespace-id",
+		BusinessID:  "workflow-id",
+		RunID:       "run-id",
+	}
+	engineCtx := chasm.NewEngineContext(context.Background(), chasmtest.NewEngine(t, chasmRegistry))
+	_, err := chasm.StartExecution(
+		engineCtx,
+		executionKey,
+		func(ctx chasm.MutableContext, _ struct{}) (*mockNexusCompletionGetterComponent, error) {
+			return &mockNexusCompletionGetterComponent{
+				completion: completion,
+				Callback:   chasm.NewComponentField(ctx, cb),
+			}, nil
+		},
+		struct{}{},
+	)
+	require.NoError(t, err)
+
+	rootRef := chasm.NewComponentRef[*mockNexusCompletionGetterComponent](executionKey)
+	callbackRef, err := chasm.ReadComponent(
+		engineCtx,
+		rootRef,
+		func(_ *mockNexusCompletionGetterComponent, chasmCtx chasm.Context, _ struct{}) (chasm.ComponentRef, error) {
+			serialized, err := chasmCtx.Ref(cb)
+			if err != nil {
+				return chasm.ComponentRef{}, err
+			}
+			return chasm.DeserializeComponentRef(serialized)
+		},
+		struct{}{},
+	)
+	require.NoError(t, err)
+	return engineCtx, callbackRef
+}
+
+// readCallbackState runs assert against the persisted callback state, so that assertions see what the task
+// handler committed rather than the in-memory component it was handed.
+func readCallbackState(
+	engineCtx context.Context,
+	t *testing.T,
+	ref chasm.ComponentRef,
+	assert func(chasm.Context, *Callback),
+) {
+	t.Helper()
+
+	_, err := chasm.ReadComponent(
+		engineCtx,
+		ref,
+		func(c *Callback, chasmCtx chasm.Context, _ struct{}) (struct{}, error) {
+			assert(chasmCtx, c)
+			return struct{}{}, nil
+		},
+		struct{}{},
+	)
+	require.NoError(t, err)
 }
 
 // Test the full executeInvocationTask flow with direct handler calls
@@ -171,17 +244,7 @@ func TestExecuteInvocationTaskNexus_Outcomes(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			// Setup namespace
-			factory := namespace.NewDefaultReplicationResolverFactory()
-			detail := &persistencespb.NamespaceDetail{
-				Info: &persistencespb.NamespaceInfo{
-					Id:   "namespace-id",
-					Name: "namespace-name",
-				},
-				Config: &persistencespb.NamespaceConfig{},
-			}
-			ns, err := namespace.FromPersistentState(detail, factory(detail))
-			require.NoError(t, err)
+			ns := test.NewNamespace(t)
 
 			// Setup metrics expectations
 			metricsHandler := metrics.NewMockHandler(ctrl)
@@ -190,13 +253,13 @@ func TestExecuteInvocationTaskNexus_Outcomes(t *testing.T) {
 			timer := metrics.NewMockTimerIface(ctrl)
 			metricsHandler.EXPECT().Counter(RequestCounter.Name()).Return(counter)
 			counter.EXPECT().Record(int64(1),
-				metrics.NamespaceTag("namespace-name"),
+				metrics.NamespaceTag(ns.Name().String()),
 				metrics.DestinationTag("http://localhost"),
 				metrics.OutcomeTag(tc.expectedMetricOutcome),
 				metrics.NexusCompletionSourceTag(testCompletionSourceFqn))
 			metricsHandler.EXPECT().Timer(RequestLatencyHistogram.Name()).Return(timer)
 			timer.EXPECT().Record(gomock.Any(),
-				metrics.NamespaceTag("namespace-name"),
+				metrics.NamespaceTag(ns.Name().String()),
 				metrics.DestinationTag("http://localhost"),
 				metrics.OutcomeTag(tc.expectedMetricOutcome),
 				metrics.NexusCompletionSourceTag(testCompletionSourceFqn))
@@ -204,14 +267,14 @@ func TestExecuteInvocationTaskNexus_Outcomes(t *testing.T) {
 			// The committed event is recorded for the outbound path too, not just the
 			// internal one, so a permanently dropped external callback is also visible.
 			eventTags := []metrics.Tag{
-				metrics.NamespaceTag("namespace-name"),
+				metrics.NamespaceTag(ns.Name().String()),
 				metrics.DestinationTag("http://localhost"),
 				metrics.OutcomeTag(tc.expectedEvent),
 			}
 			eventCounter := metrics.NewMockCounterIface(ctrl)
 			metricsHandler.EXPECT().Counter(InvocationEventCounter.Name()).Return(eventCounter)
 			eventCounter.EXPECT().Record(int64(1), eventTags)
-			if tc.expectedEvent != string(outcomeRetryableError) {
+			if tc.expectedEvent != string(outcomeEventRetryableError) {
 				attemptHistogram := metrics.NewMockHistogramIface(ctrl)
 				metricsHandler.EXPECT().
 					Histogram(InvocationAttemptsHistogram.Name(), InvocationAttemptsHistogram.Unit()).
@@ -241,14 +304,6 @@ func TestExecuteInvocationTaskNexus_Outcomes(t *testing.T) {
 				},
 			}
 
-			chasmRegistry := chasm.NewRegistry(logger)
-			err = chasmRegistry.Register(&Library{
-				InvocationTaskHandler: handler,
-			})
-			require.NoError(t, err)
-			err = chasmRegistry.Register(&mockNexusCompletionGetterLibrary{})
-			require.NoError(t, err)
-
 			callback := &Callback{
 				CallbackState: &callbackspb.CallbackState{
 					RequestId:        "request-id",
@@ -265,43 +320,7 @@ func TestExecuteInvocationTaskNexus_Outcomes(t *testing.T) {
 				},
 			}
 
-			// Create completion
-			completion := nexusrpc.CompleteOperationOptions{}
-
-			executionKey := chasm.ExecutionKey{
-				NamespaceID: "namespace-id",
-				BusinessID:  "workflow-id",
-				RunID:       "run-id",
-			}
-			testEngine := chasmtest.NewEngine(t, chasmRegistry)
-			engineCtx := chasm.NewEngineContext(context.Background(), testEngine)
-			_, err = chasm.StartExecution(
-				engineCtx,
-				executionKey,
-				func(ctx chasm.MutableContext, _ struct{}) (*mockNexusCompletionGetterComponent, error) {
-					return &mockNexusCompletionGetterComponent{
-						completion: completion,
-						Callback:   chasm.NewComponentField(ctx, callback),
-					}, nil
-				},
-				struct{}{},
-			)
-			require.NoError(t, err)
-
-			rootRef := chasm.NewComponentRef[*mockNexusCompletionGetterComponent](executionKey)
-			callbackRef, err := chasm.ReadComponent(
-				engineCtx,
-				rootRef,
-				func(_ *mockNexusCompletionGetterComponent, chasmCtx chasm.Context, _ struct{}) (chasm.ComponentRef, error) {
-					serialized, err := chasmCtx.Ref(callback)
-					if err != nil {
-						return chasm.ComponentRef{}, err
-					}
-					return chasm.DeserializeComponentRef(serialized)
-				},
-				struct{}{},
-			)
-			require.NoError(t, err)
+			engineCtx, callbackRef := newInvocationTaskTest(t, handler, callback, nexusrpc.CompleteOperationOptions{})
 
 			executeErr := handler.Execute(
 				engineCtx,
@@ -311,16 +330,9 @@ func TestExecuteInvocationTaskNexus_Outcomes(t *testing.T) {
 			)
 
 			// Verify outcome by reading component state directly.
-			resultCallback, err := chasm.ReadComponent(
-				engineCtx,
-				callbackRef,
-				func(c *Callback, _ chasm.Context, _ struct{}) (*Callback, error) {
-					return c, nil
-				},
-				struct{}{},
-			)
-			require.NoError(t, err)
-			tc.assertOutcome(t, resultCallback, executeErr)
+			readCallbackState(engineCtx, t, callbackRef, func(chasmCtx chasm.Context, c *Callback) {
+				tc.assertOutcome(t, c, executeErr)
+			})
 		})
 	}
 }

--- a/chasm/lib/nexusoperation/callbacks_test.go
+++ b/chasm/lib/nexusoperation/callbacks_test.go
@@ -1,0 +1,522 @@
+package nexusoperation
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	failurepb "go.temporal.io/api/failure/v1"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/api/workflowservice/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/lib/callback"
+	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
+	nexusoperationpb "go.temporal.io/server/chasm/lib/nexusoperation/gen/nexusoperationpb/v1"
+	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func newCallbackTestContext() *chasm.MockMutableContext {
+	return &chasm.MockMutableContext{
+		MockContext: chasm.MockContext{
+			HandleNow: func(chasm.Component) time.Time { return defaultTime },
+			HandleExecutionKey: func() chasm.ExecutionKey {
+				return chasm.ExecutionKey{NamespaceID: "ns-id", BusinessID: "op-id", RunID: "run-id"}
+			},
+			HandleNamespaceEntry: func() *namespace.Namespace {
+				return namespace.NewNamespaceForTest(&persistencespb.NamespaceInfo{Name: "ns-name"}, nil, false, nil, 0)
+			},
+			HandleExecutionInfo: func() chasm.ExecutionInfo {
+				return chasm.ExecutionInfo{CloseTime: defaultTime}
+			},
+			GoCtx: context.WithValue(context.Background(), OperationContextKey, &OperationContext{
+				MetricTagConfig: dynamicconfig.GetTypedPropertyFn(NexusMetricTagConfig{}),
+			}),
+		},
+	}
+}
+
+func TestNewStandaloneOperationAttachesCompletionCallbacks(t *testing.T) {
+	t.Parallel()
+
+	newStartReq := func(cbs ...*commonpb.Callback) *nexusoperationpb.StartNexusOperationRequest {
+		return &nexusoperationpb.StartNexusOperationRequest{
+			EndpointId: "endpoint-id",
+			FrontendRequest: &workflowservice.StartNexusOperationExecutionRequest{
+				Namespace:           "ns-name",
+				OperationId:         "op-id",
+				RequestId:           "req-id",
+				Endpoint:            "test-endpoint",
+				Service:             "test-service",
+				Operation:           "test-operation",
+				CompletionCallbacks: cbs,
+			},
+		}
+	}
+
+	t.Run("WithCallbacks", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+
+		req := newStartReq(newNexusCallback())
+		op, err := newStandaloneOperation(ctx, req, 10, newTestLinkValidator(10, 10))
+		require.NoError(t, err)
+		require.Equal(t, nexusoperationpb.OPERATION_STATUS_SCHEDULED, op.Status)
+
+		// Callbacks start in STANDBY, only transitioning to SCHEDULED when the SANO completes.
+		require.Len(t, op.Callbacks, 1)
+		attachedCB := op.Callbacks["req-id-0"].Get(ctx)
+		require.Equal(t, callbackspb.CALLBACK_STATUS_STANDBY, attachedCB.Status)
+	})
+
+	t.Run("WithoutCallbacks", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+
+		op, err := newStandaloneOperation(ctx, newStartReq(), 10, newTestLinkValidator(10, 10))
+		require.NoError(t, err)
+		require.Nil(t, op.Callbacks)
+	})
+
+	t.Run("EnforcesTheCallersLimit", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+
+		_, err := newStandaloneOperation(ctx, newStartReq(
+			newNexusCallback(),
+			newNexusCallback(),
+		), 1, newTestLinkValidator(10, 10))
+		var failedPreconditionErr *serviceerror.FailedPrecondition
+		require.ErrorAs(t, err, &failedPreconditionErr)
+		require.ErrorContains(t, err, "cannot attach more than 1 callbacks")
+	})
+}
+
+func TestAddCompletionCallbacks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("AttachesCallbacksInStandby", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+		op := newScheduledTestOperation(t, ctx)
+
+		cb1 := newNexusCallback()
+		cb1.GetNexus().Url = "https://example.com/callback-1"
+
+		// Set data on the second CB, we confirm is added to the Operation.
+		cb2 := newNexusCallback()
+		cb2.GetNexus().Url = "https://example.com/callback-2"
+		cb2.GetNexus().Header = map[string]string{
+			"key": "xxx",
+		}
+		cb2.Links = []*commonpb.Link{{Variant: &commonpb.Link_WorkflowEvent_{
+			WorkflowEvent: &commonpb.Link_WorkflowEvent{Namespace: "ns-name", WorkflowId: "wf-id"},
+		}}}
+
+		cbs := []*commonpb.Callback{
+			cb1,
+			cb2,
+		}
+
+		err := op.addCompletionCallbacks(ctx, "req-id", cbs, 10)
+		require.NoError(t, err)
+		require.Len(t, op.Callbacks, 2)
+
+		first, ok := op.Callbacks["req-id-0"]
+		require.True(t, ok)
+		firstCb := first.Get(ctx)
+		require.Equal(t, "https://example.com/callback-1", firstCb.GetCallback().GetNexus().GetUrl())
+
+		second, ok := op.Callbacks["req-id-1"]
+		require.True(t, ok)
+		secondCb := second.Get(ctx)
+		require.Equal(t, callbackspb.CALLBACK_STATUS_STANDBY, secondCb.Status)
+		require.Equal(t, defaultTime, secondCb.RegistrationTime.AsTime())
+		require.Equal(t, "https://example.com/callback-2", secondCb.GetCallback().GetNexus().GetUrl())
+		require.Equal(t, map[string]string{"key": "xxx"}, secondCb.GetCallback().GetNexus().GetHeader())
+		require.Len(t, secondCb.GetCallback().GetLinks(), 1)
+
+		// Each callback gets its own, unique request ID.
+		require.NotEqual(t, "req-id", firstCb.RequestId)
+		require.NotEqual(t, "req-id", secondCb.RequestId)
+		require.NotEqual(t, firstCb.RequestId, secondCb.RequestId)
+
+		// STANDBY means no invocation task yet; only the scheduled transition's tasks are present.
+		for _, task := range ctx.Tasks {
+			_, isInvocation := task.Payload.(*callbackspb.InvocationTask)
+			require.False(t, isInvocation, "callbacks must not be invoked while in STANDBY")
+		}
+	})
+
+	t.Run("EmptyListIsNoOp", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+		op := newScheduledTestOperation(t, ctx)
+
+		require.NoError(t, op.addCompletionCallbacks(ctx, "req-id", nil, 10))
+		require.Nil(t, op.Callbacks)
+	})
+
+	t.Run("ReAttachingTheSameRequestIsIdempotent", func(t *testing.T) {
+		// A retried start (or a retried on_conflict_options attach) must not duplicate callbacks.
+		ctx := newCallbackTestContext()
+		op := newScheduledTestOperation(t, ctx)
+		cbs := []*commonpb.Callback{newNexusCallback()}
+
+		require.NoError(t, op.addCompletionCallbacks(ctx, "req-id", cbs, 10))
+		require.NoError(t, op.addCompletionCallbacks(ctx, "req-id", cbs, 10))
+		require.Len(t, op.Callbacks, 1)
+	})
+
+	t.Run("ReAttachingTheSameRequestIsIdempotentAfterClose", func(t *testing.T) {
+		// A start request can reach addCompletionCallbacks twice: once creating the operation, then
+		// again if the client retries and the engine dedups on request ID. The operation may have closed
+		// in between, and the retry must still report success for callbacks that are already persisted
+		// rather than FailedPrecondition.
+		ctx := newCallbackTestContext()
+		op := newScheduledTestOperation(t, ctx)
+		cbs := []*commonpb.Callback{newNexusCallback()}
+
+		require.NoError(t, op.addCompletionCallbacks(ctx, "req-id", cbs, 10))
+		require.NoError(t, TransitionSucceeded.Apply(op, ctx, EventSucceeded{}))
+		require.Equal(t, callbackspb.CALLBACK_STATUS_SCHEDULED, op.Callbacks["req-id-0"].Get(ctx).Status)
+
+		tasksBefore := len(ctx.Tasks)
+		require.NoError(t, op.addCompletionCallbacks(ctx, "req-id", cbs, 10))
+
+		// The retry must leave the already-scheduled callback alone: re-attaching would reset it to
+		// STANDBY, stranding a callback the terminal transition had already released for delivery.
+		require.Len(t, op.Callbacks, 1)
+		require.Equal(t, callbackspb.CALLBACK_STATUS_SCHEDULED, op.Callbacks["req-id-0"].Get(ctx).Status)
+		require.Len(t, ctx.Tasks, tasksBefore)
+	})
+
+	t.Run("DistinctRequestsAccumulate", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+		op := newScheduledTestOperation(t, ctx)
+		cbs := []*commonpb.Callback{newNexusCallback()}
+
+		require.NoError(t, op.addCompletionCallbacks(ctx, "req-1", cbs, 10))
+		require.NoError(t, op.addCompletionCallbacks(ctx, "req-2", cbs, 10))
+		require.Len(t, op.Callbacks, 2)
+	})
+
+	t.Run("RejectsExceedingTheLimit", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+		op := newScheduledTestOperation(t, ctx)
+		cbs := []*commonpb.Callback{newNexusCallback(), newNexusCallback()}
+
+		err := op.addCompletionCallbacks(ctx, "req-id", cbs, 1)
+		var failedPreconditionErr *serviceerror.FailedPrecondition
+		require.ErrorAs(t, err, &failedPreconditionErr)
+		require.Contains(t, err.Error(), "cannot attach more than 1 callbacks")
+		require.Empty(t, op.Callbacks)
+	})
+
+	t.Run("RejectsExceedingTheLimitWithAlreadyAttachedCallbacks", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+		op := newScheduledTestOperation(t, ctx)
+
+		require.NoError(t, op.addCompletionCallbacks(ctx, "req-1", []*commonpb.Callback{
+			newNexusCallback(),
+		}, 2))
+
+		err := op.addCompletionCallbacks(ctx, "req-2", []*commonpb.Callback{
+			newNexusCallback(),
+			newNexusCallback(),
+		}, 2)
+		var failedPreconditionErr *serviceerror.FailedPrecondition
+		require.ErrorAs(t, err, &failedPreconditionErr)
+		require.Contains(t, err.Error(), "1 callbacks already attached")
+		require.Len(t, op.Callbacks, 1)
+	})
+
+	t.Run("RejectsAClosedOperation", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+		op := newScheduledTestOperation(t, ctx)
+		require.NoError(t, TransitionSucceeded.Apply(op, ctx, EventSucceeded{}))
+
+		err := op.addCompletionCallbacks(ctx, "req-id", []*commonpb.Callback{
+			newNexusCallback(),
+		}, 10)
+		var failedPreconditionErr *serviceerror.FailedPrecondition
+		require.ErrorAs(t, err, &failedPreconditionErr)
+		require.Contains(t, err.Error(), "cannot attach callbacks to a closed nexus operation")
+		require.Empty(t, op.Callbacks)
+	})
+
+	t.Run("RejectsAnEmptyRequestID", func(t *testing.T) {
+		// Callback IDs are derived from the request ID, so without one two distinct requests would
+		// produce colliding keys and silently overwrite each other. The frontend always supplies one
+		// (validator.normalizeRequestID); this guards a history-side caller that did not.
+		ctx := newCallbackTestContext()
+		op := newScheduledTestOperation(t, ctx)
+
+		err := op.addCompletionCallbacks(ctx, "", []*commonpb.Callback{
+			newNexusCallback(),
+		}, 10)
+		var invalidArgErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgErr)
+		require.Contains(t, err.Error(), "without a request ID")
+		require.Empty(t, op.Callbacks)
+	})
+}
+
+func TestScheduleCompletionCallbacksOnTerminalTransition(t *testing.T) {
+	t.Parallel()
+
+	timeoutFailure := &failurepb.Failure{
+		Message: "timed out",
+		FailureInfo: &failurepb.Failure_TimeoutFailureInfo{
+			TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
+				TimeoutType: enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE,
+			},
+		},
+	}
+
+	// In all scenarios, we expect the CHASM callbacks to be scheduled once the
+	// SANO transitions to a terminal state.
+	for _, tc := range []struct {
+		name           string
+		fromStatus     nexusoperationpb.OperationStatus
+		apply          func(*Operation, *chasm.MockMutableContext) error
+		expectedStatus nexusoperationpb.OperationStatus
+	}{
+		{
+			name: "Succeeded",
+			apply: func(o *Operation, ctx *chasm.MockMutableContext) error {
+				return TransitionSucceeded.Apply(o, ctx, EventSucceeded{})
+			},
+			expectedStatus: nexusoperationpb.OPERATION_STATUS_SUCCEEDED,
+		},
+		{
+			name: "Failed",
+			apply: func(o *Operation, ctx *chasm.MockMutableContext) error {
+				return TransitionFailed.Apply(o, ctx, EventFailed{
+					Failure: &failurepb.Failure{Message: "boom"},
+				})
+			},
+			expectedStatus: nexusoperationpb.OPERATION_STATUS_FAILED,
+		},
+		{
+			name: "Canceled",
+			apply: func(o *Operation, ctx *chasm.MockMutableContext) error {
+				return TransitionCanceled.Apply(o, ctx, EventCanceled{
+					Failure: &failurepb.Failure{Message: "canceled"},
+				})
+			},
+			expectedStatus: nexusoperationpb.OPERATION_STATUS_CANCELED,
+		},
+		{
+			name: "TimedOut",
+			apply: func(o *Operation, ctx *chasm.MockMutableContext) error {
+				return TransitionTimedOut.Apply(o, ctx, EventTimedOut{Failure: timeoutFailure})
+			},
+			expectedStatus: nexusoperationpb.OPERATION_STATUS_TIMED_OUT,
+		},
+		{
+			name: "Terminated",
+			apply: func(o *Operation, ctx *chasm.MockMutableContext) error {
+				_, err := o.Terminate(ctx, chasm.TerminateComponentRequest{
+					RequestID: "terminate-req-id",
+					Reason:    "because",
+				})
+				return err
+			},
+			expectedStatus: nexusoperationpb.OPERATION_STATUS_TERMINATED,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := newCallbackTestContext()
+			op := newScheduledTestOperation(t, ctx)
+			require.NoError(t, op.addCompletionCallbacks(ctx, "req-id", []*commonpb.Callback{
+				newNexusCallback(),
+			}, 10))
+
+			tasksBefore := len(ctx.Tasks)
+			require.NoError(t, tc.apply(op, ctx))
+			require.Equal(t, tc.expectedStatus, op.Status)
+
+			cb := op.Callbacks["req-id-0"].Get(ctx)
+			require.Equal(t, callbackspb.CALLBACK_STATUS_SCHEDULED, cb.Status)
+
+			// Closing must emit exactly one callback invocation task, routed to the callback's host.
+			newTasks := ctx.Tasks[tasksBefore:]
+			require.Len(t, newTasks, 1)
+			require.IsType(t, &callbackspb.InvocationTask{}, newTasks[0].Payload)
+
+			// The task's Destination attribute for Nexus callbacks is the hostname, which
+			// is fixed in newNexusCallback.
+			const wantHost = "https://nexus.ex.xxxxx.cluster.tmprl.cloud:7243"
+			require.Equal(t, wantHost, newTasks[0].Attributes.Destination)
+		})
+	}
+
+	t.Run("NoCallbacksIsANoOp", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+		op := newScheduledTestOperation(t, ctx)
+
+		tasksBefore := len(ctx.Tasks)
+		require.NoError(t, TransitionSucceeded.Apply(op, ctx, EventSucceeded{}))
+		require.Len(t, ctx.Tasks, tasksBefore)
+	})
+}
+
+func TestBuildCompletionCallbackInfos(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NoCallbacks", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+		op := newTestOperation()
+
+		infos, err := op.buildCompletionCallbackInfos(ctx)
+		require.NoError(t, err)
+		require.Nil(t, infos)
+	})
+
+	t.Run("ReportsStateAndOutcomePerCallback", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+		op := newTestOperation()
+
+		newCB := func(url string, status callbackspb.CallbackStatus) *callback.Callback {
+			cb := callback.NewCallback(
+				"req-id",
+				timestamppb.New(defaultTime),
+				&callbackspb.Callback{
+					Variant: &callbackspb.Callback_Nexus_{
+						Nexus: &callbackspb.Callback_Nexus{Url: url},
+					},
+				},
+			)
+			cb.SetStateMachineState(status)
+			return cb
+		}
+
+		failed := newCB("http://localhost:8080/failed", callbackspb.CALLBACK_STATUS_FAILED)
+		failed.Attempt = 3
+		failed.LastAttemptFailure = &failurepb.Failure{Message: "boom"}
+
+		op.Callbacks = chasm.Map[string, *callback.Callback]{
+			"req-id-0": chasm.NewComponentField(ctx, newCB("http://localhost:8080/standby", callbackspb.CALLBACK_STATUS_STANDBY)),
+			"req-id-1": chasm.NewComponentField(ctx, newCB("http://localhost:8080/succeeded", callbackspb.CALLBACK_STATUS_SUCCEEDED)),
+			"req-id-2": chasm.NewComponentField(ctx, failed),
+		}
+
+		infos, err := op.buildCompletionCallbackInfos(ctx)
+		require.NoError(t, err)
+		require.Len(t, infos, 3)
+
+		// Ordering follows the sorted callback IDs, not the (randomized) map iteration order.
+		require.Equal(t, "http://localhost:8080/standby", infos[0].GetInfo().GetCallback().GetNexus().GetUrl())
+		require.Equal(t, enumspb.CALLBACK_STATE_STANDBY, infos[0].GetInfo().GetState())
+		require.Equal(t, defaultTime, infos[0].GetInfo().GetRegistrationTime().AsTime())
+		// Every callback on a standalone operation is triggered by the operation completing.
+		require.NotNil(t, infos[0].GetTrigger().GetOperationCompleted())
+
+		require.Equal(t, enumspb.CALLBACK_STATE_SUCCEEDED, infos[1].GetInfo().GetState())
+
+		require.Equal(t, enumspb.CALLBACK_STATE_FAILED, infos[2].GetInfo().GetState())
+		require.Equal(t, int32(3), infos[2].GetInfo().GetAttempt())
+	})
+}
+
+// TestCompletionCallbacksRoundTripThroughTheTree exercises the Callbacks map against a real CHASM tree
+// rather than a mock context, so that a missing component registration or an unserializable field shows
+// up here instead of at runtime.
+func TestCompletionCallbacksRoundTripThroughTheTree(t *testing.T) {
+	logger := log.NewNoopLogger()
+	registry := chasm.NewRegistry(logger)
+	require.NoError(t, registry.Register(&chasm.CoreLibrary{}))
+	require.NoError(t, registry.Register(&Library{
+		componentOnlyLibrary: componentOnlyLibrary{
+			metricTagConfig: dynamicconfig.GetTypedPropertyFn(NexusMetricTagConfig{}),
+		},
+	}))
+	require.NoError(t, registry.Register(callback.NewNilLibrary()))
+
+	timeSource := clock.NewEventTimeSource()
+	timeSource.Update(defaultTime)
+	nodeBackend := &chasm.MockNodeBackend{
+		HandleNextTransitionCount: func() int64 { return 2 },
+		HandleGetCurrentVersion:   func() int64 { return 1 },
+		HandleCurrentVersionedTransition: func() *persistencespb.VersionedTransition {
+			return &persistencespb.VersionedTransition{NamespaceFailoverVersion: 1, TransitionCount: 1}
+		},
+		HandleGetNamespaceEntry: func() *namespace.Namespace {
+			return namespace.NewNamespaceForTest(&persistencespb.NamespaceInfo{Name: "ns-name"}, nil, false, nil, 0)
+		},
+	}
+	root := chasm.NewEmptyTree(registry, timeSource, nodeBackend, chasm.DefaultPathEncoder, logger, metrics.NoopMetricsHandler)
+	ctx := chasm.NewMutableContext(context.Background(), root)
+
+	op := NewOperation(&nexusoperationpb.OperationState{
+		Status:        nexusoperationpb.OPERATION_STATUS_STARTED,
+		Endpoint:      "test-endpoint",
+		ScheduledTime: timestamppb.New(defaultTime),
+	})
+	op.RequestData = chasm.NewDataField(ctx, &nexusoperationpb.OperationRequestData{})
+	op.Visibility = chasm.NewComponentField(ctx, chasm.NewVisibilityWithData(ctx, nil, nil))
+	require.NoError(t, op.addCompletionCallbacks(ctx, "req-id", []*commonpb.Callback{
+		newNexusCallback(),
+	}, 10))
+	require.NoError(t, root.SetRootComponent(op))
+	_, err := root.CloseTransaction()
+	require.NoError(t, err)
+
+	ctx = chasm.NewMutableContext(context.Background(), root)
+	require.Len(t, op.Callbacks, 1)
+	cb := op.Callbacks["req-id-0"].Get(ctx)
+	require.Equal(t, callbackspb.CALLBACK_STATUS_STANDBY, cb.Status)
+
+	// The callback resolves its parent via a ParentPtr, so the Operation must satisfy
+	// callback.CompletionSource from inside the tree, not just as a compile-time assertion.
+	require.NoError(t, TransitionSucceeded.Apply(op, ctx, EventSucceeded{Result: mustToPayload(t, "result")}))
+	require.Equal(t, callbackspb.CALLBACK_STATUS_SCHEDULED, cb.Status)
+
+	completion, err := cb.CompletionSource.Get(ctx).GetNexusCompletion(ctx, cb.RequestId)
+	require.NoError(t, err)
+	require.Nil(t, completion.Error)
+}
+
+// TestDescribeResponseIncludesCompletionCallbacks covers the plumbing from the component into the
+// DescribeNexusOperationExecution response.
+func TestDescribeResponseIncludesCompletionCallbacks(t *testing.T) {
+	t.Parallel()
+
+	newOp := func(ctx chasm.MutableContext) *Operation {
+		op := newTestOperation()
+		op.RequestData = chasm.NewDataField(ctx, &nexusoperationpb.OperationRequestData{})
+		op.Visibility = chasm.NewComponentField(ctx, chasm.NewVisibilityWithData(ctx, nil, nil))
+		return op
+	}
+	req := &nexusoperationpb.DescribeNexusOperationRequest{
+		FrontendRequest: &workflowservice.DescribeNexusOperationExecutionRequest{},
+	}
+
+	t.Run("WithCallbacks", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+		op := newOp(ctx)
+		require.NoError(t, op.addCompletionCallbacks(ctx, "req-id", []*commonpb.Callback{
+			newNexusCallback(),
+		}, 10))
+
+		resp, err := op.buildDescribeResponse(ctx, req)
+		require.NoError(t, err)
+
+		cbs := resp.GetFrontendResponse().GetCompletionCallbacks()
+		require.Len(t, cbs, 1)
+		require.Equal(t, enumspb.CALLBACK_STATE_STANDBY, cbs[0].GetInfo().GetState())
+	})
+
+	t.Run("WithoutCallbacks", func(t *testing.T) {
+		ctx := newCallbackTestContext()
+		op := newOp(ctx)
+
+		resp, err := op.buildDescribeResponse(ctx, req)
+		require.NoError(t, err)
+		require.Empty(t, resp.GetFrontendResponse().GetCompletionCallbacks())
+	})
+}

--- a/chasm/lib/nexusoperation/config.go
+++ b/chasm/lib/nexusoperation/config.go
@@ -6,8 +6,10 @@ import (
 	"text/template"
 	"time"
 
+	"go.temporal.io/server/chasm/lib/callback"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
+	"go.temporal.io/server/common/callbacks"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/headers"
@@ -33,6 +35,13 @@ var Enabled = dynamicconfig.NewNamespaceBoolSetting(
 	"nexusoperation.enableStandalone",
 	false,
 	`Toggles standalone Nexus operation functionality on the server.`,
+)
+
+var EnabledCallbackKinds = dynamicconfig.NewNamespaceTypedSettingWithConverter(
+	"nexusoperation.enabledCallbackKinds",
+	callbacks.ConvertEnabledKinds,
+	[]callbacks.Kind{}, // i.e. callbacks not enabled at all.
+	`The list of completion callback kinds that may be attached to a standalone Nexus operation execution.`,
 )
 
 var EnableChasmWorkflowOperations = dynamicconfig.NewNamespaceBoolSetting(
@@ -236,6 +245,8 @@ Added for safety. Defaults to true. Likely to be removed in future server versio
 type Config struct {
 	Enabled                                    dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	EnableChasm                                dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	EnabledCallbackKinds                       dynamicconfig.TypedPropertyFnWithNamespaceFilter[[]callbacks.Kind]
+	MaxCallbacksPerExecution                   dynamicconfig.IntPropertyFnWithNamespaceFilter
 	EnableChasmNexusWorkflowOperations         dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	ChasmNexusWorkflowOperationsRolloutPercent dynamicconfig.IntPropertyFnWithNamespaceFilter
 	NumHistoryShards                           int32
@@ -267,6 +278,8 @@ func configProvider(dc *dynamicconfig.Collection, cfg *config.Persistence) *Conf
 	return &Config{
 		Enabled:                            Enabled.Get(dc),
 		EnableChasm:                        dynamicconfig.EnableChasm.Get(dc),
+		EnabledCallbackKinds:               EnabledCallbackKinds.Get(dc),
+		MaxCallbacksPerExecution:           callback.MaxPerExecution.Get(dc),
 		EnableChasmNexusWorkflowOperations: EnableChasmWorkflowOperations.Get(dc),
 		ChasmNexusWorkflowOperationsRolloutPercent: ChasmWorkflowOperationsRolloutPercent.Get(dc),
 		NumHistoryShards:                   cfg.NumHistoryShards,

--- a/chasm/lib/nexusoperation/frontend.go
+++ b/chasm/lib/nexusoperation/frontend.go
@@ -10,6 +10,7 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/chasm"
 	nexusoperationpb "go.temporal.io/server/chasm/lib/nexusoperation/gen/nexusoperationpb/v1"
+	"go.temporal.io/server/common/callbacks"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/namespace"
 	commonnexus "go.temporal.io/server/common/nexus"
@@ -49,13 +50,15 @@ func NewFrontendHandler(
 	endpointRegistry commonnexus.EndpointRegistry,
 	saMapperProvider searchattribute.MapperProvider,
 	saValidator *searchattribute.Validator,
+	callbackValidator callbacks.Validator,
+	linkValidator *linkValidator,
 ) FrontendHandler {
 	return &frontendHandler{
 		client:            client,
 		config:            config,
 		namespaceRegistry: namespaceRegistry,
 		endpointRegistry:  endpointRegistry,
-		validator:         newValidator(config, logger, saMapperProvider, saValidator),
+		validator:         newValidator(config, logger, saMapperProvider, saValidator, callbackValidator, linkValidator),
 	}
 }
 
@@ -72,7 +75,7 @@ func (h *frontendHandler) StartNexusOperationExecution(
 		return nil, err
 	}
 
-	if err := h.validator.validateAndNormalizeStartRequest(req); err != nil {
+	if err := h.validator.validateAndNormalizeStartRequest(ctx, req); err != nil {
 		return nil, err
 	}
 

--- a/chasm/lib/nexusoperation/fx.go
+++ b/chasm/lib/nexusoperation/fx.go
@@ -31,6 +31,7 @@ import (
 var Module = fx.Module(
 	"chasm.lib.nexusoperation",
 	fx.Provide(configProvider),
+	fx.Provide(linkValidatorProvider),
 	fx.Provide(commonnexus.NewCallbackTokenGenerator),
 	fx.Provide(endpointRegistryProvider),
 	fx.Invoke(endpointRegistryLifetimeHooks),
@@ -51,6 +52,7 @@ var Module = fx.Module(
 var FrontendModule = fx.Module(
 	"chasm.lib.nexusoperation.frontend",
 	fx.Provide(configProvider),
+	fx.Provide(linkValidatorProvider),
 	fx.Provide(nexusoperationpb.NewNexusOperationServiceLayeredClient),
 	fx.Provide(NewFrontendHandler),
 	fx.Provide(newComponentOnlyLibrary),

--- a/chasm/lib/nexusoperation/handler.go
+++ b/chasm/lib/nexusoperation/handler.go
@@ -17,14 +17,16 @@ import (
 type handler struct {
 	nexusoperationpb.UnimplementedNexusOperationServiceServer
 
-	config *Config
-	logger log.Logger
+	config        *Config
+	linkValidator *linkValidator
+	logger        log.Logger
 }
 
-func newHandler(config *Config, logger log.Logger) *handler {
+func newHandler(config *Config, linkValidator *linkValidator, logger log.Logger) *handler {
 	return &handler{
-		config: config,
-		logger: logger,
+		config:        config,
+		linkValidator: linkValidator,
+		logger:        logger,
 	}
 }
 
@@ -36,14 +38,19 @@ func (h *handler) StartNexusOperation(
 	defer log.CapturePanic(h.logger, &err)
 
 	frontendReq := req.GetFrontendRequest()
+	// Read once, so it's consistent for both the creation and on-conflict paths,
+	// despite being in two transactions.
+	maxCallbacks := h.config.MaxCallbacksPerExecution(frontendReq.GetNamespace())
 
-	result, err := chasm.StartExecution[*Operation](
+	result, err := chasm.StartExecution(
 		ctx,
 		chasm.ExecutionKey{
 			NamespaceID: req.GetNamespaceId(),
 			BusinessID:  frontendReq.GetOperationId(),
 		},
-		newStandaloneOperation,
+		func(mutableCtx chasm.MutableContext, req *nexusoperationpb.StartNexusOperationRequest) (*Operation, error) {
+			return newStandaloneOperation(mutableCtx, req, maxCallbacks, h.linkValidator)
+		},
 		req,
 		chasm.WithRequestID(frontendReq.GetRequestId()),
 		chasm.WithBusinessIDPolicy(
@@ -52,6 +59,8 @@ func (h *handler) StartNexusOperation(
 		),
 	)
 	if err != nil {
+		// ExecutionAlreadyStarted would only be returned if the IDConflictPolicy were FAIL.
+		// Otherwise, we'd return the existing SANO. (And apply the OnConflictOptions next.)
 		if alreadyStartedErr, ok := errors.AsType[*chasm.ExecutionAlreadyStartedError](err); ok {
 			return nil, serviceerror.NewNexusOperationExecutionAlreadyStartedf(
 				alreadyStartedErr.CurrentRequestID,
@@ -64,12 +73,59 @@ func (h *handler) StartNexusOperation(
 		return nil, err
 	}
 
+	if !result.Created {
+		if err := h.applyOnConflictOptions(ctx, result.ExecutionKey, frontendReq, maxCallbacks); err != nil {
+			return nil, err
+		}
+	}
+
 	return &nexusoperationpb.StartNexusOperationResponse{
 		FrontendResponse: &workflowservice.StartNexusOperationExecutionResponse{
 			RunId:   result.ExecutionKey.RunID,
 			Started: result.Created,
 		},
 	}, nil
+}
+
+// applyOnConflictOptions applies the request's on_conflict_options to a SANO.
+func (h *handler) applyOnConflictOptions(
+	ctx context.Context,
+	key chasm.ExecutionKey,
+	req *workflowservice.StartNexusOperationExecutionRequest,
+	maxCallbacks int,
+) error {
+	cbs := req.GetCompletionCallbacks()
+	links := req.GetLinks()
+	onConflict := req.GetOnConflictOptions()
+	attachCallbacks := onConflict.GetAttachCompletionCallbacks() && len(cbs) > 0
+	attachLinks := onConflict.GetAttachLinks() && len(links) > 0
+	if !attachCallbacks && !attachLinks {
+		return nil
+	}
+
+	requestID := req.GetRequestId()
+	namespaceName := req.GetNamespace()
+	// TODO: Use chasm.UpdateWithStartExecution to avoid a second transaction once the engine supports
+	// BusinessIDConflictPolicyFail in the updateFn path. (Same for standalone Activities.)
+	_, _, err := chasm.UpdateComponent(
+		ctx,
+		chasm.NewComponentRef[*Operation](key),
+		func(o *Operation, ctx chasm.MutableContext, _ any) (any, error) {
+			if attachCallbacks {
+				if err := o.addCompletionCallbacks(ctx, requestID, cbs, maxCallbacks); err != nil {
+					return nil, err
+				}
+			}
+			if attachLinks {
+				if err := o.attachLinks(ctx, links, requestID, h.linkValidator, namespaceName); err != nil {
+					return nil, err
+				}
+			}
+			return nil, nil
+		},
+		nil,
+	)
+	return err
 }
 
 // DescribeNexusOperation queries current operation state, optionally as a long-poll that waits

--- a/chasm/lib/nexusoperation/link_validator.go
+++ b/chasm/lib/nexusoperation/link_validator.go
@@ -1,0 +1,37 @@
+package nexusoperation
+
+import (
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/links"
+)
+
+// linkValidator validates links attached to standalone Nexus operation executions.
+type linkValidator struct {
+	// Distinct per-component type: all CHASM lib fx modules provide into the same
+	// container, so *commonlinks.Validator cannot be injected directly.
+	*links.Validator
+}
+
+func newLinkValidator(
+	maxLinksPerRequest dynamicconfig.IntPropertyFnWithNamespaceFilter,
+	maxLinksPerComponent dynamicconfig.IntPropertyFnWithNamespaceFilter,
+	linkMaxSize dynamicconfig.IntPropertyFnWithNamespaceFilter,
+) *linkValidator {
+	return &linkValidator{
+		links.NewValidator(
+			"a nexus operation",
+			maxLinksPerRequest,
+			maxLinksPerComponent,
+			linkMaxSize,
+		),
+	}
+}
+
+// linkValidatorProvider builds the linkValidator from dynamic config.
+func linkValidatorProvider(dc *dynamicconfig.Collection) *linkValidator {
+	return newLinkValidator(
+		dynamicconfig.FrontendMaxLinksPerRequest.Get(dc),
+		dynamicconfig.MaxLinksPerComponent.Get(dc),
+		dynamicconfig.FrontendLinkMaxSize.Get(dc),
+	)
+}

--- a/chasm/lib/nexusoperation/links_test.go
+++ b/chasm/lib/nexusoperation/links_test.go
@@ -1,0 +1,259 @@
+package nexusoperation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/chasm"
+	nexusoperationpb "go.temporal.io/server/chasm/lib/nexusoperation/gen/nexusoperationpb/v1"
+	"go.temporal.io/server/common/testing/protorequire"
+)
+
+// newTestLinkValidator returns a linkValidator with the given caps and a permissive per-link size limit.
+func newTestLinkValidator(maxPerRequest, maxPerComponent int) *linkValidator {
+	return newLinkValidator(
+		func(string) int { return maxPerRequest },
+		func(string) int { return maxPerComponent },
+		func(string) int { return 4000 },
+	)
+}
+
+// newLinkTestContext returns a mock context backed by stored, standing in for the framework's
+// per-request link storage: writes land in ctx.LinksByRequest, while reads (Links/RequestLinks) are
+// served from stored. Tests copy a write into stored to simulate it having been persisted.
+func newLinkTestContext(stored map[string][]*commonpb.Link) *chasm.MockMutableContext {
+	ctx := newCallbackTestContext()
+	ctx.HandleLinks = func(chasm.Component) []*commonpb.Link {
+		var all []*commonpb.Link
+		for _, links := range stored {
+			all = append(all, links...)
+		}
+		return all
+	}
+	ctx.HandleRequestLinks = func(_ chasm.Component, requestID string) ([]*commonpb.Link, error) {
+		return stored[requestID], nil
+	}
+	return ctx
+}
+
+func testLink(workflowID string) *commonpb.Link {
+	return &commonpb.Link{Variant: &commonpb.Link_WorkflowEvent_{
+		WorkflowEvent: &commonpb.Link_WorkflowEvent{
+			Namespace:  "ns-name",
+			WorkflowId: workflowID,
+			RunId:      "wf-run-id",
+		},
+	}}
+}
+
+func TestNewStandaloneOperationAttachesLinks(t *testing.T) {
+	t.Parallel()
+
+	newStartReq := func(links ...*commonpb.Link) *nexusoperationpb.StartNexusOperationRequest {
+		return &nexusoperationpb.StartNexusOperationRequest{
+			EndpointId: "endpoint-id",
+			FrontendRequest: &workflowservice.StartNexusOperationExecutionRequest{
+				Namespace:   "ns-name",
+				OperationId: "op-id",
+				RequestId:   "req-id",
+				Endpoint:    "test-endpoint",
+				Service:     "test-service",
+				Operation:   "test-operation",
+				Links:       links,
+			},
+		}
+	}
+
+	t.Run("WithLinks", func(t *testing.T) {
+		ctx := newLinkTestContext(map[string][]*commonpb.Link{})
+		link := testLink("wf-id")
+
+		op, err := newStandaloneOperation(ctx, newStartReq(link), 10, newTestLinkValidator(10, 10))
+		require.NoError(t, err)
+		require.Equal(t, nexusoperationpb.OPERATION_STATUS_SCHEDULED, op.Status)
+
+		// Links are keyed by the request that contributed them.
+		protorequire.ProtoSliceEqual(t, []*commonpb.Link{link}, ctx.LinksByRequest[op]["req-id"])
+	})
+
+	t.Run("WithoutLinks", func(t *testing.T) {
+		ctx := newLinkTestContext(map[string][]*commonpb.Link{})
+
+		op, err := newStandaloneOperation(ctx, newStartReq(), 10, newTestLinkValidator(10, 10))
+		require.NoError(t, err)
+		require.Empty(t, ctx.LinksByRequest[op])
+	})
+
+	t.Run("RejectsAnInvalidLink", func(t *testing.T) {
+		ctx := newLinkTestContext(map[string][]*commonpb.Link{})
+		invalid := &commonpb.Link{Variant: &commonpb.Link_WorkflowEvent_{
+			WorkflowEvent: &commonpb.Link_WorkflowEvent{WorkflowId: "wf-id", RunId: "wf-run-id"},
+		}}
+
+		_, err := newStandaloneOperation(ctx, newStartReq(invalid), 10, newTestLinkValidator(10, 10))
+		require.ErrorAs(t, err, new(*serviceerror.InvalidArgument))
+		require.ErrorContains(t, err, "must not have an empty namespace")
+	})
+
+	t.Run("EnforcesThePerComponentCap", func(t *testing.T) {
+		ctx := newLinkTestContext(map[string][]*commonpb.Link{})
+
+		_, err := newStandaloneOperation(
+			ctx,
+			newStartReq(testLink("wf-1"), testLink("wf-2")),
+			10,
+			newTestLinkValidator(10, 1),
+		)
+		require.ErrorAs(t, err, new(*serviceerror.FailedPrecondition))
+		require.ErrorContains(t, err, "cannot attach more than 1 links to a nexus operation")
+	})
+}
+
+func TestOperationAttachLinks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("EmptyListIsANoOp", func(t *testing.T) {
+		stored := map[string][]*commonpb.Link{}
+		ctx := newLinkTestContext(stored)
+		op := newScheduledTestOperation(t, ctx)
+
+		require.NoError(t, op.attachLinks(ctx, nil, "req-id", newTestLinkValidator(10, 10), "ns-name"))
+		require.Empty(t, ctx.LinksByRequest[op])
+	})
+
+	t.Run("SameRequestIDIsNoOp", func(t *testing.T) {
+		// A retried start (or a retried on_conflict_options attach) must not duplicate links.
+		stored := map[string][]*commonpb.Link{}
+		ctx := newLinkTestContext(stored)
+		op := newScheduledTestOperation(t, ctx)
+		validator := newTestLinkValidator(10, 10)
+		linkA, linkB := testLink("wf-a"), testLink("wf-b")
+
+		// The first call records the request's links verbatim, without intra-batch dedup, matching
+		// the workflow and standalone activity start paths.
+		require.NoError(t, op.attachLinks(ctx, []*commonpb.Link{linkA, linkA}, "req-1", validator, "ns-name"))
+		stored["req-1"] = ctx.LinksByRequest[op]["req-1"]
+		protorequire.ProtoSliceEqual(t, []*commonpb.Link{linkA, linkA}, stored["req-1"])
+
+		// A retry under the same requestID is a no-op, even with different links.
+		require.NoError(t, op.attachLinks(ctx, []*commonpb.Link{linkB}, "req-1", validator, "ns-name"))
+		protorequire.ProtoSliceEqual(t, []*commonpb.Link{linkA, linkA}, ctx.LinksByRequest[op]["req-1"])
+	})
+
+	t.Run("DistinctRequestsAccumulate", func(t *testing.T) {
+		stored := map[string][]*commonpb.Link{}
+		ctx := newLinkTestContext(stored)
+		op := newScheduledTestOperation(t, ctx)
+		validator := newTestLinkValidator(10, 10)
+
+		require.NoError(t, op.attachLinks(ctx, []*commonpb.Link{testLink("wf-1")}, "req-1", validator, "ns-name"))
+		stored["req-1"] = ctx.LinksByRequest[op]["req-1"]
+		require.NoError(t, op.attachLinks(ctx, []*commonpb.Link{testLink("wf-2")}, "req-2", validator, "ns-name"))
+
+		require.Len(t, ctx.LinksByRequest[op], 2)
+	})
+
+	t.Run("RejectsAClosedOperation", func(t *testing.T) {
+		ctx := newLinkTestContext(map[string][]*commonpb.Link{})
+		op := newScheduledTestOperation(t, ctx)
+		require.NoError(t, TransitionSucceeded.Apply(op, ctx, EventSucceeded{}))
+
+		err := op.attachLinks(ctx, []*commonpb.Link{testLink("wf-id")}, "req-new", newTestLinkValidator(10, 10), "ns-name")
+		require.ErrorAs(t, err, new(*serviceerror.FailedPrecondition))
+		require.ErrorContains(t, err, "cannot attach links to a closed nexus operation")
+	})
+
+	t.Run("IsIdempotentAfterClose", func(t *testing.T) {
+		// The original attach succeeded but the response was lost; by the time the client retries the
+		// operation has closed. The retry must still report success for links already persisted.
+		link := testLink("wf-id")
+		ctx := newLinkTestContext(map[string][]*commonpb.Link{"req-1": {link}})
+		op := newScheduledTestOperation(t, ctx)
+		require.NoError(t, TransitionSucceeded.Apply(op, ctx, EventSucceeded{}))
+
+		require.NoError(t, op.attachLinks(ctx, []*commonpb.Link{link}, "req-1", newTestLinkValidator(10, 10), "ns-name"))
+	})
+
+	t.Run("RejectsExceedingThePerRequestCap", func(t *testing.T) {
+		ctx := newLinkTestContext(map[string][]*commonpb.Link{})
+		op := newScheduledTestOperation(t, ctx)
+
+		err := op.attachLinks(
+			ctx,
+			[]*commonpb.Link{testLink("wf-1"), testLink("wf-2")},
+			"req-id",
+			newTestLinkValidator(1, 10),
+			"ns-name",
+		)
+		require.ErrorAs(t, err, new(*serviceerror.InvalidArgument))
+		require.ErrorContains(t, err, "cannot attach more than 1 links per request")
+		require.Empty(t, ctx.LinksByRequest[op])
+	})
+
+	t.Run("RejectsExceedingThePerComponentCapWithAlreadyAttachedLinks", func(t *testing.T) {
+		ctx := newLinkTestContext(map[string][]*commonpb.Link{"req-1": {testLink("wf-existing")}})
+		op := newScheduledTestOperation(t, ctx)
+
+		err := op.attachLinks(
+			ctx,
+			[]*commonpb.Link{testLink("wf-new")},
+			"req-2",
+			newTestLinkValidator(10, 1),
+			"ns-name",
+		)
+		require.ErrorAs(t, err, new(*serviceerror.FailedPrecondition))
+		require.ErrorContains(t, err, "1 links already attached")
+	})
+}
+
+// TestDescribeResponseIncludesLinks covers the plumbing from both link sources into the
+// DescribeNexusOperationExecution response.
+func TestDescribeResponseIncludesLinks(t *testing.T) {
+	t.Parallel()
+
+	req := &nexusoperationpb.DescribeNexusOperationRequest{
+		FrontendRequest: &workflowservice.DescribeNexusOperationExecutionRequest{},
+	}
+	newOp := func(ctx chasm.MutableContext) *Operation {
+		op := newTestOperation()
+		op.RequestData = chasm.NewDataField(ctx, &nexusoperationpb.OperationRequestData{})
+		op.Visibility = chasm.NewComponentField(ctx, chasm.NewVisibilityWithData(ctx, nil, nil))
+		return op
+	}
+
+	t.Run("UnionsCallerAndHandlerLinks", func(t *testing.T) {
+		callerLink, handlerLink := testLink("caller-wf"), testLink("handler-wf")
+		ctx := newLinkTestContext(map[string][]*commonpb.Link{"req-id": {callerLink}})
+		op := newOp(ctx)
+		// Links returned by the Nexus handler on its start/completion response.
+		op.Links = []*commonpb.Link{handlerLink}
+
+		resp, err := op.buildDescribeResponse(ctx, req)
+		require.NoError(t, err)
+		protorequire.ProtoElementsMatch(t,
+			[]*commonpb.Link{callerLink, handlerLink},
+			resp.GetFrontendResponse().GetInfo().GetLinks())
+	})
+
+	t.Run("CallerLinksOnly", func(t *testing.T) {
+		callerLink := testLink("caller-wf")
+		ctx := newLinkTestContext(map[string][]*commonpb.Link{"req-id": {callerLink}})
+
+		resp, err := newOp(ctx).buildDescribeResponse(ctx, req)
+		require.NoError(t, err)
+		protorequire.ProtoSliceEqual(t,
+			[]*commonpb.Link{callerLink},
+			resp.GetFrontendResponse().GetInfo().GetLinks())
+	})
+
+	t.Run("WithoutLinks", func(t *testing.T) {
+		ctx := newLinkTestContext(map[string][]*commonpb.Link{})
+
+		resp, err := newOp(ctx).buildDescribeResponse(ctx, req)
+		require.NoError(t, err)
+		require.Empty(t, resp.GetFrontendResponse().GetInfo().GetLinks())
+	})
+}

--- a/chasm/lib/nexusoperation/operation.go
+++ b/chasm/lib/nexusoperation/operation.go
@@ -3,6 +3,7 @@ package nexusoperation
 import (
 	"fmt"
 	"maps"
+	"slices"
 	"strings"
 	"time"
 
@@ -12,14 +13,17 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
 	nexuspb "go.temporal.io/api/nexus/v1"
+	apinexusoperationpb "go.temporal.io/api/nexusoperation/v1" //nolint:importas
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/chasm/lib/callback"
 	nexusoperationpb "go.temporal.io/server/chasm/lib/nexusoperation/gen/nexusoperationpb/v1"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/metrics"
 	commonnexus "go.temporal.io/server/common/nexus"
+	"go.temporal.io/server/common/nexus/nexusrpc"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/softassert"
 	queueserrors "go.temporal.io/server/service/history/queues/errors"
@@ -40,6 +44,7 @@ var _ chasm.RootComponent = (*Operation)(nil)
 var _ chasm.StateMachine[nexusoperationpb.OperationStatus] = (*Operation)(nil)
 var _ chasm.VisibilitySearchAttributesProvider = (*Operation)(nil)
 var _ chasm.NexusCompletionHandler = (*Operation)(nil)
+var _ callback.CompletionSource = (*Operation)(nil)
 
 // ErrCancellationAlreadyRequested is returned when a cancellation has already been requested for an operation.
 var ErrCancellationAlreadyRequested = serviceerror.NewFailedPrecondition("cancellation already requested")
@@ -99,6 +104,10 @@ type Operation struct {
 	Cancellation chasm.Field[*Cancellation]
 	Outcome      chasm.Field[*nexusoperationpb.OperationOutcome]
 	Visibility   chasm.Field[*chasm.Visibility]
+
+	// Callbacks holds completion callbacks to be invoked when this reaches a terminal state.
+	// Keyed by completionCallbackID(requestID, index).
+	Callbacks chasm.Map[string, *callback.Callback]
 }
 
 // NewOperation creates a new Operation component with the given persisted state.
@@ -109,6 +118,8 @@ func NewOperation(state *nexusoperationpb.OperationState) *Operation {
 func newStandaloneOperation(
 	ctx chasm.MutableContext,
 	req *nexusoperationpb.StartNexusOperationRequest,
+	maxCallbacks int,
+	linkValidator *linkValidator,
 ) (*Operation, error) {
 	frontendReq := req.GetFrontendRequest()
 	op := NewOperation(&nexusoperationpb.OperationState{
@@ -133,6 +144,23 @@ func newStandaloneOperation(
 		frontendReq.GetSearchAttributes().GetIndexedFields(),
 		nil,
 	))
+	if err := op.addCompletionCallbacks(
+		ctx,
+		frontendReq.GetRequestId(),
+		frontendReq.GetCompletionCallbacks(),
+		maxCallbacks,
+	); err != nil {
+		return nil, err
+	}
+	if err := op.attachLinks(
+		ctx,
+		frontendReq.GetLinks(),
+		frontendReq.GetRequestId(),
+		linkValidator,
+		frontendReq.GetNamespace(),
+	); err != nil {
+		return nil, err
+	}
 	if err := TransitionScheduled.Apply(op, ctx, EventScheduled{}); err != nil {
 		return nil, err
 	}
@@ -304,6 +332,12 @@ func (o *Operation) loadStartArgs(
 	} else {
 		// Standalone operation: there is no workflow caller, so add a nexus_operation self-link
 		// as the caller link for the completion callback.
+		//
+		// Only the caller link goes to the handler. Links the client attached to the start request
+		// (and any it attached later via on_conflict_options) are recorded on the operation and
+		// surfaced through Describe, but are not forwarded: this matches the workflow-backed case,
+		// where the handler likewise receives only the workflow_event caller link and not the links
+		// carried on the StartWorkflowExecution request.
 		requestData := o.RequestData.Get(ctx)
 		invocationData = InvocationData{
 			Input:  requestData.GetInput(),
@@ -393,7 +427,7 @@ func (o *Operation) resolveUnsuccessfully(ctx chasm.MutableContext, failure *fai
 
 	// NextAttemptScheduleTime is only valid in BACKING_OFF; clear on close
 	o.NextAttemptScheduleTime = nil
-	return nil
+	return o.scheduleCompletionCallbacks(ctx)
 }
 
 func (o *Operation) getOrCreateOutcome(ctx chasm.MutableContext) *nexusoperationpb.OperationOutcome {
@@ -403,6 +437,211 @@ func (o *Operation) getOrCreateOutcome(ctx chasm.MutableContext) *nexusoperation
 	outcome := &nexusoperationpb.OperationOutcome{}
 	o.Outcome = chasm.NewDataField(ctx, outcome)
 	return outcome
+}
+
+// addCompletionCallbacks creates the child CHASM callback components. They stay in STANDBY until this
+// Operation reaches a terminal state.
+//
+// Callbacks are keyed by request ID plus their position within the request, so re-attaching the same
+// request is a no-op rather than a duplicate. The idempotency probe runs before the closed check, so a
+// retry still succeeds if the operation closed after the first attach.
+//
+// maxCallbacks is re-checked here because callback.Validator only bounds the callbacks on the start
+// request; callbacks added later via on_conflict_options bypass it.
+func (o *Operation) addCompletionCallbacks(
+	ctx chasm.MutableContext,
+	requestID string,
+	completionCallbacks []*commonpb.Callback,
+	maxCallbacks int,
+) error {
+	if len(completionCallbacks) == 0 {
+		return nil
+	}
+	if requestID == "" {
+		return serviceerror.NewInvalidArgument("cannot attach completion callbacks without a request ID")
+	}
+	// Attaching is atomic, so the presence of the first key means this request already attached all of
+	// its callbacks. See the note above on why this precedes the closed check.
+	if _, ok := o.Callbacks[completionCallbackID(requestID, 0)]; ok {
+		return nil
+	}
+	if o.isClosed() {
+		return serviceerror.NewFailedPrecondition("cannot attach callbacks to a closed nexus operation")
+	}
+
+	currentCount := len(o.Callbacks)
+	if len(completionCallbacks)+currentCount > maxCallbacks {
+		return serviceerror.NewFailedPreconditionf(
+			"cannot attach more than %d callbacks to a nexus operation (%d callbacks already attached)",
+			maxCallbacks,
+			currentCount,
+		)
+	}
+
+	if o.Callbacks == nil {
+		o.Callbacks = make(chasm.Map[string, *callback.Callback], len(completionCallbacks))
+	}
+
+	registrationTime := timestamppb.New(ctx.Now(o))
+	for idx, cb := range completionCallbacks {
+		chasmCB, err := callback.FromAPICallback(cb)
+		if err != nil {
+			return err
+		}
+
+		// Give each callback its own, unique request ID. Since using the same request ID as the
+		// operation which added the callbacks would be ambiguous if it added more than one callback.
+		cbRequestID := uuid.NewString()
+		callbackObj := callback.NewCallback(cbRequestID, registrationTime, chasmCB)
+		o.Callbacks[completionCallbackID(requestID, idx)] = chasm.NewComponentField(ctx, callbackObj)
+	}
+	return nil
+}
+
+// attachLinks records the given links on the operation keyed by requestID. Duplicates within the same
+// batch are kept as-is, matching the workflow and standalone activity start paths. If the requestID has
+// already been used to attach links the call is a no-op, making retries idempotent even after the
+// operation has closed. Returns an error if the operation is closed (and the requestID is new), if the
+// per-component cap would be exceeded, or if the request's per-link size, per-request count, or variant
+// shape is invalid.
+func (o *Operation) attachLinks(
+	ctx chasm.MutableContext,
+	links []*commonpb.Link,
+	requestID string,
+	validator *linkValidator,
+	namespaceName string,
+) error {
+	if len(links) == 0 {
+		return nil
+	}
+	// Idempotency check must run before isClosed: if a prior attach succeeded but the response was
+	// lost and the operation closed before the client retried, we must still return success rather
+	// than FailedPrecondition for work already persisted.
+	priorForRequest, err := ctx.RequestLinks(o, requestID)
+	if err != nil {
+		return err
+	}
+	if len(priorForRequest) > 0 {
+		return nil
+	}
+	if o.isClosed() {
+		return serviceerror.NewFailedPrecondition("cannot attach links to a closed nexus operation")
+	}
+	if err := validator.ValidateRequest(namespaceName, links); err != nil {
+		return err
+	}
+	// The cap bounds caller-attached links only; links returned by the Nexus handler
+	// (OperationState.links) arrive on a separate path and are not counted here.
+	if err := validator.ValidateTotal(namespaceName, len(ctx.Links(o)), len(links)); err != nil {
+		return err
+	}
+	return ctx.SetRequestLinks(o, requestID, links)
+}
+
+// allLinks returns every link associated with the operation: those attached by callers on their start
+// and on-conflict attach requests, plus any the Nexus handler returned on its start or completion
+// response (standalone operations only; workflow-backed ones carry theirs on history events).
+func (o *Operation) allLinks(ctx chasm.Context) []*commonpb.Link {
+	requestLinks := ctx.Links(o)
+	all := make([]*commonpb.Link, 0, len(requestLinks)+len(o.Links))
+	all = append(all, requestLinks...)
+	all = append(all, o.Links...)
+	return all
+}
+
+// completionCallbackID defines the stable key used for keeping track of attached completion callbacks.
+func completionCallbackID(requestID string, idx int) string {
+	return fmt.Sprintf("%s-%d", requestID, idx)
+}
+
+// scheduleCompletionCallbacks releases every STANDBY completion callback for delivery. Called from each
+// terminal transition.
+func (o *Operation) scheduleCompletionCallbacks(ctx chasm.MutableContext) error {
+	return callback.ScheduleStandbyCallbacks(ctx, o.Callbacks)
+}
+
+// GetNexusCompletion implements callback.CompletionSource, providing the result of the Nexus operation.
+func (o *Operation) GetNexusCompletion(ctx chasm.Context, _ string) (nexusrpc.CompleteOperationOptions, error) {
+	if !o.isClosed() {
+		return nexusrpc.CompleteOperationOptions{}, serviceerror.NewInternal("nexus operation has not completed yet")
+	}
+
+	key := ctx.ExecutionKey()
+	backLink := commonnexus.ConvertLinkNexusOperationToNexusLink(&commonpb.Link_NexusOperation{
+		Namespace:   ctx.NamespaceEntry().Name().String(),
+		OperationId: key.BusinessID,
+		RunId:       key.RunID,
+	})
+
+	opts := nexusrpc.CompleteOperationOptions{
+		StartTime: o.GetScheduledTime().AsTime(),
+		CloseTime: ctx.ExecutionInfo().CloseTime,
+		Links:     []nexus.Link{backLink},
+	}
+
+	result, failure := o.outcome(ctx)
+	if o.Status == nexusoperationpb.OPERATION_STATUS_SUCCEEDED {
+		opts.Result = result
+		return opts, nil
+	}
+	if failure == nil {
+		return nexusrpc.CompleteOperationOptions{},
+			serviceerror.NewInternalf("nexus operation in status %v has no outcome", o.Status)
+	}
+
+	state := nexus.OperationStateFailed
+	message := "operation failed"
+	if o.Status == nexusoperationpb.OPERATION_STATUS_CANCELED {
+		state = nexus.OperationStateCanceled
+		message = "operation canceled"
+	}
+
+	nf, err := commonnexus.TemporalFailureToNexusFailure(failure)
+	if err != nil {
+		return nexusrpc.CompleteOperationOptions{}, serviceerror.NewInternalf("failed to convert failure: %v", err)
+	}
+	opErr := &nexus.OperationError{
+		State:   state,
+		Message: message,
+		Cause:   &nexus.FailureError{Failure: nf},
+	}
+	if err := nexusrpc.MarkAsWrapperError(nexusrpc.DefaultFailureConverter(), opErr); err != nil {
+		return nexusrpc.CompleteOperationOptions{}, err
+	}
+	opts.Error = opErr
+	return opts, nil
+}
+
+// buildCompletionCallbackInfos projects the attached completion callbacks onto the API surface for the
+// describe response.
+func (o *Operation) buildCompletionCallbackInfos(ctx chasm.Context) ([]*apinexusoperationpb.CallbackInfo, error) {
+	if len(o.Callbacks) == 0 {
+		return nil, nil
+	}
+
+	// All standalone Nexus operation callbacks have the same trigger.
+	trigger := &apinexusoperationpb.CallbackInfo_Trigger{
+		Variant: &apinexusoperationpb.CallbackInfo_Trigger_OperationCompleted{
+			OperationCompleted: &apinexusoperationpb.CallbackInfo_OperationCompleted{},
+		},
+	}
+
+	// We make no attempt to return Callbacks in the specific order they were
+	// added, we just sort the Callbacks so that the returned CallbackInfo is
+	// stable.
+	sortedCallbackKeys := slices.Sorted(maps.Keys(o.Callbacks))
+	infos := make([]*apinexusoperationpb.CallbackInfo, 0, len(o.Callbacks))
+	for _, id := range sortedCallbackKeys {
+		info, err := o.Callbacks[id].Get(ctx).ToAPICallbackInfo(ctx)
+		if err != nil {
+			return nil, err
+		}
+		infos = append(infos, &apinexusoperationpb.CallbackInfo{
+			Trigger: trigger,
+			Info:    info,
+		})
+	}
+	return infos, nil
 }
 
 func (o *Operation) Terminate(
@@ -445,10 +684,16 @@ func (o *Operation) buildDescribeResponse(
 		return nil, err
 	}
 
+	callbackInfos, err := o.buildCompletionCallbackInfos(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	resp := &workflowservice.DescribeNexusOperationExecutionResponse{
-		RunId:         ctx.ExecutionKey().RunID,
-		Info:          o.buildExecutionInfo(ctx),
-		LongPollToken: token,
+		RunId:               ctx.ExecutionKey().RunID,
+		Info:                o.buildExecutionInfo(ctx),
+		LongPollToken:       token,
+		CompletionCallbacks: callbackInfos,
 	}
 	if req.GetFrontendRequest().GetIncludeInput() {
 		resp.Input = o.RequestData.Get(ctx).GetInput()
@@ -558,7 +803,7 @@ func (o *Operation) buildExecutionInfo(ctx chasm.Context) *nexuspb.NexusOperatio
 		},
 		NexusHeader:  requestData.GetNexusHeader(),
 		UserMetadata: requestData.GetUserMetadata(),
-		Links:        o.Links,
+		Links:        o.allLinks(ctx),
 		Identity:     requestData.GetIdentity(),
 	}
 

--- a/chasm/lib/nexusoperation/operation_statemachine.go
+++ b/chasm/lib/nexusoperation/operation_statemachine.go
@@ -190,8 +190,8 @@ var TransitionSucceeded = chasm.NewTransition(
 		}
 
 		o.emitOnSucceededMetrics(ctx, closeTime)
-		// Terminal state - no tasks to emit.
-		return nil
+		// Schedule the SANO's completion callbacks.
+		return o.scheduleCompletionCallbacks(ctx)
 	},
 )
 

--- a/chasm/lib/nexusoperation/task_handler_helpers.go
+++ b/chasm/lib/nexusoperation/task_handler_helpers.go
@@ -270,7 +270,7 @@ func newInvocationResult(
 	}
 
 	if opErr, ok := errors.AsType[*nexus.OperationError](callErr); ok {
-		failure, err := operationErrorToFailure(opErr)
+		failure, err := commonnexus.OperationErrorToTemporalFailure(opErr)
 		if err != nil {
 			return nil, err
 		}
@@ -307,20 +307,6 @@ func newInvocationResult(
 		return invocationResultFail{failure: failure}, nil
 	}
 	return invocationResultRetry{failure: failure}, nil
-}
-
-func operationErrorToFailure(opErr *nexus.OperationError) (*failurepb.Failure, error) {
-	var nf nexus.Failure
-	if opErr.OriginalFailure != nil {
-		nf = *opErr.OriginalFailure
-	} else {
-		var err error
-		nf, err = nexusrpc.DefaultFailureConverter().ErrorToFailure(opErr)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return commonnexus.NexusFailureToTemporalFailure(*nexusrpc.UnwrapFailure(&nf))
 }
 
 func buildCallbackURL(

--- a/chasm/lib/nexusoperation/validator.go
+++ b/chasm/lib/nexusoperation/validator.go
@@ -1,6 +1,7 @@
 package nexusoperation
 
 import (
+	"context"
 	"slices"
 	"strings"
 
@@ -10,6 +11,7 @@ import (
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/common/callbacks"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/primitives/timestamp"
@@ -33,10 +35,12 @@ type cancelOrTerminateRequest interface {
 // Requests are mutated in place: defaults are applied, values are capped to their configured
 // limits, and headers are lower-cased.
 type validator struct {
-	config           *Config
-	logger           log.Logger
-	saMapperProvider searchattribute.MapperProvider
-	saValidator      *searchattribute.Validator
+	config            *Config
+	logger            log.Logger
+	saMapperProvider  searchattribute.MapperProvider
+	saValidator       *searchattribute.Validator
+	callbackValidator callbacks.Validator
+	linkValidator     *linkValidator
 }
 
 func newValidator(
@@ -44,16 +48,23 @@ func newValidator(
 	logger log.Logger,
 	saMapperProvider searchattribute.MapperProvider,
 	saValidator *searchattribute.Validator,
+	callbackValidator callbacks.Validator,
+	linkValidator *linkValidator,
 ) *validator {
 	return &validator{
-		config:           config,
-		logger:           logger,
-		saMapperProvider: saMapperProvider,
-		saValidator:      saValidator,
+		config:            config,
+		logger:            logger,
+		saMapperProvider:  saMapperProvider,
+		saValidator:       saValidator,
+		callbackValidator: callbackValidator,
+		linkValidator:     linkValidator,
 	}
 }
 
-func (v *validator) validateAndNormalizeStartRequest(req *workflowservice.StartNexusOperationExecutionRequest) error {
+func (v *validator) validateAndNormalizeStartRequest(
+	ctx context.Context,
+	req *workflowservice.StartNexusOperationExecutionRequest,
+) error {
 	ns := req.GetNamespace()
 
 	if err := v.normalizeRequestID(&req.RequestId); err != nil {
@@ -85,6 +96,25 @@ func (v *validator) validateAndNormalizeStartRequest(req *workflowservice.StartN
 	req.NexusHeader = loweredHeaders
 
 	if err := v.validateAndNormalizeSearchAttributes(req); err != nil {
+		return err
+	}
+	// Callbacks
+	cbs := req.GetCompletionCallbacks()
+	if len(cbs) > 0 {
+		opts := callbacks.ValidatorOptions{
+			EnabledKinds: v.config.EnabledCallbackKinds(ns),
+		}
+		if err := v.callbackValidator.Validate(ctx, ns, cbs, opts); err != nil {
+			return err
+		}
+	}
+	// Links
+	links := req.GetLinks()
+	if err := v.linkValidator.ValidateRequestWithCallbacks(ns, links, cbs); err != nil {
+		return err
+	}
+
+	if err := v.validateOnConflictOptions(req); err != nil {
 		return err
 	}
 
@@ -311,6 +341,31 @@ func (v *validator) normalizeIDPolicies(req *workflowservice.StartNexusOperation
 	if req.GetIdConflictPolicy() == enumspb.NEXUS_OPERATION_ID_CONFLICT_POLICY_UNSPECIFIED {
 		req.IdConflictPolicy = enumspb.NEXUS_OPERATION_ID_CONFLICT_POLICY_FAIL
 	}
+}
+
+// validateOnConflictOptions validates the on_conflict_options of a start request:
+//   - attach_completion_callbacks requires attach_request_id, since it is embedded into the keys we use
+//     to persist them on the Operation's Callbacks map.
+//   - attach_request_id requires at least one completion callback or link, since attaching a request ID
+//     is only meaningful alongside something to attach.
+//
+// attach_links is independent and may be set on its own.
+func (v *validator) validateOnConflictOptions(req *workflowservice.StartNexusOperationExecutionRequest) error {
+	onConflictOptions := req.GetOnConflictOptions()
+	if onConflictOptions == nil {
+		return nil
+	}
+	if onConflictOptions.GetAttachCompletionCallbacks() && !onConflictOptions.GetAttachRequestId() {
+		return serviceerror.NewInvalidArgument(
+			"on_conflict_options: attach_completion_callbacks requires attach_request_id to be set")
+	}
+	if onConflictOptions.GetAttachRequestId() &&
+		len(req.GetCompletionCallbacks()) == 0 &&
+		len(req.GetLinks()) == 0 {
+		return serviceerror.NewInvalidArgument(
+			"on_conflict_options: attach_request_id requires at least one completion callback or link")
+	}
+	return nil
 }
 
 // normalizeRequestID validates the request ID, or sets it to a UUID if empty.

--- a/chasm/lib/nexusoperation/validator_test.go
+++ b/chasm/lib/nexusoperation/validator_test.go
@@ -1,6 +1,9 @@
 package nexusoperation
 
 import (
+	"context"
+	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -8,10 +11,12 @@ import (
 	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	nexusoperationpb "go.temporal.io/api/nexusoperation/v1"
 	sdkpb "go.temporal.io/api/sdk/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/callbacks"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
@@ -23,7 +28,52 @@ import (
 )
 
 func newTestValidator(config *Config) *validator {
-	return newValidator(config, log.NewNoopLogger(), nil, nil)
+	return newValidator(
+		config,
+		log.NewNoopLogger(),
+		nil,
+		nil,
+		mustNewCallbackValidator(),
+		newTestLinkValidator(10, 10),
+	)
+}
+
+func mustNewCallbackValidator() callbacks.Validator {
+	allowAllAddresses := callbacks.AddressMatchRules{
+		Rules: []callbacks.AddressMatchRule{
+			{Regexp: regexp.MustCompile(`.*`), AllowInsecure: true},
+		},
+	}
+	cfg := callbacks.ValidatorConfig{
+		MaxCallbacksPerExecution:         func(string) int { return 10 },
+		MaxIDLengthLimit:                 func() int { return 10 },
+		URLMaxLength:                     func(string) int { return 1000 },
+		HeaderMaxSize:                    func(string) int { return 4096 },
+		EndpointRules:                    func(string) callbacks.AddressMatchRules { return allowAllAddresses },
+		MaxServiceNameLength:             func(string) int { return 10 },
+		MaxOperationNameLength:           func(string) int { return 10 },
+		NexusHandlerSourceContextMaxSize: func(string) int { return 1000 },
+	}
+
+	v, err := callbacks.NewValidator(cfg)
+	if err != nil {
+		panic("creating callback validator: " + err.Error())
+	}
+	return v
+}
+
+func newNexusCallback() *commonpb.Callback {
+	return &commonpb.Callback{
+		Variant: &commonpb.Callback_Nexus_{
+			Nexus: &commonpb.Callback_Nexus{
+				Url: "https://nexus.ex.xxxxx.cluster.tmprl.cloud:7243/Namespaces/ex.xxxxx/nexus/callback",
+				Header: map[string]string{
+					"Nexus-Operation-State": "succeeded",
+					"Content-Type":          "application/json",
+				},
+			},
+		},
+	}
 }
 
 func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
@@ -56,13 +106,18 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 		MaxOperationHeaderSize:             func(string) int { return 10 },
 		DisallowedOperationHeaders:         func() []string { return []string{"disallowed-header"} },
 		MaxOperationScheduleToCloseTimeout: func(string) time.Duration { return time.Hour },
+		EnabledCallbackKinds: func(string) []callbacks.Kind {
+			return []callbacks.Kind{callbacks.KindNexus}
+		},
 	}
 
 	for _, tc := range []struct {
-		name   string
-		mutate func(*workflowservice.StartNexusOperationExecutionRequest)
-		errMsg string
-		check  func(*testing.T, *workflowservice.StartNexusOperationExecutionRequest)
+		name         string
+		mutate       func(*workflowservice.StartNexusOperationExecutionRequest)
+		mutateConfig func(*Config)
+		wantErr      string
+		// Check the request after validation, to verify situations where it normalizes values.
+		postValidateCheck func(*testing.T, *workflowservice.StartNexusOperationExecutionRequest)
 	}{
 		{
 			name: "valid request",
@@ -72,21 +127,21 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.OperationId = ""
 			},
-			errMsg: "operation_id is required",
+			wantErr: "operation_id is required",
 		},
 		{
 			name: "operation_id - exceeds length limit",
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.OperationId = strings.Repeat("x", 51)
 			},
-			errMsg: "operation_id exceeds length limit",
+			wantErr: "operation_id exceeds length limit",
 		},
 		{
 			name: "request_id - defaults empty to UUID",
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.RequestId = ""
 			},
-			check: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
+			postValidateCheck: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
 				require.Len(t, r.RequestId, 36) // UUID length
 			},
 		},
@@ -95,63 +150,63 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.RequestId = strings.Repeat("x", 51)
 			},
-			errMsg: "request_id exceeds length limit",
+			wantErr: "request_id exceeds length limit",
 		},
 		{
 			name: "identity - exceeds length limit",
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.Identity = strings.Repeat("x", 51)
 			},
-			errMsg: "identity exceeds length limit",
+			wantErr: "identity exceeds length limit",
 		},
 		{
-			name:   "endpoint - required",
-			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) { r.Endpoint = "" },
-			errMsg: "endpoint is required",
+			name:    "endpoint - required",
+			mutate:  func(r *workflowservice.StartNexusOperationExecutionRequest) { r.Endpoint = "" },
+			wantErr: "endpoint is required",
 		},
 		{
-			name:   "service - required",
-			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) { r.Service = "" },
-			errMsg: "service is required",
+			name:    "service - required",
+			mutate:  func(r *workflowservice.StartNexusOperationExecutionRequest) { r.Service = "" },
+			wantErr: "service is required",
 		},
 		{
 			name: "service - exceeds length limit",
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.Service = "too-long-svc"
 			},
-			errMsg: "service exceeds length limit",
+			wantErr: "service exceeds length limit",
 		},
 		{
-			name:   "operation - required",
-			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) { r.Operation = "" },
-			errMsg: "operation is required",
+			name:    "operation - required",
+			mutate:  func(r *workflowservice.StartNexusOperationExecutionRequest) { r.Operation = "" },
+			wantErr: "operation is required",
 		},
 		{
 			name: "operation - exceeds length limit",
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.Operation = "too-long-op!"
 			},
-			errMsg: "operation exceeds length limit",
+			wantErr: "operation exceeds length limit",
 		},
 		{
 			name: "schedule_to_close_timeout - invalid",
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.ScheduleToCloseTimeout = &durationpb.Duration{Seconds: -1}
 			},
-			errMsg: "schedule_to_close_timeout is invalid",
+			wantErr: "schedule_to_close_timeout is invalid",
 		},
 		{
 			name: "schedule_to_close_timeout - caps exceeding max",
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.ScheduleToCloseTimeout = durationpb.New(2 * time.Hour)
 			},
-			check: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
+			postValidateCheck: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
 				require.Equal(t, time.Hour, r.ScheduleToCloseTimeout.AsDuration())
 			},
 		},
 		{
 			name: "schedule_to_close_timeout - caps unset to max",
-			check: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
+			postValidateCheck: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
 				require.Equal(t, time.Hour, r.ScheduleToCloseTimeout.AsDuration())
 			},
 		},
@@ -160,7 +215,7 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.ScheduleToCloseTimeout = durationpb.New(30 * time.Minute)
 			},
-			check: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
+			postValidateCheck: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
 				require.Equal(t, 30*time.Minute, r.ScheduleToCloseTimeout.AsDuration())
 			},
 		},
@@ -169,14 +224,14 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.ScheduleToStartTimeout = &durationpb.Duration{Seconds: -1}
 			},
-			errMsg: "schedule_to_start_timeout is invalid",
+			wantErr: "schedule_to_start_timeout is invalid",
 		},
 		{
 			name: "schedule_to_start_timeout - caps to defaulted schedule_to_close_timeout",
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.ScheduleToStartTimeout = durationpb.New(2 * time.Hour)
 			},
-			check: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
+			postValidateCheck: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
 				require.Equal(t, time.Hour, r.ScheduleToCloseTimeout.AsDuration())
 				require.Equal(t, time.Hour, r.ScheduleToStartTimeout.AsDuration())
 			},
@@ -187,7 +242,7 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 				r.ScheduleToCloseTimeout = durationpb.New(30 * time.Minute)
 				r.ScheduleToStartTimeout = durationpb.New(time.Hour)
 			},
-			check: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
+			postValidateCheck: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
 				require.Equal(t, 30*time.Minute, r.ScheduleToStartTimeout.AsDuration())
 			},
 		},
@@ -197,7 +252,7 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 				r.ScheduleToCloseTimeout = durationpb.New(30 * time.Minute)
 				r.ScheduleToStartTimeout = durationpb.New(20 * time.Minute)
 			},
-			check: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
+			postValidateCheck: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
 				require.Equal(t, 20*time.Minute, r.ScheduleToStartTimeout.AsDuration())
 			},
 		},
@@ -206,14 +261,14 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.StartToCloseTimeout = &durationpb.Duration{Seconds: -1}
 			},
-			errMsg: "start_to_close_timeout is invalid",
+			wantErr: "start_to_close_timeout is invalid",
 		},
 		{
 			name: "start_to_close_timeout - caps to defaulted schedule_to_close_timeout",
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.StartToCloseTimeout = durationpb.New(2 * time.Hour)
 			},
-			check: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
+			postValidateCheck: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
 				require.Equal(t, time.Hour, r.ScheduleToCloseTimeout.AsDuration())
 				require.Equal(t, time.Hour, r.StartToCloseTimeout.AsDuration())
 			},
@@ -224,7 +279,7 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 				r.ScheduleToCloseTimeout = durationpb.New(30 * time.Minute)
 				r.StartToCloseTimeout = durationpb.New(time.Hour)
 			},
-			check: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
+			postValidateCheck: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
 				require.Equal(t, 30*time.Minute, r.StartToCloseTimeout.AsDuration())
 			},
 		},
@@ -234,7 +289,7 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 				r.ScheduleToCloseTimeout = durationpb.New(30 * time.Minute)
 				r.StartToCloseTimeout = durationpb.New(10 * time.Minute)
 			},
-			check: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
+			postValidateCheck: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
 				require.Equal(t, 10*time.Minute, r.StartToCloseTimeout.AsDuration())
 			},
 		},
@@ -249,7 +304,7 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.Input = &commonpb.Payload{Data: []byte("this-input-is-longer-than-twenty-characters")}
 			},
-			errMsg: "input exceeds size limit",
+			wantErr: "input exceeds size limit",
 		},
 		{
 			name: "user_metadata.summary - exceeds size limit",
@@ -258,7 +313,7 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 					Summary: &commonpb.Payload{Data: []byte("too-long-summary")},
 				}
 			},
-			errMsg: "user_metadata.summary exceeds size limit",
+			wantErr: "user_metadata.summary exceeds size limit",
 		},
 		{
 			name: "user_metadata.details - exceeds size limit",
@@ -267,25 +322,25 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 					Details: &commonpb.Payload{Data: []byte("this-details-payload-is-too-long")},
 				}
 			},
-			errMsg: "user_metadata.details exceeds size limit",
+			wantErr: "user_metadata.details exceeds size limit",
 		},
 		{
 			name: "nexus_header - disallowed key",
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.NexusHeader = map[string]string{"Disallowed-Header": "value"}
 			},
-			errMsg: "nexus_header contains a disallowed key",
+			wantErr: "nexus_header contains a disallowed key",
 		},
 		{
 			name: "nexus_header - exceeds size limit",
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.NexusHeader = map[string]string{"key": "too-long-val"}
 			},
-			errMsg: "nexus_header exceeds size limit",
+			wantErr: "nexus_header exceeds size limit",
 		},
 		{
 			name: "id_policies - defaults unspecified",
-			check: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
+			postValidateCheck: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
 				require.Equal(t, enumspb.NEXUS_OPERATION_ID_REUSE_POLICY_ALLOW_DUPLICATE, r.IdReusePolicy)
 				require.Equal(t, enumspb.NEXUS_OPERATION_ID_CONFLICT_POLICY_FAIL, r.IdConflictPolicy)
 			},
@@ -296,7 +351,7 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 				r.IdReusePolicy = enumspb.NEXUS_OPERATION_ID_REUSE_POLICY_REJECT_DUPLICATE
 				r.IdConflictPolicy = enumspb.NEXUS_OPERATION_ID_CONFLICT_POLICY_USE_EXISTING
 			},
-			check: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
+			postValidateCheck: func(t *testing.T, r *workflowservice.StartNexusOperationExecutionRequest) {
 				require.Equal(t, enumspb.NEXUS_OPERATION_ID_REUSE_POLICY_REJECT_DUPLICATE, r.IdReusePolicy)
 				require.Equal(t, enumspb.NEXUS_OPERATION_ID_CONFLICT_POLICY_USE_EXISTING, r.IdConflictPolicy)
 			},
@@ -312,7 +367,7 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 					},
 				}
 			},
-			errMsg: "number of search attributes",
+			wantErr: "number of search attributes",
 		},
 		{
 			name: "search_attributes - value exceeds size limit",
@@ -326,7 +381,76 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 					},
 				}
 			},
-			errMsg: "exceeds size limit",
+			wantErr: "exceeds size limit",
+		},
+		{
+			name: "completion_callbacks - accepts the nexus variant",
+			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
+				r.CompletionCallbacks = []*commonpb.Callback{newNexusCallback()}
+			},
+		},
+		{
+			name: "links - accepts a valid link",
+			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
+				r.Links = []*commonpb.Link{testLink("wf-id")}
+			},
+		},
+		{
+			name: "links - rejects an incomplete variant",
+			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
+				r.Links = []*commonpb.Link{{Variant: &commonpb.Link_WorkflowEvent_{
+					WorkflowEvent: &commonpb.Link_WorkflowEvent{WorkflowId: "wf-id", RunId: "wf-run-id"},
+				}}}
+			},
+			wantErr: "must not have an empty namespace",
+		},
+		{
+			name: "links - rejects more than the per-request limit",
+			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
+				// newTestLinkValidator below allows 10 links per request.
+				for i := range 11 {
+					r.Links = append(r.Links, testLink(fmt.Sprintf("wf-%d", i)))
+				}
+			},
+			wantErr: "cannot attach more than 10 links per request",
+		},
+		{
+			name: "on_conflict_options - attach_completion_callbacks requires attach_request_id",
+			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
+				r.CompletionCallbacks = []*commonpb.Callback{newNexusCallback()}
+				r.OnConflictOptions = &nexusoperationpb.OnConflictOptions{
+					AttachCompletionCallbacks: true,
+				}
+			},
+			wantErr: "attach_completion_callbacks requires attach_request_id",
+		},
+		{
+			name: "on_conflict_options - attach_request_id requires a completion callback or a link",
+			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
+				r.OnConflictOptions = &nexusoperationpb.OnConflictOptions{
+					AttachRequestId: true,
+				}
+			},
+			wantErr: "attach_request_id requires at least one completion callback or link",
+		},
+		{
+			name: "on_conflict_options - attach_request_id is satisfied by links alone",
+			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
+				r.Links = []*commonpb.Link{testLink("wf-id")}
+				r.OnConflictOptions = &nexusoperationpb.OnConflictOptions{
+					AttachRequestId: true,
+					AttachLinks:     true,
+				}
+			},
+		},
+		{
+			name: "on_conflict_options - attach_links may be set on its own",
+			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
+				r.Links = []*commonpb.Link{testLink("wf-id")}
+				r.OnConflictOptions = &nexusoperationpb.OnConflictOptions{
+					AttachLinks: true,
+				}
+			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -346,17 +470,22 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 			if tc.mutate != nil {
 				tc.mutate(req)
 			}
-			err := newValidator(config, log.NewNoopLogger(), nil, saValidator).
-				validateAndNormalizeStartRequest(req)
-			if tc.errMsg != "" {
+			caseConfig := *config
+			if tc.mutateConfig != nil {
+				tc.mutateConfig(&caseConfig)
+			}
+			cbValidator := mustNewCallbackValidator()
+			err := newValidator(&caseConfig, log.NewNoopLogger(), nil, saValidator, cbValidator, newTestLinkValidator(10, 10)).
+				validateAndNormalizeStartRequest(context.Background(), req)
+			if tc.wantErr != "" {
 				var invalidArgErr *serviceerror.InvalidArgument
 				require.ErrorAs(t, err, &invalidArgErr)
-				require.Contains(t, err.Error(), tc.errMsg)
+				require.Contains(t, err.Error(), tc.wantErr)
 			} else {
 				require.NoError(t, err)
 			}
-			if tc.check != nil {
-				tc.check(t, req)
+			if tc.postValidateCheck != nil {
+				tc.postValidateCheck(t, req)
 			}
 		})
 	}
@@ -787,4 +916,100 @@ func TestValidatePollNexusOperationExecutionRequest(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateOnConflictOptions(t *testing.T) {
+	t.Parallel()
+
+	// on_conflict_options validation is config-independent.
+	v := newTestValidator(&Config{})
+	cb := newNexusCallback()
+
+	t.Run("Unset", func(t *testing.T) {
+		require.NoError(t, v.validateOnConflictOptions(&workflowservice.StartNexusOperationExecutionRequest{}))
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		require.NoError(t, v.validateOnConflictOptions(&workflowservice.StartNexusOperationExecutionRequest{
+			OnConflictOptions: &nexusoperationpb.OnConflictOptions{},
+		}))
+	})
+
+	t.Run("AttachRequestIdAndCallbacksWithCallback", func(t *testing.T) {
+		require.NoError(t, v.validateOnConflictOptions(&workflowservice.StartNexusOperationExecutionRequest{
+			CompletionCallbacks: []*commonpb.Callback{cb},
+			OnConflictOptions: &nexusoperationpb.OnConflictOptions{
+				AttachRequestId:           true,
+				AttachCompletionCallbacks: true,
+			},
+		}))
+	})
+
+	t.Run("AttachRequestIdOnlyWithCallback", func(t *testing.T) {
+		require.NoError(t, v.validateOnConflictOptions(&workflowservice.StartNexusOperationExecutionRequest{
+			CompletionCallbacks: []*commonpb.Callback{cb},
+			OnConflictOptions:   &nexusoperationpb.OnConflictOptions{AttachRequestId: true},
+		}))
+	})
+
+	t.Run("AttachCallbacksWithoutAttachRequestId", func(t *testing.T) {
+		err := v.validateOnConflictOptions(&workflowservice.StartNexusOperationExecutionRequest{
+			CompletionCallbacks: []*commonpb.Callback{cb},
+			OnConflictOptions: &nexusoperationpb.OnConflictOptions{
+				AttachCompletionCallbacks: true,
+			},
+		})
+		var invalidArgErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgErr)
+		require.Contains(t, err.Error(), "attach_completion_callbacks requires attach_request_id")
+	})
+
+	t.Run("AttachRequestIdOnlyWithLink", func(t *testing.T) {
+		require.NoError(t, v.validateOnConflictOptions(&workflowservice.StartNexusOperationExecutionRequest{
+			Links:             []*commonpb.Link{testLink("wf-id")},
+			OnConflictOptions: &nexusoperationpb.OnConflictOptions{AttachRequestId: true},
+		}))
+	})
+
+	t.Run("AttachLinksOnly", func(t *testing.T) {
+		// attach_links stands on its own: links are keyed by the request ID the caller always supplies.
+		require.NoError(t, v.validateOnConflictOptions(&workflowservice.StartNexusOperationExecutionRequest{
+			Links:             []*commonpb.Link{testLink("wf-id")},
+			OnConflictOptions: &nexusoperationpb.OnConflictOptions{AttachLinks: true},
+		}))
+	})
+
+	t.Run("AttachLinksAndCallbacks", func(t *testing.T) {
+		require.NoError(t, v.validateOnConflictOptions(&workflowservice.StartNexusOperationExecutionRequest{
+			CompletionCallbacks: []*commonpb.Callback{cb},
+			Links:               []*commonpb.Link{testLink("wf-id")},
+			OnConflictOptions: &nexusoperationpb.OnConflictOptions{
+				AttachRequestId:           true,
+				AttachCompletionCallbacks: true,
+				AttachLinks:               true,
+			},
+		}))
+	})
+
+	t.Run("AttachRequestIdWithoutCallbackOrLink", func(t *testing.T) {
+		err := v.validateOnConflictOptions(&workflowservice.StartNexusOperationExecutionRequest{
+			OnConflictOptions: &nexusoperationpb.OnConflictOptions{AttachRequestId: true},
+		})
+		var invalidArgErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgErr)
+		require.Contains(t, err.Error(), "attach_request_id requires at least one completion callback or link")
+	})
+
+	t.Run("AttachRequestIdAndCallbacksWithoutCallbackProvided", func(t *testing.T) {
+		err := v.validateOnConflictOptions(&workflowservice.StartNexusOperationExecutionRequest{
+			OnConflictOptions: &nexusoperationpb.OnConflictOptions{
+				AttachRequestId:           true,
+				AttachCompletionCallbacks: true,
+			},
+		})
+		var invalidArgErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgErr)
+		require.Contains(t, err.Error(), "attach_request_id requires at least one completion callback")
+	})
+
 }

--- a/chasm/lib/nexusoperation/validator_test.go
+++ b/chasm/lib/nexusoperation/validator_test.go
@@ -76,6 +76,21 @@ func newNexusCallback() *commonpb.Callback {
 	}
 }
 
+// newNexusHandlerCallback returns a NexusHandler-variant callback.
+func newNexusHandlerCallback() *commonpb.Callback {
+	sourceContext := &commonpb.Payload{Data: make([]byte, 1024)}
+	return &commonpb.Callback{
+		Variant: &commonpb.Callback_NexusHandler_{
+			NexusHandler: &commonpb.Callback_NexusHandler{
+				TaskQueueName: "wc-queue",
+				Service:       "Adapter",
+				Operation:     "Deliver",
+				SourceContext: sourceContext,
+			},
+		},
+	}
+}
+
 func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockVisibilityManager := manager.NewMockVisibilityManager(ctrl)
@@ -390,6 +405,36 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 			},
 		},
 		{
+			// The default for enabledCallbackKinds is empty, i.e. the feature is off.
+			name: "completion_callbacks - rejected when no kinds are enabled",
+			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
+				r.CompletionCallbacks = []*commonpb.Callback{newNexusCallback()}
+			},
+			mutateConfig: func(c *Config) {
+				c.EnabledCallbackKinds = func(string) []callbacks.Kind { return nil }
+			},
+			wantErr: "nexus callbacks are not enabled for this execution type",
+		},
+		{
+			name: "completion_callbacks - rejects a kind that is not enabled",
+			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
+				r.CompletionCallbacks = []*commonpb.Callback{newNexusHandlerCallback()}
+			},
+			wantErr: "nexusHandler callbacks are not enabled for this execution type",
+		},
+		{
+			name: "source_context - rejects a single callback over the per-callback limit",
+			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
+				r.CompletionCallbacks = []*commonpb.Callback{newNexusHandlerCallback()}
+			},
+			mutateConfig: func(c *Config) {
+				c.EnabledCallbackKinds = func(string) []callbacks.Kind {
+					return []callbacks.Kind{callbacks.KindNexus, callbacks.KindNexusHandler}
+				}
+			},
+			wantErr: "source_context exceeds size limit",
+		},
+		{
 			name: "links - accepts a valid link",
 			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
 				r.Links = []*commonpb.Link{testLink("wf-id")}
@@ -411,6 +456,43 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 				for i := range 11 {
 					r.Links = append(r.Links, testLink(fmt.Sprintf("wf-%d", i)))
 				}
+			},
+			wantErr: "cannot attach more than 10 links per request",
+		},
+		{
+			// Links ride along on callbacks as well as on the request, and are validated whether or
+			// not the request brought any of its own.
+			name: "links - rejects an incomplete variant carried by a callback",
+			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
+				cb := newNexusCallback()
+				cb.Links = []*commonpb.Link{{Variant: &commonpb.Link_WorkflowEvent_{
+					WorkflowEvent: &commonpb.Link_WorkflowEvent{WorkflowId: "wf-id", RunId: "wf-run-id"},
+				}}}
+				r.CompletionCallbacks = []*commonpb.Callback{cb}
+			},
+			wantErr: "must not have an empty namespace",
+		},
+		{
+			name: "links - rejects an oversized link carried by a callback",
+			mutate: func(r *workflowservice.StartNexusOperationExecutionRequest) {
+				// newTestLinkValidator sets a default 4000 bytes per link limit.
+				cb := newNexusCallback()
+				cb.Links = []*commonpb.Link{testLink(strings.Repeat("x", 4001))}
+				r.CompletionCallbacks = []*commonpb.Callback{cb}
+			},
+			wantErr: "link exceeds allowed size of 4000",
+		},
+		{
+			// A callback's links count toward the same per-request limit as the request's own, so
+			// neither side can smuggle links past it by splitting them across the two.
+			name: "links - counts callback links toward the per-request limit",
+			mutate: func(req *workflowservice.StartNexusOperationExecutionRequest) {
+				cb := newNexusCallback()
+				for i := range 6 {
+					req.Links = append(req.Links, testLink(fmt.Sprintf("req-wf-%d", i)))
+					cb.Links = append(cb.Links, testLink(fmt.Sprintf("cb-wf-%d", i)))
+				}
+				req.CompletionCallbacks = []*commonpb.Callback{cb}
 			},
 			wantErr: "cannot attach more than 10 links per request",
 		},
@@ -474,9 +556,12 @@ func TestValidateStartNexusOperationExecutionRequest(t *testing.T) {
 			if tc.mutateConfig != nil {
 				tc.mutateConfig(&caseConfig)
 			}
+
 			cbValidator := mustNewCallbackValidator()
-			err := newValidator(&caseConfig, log.NewNoopLogger(), nil, saValidator, cbValidator, newTestLinkValidator(10, 10)).
-				validateAndNormalizeStartRequest(context.Background(), req)
+			logger := log.NewNoopLogger()
+			v := newValidator(&caseConfig, logger, nil, saValidator, cbValidator, newTestLinkValidator(10, 10))
+
+			err := v.validateAndNormalizeStartRequest(context.Background(), req)
 			if tc.wantErr != "" {
 				var invalidArgErr *serviceerror.InvalidArgument
 				require.ErrorAs(t, err, &invalidArgErr)

--- a/chasm/lib/workflow/config.go
+++ b/chasm/lib/workflow/config.go
@@ -1,8 +1,16 @@
 package workflow
 
 import (
+	commoncallbacks "go.temporal.io/server/common/callbacks"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/retrypolicy"
+)
+
+var EnabledCallbackKinds = dynamicconfig.NewNamespaceTypedSettingWithConverter(
+	"workflow.enabledCallbackKinds",
+	commoncallbacks.ConvertEnabledKinds,
+	[]commoncallbacks.Kind{commoncallbacks.KindNexus},
+	`The list of completion callback kinds that may be attached to a workflow execution.`,
 )
 
 type Config struct {

--- a/chasm/lib/workflow/workflow.go
+++ b/chasm/lib/workflow/workflow.go
@@ -157,17 +157,9 @@ func addCallbacksToMap(
 ) error {
 	chasmCBs := make([]*callbackspb.Callback, len(completionCallbacks))
 	for i, cb := range completionCallbacks {
-		chasmCB := &callbackspb.Callback{Links: cb.GetLinks()}
-		switch variant := cb.Variant.(type) {
-		case *commonpb.Callback_Nexus_:
-			chasmCB.Variant = &callbackspb.Callback_Nexus_{
-				Nexus: &callbackspb.Callback_Nexus{
-					Url:    variant.Nexus.GetUrl(),
-					Header: variant.Nexus.GetHeader(),
-				},
-			}
-		default:
-			return serviceerror.NewInvalidArgumentf("unsupported callback variant: %T", variant)
+		chasmCB, err := callback.FromAPICallback(cb)
+		if err != nil {
+			return err
 		}
 		chasmCBs[i] = chasmCB
 	}

--- a/chasm/lib/workflow/workflow.go
+++ b/chasm/lib/workflow/workflow.go
@@ -173,7 +173,7 @@ func addCallbacksToMap(
 			// Already registered, skip to avoid overwriting.
 			continue
 		}
-		callbackObj := callback.NewCallback(requestID, eventTime, &callbackspb.CallbackState{}, chasmCB)
+		callbackObj := callback.NewCallback(requestID, eventTime, chasmCB)
 		target[id] = chasm.NewComponentField(ctx, callbackObj)
 	}
 	return nil

--- a/cmd/tools/getproto/files.go
+++ b/cmd/tools/getproto/files.go
@@ -21,6 +21,7 @@ import (
 	history "go.temporal.io/api/history/v1"
 	namespace "go.temporal.io/api/namespace/v1"
 	nexus "go.temporal.io/api/nexus/v1"
+	nexusoperation "go.temporal.io/api/nexusoperation/v1"
 	protocol "go.temporal.io/api/protocol/v1"
 	query "go.temporal.io/api/query/v1"
 	replication "go.temporal.io/api/replication/v1"
@@ -82,6 +83,7 @@ func init() {
 	importMap["temporal/api/history/v1/message.proto"] = history.File_temporal_api_history_v1_message_proto
 	importMap["temporal/api/namespace/v1/message.proto"] = namespace.File_temporal_api_namespace_v1_message_proto
 	importMap["temporal/api/nexus/v1/message.proto"] = nexus.File_temporal_api_nexus_v1_message_proto
+	importMap["temporal/api/nexusoperation/v1/message.proto"] = nexusoperation.File_temporal_api_nexusoperation_v1_message_proto
 	importMap["temporal/api/protocol/v1/message.proto"] = protocol.File_temporal_api_protocol_v1_message_proto
 	importMap["temporal/api/query/v1/message.proto"] = query.File_temporal_api_query_v1_message_proto
 	importMap["temporal/api/replication/v1/message.proto"] = replication.File_temporal_api_replication_v1_message_proto

--- a/common/callbacks/kind.go
+++ b/common/callbacks/kind.go
@@ -1,0 +1,77 @@
+package callbacks
+
+import (
+	"fmt"
+	"slices"
+
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/server/common/dynamicconfig"
+)
+
+// Kind identifies a callback variant.
+type Kind string
+
+const (
+	// KindUnknown is the kind of a callback with an unset or unrecognized variant.
+	KindUnknown      Kind = "unknown"
+	KindNexus        Kind = "nexus"
+	KindNexusHandler Kind = "nexusHandler"
+)
+
+func (k Kind) String() string {
+	switch k {
+	case KindUnknown, KindNexus, KindNexusHandler:
+		return string(k)
+	default:
+		return string(KindUnknown)
+	}
+}
+
+// KindOf reports which [Kind] the given callback is.
+func KindOf(cb *commonpb.Callback) Kind {
+	switch cb.GetVariant().(type) {
+	case *commonpb.Callback_Nexus_:
+		return KindNexus
+	case *commonpb.Callback_NexusHandler_:
+		return KindNexusHandler
+	case *commonpb.Callback_Internal_:
+		// Internal-variant callbacks are not used and should be removed entirely.
+		return KindUnknown
+	default:
+		return KindUnknown
+	}
+}
+
+// ConvertEnabledKinds converts a dynamic config value, a list of kind names into a []Kind.
+//
+// Returns an error and use the default config value if any callback kinds are unrecognized.
+// An empty list not specifying any callback kinds is allowed.
+func ConvertEnabledKinds(val any) ([]Kind, error) {
+	names, err := dynamicconfig.ConvertStructure[[]string](nil)(val)
+	if err != nil {
+		return nil, err
+	}
+
+	enabledKinds := make([]Kind, 0, 2)
+	configurableKinds := map[string]Kind{
+		KindNexus.String():        KindNexus,
+		KindNexusHandler.String(): KindNexusHandler,
+	}
+	var unknownNames []string
+	for _, name := range names {
+		kind, ok := configurableKinds[name]
+		if !ok {
+			unknownNames = append(unknownNames, name)
+			continue
+		}
+		if !slices.Contains(enabledKinds, kind) {
+			enabledKinds = append(enabledKinds, kind)
+		}
+	}
+	if len(unknownNames) > 0 {
+		return nil, fmt.Errorf(
+			"%v does not match a known callback kind [nexus, nexusHandler]",
+			unknownNames)
+	}
+	return enabledKinds, nil
+}

--- a/common/callbacks/kind_test.go
+++ b/common/callbacks/kind_test.go
@@ -1,0 +1,130 @@
+package callbacks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+)
+
+func TestKindOf(t *testing.T) {
+	for _, tc := range []struct {
+		callback *commonpb.Callback
+		want     Kind
+		wantName string
+	}{
+		{
+			callback: newNexusCallback(),
+			want:     KindNexus,
+			wantName: "nexus",
+		},
+		{
+			callback: newNexusHandlerCallback(),
+			want:     KindNexusHandler,
+			wantName: "nexusHandler",
+		},
+		{
+			// Internal-variant callbacks should be removed; treated as Unknown.
+			callback: &commonpb.Callback{
+				Variant: &commonpb.Callback_Internal_{
+					Internal: &commonpb.Callback_Internal{},
+				},
+			},
+			want:     KindUnknown,
+			wantName: "unknown",
+		},
+		{
+			callback: &commonpb.Callback{},
+			want:     KindUnknown,
+			wantName: "unknown",
+		},
+		{
+			callback: nil,
+			want:     KindUnknown,
+			wantName: "unknown",
+		},
+	} {
+		t.Run(tc.wantName, func(t *testing.T) {
+			require.Equal(t, tc.want, KindOf(tc.callback))
+			require.Equal(t, tc.wantName, tc.want.String())
+		})
+	}
+}
+
+func TestConvertEnabledKinds(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		val  any
+		want []Kind
+	}{
+		// Empty lists are supported. It means no callbacks are allowed on the execution.
+		{name: "Empty", val: []string{}, want: []Kind{}},
+		{name: "Nil", val: nil, want: []Kind{}},
+
+		{name: "NexusOnly", val: []string{"nexus"}, want: []Kind{KindNexus}},
+		{name: "NexusHandlerOnly", val: []string{"nexusHandler"}, want: []Kind{KindNexusHandler}},
+		{
+			name: "Both",
+			val:  []string{"nexus", "nexusHandler"},
+			want: []Kind{KindNexus, KindNexusHandler},
+		},
+		{
+			name: "OrderPreserved",
+			val:  []string{"nexusHandler", "nexus"},
+			want: []Kind{KindNexusHandler, KindNexus},
+		},
+		{
+			name: "DuplicatesDropped",
+			val:  []string{"nexus", "nexus"},
+			want: []Kind{KindNexus},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ConvertEnabledKinds(tc.val)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+
+	// Return an error for any unrecognized name, rejecting the whole value. So dynamic config
+	// parsing will log and fall back to the setting's default value.
+	for _, tc := range []struct {
+		name   string
+		val    any
+		errMsg string
+	}{
+		{name: "NotAList", val: 42, errMsg: "source data must be an array or slice"},
+		{
+			name:   "OnlyUnknownNames",
+			val:    []string{"carrier-pigeon"},
+			errMsg: `[carrier-pigeon] does not match a known callback kind`,
+		},
+		{
+			name:   "UnknownNameBesideKnownName",
+			val:    []string{"nexsus", "nexusHandler"},
+			errMsg: `[nexsus] does not match a known callback kind`,
+		},
+		{
+			// Internal callbacks are server-generated and cannot be enabled by an operator.
+			name:   "Internal",
+			val:    []string{"nexus", "internal"},
+			errMsg: `[internal] does not match a known callback kind`,
+		},
+		{
+			name:   "NotNormalizedOrTrimmed",
+			val:    []any{" Nexus", "NEXUSHANDLER", "   nexus", "nexusHandler "},
+			errMsg: "[ Nexus NEXUSHANDLER    nexus nexusHandler ] does not match a known callback kind",
+		},
+		{
+			name:   "AllUnknownNamesReported",
+			val:    []string{"nexsus", "wroker"},
+			errMsg: `[nexsus wroker] does not match a known callback kind`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ConvertEnabledKinds(tc.val)
+			require.ErrorContains(t, err, tc.errMsg)
+			require.Nil(t, got)
+		})
+	}
+}

--- a/common/callbacks/validator.go
+++ b/common/callbacks/validator.go
@@ -96,7 +96,14 @@ func (v *validator) Validate(_ context.Context, namespaceName string, cbs []*com
 				)
 			}
 			variant.Nexus.Header = lowerCaseHeaders
+		case *commonpb.Callback_NexusHandler_:
+			// NexusHandler callbacks aren't supported anywhere. Later, we will refactor this validator
+			// to make which callback kinds are supported configurable.
+			return serviceerror.NewInvalidArgument("nexusHandler callbacks are not enabled for this execution type")
 		case *commonpb.Callback_Internal_:
+			// Internal callbacks are server-generated, so there is nothing to validate.
+			// CHASM has no Internal variant, so FromAPICallback rejects them with
+			// InvalidArgument when the execution is backed by CHASM.
 			continue
 		default:
 			return serviceerror.NewUnimplemented(fmt.Sprintf("unknown callback variant: %T", variant))

--- a/common/callbacks/validator.go
+++ b/common/callbacks/validator.go
@@ -3,43 +3,67 @@ package callbacks
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/tqid"
 	"google.golang.org/grpc/status"
 )
 
+type ValidatorOptions struct {
+	// EnabledKinds are the callback kinds that may be attached to the execution being validated.
+	// A client-supplied callback of any other kind is rejected with an InvalidArgument error.
+	EnabledKinds []Kind
+}
+
 // Validator validates completion callbacks attached to executions (e.g. workflows and standalone activities).
 type Validator interface {
-	Validate(ctx context.Context, namespaceName string, cbs []*commonpb.Callback) error
+	// Validate rejects callbacks that are not enabled for the execution, or are malformed.
+	// Will mutate the supplied Callbacks to normalize. e.g. converting Nexus headers to lower-case.
+	Validate(ctx context.Context, namespaceName string, cbs []*commonpb.Callback, opts ValidatorOptions) error
 }
 
 // ValidatorConfig holds the limits a [Validator] enforces.
 type ValidatorConfig struct {
 	MaxCallbacksPerExecution dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxIDLengthLimit         dynamicconfig.IntPropertyFn // All ID types use the same global setting.
 
 	// Nexus-variant limits.
 	URLMaxLength  dynamicconfig.IntPropertyFnWithNamespaceFilter
 	HeaderMaxSize dynamicconfig.IntPropertyFnWithNamespaceFilter
 	EndpointRules dynamicconfig.TypedPropertyFnWithNamespaceFilter[AddressMatchRules]
+
+	// NexusHandler-variant limits.
+	MaxServiceNameLength             dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxOperationNameLength           dynamicconfig.IntPropertyFnWithNamespaceFilter
+	NexusHandlerSourceContextMaxSize dynamicconfig.IntPropertyFnWithNamespaceFilter
 }
 
 func (vc *ValidatorConfig) Validate() error {
 	var missingFields []string
-	if vc.MaxCallbacksPerExecution == nil {
-		missingFields = append(missingFields, "MaxCallbacksPerExecution")
+	assertGetterIsSet := func(name string, getter dynamicconfig.IntPropertyFnWithNamespaceFilter) {
+		if getter == nil {
+			missingFields = append(missingFields, name)
+		}
 	}
-	if vc.URLMaxLength == nil {
-		missingFields = append(missingFields, "URLMaxLength")
+
+	assertGetterIsSet("MaxCallbacksPerExecution", vc.MaxCallbacksPerExecution)
+	if vc.MaxIDLengthLimit == nil {
+		missingFields = append(missingFields, "MaxIDLengthLimit")
 	}
-	if vc.HeaderMaxSize == nil {
-		missingFields = append(missingFields, "HeaderMaxSize")
-	}
+
+	assertGetterIsSet("URLMaxLength", vc.URLMaxLength)
+	assertGetterIsSet("HeaderMaxSize", vc.HeaderMaxSize)
 	if vc.EndpointRules == nil {
 		missingFields = append(missingFields, "EndpointRules")
 	}
+
+	assertGetterIsSet("MaxServiceNameLength", vc.MaxServiceNameLength)
+	assertGetterIsSet("MaxOperationNameLength", vc.MaxOperationNameLength)
+	assertGetterIsSet("NexusHandlerSourceContextMaxSize", vc.NexusHandlerSourceContextMaxSize)
 
 	if len(missingFields) != 0 {
 		return fmt.Errorf("missing required fields: %v", missingFields)
@@ -59,9 +83,14 @@ func NewValidator(config ValidatorConfig) (Validator, error) {
 	return &validator{config: config}, nil
 }
 
-// Validate validates completion callbacks: count, URL length, endpoint allowlist, header size, and normalizes header
-// keys to lowercase.
-func (v *validator) Validate(_ context.Context, namespaceName string, cbs []*commonpb.Callback) error {
+// Validate validates completion callbacks: their kind, their count, and the fields of each variant.
+// Nexus header keys are normalized to lowercase in place.
+func (v *validator) Validate(
+	_ context.Context,
+	namespaceName string,
+	cbs []*commonpb.Callback,
+	opts ValidatorOptions,
+) error {
 	if len(cbs) > v.config.MaxCallbacksPerExecution(namespaceName) {
 		return serviceerror.NewInvalidArgumentf(
 			"cannot attach more than %d callbacks to an execution", v.config.MaxCallbacksPerExecution(namespaceName),
@@ -69,45 +98,98 @@ func (v *validator) Validate(_ context.Context, namespaceName string, cbs []*com
 	}
 
 	for _, cb := range cbs {
-		switch variant := cb.GetVariant().(type) {
-		case *commonpb.Callback_Nexus_:
-			rawURL := variant.Nexus.GetUrl()
-			if len(rawURL) > v.config.URLMaxLength(namespaceName) {
-				return serviceerror.NewInvalidArgumentf(
-					"invalid url: url length longer than max length allowed of %d", v.config.URLMaxLength(namespaceName),
-				)
-			}
-			if err := v.config.EndpointRules(namespaceName).Validate(rawURL); err != nil {
-				if s, ok := status.FromError(err); ok {
-					return serviceerror.NewInvalidArgument(s.Message())
-				}
-				return serviceerror.NewInvalidArgument(err.Error())
-			}
-
-			headerSize := 0
-			lowerCaseHeaders := make(map[string]string, len(variant.Nexus.GetHeader()))
-			for k, val := range variant.Nexus.GetHeader() {
-				headerSize += len(k) + len(val)
-				lowerCaseHeaders[strings.ToLower(k)] = val
-			}
-			if headerSize > v.config.HeaderMaxSize(namespaceName) {
-				return serviceerror.NewInvalidArgumentf(
-					"invalid header: header size longer than max allowed size of %d", v.config.HeaderMaxSize(namespaceName),
-				)
-			}
-			variant.Nexus.Header = lowerCaseHeaders
-		case *commonpb.Callback_NexusHandler_:
-			// NexusHandler callbacks aren't supported anywhere. Later, we will refactor this validator
-			// to make which callback kinds are supported configurable.
-			return serviceerror.NewInvalidArgument("nexusHandler callbacks are not enabled for this execution type")
-		case *commonpb.Callback_Internal_:
-			// Internal callbacks are server-generated, so there is nothing to validate.
-			// CHASM has no Internal variant, so FromAPICallback rejects them with
-			// InvalidArgument when the execution is backed by CHASM.
-			continue
-		default:
-			return serviceerror.NewUnimplemented(fmt.Sprintf("unknown callback variant: %T", variant))
+		if err := v.validateCallback(cb, namespaceName, opts); err != nil {
+			return err
 		}
 	}
+	return nil
+}
+
+func (v *validator) validateCallback(cb *commonpb.Callback, namespaceName string, opts ValidatorOptions) error {
+	kind := KindOf(cb)
+
+	// For unknown callbacks, prefer the "unknown callback variant" error below.
+	if kind != KindUnknown && !slices.Contains(opts.EnabledKinds, kind) {
+		return serviceerror.NewInvalidArgumentf("%s callbacks are not enabled for this execution type", kind)
+	}
+
+	switch kind {
+	case KindNexus:
+		return v.validateNexus(namespaceName, cb.GetNexus())
+	case KindNexusHandler:
+		return v.validateNexusHandler(namespaceName, cb.GetNexusHandler())
+	case KindUnknown:
+		fallthrough
+	default:
+		return serviceerror.NewUnimplementedf("unknown callback variant: %T", cb.GetVariant())
+	}
+}
+
+func (v *validator) validateNexus(namespaceName string, cb *commonpb.Callback_Nexus) error {
+	rawURL := cb.GetUrl()
+	if len(rawURL) > v.config.URLMaxLength(namespaceName) {
+		return serviceerror.NewInvalidArgumentf(
+			"invalid url: url length longer than max length allowed of %d",
+			v.config.URLMaxLength(namespaceName),
+		)
+	}
+	if err := v.config.EndpointRules(namespaceName).Validate(rawURL); err != nil {
+		msg := err.Error()
+		if s, ok := status.FromError(err); ok {
+			msg = s.Message()
+		}
+		return serviceerror.NewInvalidArgument(msg)
+	}
+
+	// Validate total size of all headers, as well as normalize to lowercase.
+	headerSize := 0
+	lowerCaseHeaders := make(map[string]string, len(cb.GetHeader()))
+	for k, val := range cb.GetHeader() {
+		headerSize += len(k) + len(val)
+		lowerCaseHeaders[strings.ToLower(k)] = val
+	}
+	if headerSize > v.config.HeaderMaxSize(namespaceName) {
+		return serviceerror.NewInvalidArgumentf(
+			"invalid header: header size longer than max allowed size of %d",
+			v.config.HeaderMaxSize(namespaceName),
+		)
+	}
+	cb.Header = lowerCaseHeaders
+	return nil
+}
+
+func (v *validator) validateNexusHandler(namespaceName string, cb *commonpb.Callback_NexusHandler) error {
+	// Task Queue
+	if err := tqid.Validate(cb.GetTaskQueueName(), v.config.MaxIDLengthLimit()); err != nil {
+		return err
+	}
+
+	// Nexus handler
+	for _, field := range []struct {
+		name      string
+		value     string
+		maxLength int
+	}{
+		{"service", cb.GetService(), v.config.MaxServiceNameLength(namespaceName)},
+		{"operation", cb.GetOperation(), v.config.MaxOperationNameLength(namespaceName)},
+	} {
+		if field.value == "" {
+			return serviceerror.NewInvalidArgumentf("%s is required", field.name)
+		}
+		if len(field.value) > field.maxLength {
+			return serviceerror.NewInvalidArgumentf(
+				"%s exceeds length limit. Length=%d Limit=%d",
+				field.name, len(field.value), field.maxLength)
+		}
+	}
+
+	// Source Context blob
+	maxSize := v.config.NexusHandlerSourceContextMaxSize(namespaceName)
+	if size := cb.GetSourceContext().Size(); size > maxSize {
+		return serviceerror.NewInvalidArgumentf(
+			"source_context exceeds size limit. Length=%d Limit=%d",
+			size, v.config.NexusHandlerSourceContextMaxSize(namespaceName))
+	}
+
 	return nil
 }

--- a/common/callbacks/validator_test.go
+++ b/common/callbacks/validator_test.go
@@ -5,12 +5,58 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
 )
+
+func newNexusCallback() *commonpb.Callback {
+	return &commonpb.Callback{
+		Variant: &commonpb.Callback_Nexus_{
+			Nexus: &commonpb.Callback_Nexus{
+				Url: "https://nexus.ex.xxxxx.cluster.tmprl.cloud:7243/Namespaces/ex.xxxxx/nexus/callback",
+				Header: map[string]string{
+					"Nexus-Operation-State": "succeeded",
+					"Content-Type":          "application/json",
+				},
+			},
+		},
+	}
+}
+
+func newNexusHandlerCallback() *commonpb.Callback {
+	return &commonpb.Callback{
+		Variant: &commonpb.Callback_NexusHandler_{
+			NexusHandler: &commonpb.Callback_NexusHandler{
+				TaskQueueName: "wc-queue",
+				Service:       "CompletionService",
+				Operation:     "DeliverAsWebhook",
+				SourceContext: &commonpb.Payload{Data: []byte("data")},
+			},
+		},
+	}
+}
+
+func newValidatorConfig() ValidatorConfig {
+	allowAllAddresses := AddressMatchRules{
+		Rules: []AddressMatchRule{
+			{Regexp: regexp.MustCompile(`.*`), AllowInsecure: true},
+		},
+	}
+	return ValidatorConfig{
+		MaxCallbacksPerExecution:         func(string) int { return 10 },
+		MaxIDLengthLimit:                 func() int { return 10 },
+		URLMaxLength:                     func(string) int { return 1000 },
+		HeaderMaxSize:                    func(string) int { return 4096 },
+		EndpointRules:                    func(string) AddressMatchRules { return allowAllAddresses },
+		MaxServiceNameLength:             func(string) int { return 40 },
+		MaxOperationNameLength:           func(string) int { return 40 },
+		NexusHandlerSourceContextMaxSize: func(string) int { return 1000 },
+	}
+}
 
 func mustNewValidator(t *testing.T, cfg ValidatorConfig) Validator {
 	t.Helper()
@@ -20,10 +66,9 @@ func mustNewValidator(t *testing.T, cfg ValidatorConfig) Validator {
 }
 
 func TestValidatorConfigValidate(t *testing.T) {
-	cfg := ValidatorConfig{
-		MaxCallbacksPerExecution: func(string) int { return 10 },
-		HeaderMaxSize:            func(string) int { return 4096 },
-	}
+	cfg := newValidatorConfig()
+	cfg.URLMaxLength = nil
+	cfg.EndpointRules = nil
 
 	_, err := NewValidator(cfg)
 	require.EqualError(t, err, "missing required fields: [URLMaxLength EndpointRules]")
@@ -45,99 +90,108 @@ func TestValidatorConfigValidateNamesEveryField(t *testing.T) {
 func TestValidateCallbacks(t *testing.T) {
 	ctx := context.Background()
 
-	allowAllAddresses := AddressMatchRules{
-		Rules: []AddressMatchRule{
-			{Regexp: regexp.MustCompile(`.*`), AllowInsecure: true},
-		},
+	opts := ValidatorOptions{
+		EnabledKinds: []Kind{KindNexus, KindNexusHandler},
 	}
-	getStandardConfig := func() ValidatorConfig {
-		return ValidatorConfig{
-			MaxCallbacksPerExecution: func(string) int { return 10 },
-			URLMaxLength:             func(string) int { return 1000 },
-			HeaderMaxSize:            func(string) int { return 4096 },
-			EndpointRules:            func(string) AddressMatchRules { return allowAllAddresses },
-		}
-	}
-	v := mustNewValidator(t, getStandardConfig())
+	v := mustNewValidator(t, newValidatorConfig())
+
+	t.Run("EmptyCallbacksNoError", func(t *testing.T) {
+		err := v.Validate(ctx, "ns", nil, opts)
+		require.NoError(t, err)
+	})
 
 	t.Run("ValidNexusCallback", func(t *testing.T) {
 		cbs := []*commonpb.Callback{
-			{Variant: &commonpb.Callback_Nexus_{
-				Nexus: &commonpb.Callback_Nexus{
-					Url:    "http://localhost:8080/callback",
-					Header: map[string]string{"Content-Type": "application/json"},
-				},
-			}},
+			newNexusCallback(),
 		}
 
-		err := v.Validate(ctx, "ns", cbs)
+		err := v.Validate(ctx, "ns", cbs, opts)
 		require.NoError(t, err)
+	})
+
+	t.Run("ValidNexusHandlerCallback", func(t *testing.T) {
+		cbs := []*commonpb.Callback{
+			newNexusHandlerCallback(),
+		}
+		require.NoError(t, v.Validate(ctx, "ns", cbs, opts))
+	})
+
+	t.Run("InternalCallbacksFail", func(t *testing.T) {
+		cbs := []*commonpb.Callback{
+			{
+				Variant: &commonpb.Callback_Internal_{
+					Internal: &commonpb.Callback_Internal{},
+				},
+			},
+		}
+
+		err := v.Validate(ctx, "ns", cbs, opts)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "unknown callback variant")
 	})
 
 	t.Run("TooManyCallbacks", func(t *testing.T) {
 		cbs := []*commonpb.Callback{
-			{Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: "http://localhost/cb1"}}},
-			{Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: "http://localhost/cb2"}}},
+			newNexusCallback(),
+			newNexusCallback(),
 		}
 
-		cfg := getStandardConfig()
+		cfg := newValidatorConfig()
 		cfg.MaxCallbacksPerExecution = func(string) int { return 1 }
 		v := mustNewValidator(t, cfg)
 
-		err := v.Validate(ctx, "ns", cbs)
+		err := v.Validate(ctx, "ns", cbs, opts)
 		var invalidArgErr *serviceerror.InvalidArgument
 		require.ErrorAs(t, err, &invalidArgErr)
-		require.Contains(t, err.Error(), "cannot attach more than 1 callbacks")
+		require.ErrorContains(t, err, "cannot attach more than 1 callbacks")
 	})
 
 	t.Run("URLTooLong", func(t *testing.T) {
+		nexusCb := newNexusCallback()
+		nexusCb.GetNexus().Url = "http://localhost/" + string(make([]byte, 51))
 		cbs := []*commonpb.Callback{
-			{Variant: &commonpb.Callback_Nexus_{
-				Nexus: &commonpb.Callback_Nexus{
-					Url: "http://localhost/" + string(make([]byte, 51)),
-				},
-			}},
+			newNexusCallback(),
+			nexusCb,
 		}
 
-		cfg := getStandardConfig()
+		cfg := newValidatorConfig()
 		cfg.URLMaxLength = func(string) int { return 50 }
 		v := mustNewValidator(t, cfg)
 
-		err := v.Validate(ctx, "ns", cbs)
+		err := v.Validate(ctx, "ns", cbs, opts)
 		var invalidArgErr *serviceerror.InvalidArgument
 		require.ErrorAs(t, err, &invalidArgErr)
-		require.Contains(t, err.Error(), "url length longer than max length allowed")
+		require.ErrorContains(t, err, "invalid url: url length longer than max length allowed of 50")
 	})
 
 	t.Run("HeaderTooLarge", func(t *testing.T) {
+		nexusCb := newNexusCallback()
+		nexusCb.GetNexus().Header = map[string]string{"X-Large": string(make([]byte, 5000))}
 		cbs := []*commonpb.Callback{
-			{Variant: &commonpb.Callback_Nexus_{
-				Nexus: &commonpb.Callback_Nexus{
-					Url:    "http://localhost:8080/callback",
-					Header: map[string]string{"X-Large": string(make([]byte, 5000))},
-				},
-			}},
+			nexusCb,
 		}
 
-		err := v.Validate(ctx, "ns", cbs)
+		err := v.Validate(ctx, "ns", cbs, opts)
 		var invalidArgErr *serviceerror.InvalidArgument
 		require.ErrorAs(t, err, &invalidArgErr)
-		require.Contains(t, err.Error(), "header size longer than max allowed size")
+		require.ErrorContains(t, err, "invalid header: header size longer than max allowed size of 4096")
 	})
 
 	t.Run("HeaderKeysNormalizedToLowercase", func(t *testing.T) {
+		nexusCb := newNexusCallback()
+		nexusCb.GetNexus().Header = map[string]string{
+			"Content-Type": "application/json",
+			"X-Custom":     "value",
+		}
 		cbs := []*commonpb.Callback{
-			{Variant: &commonpb.Callback_Nexus_{
-				Nexus: &commonpb.Callback_Nexus{
-					Url:    "http://localhost:8080/callback",
-					Header: map[string]string{"Content-Type": "application/json", "X-Custom": "value"},
-				},
-			}},
+			nexusCb,
 		}
 
-		err := v.Validate(ctx, "ns", cbs)
+		err := v.Validate(ctx, "ns", cbs, opts)
 		require.NoError(t, err)
-		nexus := cbs[0].GetNexus()
+
+		// Mutation is in-place.
+		nexus := nexusCb.GetNexus()
 		require.Equal(t, "application/json", nexus.Header["content-type"])
 		require.Equal(t, "value", nexus.Header["x-custom"])
 		_, hasMixed := nexus.Header["Content-Type"]
@@ -146,65 +200,158 @@ func TestValidateCallbacks(t *testing.T) {
 
 	t.Run("URLNotInAllowlist", func(t *testing.T) {
 		cbs := []*commonpb.Callback{
-			{Variant: &commonpb.Callback_Nexus_{
-				Nexus: &commonpb.Callback_Nexus{
-					Url: "http://localhost:8080/callback",
-				},
-			}},
+			newNexusCallback(),
 		}
 
-		cfg := getStandardConfig()
-		cfg.EndpointRules = func(string) AddressMatchRules { return AddressMatchRules{} }
+		cfg := newValidatorConfig()
+		cfg.EndpointRules = func(string) AddressMatchRules {
+			// No rules in the allow list.
+			return AddressMatchRules{}
+		}
 		v := mustNewValidator(t, cfg)
 
-		err := v.Validate(ctx, "ns", cbs)
+		err := v.Validate(ctx, "ns", cbs, opts)
 		var invalidArgErr *serviceerror.InvalidArgument
 		require.ErrorAs(t, err, &invalidArgErr)
-		require.Contains(t, err.Error(), "does not match any configured callback address")
+		require.ErrorContains(t, err, "does not match any configured callback address")
 	})
 
 	t.Run("UnsupportedVariant", func(t *testing.T) {
 		cbs := []*commonpb.Callback{
-			{Variant: nil},
+			{
+				Variant: nil,
+			},
 		}
 
-		err := v.Validate(ctx, "ns", cbs)
+		err := v.Validate(ctx, "ns", cbs, opts)
 		var unimplementedErr *serviceerror.Unimplemented
 		require.ErrorAs(t, err, &unimplementedErr)
 		require.Contains(t, err.Error(), "unknown callback variant")
 	})
+}
 
-	// Confirm that NexusHandler-variant callbacks are rejected by the callback.Validator,
-	// preventing them from being accepted.
-	t.Run("NexusHandlerVariantNotSupported", func(t *testing.T) {
-		cbs := []*commonpb.Callback{
-			{Variant: &commonpb.Callback_NexusHandler_{
-				NexusHandler: &commonpb.Callback_NexusHandler{
-					TaskQueueName: "completions-task-queue",
-					Service:       "HTTPAdapter",
-					Operation:     "DeliverAsWebhook",
-				},
-			}},
-		}
-		err := v.Validate(context.Background(), "ns", cbs)
-		var argError *serviceerror.InvalidArgument
-		require.ErrorAs(t, err, &argError)
+func TestValidateNexusHandlerCallback(t *testing.T) {
+	ctx := context.Background()
+
+	cfg := newValidatorConfig()
+	v := mustNewValidator(t, cfg)
+	opts := ValidatorOptions{
+		EnabledKinds: []Kind{KindNexus, KindNexusHandler},
+	}
+
+	for _, tc := range []struct {
+		name   string
+		mutate func(*commonpb.Callback_NexusHandler)
+		errMsg string
+	}{
+		{
+			name:   "task_queue is not set",
+			mutate: func(nh *commonpb.Callback_NexusHandler) { nh.TaskQueueName = "" },
+			errMsg: "taskQueue is not set",
+		},
+		{
+			name:   "task_queue length exceeds limit",
+			mutate: func(nh *commonpb.Callback_NexusHandler) { nh.TaskQueueName = strings.Repeat("x", 11) },
+			errMsg: "taskQueue length exceeds limit",
+		},
+		{
+			name:   "task_queue uses reserved prefix",
+			mutate: func(nh *commonpb.Callback_NexusHandler) { nh.TaskQueueName = "/_sys/tq" },
+			errMsg: "task queue name cannot start with reserved prefix /_sys/",
+		},
+		{
+			name:   "service is required",
+			mutate: func(nh *commonpb.Callback_NexusHandler) { nh.Service = "" },
+			errMsg: "service is required",
+		},
+		{
+			name:   "service length",
+			mutate: func(nh *commonpb.Callback_NexusHandler) { nh.Service = strings.Repeat("x", 41) },
+			errMsg: "service exceeds length limit",
+		},
+		{
+			name:   "operation is required",
+			mutate: func(nh *commonpb.Callback_NexusHandler) { nh.Operation = "" },
+			errMsg: "operation is required",
+		},
+		{
+			name:   "operation length",
+			mutate: func(nh *commonpb.Callback_NexusHandler) { nh.Operation = strings.Repeat("x", 41) },
+			errMsg: "operation exceeds length limit",
+		},
+		{
+			name: "source_context size",
+			mutate: func(nh *commonpb.Callback_NexusHandler) {
+				nh.SourceContext = &commonpb.Payload{Data: []byte(strings.Repeat("x", 1001))}
+			},
+			errMsg: "source_context exceeds size limit",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cb := newNexusHandlerCallback()
+			tc.mutate(cb.GetNexusHandler())
+
+			cbs := []*commonpb.Callback{
+				cb,
+			}
+
+			err := v.Validate(ctx, "ns", cbs, opts)
+			var invalidArgErr *serviceerror.InvalidArgument
+			require.ErrorAs(t, err, &invalidArgErr)
+			require.ErrorContains(t, err, tc.errMsg)
+		})
+	}
+}
+
+func TestValidateEnabledKinds(t *testing.T) {
+	ctx := context.Background()
+	v := mustNewValidator(t, newValidatorConfig())
+	nexusCb := newNexusCallback()
+	nexusHandlerCb := newNexusHandlerCallback()
+
+	allowAllKindsOpts := ValidatorOptions{
+		EnabledKinds: []Kind{KindNexus, KindNexusHandler},
+	}
+	nexusOnlyOpts := ValidatorOptions{
+		EnabledKinds: []Kind{KindNexus},
+	}
+
+	t.Run("NoCallbacks", func(t *testing.T) {
+		require.NoError(t, v.Validate(ctx, "ns", nil, nexusOnlyOpts))
+	})
+
+	t.Run("AllSupported", func(t *testing.T) {
+		require.NoError(t, v.Validate(ctx, "ns",
+			[]*commonpb.Callback{nexusCb, nexusHandlerCb},
+			allowAllKindsOpts,
+		))
+	})
+
+	t.Run("NoKindsEnabled", func(t *testing.T) {
+		// The zero value supports no client-supplied kinds at all.
+		err := v.Validate(ctx, "ns", []*commonpb.Callback{nexusCb}, ValidatorOptions{})
+		var invalidArgErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgErr)
+		require.ErrorContains(t, err, "nexus callbacks are not enabled for this execution type")
+	})
+
+	t.Run("DisabledKind", func(t *testing.T) {
+		err := v.Validate(ctx, "ns",
+			[]*commonpb.Callback{nexusCb, nexusHandlerCb},
+			ValidatorOptions{EnabledKinds: []Kind{KindNexus}},
+		)
+		var invalidArgErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgErr)
 		require.ErrorContains(t, err, "nexusHandler callbacks are not enabled for this execution type")
 	})
 
-	t.Run("EmptyCallbacksNoError", func(t *testing.T) {
-		err := v.Validate(ctx, "ns", nil)
-		require.NoError(t, err)
-	})
+	t.Run("CheckEnabledBeforeValidation", func(t *testing.T) {
+		invalidNexusHandlerCb := newNexusHandlerCallback()
+		invalidNexusHandlerCb.GetNexusHandler().TaskQueueName = ""
+		err := v.Validate(ctx, "ns", []*commonpb.Callback{invalidNexusHandlerCb}, nexusOnlyOpts)
 
-	t.Run("InternalCallbackSkipped", func(t *testing.T) {
-		cbs := []*commonpb.Callback{
-			{Variant: &commonpb.Callback_Internal_{
-				Internal: &commonpb.Callback_Internal{},
-			}},
-		}
-
-		err := v.Validate(ctx, "ns", cbs)
-		require.NoError(t, err)
+		var invalidArgErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArgErr)
+		require.ErrorContains(t, err, "nexusHandler callbacks are not enabled for this execution type")
 	})
 }

--- a/common/callbacks/validator_test.go
+++ b/common/callbacks/validator_test.go
@@ -174,6 +174,24 @@ func TestValidateCallbacks(t *testing.T) {
 		require.Contains(t, err.Error(), "unknown callback variant")
 	})
 
+	// Confirm that NexusHandler-variant callbacks are rejected by the callback.Validator,
+	// preventing them from being accepted.
+	t.Run("NexusHandlerVariantNotSupported", func(t *testing.T) {
+		cbs := []*commonpb.Callback{
+			{Variant: &commonpb.Callback_NexusHandler_{
+				NexusHandler: &commonpb.Callback_NexusHandler{
+					TaskQueueName: "completions-task-queue",
+					Service:       "HTTPAdapter",
+					Operation:     "DeliverAsWebhook",
+				},
+			}},
+		}
+		err := v.Validate(context.Background(), "ns", cbs)
+		var argError *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &argError)
+		require.ErrorContains(t, err, "nexusHandler callbacks are not enabled for this execution type")
+	})
+
 	t.Run("EmptyCallbacksNoError", func(t *testing.T) {
 		err := v.Validate(ctx, "ns", nil)
 		require.NoError(t, err)

--- a/common/links/validator.go
+++ b/common/links/validator.go
@@ -62,6 +62,29 @@ func validateFields(l *commonpb.Link) error {
 		if t.BatchJob.GetJobId() == "" {
 			return serviceerror.NewInvalidArgument("batch job link must not have an empty job ID")
 		}
+	case *commonpb.Link_Callback_:
+		if t.Callback.GetNamespace() == "" {
+			return serviceerror.NewInvalidArgument("callback link must have a namespace")
+		}
+		if t.Callback.GetExecution() == nil {
+			return serviceerror.NewInvalidArgument("callback link must have an execution")
+		}
+		exType := t.Callback.GetExecution().GetType()
+		if exType == enumspb.EXECUTION_TYPE_UNSPECIFIED {
+			return serviceerror.NewInvalidArgument("callback link execution must have a type")
+		}
+		if _, ok := enumspb.ExecutionType_name[int32(exType)]; !ok {
+			return serviceerror.NewInvalidArgument("callback link execution type is unknown")
+		}
+		if t.Callback.GetExecution().GetBusinessId() == "" {
+			return serviceerror.NewInvalidArgument("callback link execution must have a business ID")
+		}
+		if t.Callback.GetExecution().GetRunId() == "" {
+			return serviceerror.NewInvalidArgument("callback link execution must have a run ID")
+		}
+		if t.Callback.GetRequestId() == "" {
+			return serviceerror.NewInvalidArgument("callback link must have a request ID")
+		}
 	case *commonpb.Link_NexusOperation_:
 		if t.NexusOperation.GetNamespace() == "" {
 			return serviceerror.NewInvalidArgument("nexus operation link must not have an empty namespace field")

--- a/common/links/validator_test.go
+++ b/common/links/validator_test.go
@@ -35,6 +35,20 @@ func TestValidate(t *testing.T) {
 			BatchJob: &commonpb.Link_BatchJob{JobId: "job"},
 		},
 	}
+	validCallback := &commonpb.Link{
+		Variant: &commonpb.Link_Callback_{
+			Callback: &commonpb.Link_Callback{
+				Namespace: "ns",
+				Execution: &commonpb.Execution{
+					Type:       enumspb.EXECUTION_TYPE_NEXUS_OPERATION,
+					BusinessId: "op",
+					RunId:      "run",
+				},
+				ComponentPath: []string{"Update", "wf-update-id"},
+				RequestId:     "req",
+			},
+		},
+	}
 	validNexusOperation := &commonpb.Link{
 		Variant: &commonpb.Link_NexusOperation_{
 			NexusOperation: &commonpb.Link_NexusOperation{
@@ -67,10 +81,11 @@ func TestValidate(t *testing.T) {
 		err := links.Validate([]*commonpb.Link{
 			validWorkflowEvent,
 			validBatchJob,
+			validCallback,
 			validNexusOperation,
 			validActivity,
 			validWorkflow,
-		}, maxLinks+2, maxSize)
+		}, maxLinks+3, maxSize)
 		require.NoError(t, err)
 	})
 
@@ -118,6 +133,20 @@ func TestValidate(t *testing.T) {
 		l.GetBatchJob().JobId = ""
 		err := links.Validate([]*commonpb.Link{l}, maxLinks, maxSize)
 		require.ErrorContains(t, err, "batch job link must not have an empty job ID")
+	})
+
+	t.Run("Callback/EmptyExecution", func(t *testing.T) {
+		l := proto.Clone(validCallback).(*commonpb.Link)
+		l.GetCallback().Execution = nil
+		err := links.Validate([]*commonpb.Link{l}, maxLinks, maxSize)
+		require.ErrorContains(t, err, "callback link must have an execution")
+	})
+
+	t.Run("Callback/RequestID", func(t *testing.T) {
+		l := proto.Clone(validCallback).(*commonpb.Link)
+		l.GetCallback().RequestId = ""
+		err := links.Validate([]*commonpb.Link{l}, maxLinks, maxSize)
+		require.ErrorContains(t, err, "callback link must have a request ID")
 	})
 
 	t.Run("NexusOperation/EmptyNamespace", func(t *testing.T) {

--- a/common/namespace/namespace_test.go
+++ b/common/namespace/namespace_test.go
@@ -7,38 +7,13 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	namespacepb "go.temporal.io/api/namespace/v1"
-	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/primitives/timestamp"
+	test "go.temporal.io/server/common/testing"
 )
 
-func base(t *testing.T) *namespace.Namespace {
-	detail := &persistencespb.NamespaceDetail{
-		Info: &persistencespb.NamespaceInfo{
-			Id:   namespace.NewID().String(),
-			Name: t.Name(),
-			Data: make(map[string]string),
-		},
-		Config: &persistencespb.NamespaceConfig{
-			BadBinaries: &namespacepb.BadBinaries{
-				Binaries: make(map[string]*namespacepb.BadBinaryInfo),
-			},
-		},
-		ReplicationConfig: &persistencespb.NamespaceReplicationConfig{
-			ActiveClusterName: "foo",
-			Clusters:          []string{"foo", "bar"},
-		},
-	}
-	factory := namespace.NewDefaultReplicationResolverFactory()
-	resolver := factory(detail)
-	ns, err := namespace.FromPersistentState(detail, resolver)
-	require.NoError(t, err)
-	return ns
-}
-
 func TestActiveInCluster(t *testing.T) {
-	base := base(t)
+	base := test.NewNamespace(t)
 
 	for _, tt := range [...]struct {
 		name        string
@@ -87,7 +62,7 @@ func TestActiveInCluster(t *testing.T) {
 
 func Test_GetRetentionDays(t *testing.T) {
 	const defaultRetention = 7 * 24 * time.Hour
-	base := base(t).Clone(namespace.WithRetention(timestamp.DurationFromDays(7)))
+	base := test.NewNamespace(t).Clone(namespace.WithRetention(timestamp.DurationFromDays(7)))
 	for _, tt := range [...]struct {
 		name       string
 		retention  string
@@ -115,7 +90,7 @@ func Test_GetRetentionDays(t *testing.T) {
 }
 
 func TestNamespace_GetCustomData(t *testing.T) {
-	base := base(t)
+	base := test.NewNamespace(t)
 	ns := base.Clone(namespace.WithData("foo", "bar"))
 	data := ns.GetCustomData("foo")
 	assert.Equal(t, "bar", data)

--- a/common/nexus/dispatch_outcome.go
+++ b/common/nexus/dispatch_outcome.go
@@ -50,12 +50,6 @@ const (
 	//     nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "cannot deserialize input")
 	DispatchOutcomeHandlerFailure DispatchOutcome = "nexus-handler-failure"
 
-	// DispatchOutcomeWorkerFailure means the worker failed the task with a failure carrying no Nexus
-	// handler failure info. RespondNexusTaskFailed rejects such a response, so matching cannot produce
-	// this outcome today. It exists so that a malformed response is classified rather than read as a
-	// handler error with no type.
-	DispatchOutcomeWorkerFailure DispatchOutcome = "worker-failure"
-
 	// DispatchOutcomeRequestTimeout means matching gave up before the task was answered: no worker
 	// was polling the task queue, or a worker took the task and never responded.
 	DispatchOutcomeRequestTimeout DispatchOutcome = "request-timeout"
@@ -88,8 +82,8 @@ type DispatchResult struct {
 	// DispatchOutcomeSyncSuccess and DispatchOutcomeAsyncSuccess.
 	Links []*nexuspb.Link
 
-	// Failure is the Temporal failure the worker reported. Set for DispatchOutcomeHandlerFailure,
-	// DispatchOutcomeWorkerFailure and DispatchOutcomeOperationFailure.
+	// Failure is the Temporal failure the worker reported. Set for DispatchOutcomeHandlerFailure
+	// and DispatchOutcomeOperationFailure.
 	//
 	// IMPORTANT: For the current response formats this aliases the proto inside the response rather
 	// than copying it, so callers that convert it in place mutate the response too.
@@ -112,11 +106,7 @@ func baseClassifyDispatchNexusTaskResponse(
 	case *matchingservice.DispatchNexusTaskResponse_Failure:
 		// A handler error is a Nexus-level refusal whose retry behavior is meaningful; anything else
 		// is an arbitrary failure the worker chose to report.
-		outcome := DispatchOutcomeWorkerFailure
-		if t.Failure.GetNexusHandlerFailureInfo() != nil {
-			outcome = DispatchOutcomeHandlerFailure
-		}
-		return DispatchResult{Outcome: outcome, Failure: t.Failure}
+		return DispatchResult{Outcome: DispatchOutcomeHandlerFailure, Failure: t.Failure}
 
 	case *matchingservice.DispatchNexusTaskResponse_HandlerError: //nolint:staticcheck // Deprecated, still sent by older workers.
 		return DispatchResult{
@@ -284,8 +274,7 @@ func (r DispatchResult) metricOutcome() string {
 			return "operation_error"
 		}
 		return "failure"
-	case DispatchOutcomeHandlerFailure,
-		DispatchOutcomeWorkerFailure:
+	case DispatchOutcomeHandlerFailure:
 		// A worker failure has no handler error type to report and will map to UNKNOWN.
 		hErrType := r.Failure.GetNexusHandlerFailureInfo().GetType()
 		return "handler_error:" + BoundHandlerErrorType(hErrType)

--- a/common/nexus/dispatch_outcome_test.go
+++ b/common/nexus/dispatch_outcome_test.go
@@ -365,23 +365,6 @@ func TestClassifyOperationDispatch(t *testing.T) {
 			},
 		},
 
-		// DispatchOutcomeWorkerFailure
-		{
-			Name:     "worker error",
-			Response: taskFailureResponse(applicationFailure("worker exploded", "ErrTypeStr")),
-			Want: DispatchResult{
-				Outcome: DispatchOutcomeWorkerFailure,
-				Failure: &failurepb.Failure{
-					Message: "worker exploded",
-					FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
-						ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
-							Type: "ErrTypeStr",
-						},
-					},
-				},
-			},
-		},
-
 		// DispatchOutcomeUnrecognized
 		{
 			Name:     "unrecognized (no outcome)",

--- a/common/nexus/dispatch_response.go
+++ b/common/nexus/dispatch_response.go
@@ -33,9 +33,7 @@ func DispatchResultToError(result DispatchResult) error {
 	}
 
 	switch result.Outcome {
-	case DispatchOutcomeHandlerFailure,
-		DispatchOutcomeWorkerFailure,
-		DispatchOutcomeOperationFailure:
+	case DispatchOutcomeHandlerFailure, DispatchOutcomeOperationFailure:
 		// The worker either failed the task (via RespondNexusTaskFailed) or answered with a failed
 		// operation. Either way the failure reports what the worker said.
 		return temporal.GetDefaultFailureConverter().FailureToError(result.Failure)

--- a/common/nexus/failure.go
+++ b/common/nexus/failure.go
@@ -15,6 +15,7 @@ import (
 	nexuspb "go.temporal.io/api/nexus/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/nexus/nexusrpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
@@ -432,4 +433,22 @@ func AdaptAuthorizeError(permissionDeniedError *serviceerror.PermissionDenied) e
 		return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeUnauthorized, "permission denied: %s", permissionDeniedError.Reason)
 	}
 	return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeUnauthorized, "permission denied")
+}
+
+func OperationErrorToTemporalFailure(opErr *nexus.OperationError) (*failurepb.Failure, error) {
+	var nf nexus.Failure
+	if opErr.OriginalFailure != nil {
+		nf = *opErr.OriginalFailure
+	} else {
+		var err error
+		nf, err = nexusrpc.DefaultFailureConverter().ErrorToFailure(opErr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// The Nexus failure may contain a metadata key requesting that the unwrapped
+	// [Cause] of the failure is sent, to avoid an unnecessary layer of indirection.
+	unwrappedFailure := nexusrpc.UnwrapFailure(&nf)
+	return NexusFailureToTemporalFailure(*unwrappedFailure)
 }

--- a/common/testing/await/report.go
+++ b/common/testing/await/report.go
@@ -42,10 +42,12 @@ func (r *timeoutReport) recordAttemptTimeout() {
 }
 
 func (r timeoutReport) reportAttemptErrors(tb testing.TB) {
+	tb.Helper()
 	reportAttemptErrors(tb, r.failures)
 }
 
 func (r timeoutReport) reportTimeout(tb testing.TB, funcName, timeoutMsg string) {
+	tb.Helper()
 	r.reportAttemptErrors(tb)
 	message := fmt.Sprintf("condition not satisfied after %v", r.effectiveTimeout)
 	if timeoutMsg != "" {
@@ -56,6 +58,7 @@ func (r timeoutReport) reportTimeout(tb testing.TB, funcName, timeoutMsg string)
 }
 
 func reportAttemptErrors(tb testing.TB, failures []attemptFailure) {
+	tb.Helper()
 	if len(failures) == 0 {
 		return
 	}

--- a/common/testing/callbacks.go
+++ b/common/testing/callbacks.go
@@ -1,0 +1,28 @@
+package testing
+
+import (
+	"regexp"
+
+	"go.temporal.io/server/common/callbacks"
+)
+
+// NewCallbacksValidatorConfig returns a valid callbacks.ValidatorConfig that can be
+// used to create a new callbacks.Validator. Tests can override fields to set arbitrary
+// limits for aspects of the Validator to be tested.
+func NewCallbacksValidatorConfig() callbacks.ValidatorConfig {
+	allowAllAddresses := callbacks.AddressMatchRules{
+		Rules: []callbacks.AddressMatchRule{
+			{Regexp: regexp.MustCompile(`.*`), AllowInsecure: true},
+		},
+	}
+	return callbacks.ValidatorConfig{
+		MaxCallbacksPerExecution:         func(string) int { return 10 },
+		MaxIDLengthLimit:                 func() int { return 100 },
+		URLMaxLength:                     func(string) int { return 1000 },
+		HeaderMaxSize:                    func(string) int { return 4096 },
+		EndpointRules:                    func(string) callbacks.AddressMatchRules { return allowAllAddresses },
+		MaxServiceNameLength:             func(string) int { return 100 },
+		MaxOperationNameLength:           func(string) int { return 100 },
+		NexusHandlerSourceContextMaxSize: func(string) int { return 1000 },
+	}
+}

--- a/common/testing/namespace.go
+++ b/common/testing/namespace.go
@@ -1,0 +1,37 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	namespacepb "go.temporal.io/api/namespace/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/namespace"
+)
+
+// NewNamespace returns a Namespace named after the running test, with a generated
+// ID and a two-cluster replication config active in "foo".
+func NewNamespace(t *testing.T) *namespace.Namespace {
+	t.Helper()
+	detail := &persistencespb.NamespaceDetail{
+		Info: &persistencespb.NamespaceInfo{
+			Id:   namespace.NewID().String(),
+			Name: t.Name(),
+			Data: make(map[string]string),
+		},
+		Config: &persistencespb.NamespaceConfig{
+			BadBinaries: &namespacepb.BadBinaries{
+				Binaries: make(map[string]*namespacepb.BadBinaryInfo),
+			},
+		},
+		ReplicationConfig: &persistencespb.NamespaceReplicationConfig{
+			ActiveClusterName: "foo",
+			Clusters:          []string{"foo", "bar"},
+		},
+	}
+	factory := namespace.NewDefaultReplicationResolverFactory()
+	resolver := factory(detail)
+	ns, err := namespace.FromPersistentState(detail, resolver)
+	require.NoError(t, err)
+	return ns
+}

--- a/common/util.go
+++ b/common/util.go
@@ -703,6 +703,19 @@ func CloneProtoMap[K comparable, T proto.Message](src map[K]T) map[K]T {
 	return result
 }
 
+// CloneProtoSlice returns a new slice containing a clone of each individual proto.
+func CloneProtoSlice[T proto.Message](src []T) []T {
+	if src == nil {
+		return nil
+	}
+
+	result := make([]T, len(src))
+	for i, v := range src {
+		result[i] = CloneProto(v)
+	}
+	return result
+}
+
 // DiscardUnknownProto discards unknown fields in a proto message.
 func DiscardUnknownProto(m proto.Message) error {
 	return protorange.Range(m.ProtoReflect(), func(values protopath.Values) error {

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
 	go.opentelemetry.io/proto/otlp v1.10.0
-	go.temporal.io/api v1.63.6-0.20260831232338-79f9bb05242b
+	go.temporal.io/api v1.63.6-0.20260909222256-20151aa90480
 	go.temporal.io/auto-scaled-workers v0.0.0-20260811170210-91f6fe1d10ab
 	go.temporal.io/sdk v1.48.0
 	go.uber.org/fx v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -481,8 +481,8 @@ go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0 h1:R
 go.opentelemetry.io/proto/slim/otlp/collector/profiles/v1development v0.3.0/go.mod h1:I89cynRj8y+383o7tEQVg2SVA6SRgDVIouWPUVXjx0U=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0 h1:CQvJSldHRUN6Z8jsUeYv8J0lXRvygALXIzsmAeCcZE0=
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.3.0/go.mod h1:xSQ+mEfJe/GjK1LXEyVOoSI1N9JV9ZI923X5kup43W4=
-go.temporal.io/api v1.63.6-0.20260831232338-79f9bb05242b h1:Ka6a9DhaedpDOGG3ffTLicvFj9iFhiG4dXLTunV1K2g=
-go.temporal.io/api v1.63.6-0.20260831232338-79f9bb05242b/go.mod h1:SrlW2JMwVlDP4nRWSNznUFqnSHd+YeMDS1BkYo63HCQ=
+go.temporal.io/api v1.63.6-0.20260909222256-20151aa90480 h1:1w2xEZFpL7R9NagEQeWTh7oZmZU3YUJGogusn9/LfCg=
+go.temporal.io/api v1.63.6-0.20260909222256-20151aa90480/go.mod h1:acM0I9WPuYg8W3Pd9jOZvEgi7mRUttUQ4+e7fowKVnM=
 go.temporal.io/auto-scaled-workers v0.0.0-20260811170210-91f6fe1d10ab h1:99wXW0317BBi49d6xgMdA0EZtvA+xbBUWV4HsTEGEcg=
 go.temporal.io/auto-scaled-workers v0.0.0-20260811170210-91f6fe1d10ab/go.mod h1:hhHijO9XRPIkAflLJJHix61M9FzbRPqk8fSydkcLkqw=
 go.temporal.io/sdk v1.48.0 h1:WDctKDVuh0Z8Nf7euAyqs/EwcPg1JTIIq1Fut8Tq118=

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -916,12 +916,17 @@ func OperatorHandlerProvider(
 // callbackValidatorProvider creates a callback Validator using the production dynamic config keys
 // so that existing operator configurations (callback.allowedAddresses) are honored.
 func callbackValidatorProvider(dc *dynamicconfig.Collection) (callbacks.Validator, error) {
-	return callbacks.NewValidator(callbacks.ValidatorConfig{
-		MaxCallbacksPerExecution: chasmcallback.MaxPerExecution.Get(dc),
-		URLMaxLength:             dynamicconfig.FrontendCallbackURLMaxLength.Get(dc),
-		HeaderMaxSize:            dynamicconfig.FrontendCallbackHeaderMaxSize.Get(dc),
-		EndpointRules:            chasmcallback.AllowedAddresses.Get(dc),
-	})
+	cfg := callbacks.ValidatorConfig{
+		MaxCallbacksPerExecution:         chasmcallback.MaxPerExecution.Get(dc),
+		MaxIDLengthLimit:                 dynamicconfig.MaxIDLengthLimit.Get(dc),
+		URLMaxLength:                     dynamicconfig.FrontendCallbackURLMaxLength.Get(dc),
+		HeaderMaxSize:                    dynamicconfig.FrontendCallbackHeaderMaxSize.Get(dc),
+		EndpointRules:                    chasmcallback.AllowedAddresses.Get(dc),
+		MaxServiceNameLength:             chasmnexus.MaxServiceNameLength.Get(dc),
+		MaxOperationNameLength:           chasmnexus.MaxOperationNameLength.Get(dc),
+		NexusHandlerSourceContextMaxSize: chasmcallback.NexusHandlerSourceContextMaxSize.Get(dc),
+	}
+	return callbacks.NewValidator(cfg)
 }
 
 func HandlerProvider(

--- a/service/frontend/nexus_dispatch_result.go
+++ b/service/frontend/nexus_dispatch_result.go
@@ -75,7 +75,7 @@ func (c *operationContext) failedDispatchToNexusError(
 	operation string,
 ) error {
 	switch result.Outcome {
-	case commonnexus.DispatchOutcomeHandlerFailure, commonnexus.DispatchOutcomeWorkerFailure:
+	case commonnexus.DispatchOutcomeHandlerFailure:
 		// A handler error round-trips as a handler error. Anything else the worker used to fail the
 		// task converts to an opaque failure error, which the SDK reports to the caller as internal.
 		// Neither is wrapped, so both errors are reported to the caller unchanged.

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -13,6 +13,7 @@ import (
 	"go.temporal.io/server/chasm/lib/activity"
 	chasmcallback "go.temporal.io/server/chasm/lib/callback"
 	chasmnexus "go.temporal.io/server/chasm/lib/nexusoperation"
+	chasmworkflow "go.temporal.io/server/chasm/lib/workflow"
 	"go.temporal.io/server/common/callbacks"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
@@ -224,6 +225,9 @@ type Config struct {
 	MaxCallbacksPerWorkflow dynamicconfig.IntPropertyFnWithNamespaceFilter
 	CallbackEndpointConfigs dynamicconfig.TypedPropertyFnWithNamespaceFilter[callbacks.AddressMatchRules]
 
+	// The callback kinds a client may attach to a workflow execution.
+	WorkflowEnabledCallbackKinds dynamicconfig.TypedPropertyFnWithNamespaceFilter[[]callbacks.Kind]
+
 	MaxNexusOperationTokenLength   dynamicconfig.IntPropertyFnWithNamespaceFilter
 	NexusRequestHeadersBlacklist   dynamicconfig.TypedPropertyFn[*regexp.Regexp]
 	NexusForwardRequestUseEndpoint dynamicconfig.BoolPropertyFn
@@ -427,7 +431,9 @@ func NewConfig(
 		LinkMaxSize:        dynamicconfig.FrontendLinkMaxSize.Get(dc),
 		MaxLinksPerRequest: dynamicconfig.FrontendMaxLinksPerRequest.Get(dc),
 
-		CallbackEndpointConfigs:     chasmcallback.AllowedAddresses.Get(dc),
+		CallbackEndpointConfigs:      chasmcallback.AllowedAddresses.Get(dc),
+		WorkflowEnabledCallbackKinds: chasmworkflow.EnabledCallbackKinds.Get(dc),
+
 		AdminEnableListHistoryTasks: dynamicconfig.AdminEnableListHistoryTasks.Get(dc),
 
 		MaskInternalErrorDetails: dynamicconfig.FrontendMaskInternalErrorDetails.Get(dc),

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -690,7 +690,10 @@ func (wh *WorkflowHandler) prepareStartWorkflowRequest(
 	}
 
 	if cbs := request.GetCompletionCallbacks(); len(cbs) > 0 {
-		if err := wh.callbackValidator.Validate(ctx, namespaceName.String(), cbs); err != nil {
+		opts := callbacks.ValidatorOptions{
+			EnabledKinds: wh.config.WorkflowEnabledCallbackKinds(namespaceName.String()),
+		}
+		if err := wh.callbackValidator.Validate(ctx, namespaceName.String(), cbs, opts); err != nil {
 			return nil, err
 		}
 	}
@@ -5562,7 +5565,10 @@ func (wh *WorkflowHandler) prepareUpdateWorkflowRequest(
 	}
 
 	if cbs := request.GetRequest().GetCompletionCallbacks(); len(cbs) > 0 {
-		if err := wh.callbackValidator.Validate(ctx, namespaceName.String(), cbs); err != nil {
+		opts := callbacks.ValidatorOptions{
+			EnabledKinds: wh.config.WorkflowEnabledCallbackKinds(namespaceName.String()),
+		}
+		if err := wh.callbackValidator.Validate(ctx, namespaceName.String(), cbs, opts); err != nil {
 			return err
 		}
 	}

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -234,6 +234,8 @@ func (s *WorkflowHandlerSuite) getWorkflowHandler(config *Config) *WorkflowHandl
 			nil,
 			s.mockResource.GetSearchAttributesMapperProvider(),
 			nil,
+			nil,
+			nil,
 		),
 		nil, // Not testing CHASM registry here
 		quotas.NoopRequestRateLimiter,

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -66,6 +66,7 @@ import (
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/searchattribute/sadefs"
 	"go.temporal.io/server/common/tasktoken"
+	test "go.temporal.io/server/common/testing"
 	"go.temporal.io/server/common/testing/protorequire"
 	"go.temporal.io/server/common/tqid"
 	"go.temporal.io/server/common/wideevents"
@@ -177,18 +178,7 @@ func (s *WorkflowHandlerSuite) getWorkflowHandler(config *Config) *WorkflowHandl
 	healthInterceptor := interceptor.NewHealthInterceptor()
 	healthInterceptor.SetHealthy(true)
 
-	cbValidator, err := callbacks.NewValidator(callbacks.ValidatorConfig{
-		MaxCallbacksPerExecution: func(string) int { return 2000 },
-		URLMaxLength:             config.CallbackURLMaxLength,
-		HeaderMaxSize:            config.CallbackHeaderMaxSize,
-		EndpointRules: func(string) callbacks.AddressMatchRules {
-			return callbacks.AddressMatchRules{
-				Rules: []callbacks.AddressMatchRule{
-					{Regexp: regexp.MustCompile(`.*`), AllowInsecure: true},
-				},
-			}
-		},
-	})
+	cbValidator, err := callbacks.NewValidator(test.NewCallbacksValidatorConfig())
 	s.NoError(err)
 
 	saValidator := searchattribute.NewValidator(

--- a/service/history/api/describeworkflow/api.go
+++ b/service/history/api/describeworkflow/api.go
@@ -19,7 +19,6 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/chasm"
 	chasmcallback "go.temporal.io/server/chasm/lib/callback"
-	callbackspb "go.temporal.io/server/chasm/lib/callback/gen/callbackpb/v1"
 	"go.temporal.io/server/chasm/lib/nexusoperation"
 	chasmworkflow "go.temporal.io/server/chasm/lib/workflow"
 	"go.temporal.io/server/common"
@@ -278,13 +277,11 @@ func Invoke(
 			)
 		}
 		chasmCallbackInfos, err := buildCallbackInfosFromChasm(
-			ctx,
 			namespaceID,
 			wf,
 			chasmCtx,
 			executionInfo,
 			executionState,
-			outboundQueueCBPool,
 			shard.GetLogger(),
 		)
 		if err != nil {
@@ -502,13 +499,11 @@ func buildCallbackInfosFromHSM(
 // buildCallbackInfosFromChasm reads callbacks from the CHASM workflow component and converts them to API format.
 // TODO(long-nt-tran): move this to chasm/lib/workflow/workflow.go to be within the CHASM workflow context.
 func buildCallbackInfosFromChasm(
-	ctx context.Context,
 	namespaceID namespace.ID,
 	wf *chasmworkflow.Workflow,
 	chasmCtx chasm.Context,
 	executionInfo *persistencespb.WorkflowExecutionInfo,
 	executionState *persistencespb.WorkflowExecutionState,
-	outboundQueueCBPool *circuitbreakerpool.OutboundQueueCircuitBreakerPool,
 	logger log.Logger,
 ) ([]*workflowpb.CallbackInfo, error) {
 	result := make([]*workflowpb.CallbackInfo, 0, len(wf.Callbacks))
@@ -519,7 +514,7 @@ func buildCallbackInfosFromChasm(
 			Variant: &workflowpb.CallbackInfo_Trigger_WorkflowClosed{},
 		}
 
-		callbackInfo, err := buildCallbackInfoFromChasm(ctx, namespaceID, callback, trigger, outboundQueueCBPool)
+		callbackInfo, err := buildChasmCallbackInfo(chasmCtx, callback, trigger)
 		if err != nil {
 			logger.Error(
 				"failed to build callback info from CHASM callback",
@@ -550,7 +545,7 @@ func buildCallbackInfosFromChasm(
 				},
 			}
 
-			callbackInfo, err := buildCallbackInfoFromChasm(ctx, namespaceID, callback, trigger, outboundQueueCBPool)
+			callbackInfo, err := buildChasmCallbackInfo(chasmCtx, callback, trigger)
 			if err != nil {
 				logger.Error(
 					"failed to build callback info from CHASM update callback",
@@ -571,35 +566,12 @@ func buildCallbackInfosFromChasm(
 	return result, nil
 }
 
-// buildCallbackInfoFromChasm converts a single CHASM callback to API format.
-func buildCallbackInfoFromChasm(
-	ctx context.Context,
-	namespaceID namespace.ID,
-	callback *chasmcallback.Callback,
-	trigger *workflowpb.CallbackInfo_Trigger,
-	outboundQueueCBPool *circuitbreakerpool.OutboundQueueCircuitBreakerPool,
-) (*workflowpb.CallbackInfo, error) {
-	// Create a circuit breaker state checker function
-	circuitBreakerState := func(destination string) bool {
-		cb := outboundQueueCBPool.Get(tasks.TaskGroupNamespaceIDAndDestination{
-			TaskGroup:   callbacks.TaskTypeInvocation,
-			NamespaceID: namespaceID.String(),
-			Destination: destination,
-		})
-		return cb.State() != gobreaker.StateClosed
-	}
-
-	return buildChasmCallbackInfo(ctx, namespaceID.String(), callback, trigger, circuitBreakerState)
-}
-
 // buildChasmCallbackInfo converts a single CHASM callback to API CallbackInfo format.
 // Returns nil if the callback should not be included in the response.
 func buildChasmCallbackInfo(
-	ctx context.Context,
-	namespaceID string,
+	ctx chasm.Context,
 	cb *chasmcallback.Callback,
 	trigger *workflowpb.CallbackInfo_Trigger,
-	circuitBreakerState func(destination string) bool,
 ) (*workflowpb.CallbackInfo, error) {
 	nexusVariant := cb.GetCallback().GetNexus()
 	if nexusVariant == nil {
@@ -607,47 +579,26 @@ func buildChasmCallbackInfo(
 		return nil, nil
 	}
 
-	cbSpec, err := cb.ToAPICallback()
+	apiCb, err := cb.ToAPICallback()
+	if err != nil {
+		return nil, err
+	}
+	state, blockedReason, err := cb.APIState(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	var state enumspb.CallbackState
-	switch cb.Status {
-	case callbackspb.CALLBACK_STATUS_UNSPECIFIED:
-		return nil, serviceerror.NewInternal("callback with UNSPECIFIED state")
-	case callbackspb.CALLBACK_STATUS_STANDBY:
-		state = enumspb.CALLBACK_STATE_STANDBY
-	case callbackspb.CALLBACK_STATUS_SCHEDULED:
-		state = enumspb.CALLBACK_STATE_SCHEDULED
-	case callbackspb.CALLBACK_STATUS_BACKING_OFF:
-		state = enumspb.CALLBACK_STATE_BACKING_OFF
-	case callbackspb.CALLBACK_STATUS_FAILED:
-		state = enumspb.CALLBACK_STATE_FAILED
-	case callbackspb.CALLBACK_STATUS_SUCCEEDED:
-		state = enumspb.CALLBACK_STATE_SUCCEEDED
-	default:
-		return nil, serviceerror.NewInternalf("unknown callback state: %v", cb.Status)
-	}
-
-	blockedReason := ""
-	if state == enumspb.CALLBACK_STATE_SCHEDULED {
-		if circuitBreakerState(cbSpec.GetNexus().GetUrl()) {
-			state = enumspb.CALLBACK_STATE_BLOCKED
-			blockedReason = "The circuit breaker is open."
-		}
-	}
-
 	return &workflowpb.CallbackInfo{
-		Callback:                cbSpec,
+		Callback:                apiCb,
 		Trigger:                 trigger,
-		RegistrationTime:        cb.RegistrationTime,
+		RegistrationTime:        common.CloneProto(cb.RegistrationTime),
 		State:                   state,
 		Attempt:                 cb.Attempt,
-		LastAttemptCompleteTime: cb.LastAttemptCompleteTime,
-		LastAttemptFailure:      cb.LastAttemptFailure,
-		NextAttemptScheduleTime: cb.NextAttemptScheduleTime,
+		LastAttemptCompleteTime: common.CloneProto(cb.LastAttemptCompleteTime),
+		LastAttemptFailure:      common.CloneProto(cb.LastAttemptFailure),
+		NextAttemptScheduleTime: common.CloneProto(cb.NextAttemptScheduleTime),
 		BlockedReason:           blockedReason,
+		RequestId:               cb.GetRequestId(),
 	}, nil
 }
 

--- a/service/history/api/describeworkflow/api.go
+++ b/service/history/api/describeworkflow/api.go
@@ -573,12 +573,6 @@ func buildChasmCallbackInfo(
 	cb *chasmcallback.Callback,
 	trigger *workflowpb.CallbackInfo_Trigger,
 ) (*workflowpb.CallbackInfo, error) {
-	nexusVariant := cb.GetCallback().GetNexus()
-	if nexusVariant == nil {
-		// Only Nexus callbacks are supported
-		return nil, nil
-	}
-
 	apiCb, err := cb.ToAPICallback()
 	if err != nil {
 		return nil, err

--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/nexus-rpc/sdk-go/nexus"
+	"github.com/sony/gobreaker"
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/chasm"
 	"go.temporal.io/server/chasm/lib/activity"
@@ -41,6 +42,7 @@ import (
 	"go.temporal.io/server/service/history/api"
 	"go.temporal.io/server/service/history/api/workflowresend"
 	"go.temporal.io/server/service/history/archival"
+	"go.temporal.io/server/service/history/circuitbreakerpool"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/events"
@@ -50,6 +52,7 @@ import (
 	hsmnexusworkflow "go.temporal.io/server/service/history/hsm/nexusoperations/workflow"
 	"go.temporal.io/server/service/history/replication"
 	"go.temporal.io/server/service/history/shard"
+	"go.temporal.io/server/service/history/tasks"
 	"go.temporal.io/server/service/history/workflow"
 	"go.temporal.io/server/service/history/workflow/cache"
 	"go.temporal.io/server/service/worker/workerdeployment"
@@ -70,6 +73,7 @@ var Module = fx.Options(
 	archival.Module,
 	ChasmEngineModule,
 	chasmtests.Module,
+	fx.Provide(CallbackDestinationBlockedProvider),
 	fx.Provide(ConfigProvider), // might be worth just using provider for configs.Config directly
 	fx.Provide(workflow.NewCommandHandlerRegistry),
 	fx.Provide(ServiceErrorInterceptorProvider),
@@ -129,6 +133,22 @@ var Module = fx.Options(
 	chasmworkflow.Module,
 	chasmworkflow.HistoryHandlerModule,
 )
+
+// CallbackDestinationBlockedProvider lets the callback library report a callback as BLOCKED while
+// the outbound queue's circuit breaker for its destination is open. Only the history service runs
+// that queue, so only it can answer.
+func CallbackDestinationBlockedProvider(
+	outboundQueueCBPool *circuitbreakerpool.OutboundQueueCircuitBreakerPool,
+) callback.DestinationBlockedFn {
+	return func(namespaceID string, destination string) bool {
+		cb := outboundQueueCBPool.Get(tasks.TaskGroupNamespaceIDAndDestination{
+			TaskGroup:   callback.InvocationTaskGroup,
+			NamespaceID: namespaceID,
+			Destination: destination,
+		})
+		return cb.State() != gobreaker.StateClosed
+	}
+}
 
 func ServerProvider(grpcServerOptions []grpc.ServerOption) *grpc.Server {
 	return grpc.NewServer(grpcServerOptions...)

--- a/tests/activity_standalone_test.go
+++ b/tests/activity_standalone_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nexus-rpc/sdk-go/nexus"
 	"github.com/stretchr/testify/require"
 	activitypb "go.temporal.io/api/activity/v1"
+	callbackpb "go.temporal.io/api/callback/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
@@ -10066,6 +10067,31 @@ func (env *standaloneActivityEnv) startActivityWithType(ctx context.Context, act
 	})
 }
 
+// awaitCallbackInfo polls DescribeActivityExecution until the activity's single completion
+// callback reaches wantState, and returns that CallbackInfo.
+func (env *standaloneActivityEnv) awaitCallbackInfo(
+	ctx context.Context,
+	t *testing.T,
+	activityID string,
+	wantState enumspb.CallbackState,
+) *callbackpb.CallbackInfo {
+	t.Helper()
+	var cbInfo *callbackpb.CallbackInfo
+	await.Require(ctx, t, func(c *await.T) {
+		descResp, err := env.FrontendClient().DescribeActivityExecution(c.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+		})
+		require.NoError(c, err)
+		require.Len(c, descResp.GetCallbacks(), 1)
+		cbInfo = descResp.GetCallbacks()[0].GetInfo()
+		require.NotNil(c, cbInfo)
+		require.Equal(c, wantState, cbInfo.GetState())
+	}, 10*time.Second, 100*time.Millisecond)
+	return cbInfo
+}
+
+// Tests verifying that completion callbacks attached to standalone Activities get triggered.
 func (s *standaloneActivityTestSuite) TestCallbacks() {
 	env := s.newTestEnv()
 	t := s.T()
@@ -10257,6 +10283,9 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		})
 		require.NoError(t, err)
 		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED, descResp.GetInfo().GetStatus())
+
+		// Wait for the callback to complete and confirm it has a Success result.
+		env.awaitCallbackInfo(s.Context(), t, activityID, enumspb.CALLBACK_STATE_SUCCEEDED)
 	})
 
 	t.Run("FailsWithCallbacks", func(t *testing.T) {
@@ -10323,6 +10352,9 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		})
 		require.NoError(t, err)
 		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_FAILED, descResp.GetInfo().GetStatus())
+
+		// The Activity may have failed, but the callback reporting the failure should be successful.
+		env.awaitCallbackInfo(s.Context(), t, activityID, enumspb.CALLBACK_STATE_SUCCEEDED)
 	})
 
 	t.Run("TerminatedWithCallbacks", func(t *testing.T) {
@@ -10390,6 +10422,9 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		})
 		require.NoError(t, err)
 		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_TERMINATED, descResp.GetInfo().GetStatus())
+
+		// The callback reporting the termination should be delivered successfully.
+		env.awaitCallbackInfo(s.Context(), t, activityID, enumspb.CALLBACK_STATE_SUCCEEDED)
 	})
 
 	t.Run("CanceledWithCallbacks", func(t *testing.T) {
@@ -10462,6 +10497,9 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		})
 		require.NoError(t, err)
 		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_CANCELED, descResp.GetInfo().GetStatus())
+
+		// The callback reporting the cancellation should be delivered successfully.
+		env.awaitCallbackInfo(s.Context(), t, activityID, enumspb.CALLBACK_STATE_SUCCEEDED)
 	})
 
 	// This test covers the timeout callback path using schedule-to-start, but the callback behavior
@@ -10517,6 +10555,99 @@ func (s *standaloneActivityTestSuite) TestCallbacks() {
 		})
 		require.NoError(t, err)
 		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_TIMED_OUT, descResp.GetInfo().GetStatus())
+
+		// The callback delivering the timeout failure should itself succeed.
+		env.awaitCallbackInfo(s.Context(), t, activityID, enumspb.CALLBACK_STATE_SUCCEEDED)
+	})
+
+	// Verify that if the callback fails to be delivered for some reason, that the failure is
+	// persisted correctly and available from the Describe operation.
+	t.Run("CallbackDeliveryFailure", func(t *testing.T) {
+		activityID := testcore.RandomizeStr(t.Name())
+		taskQueue := testcore.RandomizeStr(t.Name())
+
+		ch, callbackAddress := newNexusCompletionHandler(t)
+
+		// Start and successfully complete a standalone Activity.
+		_, err := env.FrontendClient().StartActivityExecution(s.Context(), &workflowservice.StartActivityExecutionRequest{
+			Namespace:    env.Namespace().String(),
+			ActivityId:   activityID,
+			ActivityType: env.Tv().ActivityType(),
+			Identity:     env.Tv().WorkerIdentity(),
+			Input:        defaultInput,
+			TaskQueue: &taskqueuepb.TaskQueue{
+				Name: taskQueue,
+			},
+			StartToCloseTimeout: durationpb.New(defaultStartToCloseTimeout),
+			RequestId:           env.Tv().Any().String(),
+			CompletionCallbacks: []*commonpb.Callback{{
+				Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: callbackAddress}},
+			}},
+		})
+		require.NoError(t, err)
+
+		pollResp, err := env.FrontendClient().PollActivityTaskQueue(s.Context(), &workflowservice.PollActivityTaskQueueRequest{
+			Namespace: env.Namespace().String(),
+			TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+			Identity:  env.Tv().WorkerIdentity(),
+		})
+		require.NoError(t, err)
+
+		_, err = env.FrontendClient().RespondActivityTaskCompleted(s.Context(), &workflowservice.RespondActivityTaskCompletedRequest{
+			Namespace: env.Namespace().String(),
+			TaskToken: pollResp.TaskToken,
+			Result:    defaultResult,
+			Identity:  defaultIdentity,
+		})
+		require.NoError(t, err)
+
+		// Simulate the completion handler returning a retryable error followed by
+		// an unretryable error. Confirm the SAA's CallbackInfo includes the terminal
+		// failure.
+		for deliveryAttempt := 1; deliveryAttempt <= 2; deliveryAttempt++ {
+			select {
+			case completion := <-ch.requestCh:
+				// Pull the completion request from the channel.
+				require.Equal(t, nexus.OperationStateSucceeded, completion.State)
+				if deliveryAttempt == 1 {
+					// The first attempt to deliver the Activity's completion callback reports a retryable error.
+					// Call Describe and confirm the Callback has just been scheduled.
+					cbInfo := env.awaitCallbackInfo(s.Context(), t, activityID, enumspb.CALLBACK_STATE_SCHEDULED)
+					require.EqualValues(t, 0, cbInfo.GetAttempt()) // zero attempts so far.
+					require.Nil(t, cbInfo.GetLastAttemptFailure())
+
+					// Retryable error.
+					ch.requestCompleteCh <- nexus.NewHandlerErrorf(nexus.HandlerErrorTypeUnavailable, "delivery #1")
+				} else {
+					// The second attempt to deliver the Activity's completion callback should report a
+					// non-retryable error.
+					// Call Describe and confirm the CallbackInfo describes the previous delivery attempt.
+					cbInfo := env.awaitCallbackInfo(s.Context(), t, activityID, enumspb.CALLBACK_STATE_SCHEDULED)
+					require.EqualValues(t, 1, cbInfo.GetAttempt()) // 1 attempt so far, the 2nd is in-progress.
+					require.NotNil(t, cbInfo.GetLastAttemptFailure())
+					require.Contains(t, cbInfo.GetLastAttemptFailure().GetMessage(), "delivery #1")
+
+					// Unretryable error.
+					ch.requestCompleteCh <- nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "delivery #2")
+				}
+
+			case <-s.Context().Done():
+				require.Fail(t, "timed out waiting for completion callback")
+			}
+		}
+
+		// Verify the Activity is in completed state.
+		descResp, err := env.FrontendClient().DescribeActivityExecution(s.Context(), &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: activityID,
+		})
+		require.NoError(t, err)
+		require.Equal(t, enumspb.ACTIVITY_EXECUTION_STATUS_COMPLETED, descResp.GetInfo().GetStatus())
+
+		// Verify the completion callback delivery has failed.
+		cbInfo := env.awaitCallbackInfo(s.Context(), t, activityID, enumspb.CALLBACK_STATE_FAILED)
+		const lastDeliveryFailureMessage = "handler error (BAD_REQUEST): delivery #2"
+		require.Equal(t, lastDeliveryFailureMessage, cbInfo.GetLastAttemptFailure().GetMessage())
 	})
 }
 

--- a/tests/callbacks_test.go
+++ b/tests/callbacks_test.go
@@ -315,7 +315,7 @@ func (s *CallbacksSuite) TestWorkflowCallbacks_InvalidArgument(opts []testcore.T
 			_, err := env.FrontendClient().StartWorkflowExecution(s.Context(), request)
 			var invalidArgument *serviceerror.InvalidArgument
 			s.ErrorAs(err, &invalidArgument)
-			s.Equal(tc.message, err.Error())
+			s.ErrorContains(err, tc.message)
 		})
 	}
 }

--- a/tests/comp_callbacks.go
+++ b/tests/comp_callbacks.go
@@ -1,0 +1,372 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"net/http/httptest"
+	"slices"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"github.com/stretchr/testify/require"
+	callbackpb "go.temporal.io/api/callback/v1"
+	commandpb "go.temporal.io/api/command/v1"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/common/nexus/nexusrpc"
+	"go.temporal.io/server/common/payloads"
+	"go.temporal.io/server/common/testing/await"
+	"go.temporal.io/server/tests/testcore"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+// completionCallbackTarget represents the thing receiving the callback delivery. Failures reaching this
+// target will open the circuit breaker. (e.g. an unavailable Nexus handler.)
+type completionCallbackTarget interface {
+	// newCallback returns a new completion callback addressed to this destination.
+	newCallback() *commonpb.Callback
+	// stopFailing makes every delivery from here on succeed moving forward.
+	stopFailing()
+	// deliveries reports how many deliveries have reached the destination so far.
+	deliveries() int
+}
+
+// completionCallbackBehavior determines how a baseCompletionCallbackTarget should respond to
+// the CompleteOperation method.
+type completionCallbackBehavior int32
+
+const (
+	completionCallbackBehaviorSuccess             completionCallbackBehavior = 1
+	completionCallbackBehaviorNonRetryableFailure completionCallbackBehavior = 2
+	completionCallbackBehaviorRetryableFailure    completionCallbackBehavior = 3
+)
+
+// Base implementation for all callback targets.
+// Implementations must define the newCallback() method.
+type baseCompletionCallbackTarget struct {
+	behavior      atomic.Int32 // completionCallbackBehavior
+	deliveryCount atomic.Int32
+}
+
+func (ct *baseCompletionCallbackTarget) deliveries() int {
+	return int(ct.deliveryCount.Load())
+}
+
+func (ct *baseCompletionCallbackTarget) stopFailing() {
+	ct.behavior.Store(int32(completionCallbackBehaviorSuccess))
+}
+
+func (ct *baseCompletionCallbackTarget) CompleteOperation(_ context.Context, _ *nexusrpc.CompletionRequest) error {
+	received := ct.deliveryCount.Add(1)
+	switch ct.behavior.Load() {
+	case int32(completionCallbackBehaviorSuccess):
+		return nil
+	case int32(completionCallbackBehaviorNonRetryableFailure):
+		return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "terminal failure")
+	case int32(completionCallbackBehaviorRetryableFailure):
+		fallthrough
+	default:
+		// A retryable error, so the delivery counts against the destination's circuit breaker.
+		return nexus.NewHandlerErrorf(nexus.HandlerErrorTypeInternal, "non-terminal failure (%d)", received)
+	}
+}
+
+// nexusCompletionCallbackTarget provides an implementation of callbackTarget for receiving Nexus-variant callbacks.
+type nexusCompletionCallbackTarget struct {
+	baseCompletionCallbackTarget
+	url string
+}
+
+func (nct *nexusCompletionCallbackTarget) newCallback() *commonpb.Callback {
+	return &commonpb.Callback{
+		Variant: &commonpb.Callback_Nexus_{
+			Nexus: &commonpb.Callback_Nexus{
+				Url: nct.url,
+			},
+		},
+	}
+}
+
+// newNexusCompletionCallbackTarget creates a new Nexus-variant callback target.
+// Starts a new HTTP server, will be cleaned up with the testcase.
+func newNexusCompletionCallbackTarget(t *testing.T, _ *testcore.TestEnv, behavior completionCallbackBehavior) completionCallbackTarget {
+	target := &nexusCompletionCallbackTarget{}
+	target.behavior.Store(int32(behavior))
+
+	srv := httptest.NewServer(nexusrpc.NewCompletionHTTPHandler(nexusrpc.CompletionHandlerOptions{
+		Handler: target,
+	}))
+	t.Cleanup(srv.Close)
+	target.url = srv.URL
+
+	return target
+}
+
+// executionWithCallbacks abstracts a Temporal execution type for testling completion callbacks.
+// e.g. Workflows, standalone Activities, etc.
+type executionWithCallbacks interface {
+	// startAndCompleteEx starts a new execution and has it complete successfully, attaching the
+	// supplied completion callback. Returns an execution ID that can be used for polling or any errors.
+	startAndCompleteEx(t *testing.T, env *testcore.TestEnv, callback *commonpb.Callback) (string, error)
+
+	// awaitCallbackState calls Describe- on for the execution type, and will return the
+	// attached completion callback once it reaches [wantState]. Will fail if it ever
+	// sees the callback in any of [errorStates]. Returns the last observed CallbackInfo.
+	awaitCallbackState(
+		t *testing.T,
+		executionID string,
+		env *testcore.TestEnv,
+		wantState enumspb.CallbackState,
+		errorStates []enumspb.CallbackState,
+	) *callbackpb.CallbackInfo
+}
+
+// baseExecutionWithCallbacks provides basic methods to eliminate the boilerplate for
+// implementations of the executionWithCallbacks interface.
+type baseExecutionWithCallbacks struct{}
+
+// baseAwaitCallbackState calls the Describe- function to get the execution's completion callback,
+// and polls until it reaches wantState. It fails on any of errorStates, and returns the last
+// observed CallbackInfo.
+//
+// Will abort the test on any errors returned from describeFn.
+func (b *baseExecutionWithCallbacks) baseAwaitCallbackState(
+	t *testing.T,
+	describeFn func(context.Context) (*callbackpb.CallbackInfo, error),
+	wantState enumspb.CallbackState,
+	errorStates []enumspb.CallbackState) *callbackpb.CallbackInfo {
+
+	t.Helper()
+	ctx := t.Context()
+
+	var (
+		errorStateSeen enumspb.CallbackState
+		cbInfo         *callbackpb.CallbackInfo
+	)
+	await.Require(ctx, t, func(c *await.T) {
+		ctx := c.Context()
+		// NOTE: assign to the captured cbInfo, don't shadow it with :=.
+		var err error
+		cbInfo, err = describeFn(ctx)
+		require.NoError(c, err)
+
+		got := cbInfo.GetState()
+		if slices.Contains(errorStates, got) {
+			errorStateSeen = got
+			c.Fatalf("Callback has forbidden state %s", got)
+		}
+		require.Equal(c, wantState, got)
+	}, 10*time.Second, 200*time.Millisecond)
+
+	// Confirm we never saw the callback in one of the error states.
+	require.Equal(
+		t,
+		enumspb.CALLBACK_STATE_UNSPECIFIED,
+		errorStateSeen,
+		"Callback had error state %s", errorStateSeen)
+
+	return cbInfo
+}
+
+// workflowExecutionType implements the executionWithCallbacks using Workflows.
+type workflowExecutionType struct {
+	baseExecutionWithCallbacks
+}
+
+// startAndCompleteEx implements [executionWithCallbacks].
+func (wf *workflowExecutionType) startAndCompleteEx(t *testing.T, env *testcore.TestEnv, callback *commonpb.Callback) (string, error) {
+	t.Helper()
+	ctx := t.Context()
+
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	workflowID := testcore.RandomizeStr(t.Name())
+	taskQueue := testcore.RandomizeStr(t.Name())
+
+	_, err := env.FrontendClient().StartWorkflowExecution(ctx, &workflowservice.StartWorkflowExecutionRequest{
+		Namespace:          env.Namespace().String(),
+		WorkflowId:         workflowID,
+		WorkflowType:       env.Tv().WorkflowType(),
+		Identity:           env.Tv().WorkerIdentity(),
+		Input:              payloads.EncodeString("input payload"),
+		TaskQueue:          &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		WorkflowRunTimeout: durationpb.New(10 * time.Second),
+		RequestId:          env.Tv().Any().String(),
+		CompletionCallbacks: []*commonpb.Callback{
+			callback,
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	// Simulate the worker polling for the Workflow task, and immediately completing the Workflow.
+	pollResp, err := env.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
+		Namespace: env.Namespace().String(),
+		TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		Identity:  env.Tv().WorkerIdentity(),
+	})
+	if err != nil {
+		return "", err
+	}
+	// An empty task token means the long poll timed out without a task being dispatched.
+	if len(pollResp.GetTaskToken()) == 0 {
+		return "", fmt.Errorf("no workflow task dispatched on task queue %q", taskQueue)
+	}
+
+	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+		Namespace: env.Namespace().String(),
+		TaskToken: pollResp.TaskToken,
+		Identity:  env.Tv().WorkerIdentity(),
+		Commands: []*commandpb.Command{
+			{
+				CommandType: enumspb.COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION,
+				Attributes: &commandpb.Command_CompleteWorkflowExecutionCommandAttributes{
+					CompleteWorkflowExecutionCommandAttributes: &commandpb.CompleteWorkflowExecutionCommandAttributes{
+						Result: payloads.EncodeString("output payload"),
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return workflowID, nil
+}
+
+func (wf *workflowExecutionType) awaitCallbackState(t *testing.T, executionID string, env *testcore.TestEnv, wantState enumspb.CallbackState, errorStates []enumspb.CallbackState) *callbackpb.CallbackInfo {
+	t.Helper()
+
+	describeFn := func(ctx context.Context) (*callbackpb.CallbackInfo, error) {
+		descResp, err := env.FrontendClient().DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: env.Namespace().String(),
+			Execution: &commonpb.WorkflowExecution{
+				WorkflowId: executionID,
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+		callbacks := descResp.GetCallbacks()
+		if len(callbacks) != 1 {
+			return nil, fmt.Errorf("expected 1 callback, got %d", len(callbacks))
+		}
+
+		// NOTE: Workflows do not return a callbackpb.CallbackInfo proto. Instead, it forks (rather than embeds) the type.
+		// So we convert the nearly identical proto to avoid wrapping it in an interface.
+		wfCallbackInfo := callbacks[0]
+		apiCallbackInfo := &callbackpb.CallbackInfo{
+			Callback:                wfCallbackInfo.GetCallback(),
+			RegistrationTime:        wfCallbackInfo.GetRegistrationTime(),
+			State:                   wfCallbackInfo.GetState(),
+			Attempt:                 wfCallbackInfo.GetAttempt(),
+			LastAttemptCompleteTime: wfCallbackInfo.GetLastAttemptCompleteTime(),
+			LastAttemptFailure:      wfCallbackInfo.GetLastAttemptFailure(),
+			NextAttemptScheduleTime: wfCallbackInfo.GetNextAttemptScheduleTime(),
+			BlockedReason:           wfCallbackInfo.GetBlockedReason(),
+			RequestId:               wfCallbackInfo.GetRequestId(),
+		}
+		return apiCallbackInfo, nil
+	}
+	return wf.baseAwaitCallbackState(t, describeFn, wantState, errorStates)
+}
+
+var _ executionWithCallbacks = (*workflowExecutionType)(nil)
+
+// standaloneActivityExecutionType implements the executionWithCallbacks using standalone Activities.
+type standaloneActivityExecutionType struct {
+	baseExecutionWithCallbacks
+}
+
+var _ executionWithCallbacks = (*standaloneActivityExecutionType)(nil)
+
+func (saa *standaloneActivityExecutionType) startAndCompleteEx(
+	t *testing.T,
+	env *testcore.TestEnv,
+	callback *commonpb.Callback,
+) (string, error) {
+	t.Helper()
+	ctx := t.Context()
+
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	activityID := testcore.RandomizeStr(t.Name())
+	taskQueue := testcore.RandomizeStr(t.Name())
+
+	_, err := env.FrontendClient().StartActivityExecution(ctx, &workflowservice.StartActivityExecutionRequest{
+		Namespace:           env.Namespace().String(),
+		ActivityId:          activityID,
+		ActivityType:        env.Tv().ActivityType(),
+		Identity:            env.Tv().WorkerIdentity(),
+		Input:               payloads.EncodeString("input payload"),
+		TaskQueue:           &taskqueuepb.TaskQueue{Name: taskQueue},
+		StartToCloseTimeout: durationpb.New(10 * time.Second),
+		RequestId:           env.Tv().Any().String(),
+		CompletionCallbacks: []*commonpb.Callback{
+			callback,
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	// Simulate the worker polling and ack the Activity task.
+	pollResp, err := env.FrontendClient().PollActivityTaskQueue(ctx, &workflowservice.PollActivityTaskQueueRequest{
+		Namespace: env.Namespace().String(),
+		TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		Identity:  env.Tv().WorkerIdentity(),
+	})
+	if err != nil {
+		return "", err
+	}
+	// An empty task token means the long poll timed out without a task being dispatched.
+	if len(pollResp.GetTaskToken()) == 0 {
+		return "", fmt.Errorf("no Activity task dispatched on task queue %q", taskQueue)
+	}
+
+	_, err = env.FrontendClient().RespondActivityTaskCompleted(ctx, &workflowservice.RespondActivityTaskCompletedRequest{
+		Namespace: env.Namespace().String(),
+		TaskToken: pollResp.TaskToken,
+		Result:    payloads.EncodeString("output payload"),
+		Identity:  env.Tv().WorkerIdentity(),
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return activityID, nil
+}
+
+func (saa *standaloneActivityExecutionType) awaitCallbackState(
+	t *testing.T,
+	executionID string,
+	env *testcore.TestEnv,
+	wantState enumspb.CallbackState,
+	errorStates []enumspb.CallbackState,
+) *callbackpb.CallbackInfo {
+	t.Helper()
+
+	describeFn := func(ctx context.Context) (*callbackpb.CallbackInfo, error) {
+		descResp, err := env.FrontendClient().DescribeActivityExecution(ctx, &workflowservice.DescribeActivityExecutionRequest{
+			Namespace:  env.Namespace().String(),
+			ActivityId: executionID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		callbacks := descResp.GetCallbacks()
+		if len(callbacks) != 1 {
+			return nil, fmt.Errorf("expected 1 callback, got %d", len(callbacks))
+		}
+		return callbacks[0].GetInfo(), nil
+	}
+	return saa.baseAwaitCallbackState(t, describeFn, wantState, errorStates)
+}

--- a/tests/comp_callbacks.go
+++ b/tests/comp_callbacks.go
@@ -207,8 +207,7 @@ func (nhct *nexusHandlerCompletionCallbackTarget) respond(
 
 	startOp := task.GetRequest().GetStartOperation()
 	if startOp == nil {
-		msg := fmt.Sprintf("got unexpected NexusTask: %v", task.GetRequest())
-		panic(msg)
+		return fmt.Errorf("got unexpected NexusTask: %v", task.GetRequest())
 	}
 
 	// Determine the right response based on the current behavior, and respond.
@@ -590,7 +589,7 @@ func (sno *standaloneNexusOperationExecutionType) startAndCompleteEx(
 			IncludeOutcome: true,
 		}
 		descResp, err := env.FrontendClient().DescribeNexusOperationExecution(c.Context(), descReq)
-		require.NoError(t, err)
+		require.NoError(c, err)
 
 		gotStatus := descResp.GetInfo().GetStatus()
 		require.Equal(c, enumspb.NEXUS_OPERATION_EXECUTION_STATUS_COMPLETED, gotStatus)

--- a/tests/comp_callbacks.go
+++ b/tests/comp_callbacks.go
@@ -29,8 +29,8 @@ import (
 type completionCallbackTarget interface {
 	// newCallback returns a new completion callback addressed to this destination.
 	newCallback() *commonpb.Callback
-	// stopFailing makes every delivery from here on succeed moving forward.
-	stopFailing()
+	// changeBehavior updates the way the callback target operates moving forward.
+	changeBehavior(completionCallbackBehavior)
 	// deliveries reports how many deliveries have reached the destination so far.
 	deliveries() int
 }
@@ -56,8 +56,8 @@ func (ct *baseCompletionCallbackTarget) deliveries() int {
 	return int(ct.deliveryCount.Load())
 }
 
-func (ct *baseCompletionCallbackTarget) stopFailing() {
-	ct.behavior.Store(int32(completionCallbackBehaviorSuccess))
+func (ct *baseCompletionCallbackTarget) changeBehavior(newBehavior completionCallbackBehavior) {
+	ct.behavior.Store(int32(newBehavior))
 }
 
 func (ct *baseCompletionCallbackTarget) CompleteOperation(_ context.Context, _ *nexusrpc.CompletionRequest) error {

--- a/tests/comp_callbacks.go
+++ b/tests/comp_callbacks.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http/httptest"
 	"slices"
@@ -15,10 +16,13 @@ import (
 	commandpb "go.temporal.io/api/command/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	nexuspb "go.temporal.io/api/nexus/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/common/nexus/nexusrpc"
+	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/payloads"
+	"go.temporal.io/server/common/rpc"
 	"go.temporal.io/server/common/testing/await"
 	"go.temporal.io/server/tests/testcore"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -35,8 +39,8 @@ type completionCallbackTarget interface {
 	deliveries() int
 }
 
-// completionCallbackBehavior determines how a baseCompletionCallbackTarget should respond to
-// the CompleteOperation method.
+// completionCallbackBehavior determines how a baseCompletionCallbackTarget should answer a
+// delivery reaching it.
 type completionCallbackBehavior int32
 
 const (
@@ -60,7 +64,9 @@ func (ct *baseCompletionCallbackTarget) changeBehavior(newBehavior completionCal
 	ct.behavior.Store(int32(newBehavior))
 }
 
-func (ct *baseCompletionCallbackTarget) CompleteOperation(_ context.Context, _ *nexusrpc.CompletionRequest) error {
+// deliver records a delivery having reached the target and returns how the target answers it.
+// A return value of nil means accepts the delivery, otherwise fail.
+func (ct *baseCompletionCallbackTarget) deliver() *nexus.HandlerError {
 	received := ct.deliveryCount.Add(1)
 	switch ct.behavior.Load() {
 	case int32(completionCallbackBehaviorSuccess):
@@ -91,6 +97,18 @@ func (nct *nexusCompletionCallbackTarget) newCallback() *commonpb.Callback {
 	}
 }
 
+// CompleteOperation implements the nexusrpc handler interface.
+func (nct *nexusCompletionCallbackTarget) CompleteOperation(_ context.Context, _ *nexusrpc.CompletionRequest) error {
+	handlerErr := nct.deliver()
+	if handlerErr == nil {
+		// NOTE: deliver returns a typed *nexus.HandlerError, so it can't be returned unconditionally:
+		// a nil pointer becomes a non-nil error interface, and the handler would treat every
+		// successful delivery as a failure.
+		return nil
+	}
+	return handlerErr
+}
+
 // newNexusCompletionCallbackTarget creates a new Nexus-variant callback target.
 // Starts a new HTTP server, will be cleaned up with the testcase.
 func newNexusCompletionCallbackTarget(t *testing.T, _ *testcore.TestEnv, behavior completionCallbackBehavior) completionCallbackTarget {
@@ -102,6 +120,152 @@ func newNexusCompletionCallbackTarget(t *testing.T, _ *testcore.TestEnv, behavio
 	}))
 	t.Cleanup(srv.Close)
 	target.url = srv.URL
+
+	return target
+}
+
+// nexusHandlerCompletionCallbackTarget provides an implementation of callbackTarget for receiving NexusHandler-variant callbacks.
+type nexusHandlerCompletionCallbackTarget struct {
+	baseCompletionCallbackTarget
+	// taskQueue the target's worker polls on. Distinct per nexusHandlerCompletionCallbackTarget so that
+	// an open circuitbreaker doesn't block all potential callback targets.
+	taskQueue string
+}
+
+func (nhct *nexusHandlerCompletionCallbackTarget) newCallback() *commonpb.Callback {
+	return &commonpb.Callback{
+		Variant: &commonpb.Callback_NexusHandler_{
+			NexusHandler: &commonpb.Callback_NexusHandler{
+				TaskQueueName: nhct.taskQueue,
+				Service:       "NexusHandlerService",
+				Operation:     "OnComplete",
+				SourceContext: &commonpb.Payload{
+					Data: []byte("source context payload"),
+				},
+			},
+		},
+	}
+}
+
+// pollAndRespond is the worker side of a NexusHandler callback. It polls the target's task queue and
+// answers every task it is handed according to the target's behavior at that moment.
+//
+// Runs until ctx is canceled.
+func (nhct *nexusHandlerCompletionCallbackTarget) pollAndRespond(ctx context.Context, t *testing.T, env *NexusTestEnv) {
+	for ctx.Err() == nil {
+		// Issue a long-poll request.
+		pollCtx, cancelPoll := rpc.NewContextFromParentWithTimeoutAndVersionHeaders(ctx, 30*time.Second)
+
+		task, err := env.FrontendClient().PollNexusTaskQueue(pollCtx, &workflowservice.PollNexusTaskQueueRequest{
+			Namespace: env.Namespace().String(),
+			Identity:  env.Tv().WorkerIdentity(),
+			TaskQueue: &taskqueuepb.TaskQueue{Name: nhct.taskQueue, Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		})
+		cancelPoll()
+
+		if err != nil {
+			// Cancelation is how the loop is stopped, so it isn't worth reporting.
+			if ctx.Err() != nil {
+				return
+			}
+			if errors.Is(err, context.DeadlineExceeded) {
+				// The long poll ran out of time without a task, which is business as usual.
+				continue
+			}
+			t.Logf("failed to poll Nexus task queue %q: %v", nhct.taskQueue, err)
+
+			// If the context is still valid, pause a beat and retry.
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(50 * time.Millisecond):
+			}
+			continue
+		}
+
+		// An empty task token means the long poll timed out without a task being dispatched.
+		if len(task.GetTaskToken()) == 0 {
+			continue
+		}
+
+		// Otherwise, respond to the Nexus invocation task.
+		if err := nhct.respond(ctx, env, task); err != nil {
+			t.Logf("failed to respond to Nexus task on %q: %v", nhct.taskQueue, err)
+		}
+	}
+}
+
+// respond answers a single delivered Nexus task the way the target's behavior dictates.
+func (nhct *nexusHandlerCompletionCallbackTarget) respond(
+	ctx context.Context,
+	env *NexusTestEnv,
+	task *workflowservice.PollNexusTaskQueueResponse,
+) error {
+	// The poller's own context has no deadline, it lives as long as the test does.
+	ctx, cancel := rpc.NewContextFromParentWithTimeoutAndVersionHeaders(ctx, 10*time.Second)
+	defer cancel()
+
+	startOp := task.GetRequest().GetStartOperation()
+	if startOp == nil {
+		msg := fmt.Sprintf("got unexpected NexusTask: %v", task.GetRequest())
+		panic(msg)
+	}
+
+	// Determine the right response based on the current behavior, and respond.
+	if deliveryErr := nhct.deliver(); deliveryErr != nil {
+		return env.respondNexusTaskFailed(ctx, task.GetTaskToken(), deliveryErr)
+	}
+
+	// The handler accepted the completion. Report back as if it returned a sync response.
+	result, err := payload.Encode("NexusHandler callback delivered")
+	if err != nil {
+		return err
+	}
+	_, err = env.FrontendClient().RespondNexusTaskCompleted(ctx, &workflowservice.RespondNexusTaskCompletedRequest{
+		Namespace: env.Namespace().String(),
+		Identity:  env.Tv().WorkerIdentity(),
+		TaskToken: task.GetTaskToken(),
+		Response: &nexuspb.Response{
+			Variant: &nexuspb.Response_StartOperation{
+				StartOperation: &nexuspb.StartOperationResponse{
+					Variant: &nexuspb.StartOperationResponse_SyncSuccess{
+						SyncSuccess: &nexuspb.StartOperationResponse_Sync{Payload: result},
+					},
+				},
+			},
+		},
+	})
+	return err
+}
+
+// newNexusHandlerCompletionCallbackTarget creates a new NexusHandler-variant callback target.
+func newNexusHandlerCompletionCallbackTarget(t *testing.T, env *testcore.TestEnv, behavior completionCallbackBehavior) completionCallbackTarget {
+	target := &nexusHandlerCompletionCallbackTarget{
+		taskQueue: testcore.RandomizeStr("nh-callback-tq"),
+	}
+	target.behavior.Store(int32(behavior))
+
+	// A NexusHandler callback is delivered as a Nexus task on the callback's task queue, in the
+	// source execution's own namespace. So the "worker" here is a bare poll loop against that task
+	// queue. It answers as the registered Nexus service, no endpoint required.
+
+	// The poller needs a context of its own: t.Context is canceled before cleanups run, and the
+	// poll loop has to outlive it long enough to be shut down in an orderly way.
+	pollerCtx, stopPolling := context.WithCancel(context.Background())
+	pollerDone := make(chan struct{})
+	go func() {
+		defer close(pollerDone)
+		nexusEnv := &NexusTestEnv{
+			TestEnv:             env,
+			useTemporalFailures: true,
+		}
+		target.pollAndRespond(pollerCtx, t, nexusEnv)
+	}()
+	t.Cleanup(func() {
+		stopPolling()
+		// The poll loop may report failures to t, so the poller must stop before the test does.
+		<-pollerDone
+	})
 
 	return target
 }

--- a/tests/comp_callbacks.go
+++ b/tests/comp_callbacks.go
@@ -370,3 +370,93 @@ func (saa *standaloneActivityExecutionType) awaitCallbackState(
 	}
 	return saa.baseAwaitCallbackState(t, describeFn, wantState, errorStates)
 }
+
+// standaloneNexusOperationExecutionType implements the executionWithCallbacks using standalone Nexus operations.
+type standaloneNexusOperationExecutionType struct {
+	baseExecutionWithCallbacks
+}
+
+var _ executionWithCallbacks = (*standaloneNexusOperationExecutionType)(nil)
+
+func (sno *standaloneNexusOperationExecutionType) startAndCompleteEx(
+	t *testing.T,
+	env *testcore.TestEnv,
+	callback *commonpb.Callback,
+) (string, error) {
+	t.Helper()
+	ctx := t.Context()
+
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	operationID := testcore.RandomizeStr(t.Name())
+	nexusTestEnv := NexusTestEnv{
+		TestEnv:             env,
+		useTemporalFailures: true,
+	}
+	alwaysSuccessNexusEndpoint := nexusTestEnv.createSyncSuccessEndpoint(ctx, t, "operation-result")
+
+	// Start the standalone Nexus operation.
+	startReq := &workflowservice.StartNexusOperationExecutionRequest{
+		Namespace: env.Namespace().String(),
+
+		// The always success endpoint ignores the Service/Operation fields.
+		Endpoint:  alwaysSuccessNexusEndpoint,
+		Service:   "nexus-service",
+		Operation: "nexus-operation",
+
+		OperationId:            operationID,
+		ScheduleToCloseTimeout: durationpb.New(10 * time.Second),
+		CompletionCallbacks: []*commonpb.Callback{
+			callback,
+		},
+	}
+	startResp, err := env.FrontendClient().StartNexusOperationExecution(ctx, startReq)
+	if err != nil {
+		return "", err
+	}
+
+	require.True(t, startResp.GetStarted())
+
+	// Wait for the Nexus operation to be resolved, only then are its completion callbacks triggered.
+	await.Require(ctx, t, func(c *await.T) {
+		descReq := &workflowservice.DescribeNexusOperationExecutionRequest{
+			Namespace:      env.Namespace().String(),
+			OperationId:    operationID,
+			IncludeOutcome: true,
+		}
+		descResp, err := env.FrontendClient().DescribeNexusOperationExecution(c.Context(), descReq)
+		require.NoError(t, err)
+
+		gotStatus := descResp.GetInfo().GetStatus()
+		require.Equal(c, enumspb.NEXUS_OPERATION_EXECUTION_STATUS_COMPLETED, gotStatus)
+	}, 10*time.Second, 200*time.Millisecond)
+
+	return operationID, nil
+}
+
+func (sno *standaloneNexusOperationExecutionType) awaitCallbackState(
+	t *testing.T,
+	executionID string,
+	env *testcore.TestEnv,
+	wantState enumspb.CallbackState,
+	errorStates []enumspb.CallbackState,
+) *callbackpb.CallbackInfo {
+	t.Helper()
+
+	describeFn := func(ctx context.Context) (*callbackpb.CallbackInfo, error) {
+		descResp, err := env.FrontendClient().DescribeNexusOperationExecution(ctx, &workflowservice.DescribeNexusOperationExecutionRequest{
+			Namespace:   env.Namespace().String(),
+			OperationId: executionID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		callbacks := descResp.GetCompletionCallbacks()
+		if len(callbacks) != 1 {
+			return nil, fmt.Errorf("expected 1 callback, got %d", len(callbacks))
+		}
+		return callbacks[0].GetInfo(), nil
+	}
+	return sno.baseAwaitCallbackState(t, describeFn, wantState, errorStates)
+}

--- a/tests/comp_callbacks_test.go
+++ b/tests/comp_callbacks_test.go
@@ -37,23 +37,24 @@ func TestCompletionCallbacksSuite(t *testing.T) {
 // execution types, and the retry policy dialed down so failures can accumulate within the tests's
 // lifetime. The retry policy is a global setting, hence the dedicated cluster.
 func (s *CompletionCallbacksSuite) newTestEnv() *testcore.TestEnv {
+	allCallbackKinds := []callbacks.Kind{callbacks.KindNexus, callbacks.KindNexusHandler}
 	opts := []testcore.TestOption{
 		testcore.WithDedicatedCluster(),
 		// Workflows
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
-		testcore.WithDynamicConfig(workflow.EnabledCallbackKinds, []callbacks.Kind{callbacks.KindNexus}),
+		testcore.WithDynamicConfig(workflow.EnabledCallbackKinds, allCallbackKinds),
 		// Standalone Activities
 		testcore.WithDynamicConfig(activity.Enabled, true),
 		testcore.WithDynamicConfig(activity.EnableCallbacks, true),
-		testcore.WithDynamicConfig(activity.EnabledCallbackKinds, []callbacks.Kind{callbacks.KindNexus}),
+		testcore.WithDynamicConfig(activity.EnabledCallbackKinds, allCallbackKinds),
 		// Standalone Nexus operations
 		testcore.WithDynamicConfig(nexusoperation.Enabled, true),
-		testcore.WithDynamicConfig(nexusoperation.EnabledCallbackKinds, []callbacks.Kind{callbacks.KindNexus}),
+		testcore.WithDynamicConfig(nexusoperation.EnabledCallbackKinds, allCallbackKinds),
 		// All Callbacks and Retry policy
 		testcore.WithDynamicConfig(callback.AllowedAddresses,
 			[]any{map[string]any{"Pattern": "*", "AllowInsecure": true}}),
 		testcore.WithDynamicConfig(callback.RetryPolicyInitialInterval, 10*time.Millisecond),
-		testcore.WithDynamicConfig(callback.RetryPolicyMaximumInterval, 20*time.Millisecond),
+		testcore.WithDynamicConfig(callback.RetryPolicyMaximumInterval, 50*time.Millisecond),
 		// Circuit breaker. Timeout is how long the breaker stays open before half-opening
 		// (and trying to send a request again). It defaults to 60s which is too long for a
 		// unit test to observe. But 1s is too short, and tests couldn't detect the BLOCKED
@@ -85,12 +86,12 @@ func (s *CompletionCallbacksSuite) forEachTestCombination(testFn completionCallb
 	}
 
 	// Types of callback targets.
-	// COMING SOON: The NexusHandler-variant.
 	callbackTargets := []struct {
 		Name                string
 		CBTargetConstructor newCompletionCallbackTargetFn
 	}{
 		{"Nexus", newNexusCompletionCallbackTarget},
+		{"NexusHandler", newNexusHandlerCompletionCallbackTarget},
 	}
 
 	// Run the testcase against all combinations of execution types and callback variants.
@@ -170,17 +171,7 @@ func (s *CompletionCallbacksSuite) TestUnsupportedVariants() {
 					&commonpb.Callback{Variant: nil},
 					"unknown callback variant: <nil>",
 				},
-				{
-					"NexusHandler",
-					&commonpb.Callback{
-						Variant: &commonpb.Callback_NexusHandler_{
-							NexusHandler: &commonpb.Callback_NexusHandler{
-								// Should be rejected based on type, not its contents.
-							},
-						},
-					},
-					"nexusHandler callbacks are not enabled for this execution type",
-				},
+				// All other variants are enabled by default for this test suite.
 			}
 
 			for _, tc := range cases {

--- a/tests/comp_callbacks_test.go
+++ b/tests/comp_callbacks_test.go
@@ -15,6 +15,10 @@ import (
 	"go.temporal.io/server/tests/testcore"
 )
 
+// circuitBreakerFailureThreshold is how many failures are encountered before the circuit breaker
+// opens, and starts skipping deliveries.
+const circuitBreakerFailureThreshold = 5
+
 // CompletionCallbacksSuite tests completion callback behavior.
 //
 // There are several layers of abstraction so that the test suite can run the same test against
@@ -45,6 +49,12 @@ func (s *CompletionCallbacksSuite) newTestEnv() *testcore.TestEnv {
 			[]any{map[string]any{"Pattern": "*", "AllowInsecure": true}}),
 		testcore.WithDynamicConfig(callback.RetryPolicyInitialInterval, 10*time.Millisecond),
 		testcore.WithDynamicConfig(callback.RetryPolicyMaximumInterval, 20*time.Millisecond),
+		// Circuit breaker. Timeout is how long the breaker stays open before half-opening
+		// (and trying to send a request again). It defaults to 60s which is too long for a
+		// unit test to observe. But 1s is too short, and tests couldn't detect the BLOCKED
+		// or BACKING_OFF state. 3s seems to be the sweet spot.
+		testcore.WithDynamicConfig(dynamicconfig.OutboundQueueCircuitBreakerSettings,
+			dynamicconfig.CircuitBreakerSettings{MaxRequests: 1, Timeout: 3 * time.Second}),
 	}
 	return testcore.NewEnv(s.T(), opts...)
 }
@@ -174,5 +184,101 @@ func (s *CompletionCallbacksSuite) TestUnsupportedVariants() {
 					require.ErrorContains(t, gotErr, tc.WantErr)
 				})
 			}
+		})
+}
+
+// TestBlockedWhenCircuitBreakerOpens covers deliveries that keep failing against the same
+// destination: its breaker opens and Describe reports the callback as BLOCKED.
+func (s *CompletionCallbacksSuite) TestBlockedWhenCircuitBreakerOpens() {
+	env := s.newTestEnv()
+
+	s.forEachTestCombination(
+		func(
+			s *CompletionCallbacksSuite,
+			exec executionWithCallbacks,
+			newCompCallbackTargetFn newCompletionCallbackTargetFn,
+		) {
+			t := s.T()
+
+			// Create a callback target that will always fail with a retryable error.
+			alwaysFailingCallbackTarget := newCompCallbackTargetFn(t, env, completionCallbackBehaviorRetryableFailure)
+			executionID, err := exec.startAndCompleteEx(t, env, alwaysFailingCallbackTarget.newCallback())
+			require.NoError(t, err)
+
+			// Deliveries are retried until enough have failed to open the breaker, so the callback passes
+			// through SCHEDULED and BACKING_OFF on the way to BLOCKED.
+			callbackInfo := exec.awaitCallbackState(t, executionID, env, enumspb.CALLBACK_STATE_BLOCKED, nil)
+			require.Equal(t, "The circuit breaker is open.", callbackInfo.GetBlockedReason())
+
+			require.Equal(t, "The circuit breaker is open.", callbackInfo.GetBlockedReason())
+			require.Greater(t, callbackInfo.GetAttempt(), int32(circuitBreakerFailureThreshold),
+				"the breaker should not open before the failure threshold is exceeded")
+		})
+}
+
+// TestBreakerIsPerDestination covers the isolation the per-destination key buys: one dead
+// destination must not hold back deliveries to a healthy one.
+//
+// The two executions are deliberately sequential. Attaching both callbacks to one execution does
+// not test anything: the healthy delivery succeeds immediately, long before the failing one has
+// accumulated enough failures for there to be an open breaker to be affected by.
+func (s *CompletionCallbacksSuite) TestBreakerIsPerDestination() {
+	env := s.newTestEnv()
+
+	s.forEachTestCombination(
+		func(
+			s *CompletionCallbacksSuite,
+			exec executionWithCallbacks,
+			newCompCallbackTargetFn newCompletionCallbackTargetFn,
+		) {
+			t := s.T()
+
+			// Create an execution trying to deliver a callback to an unavailable target.
+			alwaysFailingCallbackTarget := newCompCallbackTargetFn(t, env, completionCallbackBehaviorRetryableFailure)
+			failingExecutionID, err := exec.startAndCompleteEx(t, env, alwaysFailingCallbackTarget.newCallback())
+			require.NoError(t, err)
+
+			exec.awaitCallbackState(t, failingExecutionID, env, enumspb.CALLBACK_STATE_BLOCKED, nil)
+
+			// Start another execution with a callback targeting a _different_ destination for the same
+			// variant of callback. (e.g. a different Nexus handler.)
+			alwaysSucceedCallbackTarget := newCompCallbackTargetFn(t, env, completionCallbackBehaviorSuccess)
+			successfulExecutionID, err := exec.startAndCompleteEx(t, env, alwaysSucceedCallbackTarget.newCallback())
+			require.NoError(t, err)
+
+			errorStates := []enumspb.CallbackState{enumspb.CALLBACK_STATE_BLOCKED, enumspb.CALLBACK_STATE_BACKING_OFF}
+			successfulCallbackInfo := exec.awaitCallbackState(t, successfulExecutionID, env, enumspb.CALLBACK_STATE_SUCCEEDED, errorStates)
+			require.EqualValues(t, 1, successfulCallbackInfo.GetAttempt())
+		})
+}
+
+// TestRecoversFromBlocked covers BLOCKED not being terminal: once the breaker's open period elapses
+// it half-opens, and the destination, healthy again by then, gets the delivery.
+func (s *CompletionCallbacksSuite) TestRecoversFromBlocked() {
+	env := s.newTestEnv()
+
+	s.forEachTestCombination(
+		func(
+			s *CompletionCallbacksSuite,
+			exec executionWithCallbacks,
+			newCompCallbackTargetFn newCompletionCallbackTargetFn,
+		) {
+			t := s.T()
+
+			// Have the callback target always start where each request fails with a retryable error.
+			testCallbackTarget := newCompCallbackTargetFn(t, env, completionCallbackBehaviorRetryableFailure)
+			executionID, err := exec.startAndCompleteEx(t, env, testCallbackTarget.newCallback())
+			require.NoError(t, err)
+
+			blockedCbi := exec.awaitCallbackState(t, executionID, env, enumspb.CALLBACK_STATE_BLOCKED, nil)
+
+			// Simulate the destination recovering. The breaker half-opens, lets a delivery through, and it succeeds.
+			testCallbackTarget.changeBehavior(completionCallbackBehaviorSuccess)
+			successfulCbi := exec.awaitCallbackState(t, executionID, env, enumspb.CALLBACK_STATE_SUCCEEDED, nil)
+
+			// Confirm the updated CallbackInfo reflects the state change.
+			require.Equal(t, blockedCbi.GetRequestId(), successfulCbi.GetRequestId())
+			require.Less(t, blockedCbi.GetAttempt(), successfulCbi.GetAttempt())
+			require.Empty(t, successfulCbi.GetBlockedReason())
 		})
 }

--- a/tests/comp_callbacks_test.go
+++ b/tests/comp_callbacks_test.go
@@ -48,6 +48,7 @@ func (s *CompletionCallbacksSuite) newTestEnv() *testcore.TestEnv {
 		testcore.WithDynamicConfig(activity.EnabledCallbackKinds, []callbacks.Kind{callbacks.KindNexus}),
 		// Standalone Nexus operations
 		testcore.WithDynamicConfig(nexusoperation.Enabled, true),
+		testcore.WithDynamicConfig(nexusoperation.EnabledCallbackKinds, []callbacks.Kind{callbacks.KindNexus}),
 		// All Callbacks and Retry policy
 		testcore.WithDynamicConfig(callback.AllowedAddresses,
 			[]any{map[string]any{"Pattern": "*", "AllowInsecure": true}}),
@@ -74,13 +75,13 @@ type completionCallbackTestcase func(*CompletionCallbacksSuite, executionWithCal
 // forEachTestCombination runs the given testcase across all permutations of execution types and callback variants.
 func (s *CompletionCallbacksSuite) forEachTestCombination(testFn completionCallbackTestcase) {
 	// Types of Temporal executions that support completion callbacks.
-	// COMING SOON: Standalone Nexus operations (which don't support comp. callbacks yet)
 	executionTypes := []struct {
 		Name      string
 		Execution executionWithCallbacks
 	}{
-		{"Workflow", &workflowExecutionType{}},
 		{"StandaloneActivity", &standaloneActivityExecutionType{}},
+		{"StandaloneNexusOperation", &standaloneNexusOperationExecutionType{}},
+		{"Workflow", &workflowExecutionType{}},
 	}
 
 	// Types of callback targets.

--- a/tests/comp_callbacks_test.go
+++ b/tests/comp_callbacks_test.go
@@ -10,6 +10,8 @@ import (
 	"go.temporal.io/server/chasm/lib/activity"
 	"go.temporal.io/server/chasm/lib/callback"
 	"go.temporal.io/server/chasm/lib/nexusoperation"
+	"go.temporal.io/server/chasm/lib/workflow"
+	"go.temporal.io/server/common/callbacks"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/testing/parallelsuite"
 	"go.temporal.io/server/tests/testcore"
@@ -39,9 +41,11 @@ func (s *CompletionCallbacksSuite) newTestEnv() *testcore.TestEnv {
 		testcore.WithDedicatedCluster(),
 		// Workflows
 		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
+		testcore.WithDynamicConfig(workflow.EnabledCallbackKinds, []callbacks.Kind{callbacks.KindNexus}),
 		// Standalone Activities
 		testcore.WithDynamicConfig(activity.Enabled, true),
 		testcore.WithDynamicConfig(activity.EnableCallbacks, true),
+		testcore.WithDynamicConfig(activity.EnabledCallbackKinds, []callbacks.Kind{callbacks.KindNexus}),
 		// Standalone Nexus operations
 		testcore.WithDynamicConfig(nexusoperation.Enabled, true),
 		// All Callbacks and Retry policy

--- a/tests/comp_callbacks_test.go
+++ b/tests/comp_callbacks_test.go
@@ -1,0 +1,178 @@
+package tests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/server/chasm/lib/activity"
+	"go.temporal.io/server/chasm/lib/callback"
+	"go.temporal.io/server/chasm/lib/nexusoperation"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/testing/parallelsuite"
+	"go.temporal.io/server/tests/testcore"
+)
+
+// CompletionCallbacksSuite tests completion callback behavior.
+//
+// There are several layers of abstraction so that the test suite can run the same test against
+// different callback types, or different forms of execution (Workflow, standalone Activity, etc.)
+type CompletionCallbacksSuite struct {
+	parallelsuite.Suite[*CompletionCallbacksSuite]
+}
+
+func TestCompletionCallbacksSuite(t *testing.T) {
+	parallelsuite.Run(t, &CompletionCallbacksSuite{})
+}
+
+// newTestEnv builds a test environment with completion callbacks configured for all supported
+// execution types, and the retry policy dialed down so failures can accumulate within the tests's
+// lifetime. The retry policy is a global setting, hence the dedicated cluster.
+func (s *CompletionCallbacksSuite) newTestEnv() *testcore.TestEnv {
+	opts := []testcore.TestOption{
+		testcore.WithDedicatedCluster(),
+		// Workflows
+		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
+		// Standalone Activities
+		testcore.WithDynamicConfig(activity.Enabled, true),
+		testcore.WithDynamicConfig(activity.EnableCallbacks, true),
+		// Standalone Nexus operations
+		testcore.WithDynamicConfig(nexusoperation.Enabled, true),
+		// All Callbacks and Retry policy
+		testcore.WithDynamicConfig(callback.AllowedAddresses,
+			[]any{map[string]any{"Pattern": "*", "AllowInsecure": true}}),
+		testcore.WithDynamicConfig(callback.RetryPolicyInitialInterval, 10*time.Millisecond),
+		testcore.WithDynamicConfig(callback.RetryPolicyMaximumInterval, 20*time.Millisecond),
+	}
+	return testcore.NewEnv(s.T(), opts...)
+}
+
+// newCompletionCallbackTargetFn is a function for constructing a new completionCallbackTarget.
+// It's passed to testcases so they can construct new completion callback targets with a specific behavior.
+type newCompletionCallbackTargetFn func(*testing.T, *testcore.TestEnv, completionCallbackBehavior) completionCallbackTarget
+
+// completionCallbackTestcase defines the logic for a testcase that runs against an abstracted "execution type"
+// and "completion callback target",
+type completionCallbackTestcase func(*CompletionCallbacksSuite, executionWithCallbacks, newCompletionCallbackTargetFn)
+
+// forEachTestCombination runs the given testcase across all permutations of execution types and callback variants.
+func (s *CompletionCallbacksSuite) forEachTestCombination(testFn completionCallbackTestcase) {
+	// Types of Temporal executions that support completion callbacks.
+	// COMING SOON: Standalone Nexus operations (which don't support comp. callbacks yet)
+	executionTypes := []struct {
+		Name      string
+		Execution executionWithCallbacks
+	}{
+		{"Workflow", &workflowExecutionType{}},
+		{"StandaloneActivity", &standaloneActivityExecutionType{}},
+	}
+
+	// Types of callback targets.
+	// COMING SOON: The NexusHandler-variant.
+	callbackTargets := []struct {
+		Name                string
+		CBTargetConstructor newCompletionCallbackTargetFn
+	}{
+		{"Nexus", newNexusCompletionCallbackTarget},
+	}
+
+	// Run the testcase against all combinations of execution types and callback variants.
+	// If this proves to be too slow, we can run a randomized subset or something.
+	for _, executionType := range executionTypes {
+		s.Run(executionType.Name, func(s *CompletionCallbacksSuite) {
+			for _, callbackTarget := range callbackTargets {
+				s.Run(callbackTarget.Name, func(s *CompletionCallbacksSuite) {
+					cbTargetCtor := callbackTarget.CBTargetConstructor
+					testFn(s, executionType.Execution, cbTargetCtor)
+				})
+			}
+		})
+	}
+}
+
+// TestCallbackBasics covers the 80% case of completion callbacks being successful or failing
+// with a terminal error. (Retries are covered elsewhere.)
+func (s *CompletionCallbacksSuite) TestCallbackBasics() {
+	env := s.newTestEnv()
+
+	s.forEachTestCombination(
+		func(
+			s *CompletionCallbacksSuite,
+			exec executionWithCallbacks,
+			newCompCallbackTargetFn newCompletionCallbackTargetFn,
+		) {
+			t := s.T()
+
+			// Create a callback target that will be successful.
+			successfulTarget := newCompCallbackTargetFn(t, env, completionCallbackBehaviorSuccess)
+			cbSucceedesExecutionID, err := exec.startAndCompleteEx(t, env, successfulTarget.newCallback())
+			require.NoError(t, err)
+
+			invalidStates := []enumspb.CallbackState{
+				enumspb.CALLBACK_STATE_BACKING_OFF,
+				enumspb.CALLBACK_STATE_BLOCKED,
+				enumspb.CALLBACK_STATE_FAILED,
+			}
+			successfulCallbackInfo := exec.awaitCallbackState(t, cbSucceedesExecutionID, env, enumspb.CALLBACK_STATE_SUCCEEDED, invalidStates)
+			require.EqualValues(t, 1, successfulCallbackInfo.GetAttempt())
+			require.Nil(t, successfulCallbackInfo.LastAttemptFailure)
+
+			// Create a callback target that will always fail.
+			failingTarget := newCompCallbackTargetFn(t, env, completionCallbackBehaviorNonRetryableFailure)
+			cbFailsExecutionID, err := exec.startAndCompleteEx(t, env, failingTarget.newCallback())
+			require.NoError(t, err)
+
+			failedCallbackInfo := exec.awaitCallbackState(t, cbFailsExecutionID, env, enumspb.CALLBACK_STATE_FAILED, nil)
+			require.EqualValues(t, 1, failedCallbackInfo.GetAttempt())
+			gotTermFailure := failedCallbackInfo.LastAttemptFailure
+			require.NotNil(t, gotTermFailure)
+			require.Equal(t, "handler error (BAD_REQUEST): terminal failure", gotTermFailure.GetMessage())
+		})
+}
+
+func (s *CompletionCallbacksSuite) TestUnsupportedVariants() {
+	env := s.newTestEnv()
+
+	s.forEachTestCombination(
+		func(
+			s *CompletionCallbacksSuite,
+			exec executionWithCallbacks,
+			newCompCallbackTargetFn newCompletionCallbackTargetFn,
+		) {
+			t := s.T()
+
+			// Try to run start an execution with an invalid completion callback variant. Confirm
+			// it fails with the given error.
+			cases := []struct {
+				Name     string
+				Callback *commonpb.Callback
+				WantErr  string
+			}{
+				{
+					"NoVariant",
+					&commonpb.Callback{Variant: nil},
+					"unknown callback variant: <nil>",
+				},
+				{
+					"NexusHandler",
+					&commonpb.Callback{
+						Variant: &commonpb.Callback_NexusHandler_{
+							NexusHandler: &commonpb.Callback_NexusHandler{
+								// Should be rejected based on type, not its contents.
+							},
+						},
+					},
+					"nexusHandler callbacks are not enabled for this execution type",
+				},
+			}
+
+			for _, tc := range cases {
+				t.Run(tc.Name, func(t *testing.T) {
+					_, gotErr := exec.startAndCompleteEx(t, env, tc.Callback)
+					require.ErrorContains(t, gotErr, tc.WantErr)
+				})
+			}
+		})
+}

--- a/tests/mixedbrain/go.mod
+++ b/tests/mixedbrain/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/siderolabs/grpc-proxy v0.5.2
 	github.com/stretchr/testify v1.11.1
 	github.com/temporalio/omes v0.0.0-20260529203146-c6ee1f56c726
-	go.temporal.io/api v1.63.6-0.20260831232338-79f9bb05242b
+	go.temporal.io/api v1.63.6-0.20260909222256-20151aa90480
 	go.temporal.io/server v0.0.0-00010101000000-000000000000
 	google.golang.org/grpc v1.83.2
 	google.golang.org/protobuf v1.36.11

--- a/tests/mixedbrain/go.sum
+++ b/tests/mixedbrain/go.sum
@@ -55,8 +55,8 @@ go.opentelemetry.io/otel/sdk/metric v1.44.0 h1:3LlKgI+VjbVsjNRFZJZAJ30WjXC5VkNRk
 go.opentelemetry.io/otel/sdk/metric v1.44.0/go.mod h1:5B5pMARnXxKhltooO4xUuCBorl65a4EpnTalObqOigA=
 go.opentelemetry.io/otel/trace v1.44.0 h1:jxF5CsGYCe74MCRx2X4g7WsY/VBKRqqpNvXlX/6gtIk=
 go.opentelemetry.io/otel/trace v1.44.0/go.mod h1:oLl1jrMQAVo6v3GAggN+1VH9VIz9iUSvW53sW1Q8PIE=
-go.temporal.io/api v1.63.6-0.20260831232338-79f9bb05242b h1:Ka6a9DhaedpDOGG3ffTLicvFj9iFhiG4dXLTunV1K2g=
-go.temporal.io/api v1.63.6-0.20260831232338-79f9bb05242b/go.mod h1:SrlW2JMwVlDP4nRWSNznUFqnSHd+YeMDS1BkYo63HCQ=
+go.temporal.io/api v1.63.6-0.20260909222256-20151aa90480 h1:1w2xEZFpL7R9NagEQeWTh7oZmZU3YUJGogusn9/LfCg=
+go.temporal.io/api v1.63.6-0.20260909222256-20151aa90480/go.mod h1:acM0I9WPuYg8W3Pd9jOZvEgi7mRUttUQ4+e7fowKVnM=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/tests/nexus_standalone_callbacks_test.go
+++ b/tests/nexus_standalone_callbacks_test.go
@@ -1,0 +1,453 @@
+package tests
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"github.com/stretchr/testify/require"
+	callbackpb "go.temporal.io/api/callback/v1"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	nexusoperationpb "go.temporal.io/api/nexusoperation/v1"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/chasm/lib/callback"
+	"go.temporal.io/server/chasm/lib/nexusoperation"
+	"go.temporal.io/server/common/callbacks"
+	"go.temporal.io/server/common/dynamicconfig"
+	commonnexus "go.temporal.io/server/common/nexus"
+	"go.temporal.io/server/common/nexus/nexustest"
+	"go.temporal.io/server/common/testing/await"
+	"go.temporal.io/server/common/testing/parallelsuite"
+	"go.temporal.io/server/common/testing/protorequire"
+	"go.temporal.io/server/common/testing/testvars"
+	"go.temporal.io/server/tests/testcore"
+)
+
+// NexusStandaloneCallbacksTestSuite covers standalone Nexus operation
+// behavior with regard to completion callbacks.
+type NexusStandaloneCallbacksTestSuite struct {
+	parallelsuite.Suite[*NexusStandaloneCallbacksTestSuite]
+}
+
+func TestNexusStandaloneCallbacksTestSuite(t *testing.T) {
+	parallelsuite.Run(t, &NexusStandaloneCallbacksTestSuite{})
+}
+
+func (s *NexusStandaloneCallbacksTestSuite) newTestEnv(enableCallbacks bool) *NexusTestEnv {
+	var kinds []callbacks.Kind
+	if enableCallbacks {
+		kinds = append(kinds, callbacks.KindNexus)
+	}
+
+	env := newNexusTestEnv(s.T(), true,
+		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, true),
+		testcore.WithDynamicConfig(nexusoperation.Enabled, true),
+		testcore.WithDynamicConfig(nexusoperation.EnabledCallbackKinds, kinds),
+	)
+	if enableCallbacks {
+		env.OverrideDynamicConfig(
+			callback.AllowedAddresses,
+			[]any{map[string]any{"Pattern": "*", "AllowInsecure": true}},
+		)
+	}
+	return env
+}
+
+// awaitCallbackInfo polls DescribeNexusOperationExecution until the operation's single completion
+// callback reaches wantState, then returns it.
+func (s *NexusStandaloneCallbacksTestSuite) awaitCallbackInfo(
+	env *NexusTestEnv,
+	operationID string,
+	wantState enumspb.CallbackState,
+) *callbackpb.CallbackInfo {
+	s.T().Helper()
+
+	var cbInfo *callbackpb.CallbackInfo
+	await.Require(s.Context(), s.T(), func(c *await.T) {
+		cbs := env.describeNexusOperation(c.Context(), c, operationID).GetCompletionCallbacks()
+		require.Len(c, cbs, 1)
+		cbInfo = cbs[0].GetInfo()
+		require.NotNil(c, cbInfo)
+		require.Equal(c, wantState, cbInfo.GetState())
+	}, 10*time.Second, 100*time.Millisecond)
+	return cbInfo
+}
+
+func (s *NexusStandaloneCallbacksTestSuite) TestCompletionCallbacks() {
+	env := s.newTestEnv(true)
+	alwaysSuccessEndpointName := env.createSyncSuccessEndpoint(s.Context(), s.T(), "operation-result")
+
+	s.Run("DeliveredOnSuccess", func(s *NexusStandaloneCallbacksTestSuite) {
+		ctx := s.Context()
+		ch, callbackAddress := newNexusCompletionHandler(s.T())
+
+		operationID := testvars.New(s.T()).Any().String()
+		startResp, err := env.startNexusOperation(ctx, &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId:         operationID,
+			Endpoint:            alwaysSuccessEndpointName,
+			CompletionCallbacks: []*commonpb.Callback{nexusCompletionCallback(callbackAddress)},
+		})
+		s.NoError(err)
+		s.True(startResp.GetStarted())
+
+		// Verify the callback was actually delivered with the operation's result.
+		var completionBody []byte
+		select {
+		case completion := <-ch.requestCh:
+			s.Equal(nexus.OperationStateSucceeded, completion.State)
+			s.Nil(completion.Error)
+			s.False(completion.StartTime.IsZero())
+			s.False(completion.CloseTime.IsZero())
+			body, readErr := io.ReadAll(completion.HTTPRequest.Body)
+			_ = completion.HTTPRequest.Body.Close()
+			s.NoError(readErr)
+			s.JSONEq(`"operation-result"`, string(body))
+			completionBody = body
+			// The completion carries a back-link to the operation that produced it.
+			wantLink := commonnexus.ConvertLinkNexusOperationToNexusLink(&commonpb.Link_NexusOperation{
+				Namespace:   env.Namespace().String(),
+				OperationId: operationID,
+				RunId:       startResp.GetRunId(),
+			})
+			s.Require().Len(completion.Links, 1)
+			s.Equal(wantLink.URL.String(), completion.Links[0].URL.String())
+			s.Equal(wantLink.Type, completion.Links[0].Type)
+			// Unblock CompleteOperation so it returns 200 OK to the callback library.
+			ch.requestCompleteCh <- nil
+		case <-ctx.Done():
+			s.FailNow("timed out waiting for the completion callback")
+		}
+
+		// Verify the operation is in completed state, and that the callback delivered the
+		// same result the operation.
+		descResp := env.describeNexusOperation(ctx, s.T(), operationID)
+		s.Equal(enumspb.NEXUS_OPERATION_EXECUTION_STATUS_COMPLETED, descResp.GetInfo().GetStatus())
+		s.Equal(string(descResp.GetResult().GetData()), string(completionBody))
+
+		// Wait for the callback to complete and confirm it has a Success result.
+		cbInfo := s.awaitCallbackInfo(env, operationID, enumspb.CALLBACK_STATE_SUCCEEDED)
+		s.Equal(callbackAddress, cbInfo.GetCallback().GetNexus().GetUrl())
+	})
+
+	s.Run("DeliveredOnFailure", func(s *NexusStandaloneCallbacksTestSuite) {
+		ctx := s.Context()
+		alwaysFailingEndpointName := env.createRandomExternalNexusServer(ctx, s.T(), nexustest.Handler{
+			OnStartOperation: func(
+				ctx context.Context,
+				service, operation string,
+				input *nexus.LazyValue,
+				options nexus.StartOperationOptions,
+			) (nexus.HandlerStartOperationResult[any], error) {
+				return nil, &nexus.OperationError{
+					State: nexus.OperationStateFailed,
+					Cause: &nexus.FailureError{Failure: nexus.Failure{Message: "deliberate failure"}},
+				}
+			},
+		})
+		ch, callbackAddress := newNexusCompletionHandler(s.T())
+
+		operationID := testvars.New(s.T()).Any().String()
+		_, err := env.startNexusOperation(ctx, &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId:         operationID,
+			Endpoint:            alwaysFailingEndpointName,
+			CompletionCallbacks: []*commonpb.Callback{nexusCompletionCallback(callbackAddress)},
+		})
+		s.NoError(err)
+
+		// Verify the callback was actually delivered with failure state.
+		select {
+		case completion := <-ch.requestCh:
+			s.Equal(nexus.OperationStateFailed, completion.State)
+			s.False(completion.StartTime.IsZero())
+			s.False(completion.CloseTime.IsZero())
+			s.Require().NotNil(completion.Error)
+			var failureErr *nexus.FailureError
+			s.Require().ErrorAs(completion.Error.Cause, &failureErr)
+			// The handler's error is wrapped as an OperationError whose cause carries the original
+			// message, which is how a Nexus operation failure round-trips through a completion.
+			tFailure, convErr := commonnexus.NexusFailureToTemporalFailure(failureErr.Failure)
+			s.NoError(convErr)
+			s.Equal("OperationError", tFailure.GetApplicationFailureInfo().GetType())
+			s.Equal("deliberate failure", tFailure.GetCause().GetMessage())
+			ch.requestCompleteCh <- nil
+		case <-ctx.Done():
+			s.FailNow("timed out waiting for the completion callback")
+		}
+
+		// Verify the operation is in failed state.
+		descResp := env.describeNexusOperation(ctx, s.T(), operationID)
+		s.Equal(enumspb.NEXUS_OPERATION_EXECUTION_STATUS_FAILED, descResp.GetInfo().GetStatus())
+
+		// The operation may have failed, but the callback reporting that failure was successful.
+		s.awaitCallbackInfo(env, operationID, enumspb.CALLBACK_STATE_SUCCEEDED)
+	})
+
+	// Verify that if the callback fails to be delivered for some reason, that the failure is
+	// persisted correctly and available from the Describe operation.
+	s.Run("CallbackDeliveryFailure", func(s *NexusStandaloneCallbacksTestSuite) {
+		ctx := s.Context()
+		ch, callbackAddress := newNexusCompletionHandler(s.T())
+
+		operationID := testvars.New(s.T()).Any().String()
+		_, err := env.startNexusOperation(ctx, &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId:         operationID,
+			Endpoint:            alwaysSuccessEndpointName,
+			CompletionCallbacks: []*commonpb.Callback{nexusCompletionCallback(callbackAddress)},
+		})
+		s.NoError(err)
+
+		// Simulate the completion handler returning a retryable error followed by an unretryable
+		// error. Confirm the SANO's CallbackInfo includes the terminal failure.
+		for deliveryAttempt := 1; deliveryAttempt <= 2; deliveryAttempt++ {
+			select {
+			case completion := <-ch.requestCh:
+				s.Equal(nexus.OperationStateSucceeded, completion.State)
+				if deliveryAttempt == 1 {
+					// While the handler is blocked here the callback is in flight: Describe reports
+					// it as scheduled, with no attempts recorded yet.
+					cbInfo := s.awaitCallbackInfo(env, operationID, enumspb.CALLBACK_STATE_SCHEDULED)
+					s.EqualValues(0, cbInfo.GetAttempt())
+					s.Nil(cbInfo.GetLastAttemptFailure())
+
+					// Retryable error.
+					ch.requestCompleteCh <- nexus.NewHandlerErrorf(nexus.HandlerErrorTypeUnavailable, "delivery #1")
+				} else {
+					// The second delivery attempt: Describe now describes the previous attempt.
+					cbInfo := s.awaitCallbackInfo(env, operationID, enumspb.CALLBACK_STATE_SCHEDULED)
+					s.EqualValues(1, cbInfo.GetAttempt()) // 1 attempt so far, the 2nd is in-progress.
+					s.NotNil(cbInfo.GetLastAttemptFailure())
+					s.Contains(cbInfo.GetLastAttemptFailure().GetMessage(), "delivery #1")
+
+					// Unretryable error.
+					ch.requestCompleteCh <- nexus.NewHandlerErrorf(nexus.HandlerErrorTypeBadRequest, "delivery #2")
+				}
+			case <-ctx.Done():
+				s.FailNow("timed out waiting for the completion callback")
+			}
+		}
+
+		// A failed callback delivery does not affect the operation itself.
+		gotStatus := env.describeNexusOperation(ctx, s.T(), operationID).GetInfo().GetStatus()
+		s.Equal(enumspb.NEXUS_OPERATION_EXECUTION_STATUS_COMPLETED, gotStatus)
+
+		// Verify the completion callback delivery has failed.
+		cbInfo := s.awaitCallbackInfo(env, operationID, enumspb.CALLBACK_STATE_FAILED)
+		// Both the last delivery failure and the terminal failure come from delivery #2.
+		const lastDeliveryFailureMessage = "handler error (BAD_REQUEST): delivery #2"
+		s.Equal(lastDeliveryFailureMessage, cbInfo.GetLastAttemptFailure().GetMessage())
+	})
+
+	s.Run("DescribeReportsStandbyBeforeClose", func(s *NexusStandaloneCallbacksTestSuite) {
+		ctx := s.Context()
+		endpointName := env.createAsyncEndpoint(ctx, s.T())
+
+		operationID := testvars.New(s.T()).Any().String()
+		_, err := env.startNexusOperation(ctx, &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId: operationID,
+			Endpoint:    endpointName,
+			CompletionCallbacks: []*commonpb.Callback{
+				nexusCompletionCallback("http://localhost/cb1"),
+				nexusCompletionCallback("http://localhost/cb2"),
+			},
+		})
+		s.NoError(err)
+
+		// The operation stays STARTED, so its callbacks stay in STANDBY with no result.
+		infos := env.describeNexusOperation(ctx, s.T(), operationID).GetCompletionCallbacks()
+		s.Len(infos, 2)
+		for _, info := range infos {
+			// Every callback on a standalone operation is triggered by the operation completing.
+			s.NotNil(info.GetTrigger().GetOperationCompleted())
+			s.Equal(enumspb.CALLBACK_STATE_STANDBY, info.GetInfo().GetState())
+			s.NotNil(info.GetInfo().GetRegistrationTime())
+		}
+	})
+
+	s.Run("AttachOnConflict", func(s *NexusStandaloneCallbacksTestSuite) {
+		ctx := s.Context()
+		endpointName := env.createAsyncEndpoint(ctx, s.T())
+
+		operationID := testvars.New(s.T()).Any().String()
+		startResp, err := env.startNexusOperation(ctx, &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId:         operationID,
+			Endpoint:            endpointName,
+			RequestId:           "first-request",
+			CompletionCallbacks: []*commonpb.Callback{nexusCompletionCallback("http://localhost/cb1")},
+		})
+		s.NoError(err)
+		s.True(startResp.GetStarted())
+
+		attachReq := &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId:         operationID,
+			Endpoint:            endpointName,
+			RequestId:           "second-request",
+			CompletionCallbacks: []*commonpb.Callback{nexusCompletionCallback("http://localhost/cb2")},
+			IdConflictPolicy:    enumspb.NEXUS_OPERATION_ID_CONFLICT_POLICY_USE_EXISTING,
+			OnConflictOptions: &nexusoperationpb.OnConflictOptions{
+				AttachRequestId:           true,
+				AttachCompletionCallbacks: true,
+			},
+		}
+		attachResp, err := env.startNexusOperation(ctx, attachReq)
+		s.NoError(err)
+		s.False(attachResp.GetStarted(), "the second request must not have created an operation")
+		s.Equal(startResp.GetRunId(), attachResp.GetRunId())
+
+		callbackInfos := env.describeNexusOperation(ctx, s.T(), operationID).GetCompletionCallbacks()
+		s.Require().Len(callbackInfos, 2)
+		s.Equal("http://localhost/cb1", callbackInfos[0].GetInfo().GetCallback().GetNexus().GetUrl())
+		s.Equal("http://localhost/cb2", callbackInfos[1].GetInfo().GetCallback().GetNexus().GetUrl())
+		s.Equal(enumspb.CALLBACK_STATE_STANDBY, callbackInfos[0].GetInfo().GetState())
+		s.Equal(enumspb.CALLBACK_STATE_STANDBY, callbackInfos[1].GetInfo().GetState())
+
+		// Replaying the same attach must not duplicate any of the callbacks.
+		_, err = env.startNexusOperation(ctx, attachReq)
+		s.NoError(err)
+		newDescribeResp := env.describeNexusOperation(ctx, s.T(), operationID)
+		s.Len(newDescribeResp.GetCompletionCallbacks(), 2)
+	})
+
+	// Confirm that SANO fails with callback kinds that are not enabled.
+	s.Run("RejectNonNexusCallbacks", func(s *NexusStandaloneCallbacksTestSuite) {
+		for _, tc := range []struct {
+			name     string
+			callback *commonpb.Callback
+			// errTarget is a pointer to a serviceerror pointer, as ErrorAs expects.
+			errTarget any
+			errMsg    string
+		}{
+			{
+				name: "nexus handler",
+				callback: &commonpb.Callback{Variant: &commonpb.Callback_NexusHandler_{NexusHandler: &commonpb.Callback_NexusHandler{
+					TaskQueueName: "completions-task-queue",
+					Service:       "HTTPAdapter",
+					Operation:     "DeliverAsWebhook",
+				}}},
+				// The callback is well-formed, but the NexusHandler kind is not enabled (see
+				// newTestEnv). A disabled kind is an InvalidArgument, not the Unimplemented that
+				// a variant the server does not recognize at all gets.
+				errTarget: new(*serviceerror.InvalidArgument),
+				errMsg:    "nexusHandler callbacks are not enabled for this execution type",
+			},
+			{
+				name:      "unset",
+				callback:  &commonpb.Callback{},
+				errTarget: new(*serviceerror.Unimplemented),
+				errMsg:    "unknown callback variant",
+			},
+		} {
+			s.Run(tc.name, func(s *NexusStandaloneCallbacksTestSuite) {
+				resp, err := env.startNexusOperation(s.Context(), &workflowservice.StartNexusOperationExecutionRequest{
+					OperationId:         testvars.New(s.T()).Any().String(),
+					Endpoint:            alwaysSuccessEndpointName,
+					CompletionCallbacks: []*commonpb.Callback{tc.callback},
+				})
+				s.Nil(resp)
+
+				s.ErrorAs(err, tc.errTarget)
+				s.ErrorContains(err, tc.errMsg)
+			})
+		}
+	})
+
+	// Links and callbacks are attached by independent options, so a single request may carry both.
+	s.Run("AttachLinksAndCallbacksOnConflict", func(s *NexusStandaloneCallbacksTestSuite) {
+		ctx := s.Context()
+		t := s.T()
+
+		endpointName := env.createRandomExternalNexusServer(s.Context(), t, nexustest.Handler{
+			OnStartOperation: func(
+				ctx context.Context,
+				service, operation string,
+				input *nexus.LazyValue,
+				options nexus.StartOperationOptions,
+			) (nexus.HandlerStartOperationResult[any], error) {
+				return &nexus.HandlerStartOperationResultAsync{OperationToken: "test-operation-token"}, nil
+			},
+		})
+
+		firstLink := standaloneNexusTestLink(env, "first-wf")
+		secondLink := standaloneNexusTestLink(env, "second-wf")
+
+		operationID := testvars.New(t).Any().String()
+		startResp, err := env.startNexusOperation(ctx, &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId:         operationID,
+			Endpoint:            endpointName,
+			RequestId:           "first-request",
+			CompletionCallbacks: []*commonpb.Callback{nexusCompletionCallback("http://localhost/cb1")},
+			Links:               []*commonpb.Link{firstLink},
+		})
+		s.NoError(err)
+		s.True(startResp.GetStarted())
+
+		attachResp, err := env.startNexusOperation(ctx, &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId:         operationID,
+			Endpoint:            endpointName,
+			RequestId:           "second-request",
+			CompletionCallbacks: []*commonpb.Callback{nexusCompletionCallback("http://localhost/cb2")},
+			Links:               []*commonpb.Link{secondLink},
+			IdConflictPolicy:    enumspb.NEXUS_OPERATION_ID_CONFLICT_POLICY_USE_EXISTING,
+			OnConflictOptions: &nexusoperationpb.OnConflictOptions{
+				AttachRequestId:           true,
+				AttachCompletionCallbacks: true,
+				AttachLinks:               true,
+			},
+		})
+		s.NoError(err)
+		s.False(attachResp.GetStarted(), "the second request must not have created an operation")
+
+		descResp, err := env.FrontendClient().DescribeNexusOperationExecution(s.Context(), &workflowservice.DescribeNexusOperationExecutionRequest{
+			Namespace:   env.Namespace().String(),
+			OperationId: operationID,
+		})
+		s.NoError(err)
+		// Links are stored per request ID, so their relative order is non-deterministic.
+		protorequire.ProtoElementsMatch(t,
+			[]*commonpb.Link{firstLink, secondLink},
+			descResp.GetInfo().GetLinks())
+	})
+}
+
+// TestCallbacksDisabled confirms that an empty nexusoperation.enabledCallbackKinds gates the whole
+// surface, including the on-conflict attach path.
+func (s *NexusStandaloneCallbacksTestSuite) TestCallbacksDisabled() {
+	// Test environment with SANO not supporting completion callbacks.
+	env := s.newTestEnv(false)
+	endpointName := env.createRandomExternalNexusServer(s.Context(), s.T(), nexustest.Handler{})
+	cbs := []*commonpb.Callback{nexusCompletionCallback("http://localhost/cb")}
+
+	s.Run("StartWithCallbacksFails", func(s *NexusStandaloneCallbacksTestSuite) {
+		_, err := env.startNexusOperation(s.Context(), &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId:         testvars.New(s.T()).Any().String(),
+			Endpoint:            endpointName,
+			CompletionCallbacks: cbs,
+		})
+		s.ErrorContains(err, "nexus callbacks are not enabled for this execution type")
+	})
+
+	s.Run("OnConflictAttachCallbacksFails", func(s *NexusStandaloneCallbacksTestSuite) {
+		_, err := env.startNexusOperation(s.Context(), &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId:         testvars.New(s.T()).Any().String(),
+			Endpoint:            endpointName,
+			CompletionCallbacks: cbs,
+			IdConflictPolicy:    enumspb.NEXUS_OPERATION_ID_CONFLICT_POLICY_USE_EXISTING,
+			OnConflictOptions: &nexusoperationpb.OnConflictOptions{
+				AttachRequestId:           true,
+				AttachCompletionCallbacks: true,
+			},
+		})
+		s.ErrorContains(err, "nexus callbacks are not enabled for this execution type")
+	})
+}
+
+// nexusCompletionCallback builds a Nexus-variant completion callback targeting url, typically the URL
+// returned by [newNexusCompletionHandler].
+func nexusCompletionCallback(url string) *commonpb.Callback {
+	return &commonpb.Callback{
+		Variant: &commonpb.Callback_Nexus_{Nexus: &commonpb.Callback_Nexus{Url: url}},
+	}
+}

--- a/tests/nexus_standalone_test.go
+++ b/tests/nexus_standalone_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/nexus-rpc/sdk-go/nexus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,6 +16,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
 	nexuspb "go.temporal.io/api/nexus/v1"
+	nexusoperationpb "go.temporal.io/api/nexusoperation/v1"
 	sdkpb "go.temporal.io/api/sdk/v1"
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
@@ -223,6 +225,143 @@ func (s *NexusStandaloneTestSuite) TestStartStandaloneNexusOperation() {
 		s.Equal(resp1.RunId, resp2.RunId)
 		s.False(resp2.GetStarted())
 	})
+}
+
+// standaloneNexusTestLink returns a new workflow event link.
+func standaloneNexusTestLink(env *NexusTestEnv, workflowID string) *commonpb.Link {
+	return &commonpb.Link{
+		Variant: &commonpb.Link_WorkflowEvent_{
+			WorkflowEvent: &commonpb.Link_WorkflowEvent{
+				Namespace:  env.Namespace().String(),
+				WorkflowId: workflowID,
+				RunId:      "wf-run-id",
+				Reference: &commonpb.Link_WorkflowEvent_EventRef{
+					EventRef: &commonpb.Link_WorkflowEvent_EventReference{
+						EventId:   1,
+						EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestStandaloneNexusOperationLinks covers links a caller attaches to a standalone Nexus operation,
+// on start and via on_conflict_options, along with the limits enforced on both paths.
+func (s *NexusStandaloneTestSuite) TestStandaloneNexusOperationLinks() {
+	ctx := context.Background()
+	env := s.newTestEnv()
+
+	// The async operation remains STARTED, so it remains open for on-conflict attaches.
+	endpointName := env.createAsyncEndpoint(ctx, s.T())
+
+	// Calls Describe- and returns the attached links.
+	describeLinks := func(s *NexusStandaloneTestSuite, operationID string) []*commonpb.Link {
+		t := s.T()
+		t.Helper()
+		descResp, err := env.FrontendClient().DescribeNexusOperationExecution(
+			ctx,
+			&workflowservice.DescribeNexusOperationExecutionRequest{
+				Namespace:   env.Namespace().String(),
+				OperationId: operationID,
+			})
+		require.NoError(t, err)
+		return descResp.GetInfo().GetLinks()
+	}
+
+	s.Run("AttachedOnStart", func(s *NexusStandaloneTestSuite) {
+		t := s.T()
+		operationID := uuid.NewString()
+		links := []*commonpb.Link{
+			standaloneNexusTestLink(env, "start-wf-1"),
+			standaloneNexusTestLink(env, "start-wf-2"),
+		}
+
+		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId: operationID,
+			Endpoint:    endpointName,
+			Links:       links,
+		})
+		s.NoError(err)
+		s.True(startResp.GetStarted())
+
+		gotLinks := describeLinks(s, operationID)
+		protorequire.ProtoSliceEqual(t, links, gotLinks)
+	})
+
+	s.Run("AttachLinksOnConflictMergesLinks", func(s *NexusStandaloneTestSuite) {
+		t := s.T()
+		operationID := uuid.NewString()
+		firstLink := standaloneNexusTestLink(env, "merge-wf-1")
+		secondLink := standaloneNexusTestLink(env, "merge-wf-2")
+
+		startResp, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId: operationID,
+			Endpoint:    endpointName,
+			RequestId:   "first-request",
+			Links:       []*commonpb.Link{firstLink},
+		})
+		s.NoError(err)
+		s.True(startResp.GetStarted())
+
+		// Call Start again with the same operation ID, with the conflict policy to
+		// use the existing SANO but attach links.
+		attachReq := &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId:      operationID,
+			Endpoint:         endpointName,
+			RequestId:        "second-request",
+			Links:            []*commonpb.Link{secondLink},
+			IdConflictPolicy: enumspb.NEXUS_OPERATION_ID_CONFLICT_POLICY_USE_EXISTING,
+			OnConflictOptions: &nexusoperationpb.OnConflictOptions{
+				AttachLinks: true,
+			},
+		}
+		attachResp, err := s.startNexusOperation(env, attachReq)
+		s.NoError(err)
+		s.False(attachResp.GetStarted())
+		s.Equal(startResp.GetRunId(), attachResp.GetRunId())
+
+		expected := []*commonpb.Link{firstLink, secondLink}
+		// Links are stored per request ID, so their relative order is non-deterministic.
+		gotLinks := describeLinks(s, operationID)
+		protorequire.ProtoElementsMatch(t, expected, gotLinks)
+
+		// Replaying the same request must not duplicate the links it already attached.
+		_, err = s.startNexusOperation(env, attachReq)
+		s.NoError(err)
+		gotLinks = describeLinks(s, operationID)
+		protorequire.ProtoElementsMatch(t, expected, gotLinks)
+	})
+
+	s.Run("LinksIgnoredOnConflictWithoutAttachLinks", func(s *NexusStandaloneTestSuite) {
+		t := s.T()
+		operationID := uuid.NewString()
+		firstLink := standaloneNexusTestLink(env, "ignored-wf-1")
+
+		_, err := s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId: operationID,
+			Endpoint:    endpointName,
+			RequestId:   "first-request",
+			Links:       []*commonpb.Link{firstLink},
+		})
+		s.NoError(err)
+
+		_, err = s.startNexusOperation(env, &workflowservice.StartNexusOperationExecutionRequest{
+			OperationId:      operationID,
+			Endpoint:         endpointName,
+			RequestId:        "second-request",
+			Links:            []*commonpb.Link{standaloneNexusTestLink(env, "ignored-wf-2")},
+			IdConflictPolicy: enumspb.NEXUS_OPERATION_ID_CONFLICT_POLICY_USE_EXISTING,
+			// attach_links intentionally omitted — the second request's links must be dropped.
+		})
+		s.NoError(err)
+
+		gotLinks := describeLinks(s, operationID)
+		protorequire.ProtoSliceEqual(t, []*commonpb.Link{firstLink}, gotLinks)
+	})
+
+	// The per-request and per-execution link caps are covered by unit tests
+	// TestNewStandaloneOperationAttachesLinks and TestOperationAttachLinks.
 }
 
 func (s *NexusStandaloneTestSuite) TestDescribeStandaloneNexusOperation() {

--- a/tests/nexus_test_base.go
+++ b/tests/nexus_test_base.go
@@ -1,10 +1,12 @@
 package tests
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/nexus-rpc/sdk-go/nexus"
@@ -20,6 +22,7 @@ import (
 	"go.temporal.io/server/common/nexus/nexusrpc"
 	"go.temporal.io/server/common/nexus/nexustest"
 	"go.temporal.io/server/tests/testcore"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 type NexusTestEnv struct {
@@ -32,6 +35,38 @@ func newNexusTestEnv(t *testing.T, useTemporalFailures bool, opts ...testcore.Te
 		TestEnv:             testcore.NewEnv(t, opts...),
 		useTemporalFailures: useTemporalFailures,
 	}
+}
+
+// startNexusOperation starts a standalone Nexus operation, applying defaults for
+// required fields tests usually don't care about.
+func (env *NexusTestEnv) startNexusOperation(
+	ctx context.Context,
+	req *workflowservice.StartNexusOperationExecutionRequest,
+) (*workflowservice.StartNexusOperationExecutionResponse, error) {
+	req.Namespace = cmp.Or(req.Namespace, env.Namespace().String())
+	req.Service = cmp.Or(req.Service, "test-service")
+	req.Operation = cmp.Or(req.Operation, "test-operation")
+	req.RequestId = cmp.Or(req.RequestId, env.Tv().RequestID())
+	if req.ScheduleToCloseTimeout == nil {
+		req.ScheduleToCloseTimeout = durationpb.New(10 * time.Minute)
+	}
+
+	return env.FrontendClient().StartNexusOperationExecution(ctx, req)
+}
+
+// describeNexusOperation describes a standalone Nexus operation by ID, including its outcome.
+func (env *NexusTestEnv) describeNexusOperation(
+	ctx context.Context,
+	t require.TestingT,
+	operationID string,
+) *workflowservice.DescribeNexusOperationExecutionResponse {
+	descResp, err := env.FrontendClient().DescribeNexusOperationExecution(ctx, &workflowservice.DescribeNexusOperationExecutionRequest{
+		Namespace:      env.Namespace().String(),
+		OperationId:    operationID,
+		IncludeOutcome: true,
+	})
+	require.NoError(t, err)
+	return descResp
 }
 
 func (env *NexusTestEnv) createNexusEndpoint(ctx context.Context, t *testing.T, name string, taskQueue string) *nexuspb.Endpoint {
@@ -113,6 +148,37 @@ func (env *NexusTestEnv) dispatchByNamespaceAndTaskQueueURL(namespace string, ta
 			Namespace: namespace,
 			TaskQueue: taskQueue,
 		})
+}
+
+// createSyncSuccessEndpoint registers an endpoint whose handler completes every operation
+// synchronously with the supplied result payload. Shutdown as part with the test's Cleanup.
+func (env *NexusTestEnv) createSyncSuccessEndpoint(ctx context.Context, t *testing.T, result string) string {
+	return env.createRandomExternalNexusServer(ctx, t, nexustest.Handler{
+		OnStartOperation: func(
+			ctx context.Context,
+			service, operation string,
+			input *nexus.LazyValue,
+			options nexus.StartOperationOptions,
+		) (nexus.HandlerStartOperationResult[any], error) {
+			return &nexus.HandlerStartOperationResultSync[any]{Value: result}, nil
+		},
+	})
+}
+
+// createAsyncEndpoint registers an endpoint whose handler leaves every operation running async,
+// so calls to the endpoint remain in the STARTED state until it is completed by other means.
+// (e.g. the Nexus operation gets canceled or terminated.)
+func (env *NexusTestEnv) createAsyncEndpoint(ctx context.Context, t *testing.T) string {
+	return env.createRandomExternalNexusServer(ctx, t, nexustest.Handler{
+		OnStartOperation: func(
+			ctx context.Context,
+			service, operation string,
+			input *nexus.LazyValue,
+			options nexus.StartOperationOptions,
+		) (nexus.HandlerStartOperationResult[any], error) {
+			return &nexus.HandlerStartOperationResultAsync{OperationToken: "test-operation-token"}, nil
+		},
+	})
 }
 
 // nexusTaskResponse represents a successful response from a nexus task handler.


### PR DESCRIPTION
## What changed?

This PR contains the series of PRs for adding `NexusHandler`-variant completion callbacks to Workflows, Workflow Updates, standalone Activities, as well as standalone Nexus operations. (Which previously didn't support completion callbacks at all.)

> This will introduce a breaking change in the `saas-temporal` repo, since this makes a breaking change to the `common/callbacks.Validator` interface. https://github.com/temporalio/saas-temporal/pull/8783 is ready for when this gets merged to get that addressed.

## Why?

The earlier PRs were merged into the `feature/worker-callbacks` branch so that the server-side changes could stabilize and be merged shortly after the API changes. (Which landed in https://github.com/temporalio/api/pull/863.)

## How did you test it?

- [x] built
- [x] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)

## Potential risks

Only that this new feature might be _too_ amazing.
