### PR TITLE
Update defaultCliVersion to 1.9.0

### DIFF
--- a/.github/actions/build-docker-images/scripts/main.go
+++ b/.github/actions/build-docker-images/scripts/main.go
@@ -14,7 +14,7 @@ import (
 var validArchs = []string{"amd64", "arm64"}
 
 // defaultCliVersion should be updated to the latest cli version
-const defaultCliVersion = "1.6.1"
+const defaultCliVersion = "1.9.0"
 
 func main() {
 	if len(os.Args) < 2 {


### PR DESCRIPTION
## What changed?
Bumps `defaultCliVersion` in `.github/actions/build-docker-images/scripts/main.go` from `1.6.1` to `1.9.0`.

## Why?
The v1.32.0 admin-tools image was built through the manual Docker build workflow with a `cli-version=1.9.0` input, which overrides this constant, so the release image itself is already correct.

Automatic builds on this branch are a different path. `build-and-publish.yml` runs on every push to `release/*` and passes no CLI version, so `downloadCLIForArch` falls back to `defaultCliVersion`. Left at `1.6.1`, the next automatic build here (a v1.32.1 cherry-pick, for example) would produce an admin-tools image whose `temporal` CLI embeds an older dev server, and image scans would report CVEs that have already been fixed.

This keeps the branch default aligned with the CLI version actually shipped for 1.32.

## How did you test it?
- [x] built
- [ ] run locally and tested manually
- [ ] covered by existing tests
- [ ] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
n/a
