### PR TITLE
Clear scaleInfo when scaler is disabled (#12026)

### DIFF
--- a/client/matching/loadbalancer.go
+++ b/client/matching/loadbalancer.go
@@ -97,7 +97,7 @@ func (lb *defaultLoadBalancer) PickWritePartition(
 	}
 
 	var partitionCount int
-	if pc.Write > 0 {
+	if pc.Valid() {
 		partitionCount = int(pc.Write)
 	} else {
 		partitionCount = max(1, lb.nWritePartitions(nsName.String(), taskQueue.Name(), taskQueue.TaskType()))
@@ -157,7 +157,7 @@ func (lb *defaultLoadBalancer) PickReadPartition(
 	var partitionCount = dynamicconfig.GlobalDefaultNumTaskQueuePartitions
 	namespaceName, namespaceErr := lb.namespaceIDToName(namespace.ID(taskQueue.NamespaceId()))
 
-	if pc.Read > 0 {
+	if pc.Valid() {
 		partitionCount = int(pc.Read)
 	} else if namespaceErr == nil {
 		partitionCount = lb.nReadPartitions(string(namespaceName), taskQueue.Name(), taskQueue.TaskType())

--- a/service/matching/partition_scaler_interface.go
+++ b/service/matching/partition_scaler_interface.go
@@ -24,7 +24,7 @@ type PartitionScaler interface {
 	// It will be given the current partition count target, current backlog counts, and its
 	// private state (optional). It returns a PartitionScalerDecision, which will usually be
 	// "no change". To make a change, it should return a number in NewTarget. Zero means
-	// disable managed scaling.
+	// disable managed scaling and requires BacklogCap to also be zero.
 	//
 	// Changes may be ignored if values are out of range, if changed too often, or other
 	// reasons. Private state will not be updated if target doesn't also change, or if the
@@ -47,6 +47,6 @@ type PartitionScalerInput struct {
 type PartitionScalerDecision struct {
 	NoChange     bool       // if true, don't do anything
 	NewTarget    int        // if zero, disable managed scaling, otherwise set partition target
-	BacklogCap   int        // target cap for backlog count
+	BacklogCap   int        // target cap for backlog count; must be zero when NewTarget is zero
 	PrivateState *anypb.Any // optional private state to be stored with target
 }

--- a/service/matching/scale_manager.go
+++ b/service/matching/scale_manager.go
@@ -194,9 +194,15 @@ func (sm *scaleManager) callScaler() {
 		PrivateState:  sm.scaleState.GetPrivateScalerState(),
 	})
 	backlogCapC8 := number.EncodeCompact8(int64(decision.BacklogCap))
+	disabledStateNeedsCleanup := decision.NewTarget == 0 &&
+		(len(sm.scaleState.GetBacklogState()) > 0 ||
+			len(sm.scaleState.GetBacklogCounts()) > 0 ||
+			sm.scaleState.GetBacklogCap() != 0 ||
+			sm.scaleState.GetPrivateScalerState() != nil)
 	if decision.NoChange ||
 		decision.NewTarget == int(sm.scaleState.GetTarget()) &&
-			backlogCapC8 == number.Compact8(sm.scaleState.GetBacklogCap()) {
+			backlogCapC8 == number.Compact8(sm.scaleState.GetBacklogCap()) &&
+			!disabledStateNeedsCleanup {
 		return
 	}
 
@@ -212,9 +218,20 @@ func (sm *scaleManager) callScaler() {
 	newState.TargetVersion = sm.timeSource.Now().UnixNano()
 	newState.BacklogCap = int32(backlogCapC8)
 	newState.PrivateScalerState = decision.PrivateState
+	var prevRead, prevWrite int32
+	if target == 0 {
+		// Disabling managed scaling is a clean break to dynamic config; any backlog
+		// outside its read range remains unpolled until it times out.
+		prevInfo := scaleStateToInfo(sm.scaleState, settings)
+		prevRead, prevWrite = prevInfo.Read, prevInfo.Write
+		newState.BacklogState = nil
+		newState.BacklogCounts = nil
+		newState.BacklogCap = 0
+		newState.PrivateScalerState = nil
+	}
 
 	mayHaveBacklog := target
-	if prevTarget == 0 {
+	if prevTarget == 0 && target > 0 {
 		// Turning on managed partition scaling: consider all partitions from dynamic
 		// config as having backlog also.
 		mayHaveBacklog = max(mayHaveBacklog, int32(sm.getWritePartitions()))
@@ -249,11 +266,17 @@ func (sm *scaleManager) callScaler() {
 	cooldown := time.Duration(float32(time.Second) / settings.MaxRate)
 	sm.nextDecision = sm.timeSource.Now().Add(cooldown)
 
-	sm.logger.Info("new target",
-		tag.Int32("target", target),
-		tag.Int32("prev-target", prevTarget),
-		tag.Int32("max-target", newState.MaxTarget),
-		tag.Bool(metrics.ScalerShadowModeTagName, shadowMode))
+	if target == 0 {
+		sm.logger.Info("disabled managed scaling",
+			tag.Int32("prev-read", prevRead),
+			tag.Int32("prev-write", prevWrite))
+	} else {
+		sm.logger.Info("new target",
+			tag.Int32("target", target),
+			tag.Int32("prev-target", prevTarget),
+			tag.Int32("max-target", newState.MaxTarget),
+			tag.Bool(metrics.ScalerShadowModeTagName, shadowMode))
+	}
 	metrics.PartitionScaleEvents.With(sm.metricsHandler.WithTags(metrics.ScalerShadowModeTag(shadowMode))).Record(1)
 }
 

--- a/service/matching/scale_manager_test.go
+++ b/service/matching/scale_manager_test.go
@@ -367,6 +367,53 @@ func (s *ScaleManagerSuite) TestDecisionPersistsAndUpdatesEphemeralData() {
 	s.Equal(int32(2), info.Write)
 }
 
+func (s *ScaleManagerSuite) TestDisabledScalerClearsManagedScaleState() {
+	s.settings.ShrinkRatio = 0.1
+	s.settings.ShrinkDelta = 8
+	priv := protoutils.MarshalAny(s.T(), wrapperspb.String("managed-state"))
+	s.scaler.EXPECT().OnTasks(gomock.Any()).
+		Return(PartitionScalerDecision{NewTarget: 0})
+
+	dbWrites := make(chan *persistencespb.PartitionScaleState, 1)
+	s.scaleDB.EXPECT().UpdateScaleState(gomock.Any(), true).
+		Do(func(state *persistencespb.PartitionScaleState, _ bool) {
+			dbWrites <- common.CloneProto(state)
+		}).
+		Return(nil)
+
+	scaleInfos := make(chan *taskqueuespb.PartitionScaleInfo, 2)
+	s.userData.EXPECT().SetPartitionScale(gomock.Any()).
+		Do(func(info *taskqueuespb.PartitionScaleInfo) { scaleInfos <- info }).Times(2)
+
+	initial := &persistencespb.PartitionScaleState{
+		Target:             0,
+		MaxTarget:          4,
+		BacklogState:       bitSet(nil).set(0).set(1).set(2).set(3),
+		BacklogCounts:      []byte{1, 2, 3, 4},
+		BacklogCap:         5,
+		PrivateScalerState: priv,
+	}
+	s.startManager(4, initial)
+	s.sm.AddedTasks(3)
+
+	state := waitRecv(s, dbWrites, "disabled state was not cleaned up")
+	s.Zero(state.Target)
+	s.Equal(int32(4), state.MaxTarget)
+	s.Empty(state.BacklogState)
+	s.Empty(state.BacklogCounts)
+	s.Zero(state.BacklogCap)
+	s.Nil(state.PrivateScalerState)
+
+	stale := waitRecv(s, scaleInfos, "initial scale info was not pushed")
+	s.Equal(int32(4), stale.Read)
+	s.Equal(int32(3), stale.Write)
+	disabled := waitRecv(s, scaleInfos, "disabled scale info was not pushed")
+	s.Zero(disabled.Read)
+	s.Zero(disabled.Write)
+	s.Empty(disabled.BacklogCounts)
+	s.Zero(disabled.BacklogCap)
+}
+
 // TestEmitsGaugeMetrics verifies that when gauge emission is enabled, a scale
 // decision records the read, write, and target gauges with the expected values.
 func (s *ScaleManagerSuite) TestEmitsGaugeMetrics() {


### PR DESCRIPTION
Clear scaleInfo when scaler is disabled

Not clearing scaleInfo meant that clients were still reading and writing based on scaleInfo.Read and scaleInfo.Write, even though target was cleared.

We want disabling the scaler to be a clean and complete break back to the mode of dynamic-config hard-coded partition counts.

- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task-queue partition routing when managed scaling is turned off; mis-cleanup could affect poll/add distribution until state converges, but behavior is covered by a new unit test.
> 
> **Overview**
> **Disabling managed partition scaling now fully clears persisted and ephemeral scale state** so clients stop routing on stale `PartitionScaleInfo` and revert to dynamic-config partition counts.
> 
> When the scaler returns `NewTarget == 0`, `scale_manager` wipes `BacklogState`, `BacklogCounts`, `BacklogCap`, and private scaler state, pushes zeroed scale info to user data, and still runs cleanup if target was already 0 but leftover managed fields remained. Scale-up backlog-bit seeding is limited to **`prevTarget == 0 && target > 0`** so disable does not treat all dynamic-config partitions as backlogged. Interface docs require **`BacklogCap == 0`** when disabling.
> 
> The matching load balancer uses **`pc.Valid()`** (both read and write &gt; 0) instead of checking write or read alone, so partially cleared or disabled scale info does not override dynamic config. A unit test covers the disable-and-cleanup path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e1e0a428deb9647b7c5c38fd1a30f7e49f10484. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->