### PR TITLE
Trim external signal tasks when workflow closes

### DIFF
--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -8336,6 +8336,7 @@ func (ms *MutableStateImpl) closeTransactionPrepareTasks(
 	}
 
 	ms.closeTransactionCollapseVisibilityTasks()
+	ms.closeTransactionTrimTasksForClosedWorkflow()
 
 	if err := ms.closeTransactionGenerateChasmRetentionTask(transactionPolicy); err != nil {
 		return err
@@ -9112,6 +9113,27 @@ func (ms *MutableStateImpl) closeTransactionCollapseVisibilityTasks() {
 		}
 	}
 	ms.InsertTasks[tasks.CategoryVisibility] = collapsedVisTasks
+}
+
+func (ms *MutableStateImpl) closeTransactionTrimTasksForClosedWorkflow() {
+	if ms.IsWorkflowExecutionRunning() {
+		return
+	}
+
+	// External signals are abandoned when the source workflow closes. Avoid persisting
+	// tasks that the active and standby executors would immediately discard.
+	transferTasks := slices.DeleteFunc(
+		ms.InsertTasks[tasks.CategoryTransfer],
+		func(task tasks.Task) bool {
+			_, isSignalExecutionTask := task.(*tasks.SignalExecutionTask)
+			return isSignalExecutionTask
+		},
+	)
+	if len(transferTasks) == 0 {
+		delete(ms.InsertTasks, tasks.CategoryTransfer)
+		return
+	}
+	ms.InsertTasks[tasks.CategoryTransfer] = transferTasks
 }
 
 func (ms *MutableStateImpl) generateReplicationTask() bool {

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -4448,6 +4448,23 @@ func (s *mutableStateSuite) TestCollapseVisibilityTasks() {
 	}
 }
 
+func (s *mutableStateSuite) TestCloseTransactionTrimTasksForClosedWorkflow() {
+	signalTask := &tasks.SignalExecutionTask{}
+	closeTask := &tasks.CloseExecutionTask{}
+
+	s.mutableState.InsertTasks[tasks.CategoryTransfer] = []tasks.Task{signalTask, closeTask}
+	s.mutableState.closeTransactionTrimTasksForClosedWorkflow()
+	s.Equal([]tasks.Task{signalTask, closeTask}, s.mutableState.InsertTasks[tasks.CategoryTransfer])
+
+	s.mutableState.executionState.State = enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED
+	s.mutableState.closeTransactionTrimTasksForClosedWorkflow()
+	s.Equal([]tasks.Task{closeTask}, s.mutableState.InsertTasks[tasks.CategoryTransfer])
+
+	s.mutableState.InsertTasks[tasks.CategoryTransfer] = []tasks.Task{signalTask}
+	s.mutableState.closeTransactionTrimTasksForClosedWorkflow()
+	s.NotContains(s.mutableState.InsertTasks, tasks.CategoryTransfer)
+}
+
 func (s *mutableStateSuite) TestStartChildWorkflowRequestID() {
 	workflowTaskCompletionEventID := rand.Int63()
 	attributes := &commandpb.StartChildWorkflowExecutionCommandAttributes{}


### PR DESCRIPTION
## Summary

- trim newly generated external signal transfer tasks when the source workflow closes in the same transaction
- preserve all other transfer tasks
- avoid persisting work that both active and standby executors discard for closed workflows

## Testing

- go test ./service/history/workflow -run TestMutableStateSuite/.*/TestCloseTransactionTrimTasksForClosedWorkflow -count=1