### PR TITLE
Fix CI on release/v1.30.x

### DIFF
--- a/.github/workflows/features-integration.yml
+++ b/.github/workflows/features-integration.yml
@@ -74,6 +74,14 @@ jobs:
       version: __latest_features_docker_image__
       version-is-repo-ref: false
       docker-image-artifact-name: temporal-server-docker
+      # These jobs run temporalio/features@main, whose nexus/sync_success test
+      # needs worker-target Nexus callbacks to use temporal://system. Server
+      # main does that unconditionally; on 1.30.x it is off by default and the
+      # callback URL template it falls back to is never set.
+      dynamic-config-values: |
+        component.nexusoperations.useSystemCallbackURL:
+          - value: true
+            constraints: {}
 
   feature-tests-go:
     needs: build-docker-image
@@ -82,6 +90,14 @@ jobs:
       version: __latest_features_docker_image__
       version-is-repo-ref: false
       docker-image-artifact-name: temporal-server-docker
+      # These jobs run temporalio/features@main, whose nexus/sync_success test
+      # needs worker-target Nexus callbacks to use temporal://system. Server
+      # main does that unconditionally; on 1.30.x it is off by default and the
+      # callback URL template it falls back to is never set.
+      dynamic-config-values: |
+        component.nexusoperations.useSystemCallbackURL:
+          - value: true
+            constraints: {}
 
   feature-tests-python:
     needs: build-docker-image
@@ -90,6 +106,14 @@ jobs:
       version: __latest_features_docker_image__
       version-is-repo-ref: false
       docker-image-artifact-name: temporal-server-docker
+      # These jobs run temporalio/features@main, whose nexus/sync_success test
+      # needs worker-target Nexus callbacks to use temporal://system. Server
+      # main does that unconditionally; on 1.30.x it is off by default and the
+      # callback URL template it falls back to is never set.
+      dynamic-config-values: |
+        component.nexusoperations.useSystemCallbackURL:
+          - value: true
+            constraints: {}
 
   feature-tests-java:
     needs: build-docker-image
@@ -98,6 +122,14 @@ jobs:
       version: __latest_features_docker_image__
       version-is-repo-ref: false
       docker-image-artifact-name: temporal-server-docker
+      # These jobs run temporalio/features@main, whose nexus/sync_success test
+      # needs worker-target Nexus callbacks to use temporal://system. Server
+      # main does that unconditionally; on 1.30.x it is off by default and the
+      # callback URL template it falls back to is never set.
+      dynamic-config-values: |
+        component.nexusoperations.useSystemCallbackURL:
+          - value: true
+            constraints: {}
 
   feature-tests-dotnet:
     needs: build-docker-image
@@ -106,6 +138,14 @@ jobs:
       version: __latest_features_docker_image__
       version-is-repo-ref: false
       docker-image-artifact-name: temporal-server-docker
+      # These jobs run temporalio/features@main, whose nexus/sync_success test
+      # needs worker-target Nexus callbacks to use temporal://system. Server
+      # main does that unconditionally; on 1.30.x it is off by default and the
+      # callback URL template it falls back to is never set.
+      dynamic-config-values: |
+        component.nexusoperations.useSystemCallbackURL:
+          - value: true
+            constraints: {}
 
   feature-tests-status:
     name: Tests Status

--- a/tests/chasm_test.go
+++ b/tests/chasm_test.go
@@ -405,7 +405,7 @@ func (s *ChasmTestSuite) TestCountExecutions_GroupBy() {
 					Query:         "GROUP BY `PayloadExecutionStatus`",
 				},
 			)
-			return err == nil && countResp != nil && countResp.Count > 0
+			return err == nil && countResp != nil && countResp.Count >= 5
 		},
 		testcore.WaitForESToSettle,
 		100*time.Millisecond,

--- a/tests/xdc/base.go
+++ b/tests/xdc/base.go
@@ -477,3 +477,20 @@ func (s *xdcBaseSuite) newClientAndWorker(hostport, ns, taskqueue, identity stri
 
 	return sdkClient, worker
 }
+
+// waitForVisibilityCount waits for the visibility store to index the expected number of workflow
+// executions in the given namespace before proceeding. This is important before starting
+// force-replication, which uses ListWorkflowExecutions with an empty query to discover all
+// workflows in a namespace.
+func (s *xdcBaseSuite) waitForVisibilityCount(ctx context.Context, ns string, expectedCount int64) {
+	frontendClient := s.clusters[0].FrontendClient()
+	s.Eventually(func() bool {
+		countResp, err := frontendClient.CountWorkflowExecutions(ctx, &workflowservice.CountWorkflowExecutionsRequest{
+			Namespace: ns,
+		})
+		if err != nil {
+			return false
+		}
+		return countResp.GetCount() == expectedCount
+	}, 15*time.Second, 200*time.Millisecond, "visibility should index %d workflow runs before force-replication", expectedCount)
+}

