### PR TITLE
Backport #12022 to cloud/v1.32.0-162

### DIFF
--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -143,6 +143,7 @@ type (
 		FairnessPassDither            dynamicconfig.BoolPropertyFnWithTaskQueueFilter
 		PartitionScaleAllowedDrift    dynamicconfig.TypedPropertyFnWithTaskQueueFilter[dynamicconfig.PartitionScaleAllowedDrift]
 		PartitionScaleManagerSettings dynamicconfig.TypedPropertyFnWithTaskQueueFilter[dynamicconfig.PartitionScaleManagerSettings]
+		PartitionScalerSettings       dynamicconfig.TypedPropertyFnWithTaskQueueFilter[dynamicconfig.SimplePartitionScalerSettings]
 
 		LogAllReqErrors dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	}
@@ -237,6 +238,7 @@ type (
 		FairnessPassDither            func() bool
 		PartitionScaleAllowedDrift    func() dynamicconfig.PartitionScaleAllowedDrift
 		PartitionScaleManagerSettings func() dynamicconfig.PartitionScaleManagerSettings
+		PartitionScalerSettings       func() dynamicconfig.SimplePartitionScalerSettings
 
 		loadCause loadCause
 	}
@@ -390,6 +392,7 @@ func NewConfig(
 		FairnessPassDither:            dynamicconfig.MatchingFairnessPassDither.Get(dc),
 		PartitionScaleAllowedDrift:    dynamicconfig.MatchingPartitionScaleAllowedDrift.Get(dc),
 		PartitionScaleManagerSettings: dynamicconfig.MatchingPartitionScaleManager.Get(dc),
+		PartitionScalerSettings:       dynamicconfig.MatchingPartitionScaler.Get(dc),
 
 		LogAllReqErrors: dynamicconfig.LogAllReqErrors.Get(dc),
 
@@ -575,6 +578,9 @@ func newTaskQueueConfig(tq *tqid.TaskQueue, config *Config, ns namespace.Name) *
 		},
 		PartitionScaleManagerSettings: func() dynamicconfig.PartitionScaleManagerSettings {
 			return config.PartitionScaleManagerSettings(ns.String(), taskQueueName, taskType)
+		},
+		PartitionScalerSettings: func() dynamicconfig.SimplePartitionScalerSettings {
+			return config.PartitionScalerSettings(ns.String(), taskQueueName, taskType)
 		},
 		MaxVersionsInTaskQueue: func() int { return config.MaxVersionsInTaskQueue(ns.String()) },
 	}

--- a/service/matching/task_queue_partition_manager.go
+++ b/service/matching/task_queue_partition_manager.go
@@ -361,6 +361,15 @@ func (pm *taskQueuePartitionManagerImpl) checkPartitionCounts(ctx context.Contex
 	if !ok {
 		return nil // only normal partitions do dynamic scaling
 	}
+
+	// The scaler may have been disabled after it wrote scale state. That state is
+	// republished to ephemeral data on every task queue load, so it would keep
+	// rejecting RPCs with no scaler left to correct it.
+	// TODO: clear the published scale info in scaleManager instead.
+	if !pm.config.PartitionScalerSettings().Enabled {
+		return nil
+	}
+
 	id := normal.PartitionId()
 
 	// userDataManager must be initialized here already so we can just ask it for scale info

--- a/service/matching/validate_partition_counts_test.go
+++ b/service/matching/validate_partition_counts_test.go
@@ -1,15 +1,57 @@
 package matching
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	taskqueuespb "go.temporal.io/server/api/taskqueue/v1"
 	"go.temporal.io/server/client/matching"
 	"go.temporal.io/server/common/dynamicconfig"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
+	"go.temporal.io/server/common/tqid"
 )
+
+func TestCheckPartitionCountsScalerEnablement(t *testing.T) {
+	t.Parallel()
+
+	var stale *serviceerrors.StalePartitionCounts
+	tests := []struct {
+		name    string
+		enabled bool
+	}{
+		{name: "disabled", enabled: false},
+		{name: "enabled", enabled: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			partition := tqid.UnsafeTaskQueueFamily(namespaceID, taskQueueName).
+				TaskQueue(enumspb.TASK_QUEUE_TYPE_WORKFLOW).
+				NormalPartition(10)
+			pm := &taskQueuePartitionManagerImpl{
+				partition: partition,
+				userDataManager: &mockUserDataManager{
+					scaleInfo: &taskqueuespb.PartitionScaleInfo{Read: 8, Write: 4},
+				},
+				config: &taskQueueConfig{
+					PartitionScalerSettings: func() dynamicconfig.SimplePartitionScalerSettings {
+						return dynamicconfig.SimplePartitionScalerSettings{Enabled: tc.enabled}
+					},
+				},
+			}
+
+			err := pm.checkPartitionCounts(context.Background(), true)
+			if tc.enabled {
+				require.ErrorAs(t, err, &stale)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
 
 func TestValidatePartitionCounts(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## What changed?

Backports #12022 so matching skips partition-count drift checks when the partition scaler is disabled.

### Original PRs

- #12022
