### PR TITLE
Upgrade go.temporal.io/auto-scaled-workers to v0.0.0-1.31.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	go.temporal.io/api v1.62.8
-	go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2
+	go.temporal.io/auto-scaled-workers v0.0.0-1.31.2
 	go.temporal.io/sdk v1.41.1
 	go.uber.org/fx v1.24.0
 	go.uber.org/mock v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -444,8 +444,8 @@ go.opentelemetry.io/proto/otlp v1.7.1 h1:gTOMpGDb0WTBOP8JaO72iL3auEZhVmAQg4ipjOV
 go.opentelemetry.io/proto/otlp v1.7.1/go.mod h1:b2rVh6rfI/s2pHWNlB7ILJcRALpcNDzKhACevjI+ZnE=
 go.temporal.io/api v1.62.8 h1:g8RAZmdebYODoNa2GLA4M4TsXNe1096WV3n26C4+fdw=
 go.temporal.io/api v1.62.8/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
-go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2 h1:1hKeH3GyR6YD6LKMHGCZ76t6h1Sgha0hXVQBxWi3dlQ=
-go.temporal.io/auto-scaled-workers v0.0.0-20260407181057-edd947d743d2/go.mod h1:T8dnzVPeO+gaUTj9eDgm/lT2lZH4+JXNvrGaQGyVi50=
+go.temporal.io/auto-scaled-workers v0.0.0-1.31.2 h1:a0V+5R27c0FVVN7BN6HS8P9qUSsWDZ6bXtsk1dBmB1o=
+go.temporal.io/auto-scaled-workers v0.0.0-1.31.2/go.mod h1:ZujT1gYsXlL131sUcbrQBgC5tfVcqeUjejcTgecltNU=
 go.temporal.io/sdk v1.41.1 h1:yOpvsHyDD1lNuwlGBv/SUodCPhjv9nDeC9lLHW/fJUA=
 go.temporal.io/sdk v1.41.1/go.mod h1:/InXQT5guZ6AizYzpmzr5avQ/GMgq1ZObcKlKE2AhTc=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=


### PR DESCRIPTION
## What changed?
Bump `go.temporal.io/auto-scaled-workers` from the
`v0.0.0-20260407181057-edd947d743d2` pseudo-version to the tagged
`v0.0.0-1.31.2` release.

## Why?
Port of #12021 to release/v1.31.x.

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
n/a
