### PR TITLE
Clear scaleInfo when scaler is disabled (#12026)

### DIFF
--- a/client/matching/loadbalancer.go
+++ b/client/matching/loadbalancer.go
@@ -90,7 +90,7 @@ func (lb *defaultLoadBalancer) PickWritePartition(
 	pc PartitionCounts,
 ) (*tqid.NormalPartition, int) {
 	var partitionCount int
-	if pc.Write > 0 {
+	if pc.Valid() {
 		partitionCount = int(pc.Write)
 	} else {
 		nsName, err := lb.namespaceIDToName(namespace.ID(taskQueue.NamespaceId()))
@@ -199,7 +199,7 @@ func (lb *defaultLoadBalancer) PickReadPartition(
 	var partitionCount = dynamicconfig.GlobalDefaultNumTaskQueuePartitions
 	namespaceName, namespaceErr := lb.namespaceIDToName(namespace.ID(taskQueue.NamespaceId()))
 
-	if pc.Read > 0 {
+	if pc.Valid() {
 		partitionCount = int(pc.Read)
 	} else if namespaceErr == nil {
 		partitionCount = lb.nReadPartitions(string(namespaceName), taskQueue.Name(), taskQueue.TaskType())

--- a/client/matching/loadbalancer_test.go
+++ b/client/matching/loadbalancer_test.go
@@ -358,6 +358,7 @@ func TestPickWritePartitionRootFloorPreservesNonRootWeights(t *testing.T) {
 	backlogCounts[0] = backlogCap
 	backlogCounts[partitionCount-1] = number.EncodeCompact8(number.DecodeCompact8(backlogCap) - 100)
 	pc := PartitionCounts{
+		Read:         partitionCount,
 		Write:        partitionCount,
 		BacklogCap:   backlogCap,
 		BacklogCount: backlogCounts,
@@ -519,7 +520,7 @@ func TestPickWritePartition_Forced(t *testing.T) {
 		namespaceIDToName: func(namespace.ID) (namespace.Name, error) { return "fake-namespace", nil },
 		testHooks:         testHooks,
 	}
-	pc := PartitionCounts{Write: 4}
+	pc := PartitionCounts{Read: 4, Write: 4}
 
 	for partitionID, expectedEstimate := range map[int]int{0: 4, 1: 0} {
 		cleanup := testhooks.Set(testHooks, testhooks.MatchingLBForceWritePartition, partitionID, namespace.ID(taskQueue.NamespaceId()))

--- a/service/matching/partition_scaler_interface.go
+++ b/service/matching/partition_scaler_interface.go
@@ -24,7 +24,7 @@ type PartitionScaler interface {
 	// It will be given the current partition count target, current backlog counts, and its
 	// private state (optional). It returns a PartitionScalerDecision, which will usually be
 	// "no change". To make a change, it should return a number in NewTarget. Zero means
-	// disable managed scaling.
+	// disable managed scaling and requires BacklogCap to also be zero.
 	//
 	// Changes may be ignored if values are out of range, if changed too often, or other
 	// reasons. Private state will not be updated if target doesn't also change, or if the
@@ -47,6 +47,6 @@ type PartitionScalerInput struct {
 type PartitionScalerDecision struct {
 	NoChange     bool       // if true, don't do anything
 	NewTarget    int        // if zero, disable managed scaling, otherwise set partition target
-	BacklogCap   int        // target cap for backlog count
+	BacklogCap   int        // target cap for backlog count; must be zero when NewTarget is zero
 	PrivateState *anypb.Any // optional private state to be stored with target
 }

--- a/service/matching/scale_manager.go
+++ b/service/matching/scale_manager.go
@@ -203,9 +203,15 @@ func (sm *scaleManager) callScaler() {
 		PrivateState:  sm.scaleState.GetPrivateScalerState(),
 	})
 	backlogCapC8 := number.EncodeCompact8(int64(decision.BacklogCap))
+	disabledStateNeedsCleanup := decision.NewTarget == 0 &&
+		(len(sm.scaleState.GetBacklogState()) > 0 ||
+			len(sm.scaleState.GetBacklogCounts()) > 0 ||
+			sm.scaleState.GetBacklogCap() != 0 ||
+			sm.scaleState.GetPrivateScalerState() != nil)
 	if decision.NoChange ||
 		decision.NewTarget == int(sm.scaleState.GetTarget()) &&
-			backlogCapC8 == number.Compact8(sm.scaleState.GetBacklogCap()) {
+			backlogCapC8 == number.Compact8(sm.scaleState.GetBacklogCap()) &&
+			!disabledStateNeedsCleanup {
 		return
 	}
 
@@ -221,9 +227,20 @@ func (sm *scaleManager) callScaler() {
 	newState.TargetVersion = sm.timeSource.Now().UnixNano()
 	newState.BacklogCap = int32(backlogCapC8)
 	newState.PrivateScalerState = decision.PrivateState
+	var prevRead, prevWrite int32
+	if target == 0 {
+		// Disabling managed scaling is a clean break to dynamic config; any backlog
+		// outside its read range remains unpolled until it times out.
+		prevInfo := scaleStateToInfo(sm.scaleState, settings)
+		prevRead, prevWrite = prevInfo.Read, prevInfo.Write
+		newState.BacklogState = nil
+		newState.BacklogCounts = nil
+		newState.BacklogCap = 0
+		newState.PrivateScalerState = nil
+	}
 
 	mayHaveBacklog := target
-	if prevTarget == 0 {
+	if prevTarget == 0 && target > 0 {
 		// Turning on managed partition scaling: consider all partitions from dynamic
 		// config as having backlog also.
 		mayHaveBacklog = max(mayHaveBacklog, int32(sm.getWritePartitions()))
@@ -258,11 +275,17 @@ func (sm *scaleManager) callScaler() {
 	cooldown := time.Duration(float32(time.Second) / settings.MaxRate)
 	sm.nextDecision = sm.timeSource.Now().Add(cooldown)
 
-	sm.logger.Info("new target",
-		tag.Int32("target", target),
-		tag.Int32("prev-target", prevTarget),
-		tag.Int32("max-target", newState.MaxTarget),
-		tag.Bool(metrics.ScalerShadowModeTagName, shadowMode))
+	if target == 0 {
+		sm.logger.Info("disabled managed scaling",
+			tag.Int32("prev-read", prevRead),
+			tag.Int32("prev-write", prevWrite))
+	} else {
+		sm.logger.Info("new target",
+			tag.Int32("target", target),
+			tag.Int32("prev-target", prevTarget),
+			tag.Int32("max-target", newState.MaxTarget),
+			tag.Bool(metrics.ScalerShadowModeTagName, shadowMode))
+	}
 	metrics.PartitionScaleEvents.With(sm.metricsHandler.WithTags(metrics.ScalerShadowModeTag(shadowMode))).Record(1)
 }
 

--- a/service/matching/scale_manager_test.go
+++ b/service/matching/scale_manager_test.go
@@ -390,6 +390,53 @@ func (s *ScaleManagerSuite) TestDecisionPersistsAndUpdatesEphemeralData() {
 	s.Equal(int32(2), info.Write)
 }
 
+func (s *ScaleManagerSuite) TestDisabledScalerClearsManagedScaleState() {
+	s.settings.ShrinkRatio = 0.1
+	s.settings.ShrinkDelta = 8
+	priv := protoutils.MarshalAny(s.T(), wrapperspb.String("managed-state"))
+	s.scaler.EXPECT().OnTasks(gomock.Any()).
+		Return(PartitionScalerDecision{NewTarget: 0})
+
+	dbWrites := make(chan *persistencespb.PartitionScaleState, 1)
+	s.scaleDB.EXPECT().UpdateScaleState(gomock.Any(), true).
+		Do(func(state *persistencespb.PartitionScaleState, _ bool) {
+			dbWrites <- common.CloneProto(state)
+		}).
+		Return(nil)
+
+	scaleInfos := make(chan *taskqueuespb.PartitionScaleInfo, 2)
+	s.userData.EXPECT().SetPartitionScale(gomock.Any()).
+		Do(func(info *taskqueuespb.PartitionScaleInfo) { scaleInfos <- info }).Times(2)
+
+	initial := &persistencespb.PartitionScaleState{
+		Target:             0,
+		MaxTarget:          4,
+		BacklogState:       bitSet(nil).set(0).set(1).set(2).set(3),
+		BacklogCounts:      []byte{1, 2, 3, 4},
+		BacklogCap:         5,
+		PrivateScalerState: priv,
+	}
+	s.startManager(4, initial)
+	s.sm.AddedTasks(3)
+
+	state := waitRecv(s, dbWrites, "disabled state was not cleaned up")
+	s.Zero(state.Target)
+	s.Equal(int32(4), state.MaxTarget)
+	s.Empty(state.BacklogState)
+	s.Empty(state.BacklogCounts)
+	s.Zero(state.BacklogCap)
+	s.Nil(state.PrivateScalerState)
+
+	stale := waitRecv(s, scaleInfos, "initial scale info was not pushed")
+	s.Equal(int32(4), stale.Read)
+	s.Equal(int32(3), stale.Write)
+	disabled := waitRecv(s, scaleInfos, "disabled scale info was not pushed")
+	s.Zero(disabled.Read)
+	s.Zero(disabled.Write)
+	s.Empty(disabled.BacklogCounts)
+	s.Zero(disabled.BacklogCap)
+}
+
 // TestEmitsGaugeMetrics verifies that when gauge emission is enabled, a scale
 // decision records the read, write, and target gauges with the expected values.
 func (s *ScaleManagerSuite) TestEmitsGaugeMetrics() {


### PR DESCRIPTION
## What changed?
Clear scaleInfo when scaler is disabled

## Why?
Not clearing scaleInfo meant that clients were still reading and writing based on scaleInfo.Read and scaleInfo.Write, even though target was cleared.

We want disabling the scaler to be a clean and complete break back to the mode of dynamic-config hard-coded partition counts.

## How did you test it?
- [ ] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task-queue partition routing when scaling is disabled and alters scale-state persistence; incorrect cleanup could strand backlog or mis-route polls/writes.
> 
> **Overview**
> When the partition scaler disables managed scaling (`NewTarget == 0`), the scale manager now **wipes managed state** (backlog bits, backlog counts, backlog cap, private scaler state) and pushes **`PartitionScaleInfo` with Read/Write zero**, so clients stop routing on stale scaled partition counts and fall back to **dynamic-config** partition settings.
> 
> The manager also applies that cleanup when the target is already zero but leftover managed fields remain, and only treats scale-up as “turn on from baseline” when **`prevTarget == 0 && target > 0`** (not on every disable path). Disable events get dedicated logging with previous read/write counts.
> 
> Matching **load balancer** pick paths now gate on **`PartitionCounts.Valid()`** (both Read and Write &gt; 0) instead of checking Write or Read alone, aligning with cleared scale info. Scaler interface docs note that disabling requires **`BacklogCap == 0`**. New unit test **`TestDisabledScalerClearsManagedScaleState`** covers persistence and ephemeral pushes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2e3088bb0ca236ccfd3ebe72c77f3c983f55271. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->