### PR TITLE
Cloud/v1.32.0-163: Fix branch-token pagination

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1757,6 +1757,12 @@ execution.`,
 		`EnablePaginationTokenBranchValidationShadowMode logs and emits metrics for a page token whose
 branch token is not the execution's current one, but still serves the read.`,
 	)
+	EnablePaginationTokenBranchReplacement = NewGlobalBoolSetting(
+		"history.enablePaginationTokenBranchReplacement",
+		true,
+		`EnablePaginationTokenBranchReplacement, when pagination-token branch validation is enforced,
+replaces a page token's branch token when it identifies the current branch but has different metadata.`,
+	)
 
 	EnableReplicationStream = NewGlobalBoolSetting(
 		"history.enableReplicationStream",

--- a/service/history/api/getworkflowexecutionhistory/api.go
+++ b/service/history/api/getworkflowexecutionhistory/api.go
@@ -257,7 +257,7 @@ func Invoke(
 			continuationToken.NextEventId = nextEventID
 			continuationToken.IsWorkflowRunning = isWorkflowRunning
 		} else {
-			if err = api.ValidateBranchTokenForExecution(
+			if continuationToken.BranchToken, err = api.ValidateBranchTokenForExecution(
 				ctx,
 				shardContext,
 				workflowConsistencyChecker,

--- a/service/history/api/getworkflowexecutionhistoryreverse/api.go
+++ b/service/history/api/getworkflowexecutionhistoryreverse/api.go
@@ -108,7 +108,7 @@ func Invoke(
 		if entry, err := shardContext.GetNamespaceRegistry().GetNamespaceByID(namespaceID); err == nil {
 			namespaceName = entry.Name()
 		}
-		if err = api.ValidateBranchTokenForExecution(
+		continuationToken.BranchToken, err = api.ValidateBranchTokenForExecution(
 			ctx,
 			shardContext,
 			workflowConsistencyChecker,
@@ -117,7 +117,8 @@ func Invoke(
 			namespaceID,
 			execution,
 			continuationToken.BranchToken,
-		); err != nil {
+		)
+		if err != nil {
 			return nil, err
 		}
 	}

--- a/service/history/api/token.go
+++ b/service/history/api/token.go
@@ -5,13 +5,13 @@ import (
 	"context"
 
 	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/api/serviceerror"
 	historyspb "go.temporal.io/server/api/history/v1"
 	"go.temporal.io/server/api/historyservice/v1"
 	tokenspb "go.temporal.io/server/api/token/v1"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
-	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/events"
 	historyi "go.temporal.io/server/service/history/interfaces"
@@ -234,10 +234,5 @@ func ValidateBranchTokenForExecution(
 	if config.EnablePaginationTokenBranchValidationShadowMode() {
 		return nil
 	}
-	return serviceerrors.NewCurrentBranchChanged(
-		currentBranchToken,
-		requestBranchToken,
-		nil,
-		nil,
-	)
+	return serviceerror.NewInvalidArgument("request branchToken is not current.")
 }

--- a/service/history/api/token.go
+++ b/service/history/api/token.go
@@ -12,6 +12,7 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/events"
 	historyi "go.temporal.io/server/service/history/interfaces"
@@ -129,14 +130,16 @@ func ValidatePaginationToken(
 
 const (
 	// branchTokenMismatchReasonNonCurrent is a branch this execution records but no longer reads from.
-	branchTokenMismatchReasonNonCurrent metrics.ReasonString = "non_current_branch"
-	branchTokenMismatchReasonForeign    metrics.ReasonString = "foreign_branch"
+	branchTokenMismatchReasonNonCurrent         metrics.ReasonString = "non_current_branch"
+	branchTokenMismatchReasonSameBranchMetadata metrics.ReasonString = "same_branch_metadata_mismatch"
+	branchTokenMismatchReasonForeign            metrics.ReasonString = "foreign_branch"
 )
 
 // maxLoggedBranchTokenLen bounds caller-supplied bytes reaching the log.
 const maxLoggedBranchTokenLen = 4096
 
 func branchTokenMismatchReason(
+	branchUtil persistence.HistoryBranchUtil,
 	currentBranchToken []byte,
 	requestBranchToken []byte,
 	versionHistories *historyspb.VersionHistories,
@@ -144,12 +147,27 @@ func branchTokenMismatchReason(
 	if bytes.Equal(requestBranchToken, currentBranchToken) {
 		return ""
 	}
+	if branchTokensReferToSameBranch(branchUtil, currentBranchToken, requestBranchToken) {
+		return branchTokenMismatchReasonSameBranchMetadata
+	}
 	for _, versionHistory := range versionHistories.GetHistories() {
 		if bytes.Equal(versionHistory.GetBranchToken(), requestBranchToken) {
 			return branchTokenMismatchReasonNonCurrent
 		}
 	}
 	return branchTokenMismatchReasonForeign
+}
+
+func branchTokensReferToSameBranch(
+	branchUtil persistence.HistoryBranchUtil,
+	currentBranchToken []byte,
+	requestBranchToken []byte,
+) bool {
+	currentBranch, currentErr := branchUtil.ParseHistoryBranchInfo(currentBranchToken)
+	requestBranch, requestErr := branchUtil.ParseHistoryBranchInfo(requestBranchToken)
+	return currentErr == nil && requestErr == nil &&
+		currentBranch.GetTreeId() == requestBranch.GetTreeId() &&
+		currentBranch.GetBranchId() == requestBranch.GetBranchId()
 }
 
 func reportBranchTokenMismatch(
@@ -179,8 +197,8 @@ func reportBranchTokenMismatch(
 	)
 }
 
-// ValidateBranchTokenForExecution rejects a paging branch token that is not the execution's current
-// one.
+// ValidateBranchTokenForExecution replaces stale metadata for the current branch and rejects tokens
+// that refer to a different branch.
 func ValidateBranchTokenForExecution(
 	ctx context.Context,
 	shardContext historyi.ShardContext,
@@ -190,14 +208,15 @@ func ValidateBranchTokenForExecution(
 	namespaceID namespace.ID,
 	execution *commonpb.WorkflowExecution,
 	requestBranchToken []byte,
-) error {
+) ([]byte, error) {
 	config := shardContext.GetConfig()
 	if !config.EnablePaginationTokenBranchValidation() {
-		return nil
+		return requestBranchToken, nil
 	}
 	if len(requestBranchToken) == 0 {
-		return consts.ErrInvalidNextPageToken
+		return nil, consts.ErrInvalidNextPageToken
 	}
+	shadowMode := config.EnablePaginationTokenBranchValidationShadowMode()
 
 	response, err := GetOrPollWorkflowMutableState(
 		ctx,
@@ -210,17 +229,18 @@ func ValidateBranchTokenForExecution(
 		eventNotifier,
 	)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	currentBranchToken := response.GetCurrentBranchToken()
 	mismatchReason := branchTokenMismatchReason(
+		shardContext.GetExecutionManager().GetHistoryBranchUtil(),
 		currentBranchToken,
 		requestBranchToken,
 		response.GetVersionHistories(),
 	)
 	if mismatchReason == "" {
-		return nil
+		return currentBranchToken, nil
 	}
 
 	reportBranchTokenMismatch(
@@ -231,8 +251,12 @@ func ValidateBranchTokenForExecution(
 		currentBranchToken,
 		requestBranchToken,
 	)
-	if config.EnablePaginationTokenBranchValidationShadowMode() {
-		return nil
+	if shadowMode {
+		return requestBranchToken, nil
 	}
-	return serviceerror.NewInvalidArgument("request branchToken is not current.")
+	if mismatchReason == branchTokenMismatchReasonSameBranchMetadata &&
+		config.EnablePaginationTokenBranchReplacement() {
+		return currentBranchToken, nil
+	}
+	return nil, serviceerror.NewInvalidArgument("request branchToken is not current.")
 }

--- a/service/history/api/token_test.go
+++ b/service/history/api/token_test.go
@@ -44,6 +44,7 @@ func testVersionHistories(tokens ...[]byte) *historyspb.VersionHistories {
 }
 
 func TestBranchTokenMismatchReason(t *testing.T) {
+	branchUtil := persistence.NewHistoryBranchUtil(serialization.NewSerializer())
 	treeID := primitives.NewUUID().String()
 	branchID := primitives.NewUUID().String()
 	otherTreeID := primitives.NewUUID().String()
@@ -53,45 +54,75 @@ func TestBranchTokenMismatchReason(t *testing.T) {
 	nonCurrent := newTestBranchToken(t, otherTreeID, otherBranchID, nil)
 
 	t.Run("matches the current branch token", func(t *testing.T) {
-		got := branchTokenMismatchReason(current, current, testVersionHistories(current))
+		got := branchTokenMismatchReason(branchUtil, current, current, testVersionHistories(current))
 		require.Empty(t, got)
 	})
 
 	t.Run("matches the current token when an identical token is recorded twice", func(t *testing.T) {
-		got := branchTokenMismatchReason(current, current, testVersionHistories(current, current))
+		got := branchTokenMismatchReason(branchUtil, current, current, testVersionHistories(current, current))
 		require.Empty(t, got)
 	})
 
 	t.Run("matches opaque tokens the branch parser cannot read", func(t *testing.T) {
 		opaque := []byte{1, 2, 3}
-		got := branchTokenMismatchReason(opaque, opaque, testVersionHistories(opaque))
+		got := branchTokenMismatchReason(branchUtil, opaque, opaque, testVersionHistories(opaque))
 		require.Empty(t, got)
 	})
 
 	t.Run("reports a non-current branch when the token names an older history", func(t *testing.T) {
 		histories := testVersionHistories(nonCurrent, current)
-		got := branchTokenMismatchReason(current, nonCurrent, histories)
+		got := branchTokenMismatchReason(branchUtil, current, nonCurrent, histories)
 		require.Equal(t, branchTokenMismatchReasonNonCurrent, got)
 	})
 
 	t.Run("reports foreign for a different branch in the same tree", func(t *testing.T) {
 		request := newTestBranchToken(t, treeID, otherBranchID, nil)
-		got := branchTokenMismatchReason(current, request, testVersionHistories(current))
+		got := branchTokenMismatchReason(branchUtil, current, request, testVersionHistories(current))
 		require.Equal(t, branchTokenMismatchReasonForeign, got)
 	})
 
-	t.Run("reports foreign for the current branch carrying injected ancestors", func(t *testing.T) {
+	t.Run("reports same branch for changed metadata", func(t *testing.T) {
 		request := newTestBranchToken(t, treeID, branchID, []*persistencespb.HistoryBranchRange{
 			{BranchId: otherBranchID, BeginNodeId: 1, EndNodeId: 1000},
 		})
-		got := branchTokenMismatchReason(current, request, testVersionHistories(current))
-		require.Equal(t, branchTokenMismatchReasonForeign, got)
+		got := branchTokenMismatchReason(branchUtil, current, request, testVersionHistories(current))
+		require.Equal(t, branchTokenMismatchReasonSameBranchMetadata, got)
 	})
 
 	t.Run("reports foreign when there are no version histories", func(t *testing.T) {
-		got := branchTokenMismatchReason(current, nonCurrent, nil)
+		got := branchTokenMismatchReason(branchUtil, current, nonCurrent, nil)
 		require.Equal(t, branchTokenMismatchReasonForeign, got)
 	})
+}
+
+func TestBranchTokensReferToSameBranch(t *testing.T) {
+	branchUtil := persistence.NewHistoryBranchUtil(serialization.NewSerializer())
+	treeID := primitives.NewUUID().String()
+	branchID := primitives.NewUUID().String()
+	otherTreeID := primitives.NewUUID().String()
+	otherBranchID := primitives.NewUUID().String()
+	current := newTestBranchToken(t, treeID, branchID, nil)
+
+	for _, tc := range []struct {
+		name    string
+		request []byte
+		want    bool
+	}{
+		{
+			name: "same tree and branch with different metadata",
+			request: newTestBranchToken(t, treeID, branchID, []*persistencespb.HistoryBranchRange{
+				{BranchId: otherBranchID, BeginNodeId: 1, EndNodeId: 10},
+			}),
+			want: true,
+		},
+		{name: "different tree", request: newTestBranchToken(t, otherTreeID, branchID, nil)},
+		{name: "different branch", request: newTestBranchToken(t, treeID, otherBranchID, nil)},
+		{name: "malformed request token", request: []byte{1, 2, 3}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, branchTokensReferToSameBranch(branchUtil, current, tc.request))
+		})
+	}
 }
 
 func TestValidateBranchTokenForExecution_EmptyRequestToken(t *testing.T) {
@@ -109,7 +140,7 @@ func TestValidateBranchTokenForExecution_EmptyRequestToken(t *testing.T) {
 				EnablePaginationTokenBranchValidation: dynamicconfig.GetBoolPropertyFn(tc.validation),
 			}).AnyTimes()
 
-			err := ValidateBranchTokenForExecution(
+			_, err := ValidateBranchTokenForExecution(
 				context.Background(), shardContext, nil, nil, "", "", nil, nil)
 			require.ErrorIs(t, err, tc.wantErr)
 		})

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -432,6 +432,7 @@ type Config struct {
 
 	EnablePaginationTokenBranchValidation           dynamicconfig.BoolPropertyFn
 	EnablePaginationTokenBranchValidationShadowMode dynamicconfig.BoolPropertyFn
+	EnablePaginationTokenBranchReplacement          dynamicconfig.BoolPropertyFn
 
 	WorkflowIdReuseMinimalInterval           dynamicconfig.DurationPropertyFnWithNamespaceFilter
 	EnableWorkflowIdReuseStartTimeValidation dynamicconfig.BoolPropertyFnWithNamespaceFilter
@@ -848,6 +849,7 @@ func NewConfig(
 
 		EnablePaginationTokenBranchValidation:           dynamicconfig.EnablePaginationTokenBranchValidation.Get(dc),
 		EnablePaginationTokenBranchValidationShadowMode: dynamicconfig.EnablePaginationTokenBranchValidationShadowMode.Get(dc),
+		EnablePaginationTokenBranchReplacement:          dynamicconfig.EnablePaginationTokenBranchReplacement.Get(dc),
 
 		WorkflowIdReuseMinimalInterval:           dynamicconfig.WorkflowIdReuseMinimalInterval.Get(dc),
 		EnableWorkflowIdReuseStartTimeValidation: dynamicconfig.EnableWorkflowIdReuseStartTimeValidation.Get(dc),

--- a/service/history/history_engine_test.go
+++ b/service/history/history_engine_test.go
@@ -56,7 +56,6 @@ import (
 	"go.temporal.io/server/common/rpc/interceptor"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/searchattribute/sadefs"
-	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/common/tasktoken"
 	"go.temporal.io/server/common/testing/protorequire"
 	"go.temporal.io/server/common/testing/testhooks"
@@ -7150,8 +7149,10 @@ func (s *engineSuite) TestGetWorkflowExecutionHistory_BranchTokenNotOwnedByExecu
 	for _, sendRawHistory := range []bool{false, true} {
 		s.config.SendRawWorkflowHistory = func(string) bool { return sendRawHistory }
 		_, err = engine.GetWorkflowExecutionHistory(context.Background(), req)
-		var branchErr *serviceerrors.CurrentBranchChanged
-		s.ErrorAs(err, &branchErr, "sendRawHistory=%v", sendRawHistory)
+		var invalidArgument *serviceerror.InvalidArgument
+		s.Require().ErrorAs(err, &invalidArgument, "sendRawHistory=%v", sendRawHistory)
+		s.Require().Equal("request branchToken is not current.", err.Error())
+		s.Require().Empty(serviceerror.ToStatus(err).Proto().GetDetails())
 	}
 }
 
@@ -7249,6 +7250,8 @@ func (s *engineSuite) TestGetWorkflowExecutionHistoryReverse_BranchTokenNotOwned
 			},
 		},
 	)
-	var branchErr *serviceerrors.CurrentBranchChanged
-	s.ErrorAs(err, &branchErr)
+	var invalidArgument *serviceerror.InvalidArgument
+	s.Require().ErrorAs(err, &invalidArgument)
+	s.Require().Equal("request branchToken is not current.", err.Error())
+	s.Require().Empty(serviceerror.ToStatus(err).Proto().GetDetails())
 }

--- a/service/history/history_engine_test.go
+++ b/service/history/history_engine_test.go
@@ -45,6 +45,7 @@ import (
 	"go.temporal.io/server/common/locks"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/metrics/metricstest"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/payloads"
@@ -7061,6 +7062,37 @@ func (s *engineSuite) mockExecutionWithForeignBranchToken(
 	foreignBranchToken, err := branchUtil.NewHistoryBranch(
 		tests.NamespaceID.String(), we.WorkflowId, we.RunId, treeID, &foreignBranchID, nil, 0, 0, 0)
 	s.NoError(err)
+	s.mockExecutionWithCurrentBranchToken(we, ownedBranchToken)
+
+	return ownedBranchToken, foreignBranchToken
+}
+
+func (s *engineSuite) mockExecutionWithRewrittenBranchToken(
+	we *commonpb.WorkflowExecution,
+) (currentToken []byte, previousToken []byte) {
+	branchUtil := persistence.NewHistoryBranchUtil(serialization.NewSerializer())
+	treeID := uuid.NewString()
+	branchID := uuid.NewString()
+
+	currentBranchToken, err := branchUtil.NewHistoryBranch(
+		tests.NamespaceID.String(), we.WorkflowId, we.RunId, treeID, &branchID, nil, 0, 0, 0)
+	s.NoError(err)
+	previousBranchToken, err := branchUtil.NewHistoryBranch(
+		tests.NamespaceID.String(), we.WorkflowId, we.RunId, treeID, &branchID,
+		[]*persistencespb.HistoryBranchRange{{BranchId: uuid.NewString(), BeginNodeId: 1, EndNodeId: 2}}, 0, 0, 0)
+	s.NoError(err)
+	s.mockExecutionWithCurrentBranchToken(we, currentBranchToken)
+
+	return currentBranchToken, previousBranchToken
+}
+
+func (s *engineSuite) mockExecutionWithCurrentBranchToken(
+	we *commonpb.WorkflowExecution,
+	currentBranchToken []byte,
+) {
+	s.mockExecutionMgr.EXPECT().GetHistoryBranchUtil().Return(
+		persistence.NewHistoryBranchUtil(serialization.NewSerializer()),
+	).AnyTimes()
 
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.GetWorkflowExecutionResponse{
 		State: &persistencespb.WorkflowMutableState{
@@ -7077,7 +7109,7 @@ func (s *engineSuite) mockExecutionWithForeignBranchToken(
 					CurrentVersionHistoryIndex: 0,
 					Histories: []*historyspb.VersionHistory{
 						{
-							BranchToken: ownedBranchToken,
+							BranchToken: currentBranchToken,
 							Items: []*historyspb.VersionHistoryItem{
 								{EventId: 4, Version: 0},
 							},
@@ -7088,8 +7120,6 @@ func (s *engineSuite) mockExecutionWithForeignBranchToken(
 		},
 		MutableStateStats: persistence.MutableStateStatistics{},
 	}, nil).AnyTimes()
-
-	return ownedBranchToken, foreignBranchToken
 }
 
 func (s *engineSuite) getHistoryRequestWithPageToken(
@@ -7098,7 +7128,7 @@ func (s *engineSuite) getHistoryRequestWithPageToken(
 	waitNewEvent bool,
 ) *historyservice.GetWorkflowExecutionHistoryRequest {
 	nextPageToken, err := api.SerializeHistoryToken(continuation)
-	s.NoError(err)
+	s.Require().NoError(err)
 	return &historyservice.GetWorkflowExecutionHistoryRequest{
 		NamespaceId: tests.NamespaceID.String(),
 		Request: &workflowservice.GetWorkflowExecutionHistoryRequest{
@@ -7123,6 +7153,29 @@ func (s *engineSuite) expectHistoryReadWithBranchToken(branchToken []byte) {
 			return &persistence.ReadHistoryBranchResponse{HistoryEvents: []*historypb.HistoryEvent{}}, nil
 		},
 	).MinTimes(1)
+}
+
+func (s *engineSuite) expectRawHistoryReadWithBranchToken(branchToken []byte) {
+	s.mockExecutionMgr.EXPECT().ReadRawHistoryBranch(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, request *persistence.ReadHistoryBranchRequest) (*persistence.ReadRawHistoryBranchResponse, error) {
+			s.Equal(branchToken, request.BranchToken)
+			return &persistence.ReadRawHistoryBranchResponse{}, nil
+		},
+	).MinTimes(1)
+}
+
+func (s *engineSuite) expectReverseHistoryReadWithBranchToken(branchToken []byte) {
+	s.mockNamespaceCache.EXPECT().GetNamespaceName(tests.NamespaceID).Return(tests.Namespace, nil)
+	s.mockSearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), false).
+		Return(searchattribute.TestNameTypeMap(), nil)
+	s.mockVisibilityMgr.EXPECT().GetIndexName().Return(esIndexName)
+	s.mockExecutionMgr.EXPECT().ReadHistoryBranchReverse(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, request *persistence.ReadHistoryBranchReverseRequest) (*persistence.ReadHistoryBranchReverseResponse, error) {
+			s.Equal(branchToken, request.BranchToken)
+			s.Equal([]byte("some random persistence token"), request.NextPageToken)
+			return &persistence.ReadHistoryBranchReverseResponse{}, nil
+		},
+	)
 }
 
 func (s *engineSuite) TestGetWorkflowExecutionHistory_BranchTokenNotOwnedByExecution() {
@@ -7192,6 +7245,114 @@ func (s *engineSuite) TestGetWorkflowExecutionHistory_ForeignBranchTokenServedWh
 	}
 }
 
+func (s *engineSuite) TestGetWorkflowExecutionHistory_RewrittenBranchTokenUsesCurrentToken() {
+	we := commonpb.WorkflowExecution{WorkflowId: "wid-rewritten-branch", RunId: uuid.NewString()}
+
+	engine, err := s.historyEngine.shardContext.GetEngine(context.Background())
+	s.Require().NoError(err)
+	metricsHandler := metricstest.NewCaptureHandler()
+	capture := metricsHandler.StartCapture()
+	defer metricsHandler.StopCapture(capture)
+	s.mockShard.SetMetricsHandler(metricsHandler)
+
+	s.config.EnablePaginationTokenBranchValidation = dynamicconfig.GetBoolPropertyFn(true)
+	s.config.EnablePaginationTokenBranchValidationShadowMode = dynamicconfig.GetBoolPropertyFn(false)
+	s.config.EnablePaginationTokenBranchReplacement = dynamicconfig.GetBoolPropertyFn(true)
+	currentBranchToken, previousBranchToken := s.mockExecutionWithRewrittenBranchToken(&we)
+	s.expectHistoryReadWithBranchToken(currentBranchToken)
+	s.expectRawHistoryReadWithBranchToken(currentBranchToken)
+
+	for _, sendRawHistory := range []bool{false, true} {
+		s.config.SendRawWorkflowHistory = func(string) bool { return sendRawHistory }
+
+		_, err = engine.GetWorkflowExecutionHistory(
+			context.Background(),
+			s.getHistoryRequestWithPageToken(&we, &tokenspb.HistoryContinuation{
+				RunId:             we.GetRunId(),
+				FirstEventId:      common.FirstEventID,
+				NextEventId:       5,
+				PersistenceToken:  []byte("some random persistence token"),
+				BranchToken:       previousBranchToken,
+				IsWorkflowRunning: true,
+			}, false),
+		)
+		s.Require().NoError(err, "sendRawHistory=%v", sendRawHistory)
+	}
+	recordings := capture.Snapshot()[metrics.PaginationTokenBranchMismatchCounter.Name()]
+	s.Require().Len(recordings, 2)
+	for _, recording := range recordings {
+		s.Equal("same_branch_metadata_mismatch", recording.Tags[metrics.ReasonTag("").Key])
+	}
+}
+
+func (s *engineSuite) TestGetWorkflowExecutionHistory_RewrittenBranchTokenRejectedWhenReplacementDisabled() {
+	we := commonpb.WorkflowExecution{WorkflowId: "wid-rewritten-branch-rejected", RunId: uuid.NewString()}
+
+	engine, err := s.historyEngine.shardContext.GetEngine(context.Background())
+	s.Require().NoError(err)
+
+	s.config.EnablePaginationTokenBranchValidation = dynamicconfig.GetBoolPropertyFn(true)
+	s.config.EnablePaginationTokenBranchValidationShadowMode = dynamicconfig.GetBoolPropertyFn(false)
+	s.config.EnablePaginationTokenBranchReplacement = dynamicconfig.GetBoolPropertyFn(false)
+	_, previousBranchToken := s.mockExecutionWithRewrittenBranchToken(&we)
+
+	s.mockExecutionMgr.EXPECT().ReadHistoryBranch(gomock.Any(), gomock.Any()).Times(0)
+	s.mockExecutionMgr.EXPECT().ReadRawHistoryBranch(gomock.Any(), gomock.Any()).Times(0)
+
+	_, err = engine.GetWorkflowExecutionHistory(
+		context.Background(),
+		s.getHistoryRequestWithPageToken(&we, &tokenspb.HistoryContinuation{
+			RunId:             we.GetRunId(),
+			FirstEventId:      common.FirstEventID,
+			NextEventId:       5,
+			PersistenceToken:  []byte("some random persistence token"),
+			BranchToken:       previousBranchToken,
+			IsWorkflowRunning: true,
+		}, false),
+	)
+	var invalidArgument *serviceerror.InvalidArgument
+	s.Require().ErrorAs(err, &invalidArgument)
+}
+
+func (s *engineSuite) TestGetWorkflowExecutionHistory_RewrittenBranchTokenPreservedInShadowMode() {
+	we := commonpb.WorkflowExecution{WorkflowId: "wid-rewritten-branch-shadow", RunId: uuid.NewString()}
+
+	engine, err := s.historyEngine.shardContext.GetEngine(context.Background())
+	s.Require().NoError(err)
+	metricsHandler := metricstest.NewCaptureHandler()
+	capture := metricsHandler.StartCapture()
+	defer metricsHandler.StopCapture(capture)
+	s.mockShard.SetMetricsHandler(metricsHandler)
+
+	s.config.EnablePaginationTokenBranchValidation = dynamicconfig.GetBoolPropertyFn(true)
+	s.config.EnablePaginationTokenBranchValidationShadowMode = dynamicconfig.GetBoolPropertyFn(true)
+	s.config.EnablePaginationTokenBranchReplacement = dynamicconfig.GetBoolPropertyFn(true)
+	_, previousBranchToken := s.mockExecutionWithRewrittenBranchToken(&we)
+	s.expectHistoryReadWithBranchToken(previousBranchToken)
+	s.expectRawHistoryReadWithBranchToken(previousBranchToken)
+
+	for _, sendRawHistory := range []bool{false, true} {
+		s.config.SendRawWorkflowHistory = func(string) bool { return sendRawHistory }
+		_, err = engine.GetWorkflowExecutionHistory(
+			context.Background(),
+			s.getHistoryRequestWithPageToken(&we, &tokenspb.HistoryContinuation{
+				RunId:             we.GetRunId(),
+				FirstEventId:      common.FirstEventID,
+				NextEventId:       5,
+				PersistenceToken:  []byte("some random persistence token"),
+				BranchToken:       previousBranchToken,
+				IsWorkflowRunning: true,
+			}, false),
+		)
+		s.Require().NoError(err, "sendRawHistory=%v", sendRawHistory)
+	}
+	recordings := capture.Snapshot()[metrics.PaginationTokenBranchMismatchCounter.Name()]
+	s.Require().Len(recordings, 2)
+	for _, recording := range recordings {
+		s.Equal("same_branch_metadata_mismatch", recording.Tags[metrics.ReasonTag("").Key])
+	}
+}
+
 func (s *engineSuite) TestGetWorkflowExecutionHistory_LongPollDiscardsRequestBranchToken() {
 	we := commonpb.WorkflowExecution{WorkflowId: "wid-longpoll-overwrite", RunId: uuid.NewString()}
 
@@ -7254,4 +7415,74 @@ func (s *engineSuite) TestGetWorkflowExecutionHistoryReverse_BranchTokenNotOwned
 	s.Require().ErrorAs(err, &invalidArgument)
 	s.Require().Equal("request branchToken is not current.", err.Error())
 	s.Require().Empty(serviceerror.ToStatus(err).Proto().GetDetails())
+}
+
+func (s *engineSuite) TestGetWorkflowExecutionHistoryReverse_RewrittenBranchTokenUsesCurrentToken() {
+	we := commonpb.WorkflowExecution{WorkflowId: "wid-rewritten-branch-reverse", RunId: uuid.NewString()}
+
+	engine, err := s.historyEngine.shardContext.GetEngine(context.Background())
+	s.Require().NoError(err)
+
+	s.config.EnablePaginationTokenBranchValidation = dynamicconfig.GetBoolPropertyFn(true)
+	s.config.EnablePaginationTokenBranchValidationShadowMode = dynamicconfig.GetBoolPropertyFn(false)
+	s.config.EnablePaginationTokenBranchReplacement = dynamicconfig.GetBoolPropertyFn(true)
+	currentBranchToken, previousBranchToken := s.mockExecutionWithRewrittenBranchToken(&we)
+	s.expectReverseHistoryReadWithBranchToken(currentBranchToken)
+
+	nextPageToken, err := api.SerializeHistoryToken(&tokenspb.HistoryContinuation{
+		RunId:            we.GetRunId(),
+		FirstEventId:     common.FirstEventID,
+		NextEventId:      5,
+		PersistenceToken: []byte("some random persistence token"),
+		BranchToken:      previousBranchToken,
+	})
+	s.Require().NoError(err)
+
+	_, err = engine.GetWorkflowExecutionHistoryReverse(
+		context.Background(),
+		&historyservice.GetWorkflowExecutionHistoryReverseRequest{
+			NamespaceId: tests.NamespaceID.String(),
+			Request: &workflowservice.GetWorkflowExecutionHistoryReverseRequest{
+				Execution:       &we,
+				MaximumPageSize: 10,
+				NextPageToken:   nextPageToken,
+			},
+		},
+	)
+	s.Require().NoError(err)
+}
+
+func (s *engineSuite) TestGetWorkflowExecutionHistoryReverse_RewrittenBranchTokenPreservedInShadowMode() {
+	we := commonpb.WorkflowExecution{WorkflowId: "wid-rewritten-branch-reverse-shadow", RunId: uuid.NewString()}
+
+	engine, err := s.historyEngine.shardContext.GetEngine(context.Background())
+	s.Require().NoError(err)
+
+	s.config.EnablePaginationTokenBranchValidation = dynamicconfig.GetBoolPropertyFn(true)
+	s.config.EnablePaginationTokenBranchValidationShadowMode = dynamicconfig.GetBoolPropertyFn(true)
+	s.config.EnablePaginationTokenBranchReplacement = dynamicconfig.GetBoolPropertyFn(true)
+	_, previousBranchToken := s.mockExecutionWithRewrittenBranchToken(&we)
+	s.expectReverseHistoryReadWithBranchToken(previousBranchToken)
+
+	nextPageToken, err := api.SerializeHistoryToken(&tokenspb.HistoryContinuation{
+		RunId:            we.GetRunId(),
+		FirstEventId:     common.FirstEventID,
+		NextEventId:      5,
+		PersistenceToken: []byte("some random persistence token"),
+		BranchToken:      previousBranchToken,
+	})
+	s.Require().NoError(err)
+
+	_, err = engine.GetWorkflowExecutionHistoryReverse(
+		context.Background(),
+		&historyservice.GetWorkflowExecutionHistoryReverseRequest{
+			NamespaceId: tests.NamespaceID.String(),
+			Request: &workflowservice.GetWorkflowExecutionHistoryReverseRequest{
+				Execution:       &we,
+				MaximumPageSize: 10,
+				NextPageToken:   nextPageToken,
+			},
+		},
+	)
+	s.Require().NoError(err)
 }


### PR DESCRIPTION
## What changed?

Cherry-picks the branch-token error and stale-metadata pagination fixes into the 163 release branch.

### Original PRs

- https://github.com/temporalio/temporal/pull/11940
- https://github.com/temporalio/temporal/pull/11983

## Why is this necessary as a patch?

Branch-token mismatches currently carry a server-only error detail that some HTTP gateways cannot marshal, producing HTTP 500 instead of `InvalidArgument`. Some operations can update branch metadata between pages without changing the branch; accepting the current token for the same branch keeps valid pagination from failing.

## What testing or retesting is appropriate for this patch after merge?

VCR is not needed as will not exercise this path