### PR TITLE
Fix visibility filter query corruption when string values contain '?'

### DIFF
--- a/common/persistence/visibility/store/sql/query_converter.go
+++ b/common/persistence/visibility/store/sql/query_converter.go
@@ -31,6 +31,10 @@ var (
 		"\r", "\\r",
 		"\t", "\\t",
 		"\\", "\\\\",
+		// Escape literal '?' in string values so sqlx.Rebind (which
+		// replaces bare '?' with PostgreSQL $N placeholders) does not
+		// corrupt user-provided filter values containing '?'.
+		"?", "??",
 	}
 
 	defaultLikeEscapeExpr = query.NewUnsafeSQLString(string(defaultLikeEscapeChar))


### PR DESCRIPTION
Fixes #11797

## What

Added ? → ?? to the escapeCharMap in query_converter.go. Without this, user-provided filter values containing ? were inlined into the raw SQL as string literals (via unsafeSQLString), and sqlx.Rebind replaced every ? character — including those inside string literals — with PostgreSQL dollar-N placeholders, corrupting the query and causing 'could not determine data type of parameter' errors.

## Why

escapeCharMap already escaped quotes, backslashes, and control characters, but not ?. sqlx's PostgreSQL Rebind treats bare ? as a placeholder position marker. ?? is the sqlx-standard escape for a literal ? and is left unchanged by Rebind.

## How tested

Manual verification: ? in a filter value now survives Rebind as a literal ? inside the string literal, and the query executes without placeholder errors.

Signed-off-by: simpleqt <89645338+simpleqt@users.noreply.github.com>