--- a/tests/xdc/failover_test.go
+++ b/tests/xdc/failover_test.go
@@ -2337,6 +2337,9 @@ func (s *FunctionalClustersTestSuite) TestLocalNamespaceMigration() {
 	err = run3.Get(testCtx, nil)
 	s.NoError(err)
 
+	// Wait for all 6 workflow runs (wf1, wf2, wf3, wf6, wf7, wf8) to be indexed before force-replication.
+	s.waitForVisibilityCount(testCtx, namespace, 6)
+
 	// start force-replicate wf
 	sysClient, err := sdkclient.Dial(sdkclient.Options{
 		HostPort:  s.clusters[0].Host().FrontendGRPCAddress(),
@@ -2480,6 +2483,9 @@ func (s *FunctionalClustersTestSuite) TestForceMigration_ClosedWorkflow() {
 	// Update ns to have 2 clusters
 	s.updateNamespaceClusters(namespace, 0, s.clusters)
 
+	// Wait for wf1 to be indexed before force-replication.
+	s.waitForVisibilityCount(testCtx, namespace, 1)
+
 	// Start force-replicate wf
 	sysClient, err := sdkclient.Dial(sdkclient.Options{
 		HostPort:  s.clusters[0].Host().FrontendGRPCAddress(),
@@ -2589,20 +2595,8 @@ func (s *FunctionalClustersTestSuite) TestForceMigration_ResetWorkflow() {
 	// Update ns to have 2 clusters
 	s.updateNamespaceClusters(namespace, 0, s.clusters)
 
-	// Wait for visibility to index both workflow runs before starting force-replication.
-	// Force-replication uses ListWorkflowExecutions with an empty query (all workflows in namespace),
-	// so we use the same empty query here to match exactly what force-replication will see.
-	frontendClient0 := s.clusters[0].FrontendClient()
-	s.Eventually(func() bool {
-		countResp, err := frontendClient0.CountWorkflowExecutions(testCtx, &workflowservice.CountWorkflowExecutionsRequest{
-			Namespace: namespace,
-		})
-		if err != nil {
-			return false
-		}
-		// Expect exactly 2 runs: original run + reset run
-		return countResp.GetCount() == 2
-	}, 15*time.Second, 200*time.Millisecond, "visibility should index both workflow runs before force-replication")
+	// Wait for both workflow runs (original + reset) to be indexed before force-replication.
+	s.waitForVisibilityCount(testCtx, namespace, 2)
 
 	// Start force-replicate wf
 	sysClient, err := sdkclient.Dial(sdkclient.Options{

--- a/tests/xdc/failover_test.go
+++ b/tests/xdc/failover_test.go
@@ -2589,6 +2589,21 @@ func (s *FunctionalClustersTestSuite) TestForceMigration_ResetWorkflow() {
 	// Update ns to have 2 clusters
 	s.updateNamespaceClusters(namespace, 0, s.clusters)
 
+	// Wait for visibility to index both workflow runs before starting force-replication.
+	// Force-replication uses ListWorkflowExecutions with an empty query (all workflows in namespace),
+	// so we use the same empty query here to match exactly what force-replication will see.
+	frontendClient0 := s.clusters[0].FrontendClient()
+	s.Eventually(func() bool {
+		countResp, err := frontendClient0.CountWorkflowExecutions(testCtx, &workflowservice.CountWorkflowExecutionsRequest{
+			Namespace: namespace,
+		})
+		if err != nil {
+			return false
+		}
+		// Expect exactly 2 runs: original run + reset run
+		return countResp.GetCount() == 2
+	}, 15*time.Second, 200*time.Millisecond, "visibility should index both workflow runs before force-replication")
+
 	// Start force-replicate wf
 	sysClient, err := sdkclient.Dial(sdkclient.Options{
 		HostPort:  s.clusters[0].Host().FrontendGRPCAddress(),
@@ -2609,6 +2624,40 @@ func (s *FunctionalClustersTestSuite) TestForceMigration_ResetWorkflow() {
 	s.NoError(err)
 	err = sysWfRun.Get(testCtx, nil)
 	s.NoError(err)
+
+	// Verify the force-replication workflow actually ran VerifyReplicationTasks activities
+	// and that they verified exactly the expected number of workflow runs.
+	var totalVerifiedCount int64
+	scheduledActivityTypes := make(map[int64]string) // scheduledEventId -> activity type name
+	histIter := sysClient.GetWorkflowHistory(testCtx, forceReplicationWorkflowID, sysWfRun.GetRunID(),
+		false, enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
+	for histIter.HasNext() {
+		event, err := histIter.Next()
+		s.NoError(err)
+		switch event.GetEventType() {
+		case enumspb.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED:
+			attrs := event.GetActivityTaskScheduledEventAttributes()
+			scheduledActivityTypes[event.GetEventId()] = attrs.GetActivityType().GetName()
+		case enumspb.EVENT_TYPE_ACTIVITY_TASK_COMPLETED:
+			attrs := event.GetActivityTaskCompletedEventAttributes()
+			activityType := scheduledActivityTypes[attrs.GetScheduledEventId()]
+			if activityType != "VerifyReplicationTasks" {
+				continue
+			}
+			result := attrs.GetResult()
+			if result != nil && len(result.GetPayloads()) > 0 {
+				var resp struct {
+					VerifiedWorkflowCount int64
+				}
+				s.NoError(payloads.Decode(result, &resp))
+				totalVerifiedCount += resp.VerifiedWorkflowCount
+			}
+		default:
+		}
+	}
+	// Expect exactly 2 verified workflow runs: original run + reset run
+	s.Equal(int64(2), totalVerifiedCount,
+		"force-replication should have verified exactly 2 workflow runs (original + reset run)")
 
 	s.waitForClusterSynced()
 

--- a/tests/xdc/failover_test.go
+++ b/tests/xdc/failover_test.go
@@ -2510,10 +2510,14 @@ func (s *FunctionalClustersTestSuite) TestForceMigration_ClosedWorkflow() {
 	// Verify all wf in ns is now available in cluster2
 	client1, worker1 := s.newClientAndWorker(s.clusters[1].Host().FrontendGRPCAddress(), namespace, taskqueue, "worker1")
 	verify := func(wfID string, expectedRunID string) {
-		desc1, err := client1.DescribeWorkflowExecution(testCtx, wfID, "")
-		s.NoError(err)
-		s.Equal(expectedRunID, desc1.WorkflowExecutionInfo.Execution.RunId)
-		s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, desc1.WorkflowExecutionInfo.Status)
+		s.Eventually(func() bool {
+			desc1, err := client1.DescribeWorkflowExecution(testCtx, wfID, "")
+			if err != nil {
+				return false
+			}
+			return desc1.WorkflowExecutionInfo.Execution.RunId == expectedRunID &&
+				desc1.WorkflowExecutionInfo.Status == enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED
+		}, 15*time.Second, 200*time.Millisecond, "workflow %s should be replicated to cluster2", wfID)
 	}
 	verify(workflowID, run1.GetRunID())
 
@@ -2540,9 +2544,13 @@ func (s *FunctionalClustersTestSuite) TestForceMigration_ClosedWorkflow() {
 	err = resetRun.Get(testCtx, nil)
 	s.NoError(err)
 
-	descResp, err := client1.DescribeWorkflowExecution(testCtx, workflowID, resetResp.GetRunId())
-	s.NoError(err)
-	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, descResp.GetWorkflowExecutionInfo().Status)
+	s.Eventually(func() bool {
+		descResp, err := client1.DescribeWorkflowExecution(testCtx, workflowID, resetResp.GetRunId())
+		if err != nil {
+			return false
+		}
+		return descResp.GetWorkflowExecutionInfo().Status == enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED
+	}, 15*time.Second, 200*time.Millisecond, "reset workflow should be visible on cluster2")
 }
 
 func (s *FunctionalClustersTestSuite) TestForceMigration_ResetWorkflow() {

--- a/tests/xdc/failover_test.go
+++ b/tests/xdc/failover_test.go
@@ -2349,8 +2349,10 @@ func (s *FunctionalClustersTestSuite) TestLocalNamespaceMigration() {
 		TaskQueue:          primitives.DefaultWorkerTaskQueue,
 		WorkflowRunTimeout: time.Second * 30,
 	}, "force-replication", migration.ForceReplicationParams{
-		Namespace:  namespace,
-		OverallRps: 10,
+		Namespace:          namespace,
+		OverallRps:         10,
+		EnableVerification: true,
+		TargetClusterName:  s.clusters[1].ClusterName(),
 	})
 
 	s.NoError(err)
@@ -2490,8 +2492,10 @@ func (s *FunctionalClustersTestSuite) TestForceMigration_ClosedWorkflow() {
 		TaskQueue:          primitives.DefaultWorkerTaskQueue,
 		WorkflowRunTimeout: time.Second * 30,
 	}, "force-replication", migration.ForceReplicationParams{
-		Namespace:  namespace,
-		OverallRps: 10,
+		Namespace:          namespace,
+		OverallRps:         10,
+		EnableVerification: true,
+		TargetClusterName:  s.clusters[1].ClusterName(),
 	})
 	s.NoError(err)
 	err = sysWfRun.Get(testCtx, nil)
@@ -2597,8 +2601,10 @@ func (s *FunctionalClustersTestSuite) TestForceMigration_ResetWorkflow() {
 		TaskQueue:          primitives.DefaultWorkerTaskQueue,
 		WorkflowRunTimeout: time.Second * 30,
 	}, "force-replication", migration.ForceReplicationParams{
-		Namespace:  namespace,
-		OverallRps: 10,
+		Namespace:          namespace,
+		OverallRps:         10,
+		EnableVerification: true,
+		TargetClusterName:  s.clusters[1].ClusterName(),
 	})
 	s.NoError(err)
 	err = sysWfRun.Get(testCtx, nil)

--- a/tests/xdc/nexus_state_replication_test.go
+++ b/tests/xdc/nexus_state_replication_test.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/nexus-rpc/sdk-go/nexus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	commandpb "go.temporal.io/api/command/v1"
 	commonpb "go.temporal.io/api/common/v1"
@@ -72,6 +74,13 @@ func (s *NexusStateReplicationSuite) SetupSuite() {
 		callbacks.AllowedAddresses.Key(): []any{map[string]any{
 			"Pattern": "*", "AllowInsecure": true,
 		}},
+		// Cap callback retry backoff to avoid long waits after failover.
+		callbacks.RetryPolicyMaximumInterval.Key(): 1 * time.Second,
+		// Set a short circuit breaker timeout so it recovers quickly from bursts of failures.
+		dynamicconfig.OutboundQueueCircuitBreakerSettings.Key(): dynamicconfig.CircuitBreakerSettings{
+			MaxRequests: 1,
+			Timeout:     1 * time.Second,
+		},
 	}
 	s.setupSuite()
 }
@@ -706,11 +715,11 @@ func (s *NexusStateReplicationSuite) waitCallback(
 	execution *commonpb.WorkflowExecution,
 	condition func(callback *workflowpb.CallbackInfo) bool,
 ) {
-	s.Eventually(func() bool {
+	s.EventuallyWithT(func(t *assert.CollectT) {
 		descResp, err := sdkClient.DescribeWorkflowExecution(ctx, execution.WorkflowId, execution.RunId)
-		s.NoError(err)
-		s.Len(descResp.GetCallbacks(), 1)
-		return condition(descResp.GetCallbacks()[0])
+		require.NoError(t, err)
+		require.Len(t, descResp.GetCallbacks(), 1)
+		require.True(t, condition(descResp.GetCallbacks()[0]))
 	}, time.Second*20, time.Millisecond*100)
 }
 


### PR DESCRIPTION
## What changed?
Fix CI on this branch. Sets `component.nexusoperations.useSystemCallbackURL` for
the features jobs, and cherry-picks six test-only fixes that landed on main
after the branch was cut: #9003, #9489, #9496, #9514, #9541, #9587.

## Why?
Three unrelated failures, all from the branch running tests written against
newer server defaults:

- `nexus/sync_success` — the features jobs track `temporalio/features@main`.
  The test needs worker-target callbacks to use `temporal://system`, which
  1.30.x gates behind a setting defaulting to false, so it falls back to a
  callback URL template nothing sets.
- `TestCountExecutions_GroupBy` — waits for any non-zero count, then asserts 5.
- xdc `TestNexusCallbackReplicated` and `TestForceMigration_{Closed,Reset}Workflow`
  — assert before replication and visibility have caught up.

## How did you test it?
- [x] covered by existing tests

Test and CI scope only; no server code. Features Integration is green with the
config override. `TestCountExecutions_GroupBy` verified locally: fails
repeatedly at `-count=8` before, passes 8/8 after. The xdc fixes make both
`TestForceMigration_*` byte-identical to main; CI on this PR is the real check.

## Potential risks
None to the shipped binary — the code default stays false, which mixed-version
deployments with 1.29 need.