### PR TITLE
Cherry-pick PRs labeled for v1.30.7 release

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -332,6 +332,7 @@ jobs:
             cassandra
             mysql
             postgresql
+            elasticsearch
           down-flags: -v
 
       - uses: actions/setup-go@v6

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1460,6 +1460,20 @@ to remove expired entries. Should be shorter than EntryTTL for timely cleanup. L
 
 	// keys for history
 
+	EnablePaginationTokenBranchValidation = NewGlobalBoolSetting(
+		"history.enablePaginationTokenBranchValidation",
+		true,
+		`EnablePaginationTokenBranchValidation enables checking that the branch token in a
+GetWorkflowExecutionHistory(Reverse) page token is the current branch token of the requested
+execution.`,
+	)
+	EnablePaginationTokenBranchValidationShadowMode = NewGlobalBoolSetting(
+		"history.enablePaginationTokenBranchValidationShadowMode",
+		false,
+		`EnablePaginationTokenBranchValidationShadowMode logs and emits metrics for a page token whose
+branch token is not the execution's current one, but still serves the read.`,
+	)
+
 	EnableReplicationStream = NewGlobalBoolSetting(
 		"history.enableReplicationStream",
 		true,

--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -264,6 +264,11 @@ func WorkflowBranchToken(branchToken []byte) ZapTag {
 	return NewBinaryTag("wf-branch-token", branchToken)
 }
 
+// WorkflowRequestBranchToken returns tag for a branch token supplied by the caller
+func WorkflowRequestBranchToken(branchToken []byte) ZapTag {
+	return NewBinaryTag("wf-request-branch-token", branchToken)
+}
+
 // WorkflowTreeID returns tag for WorkflowTreeID
 func WorkflowTreeID(treeID string) ZapTag {
 	return NewStringTag("wf-tree-id", treeID)

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -917,6 +917,7 @@ var (
 	FailedWorkflowTasksCounter                    = NewCounterDef("failed_workflow_tasks")
 	WorkflowTaskAttempt                           = NewDimensionlessHistogramDef("workflow_task_attempt")
 	StaleMutableStateCounter                      = NewCounterDef("stale_mutable_state")
+	PaginationTokenBranchMismatchCounter          = NewCounterDef("pagination_token_branch_mismatch")
 	AutoResetPointsLimitExceededCounter           = NewCounterDef("auto_reset_points_exceed_limit")
 	AutoResetPointCorruptionCounter               = NewCounterDef("auto_reset_point_corruption")
 	BatchableTaskBatchCount                       = NewGaugeDef("batchable_task_batch_count")

--- a/common/persistence/persistence-tests/elasticsearch_test_cluster.go
+++ b/common/persistence/persistence-tests/elasticsearch_test_cluster.go
@@ -1,0 +1,189 @@
+package persistencetests
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"path"
+	"time"
+
+	"go.temporal.io/server/common/backoff"
+	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	esclient "go.temporal.io/server/common/persistence/visibility/store/elasticsearch/client"
+	"go.temporal.io/server/common/searchattribute"
+	"go.temporal.io/server/temporal/environment"
+	"go.temporal.io/server/tests/testutils"
+)
+
+type esTestCluster struct {
+	cfg    *esclient.Config
+	logger log.Logger
+
+	indexName string
+}
+
+var _ PersistenceTestCluster = (*esTestCluster)(nil)
+
+func newEsTestCluster(
+	hostname string,
+	port int,
+	username string,
+	password string,
+	indexName string,
+	logger log.Logger,
+) *esTestCluster {
+	//nolint:revive // insecure scheme is fine in tests
+	addr, err := url.Parse(fmt.Sprintf("http://%s:%d", hostname, port))
+	if err != nil {
+		panic(err)
+	}
+	return &esTestCluster{
+		cfg: &esclient.Config{
+			Version:  environment.GetESVersion(),
+			URL:      *addr,
+			Username: username,
+			Password: password,
+			Indices: map[string]string{
+				esclient.VisibilityAppName: indexName,
+			},
+		},
+		logger:    logger,
+		indexName: indexName,
+	}
+}
+
+// Config implements [PersistenceTestCluster].
+func (c *esTestCluster) Config() config.Persistence {
+	return config.Persistence{
+		VisibilityStore: "test-es-visibility",
+		DataStores: map[string]config.DataStore{
+			"test-es-visibility": {
+				Elasticsearch: c.cfg,
+			},
+		},
+	}
+}
+
+// SetupTestDatabase implements [PersistenceTestCluster].
+func (c *esTestCluster) SetupTestDatabase() {
+	if err := SetupEsIndex(c.cfg, c.logger); err != nil {
+		panic(err)
+	}
+}
+
+// TearDownTestDatabase implements [PersistenceTestCluster].
+func (c *esTestCluster) TearDownTestDatabase() {
+	if err := DeleteEsIndex(c.cfg, c.logger); err != nil {
+		panic(err)
+	}
+}
+
+func SetupEsIndex(esConfig *esclient.Config, logger log.Logger) error {
+	ctx := context.Background()
+	var esClient esclient.IntegrationTestsClient
+	op := func() error {
+		var err error
+		esClient, err = esclient.NewFunctionalTestsClient(esConfig, logger)
+		if err != nil {
+			return err
+		}
+
+		return esClient.Ping(ctx)
+	}
+
+	err := backoff.ThrottleRetry(
+		op,
+		backoff.NewExponentialRetryPolicy(time.Second).WithExpirationInterval(time.Minute),
+		nil,
+	)
+	if err != nil {
+		logger.Fatal("Failed to connect to elasticsearch", tag.Error(err))
+	}
+
+	exists, err := esClient.IndexExists(ctx, esConfig.GetVisibilityIndex())
+	if err != nil {
+		return err
+	}
+	if exists {
+		logger.Info("Index already exists.", tag.ESIndex(esConfig.GetVisibilityIndex()))
+		err = DeleteEsIndex(esConfig, logger)
+		if err != nil {
+			return err
+		}
+	}
+
+	indexTemplateFile := path.Join(testutils.GetRepoRootDirectory(), "schema/elasticsearch/visibility/index_template_v7.json")
+	logger.Info("Creating index template.", tag.String("templatePath", indexTemplateFile))
+	template, err := os.ReadFile(indexTemplateFile)
+	if err != nil {
+		return err
+	}
+	// Template name doesn't matter.
+	// This operation is idempotent and won't return an error even if template already exists.
+	_, err = esClient.IndexPutTemplate(ctx, "temporal_visibility_v1_template", string(template))
+	if err != nil {
+		return err
+	}
+	logger.Info("Index template created.")
+
+	logger.Info("Creating index.", tag.ESIndex(esConfig.GetVisibilityIndex()))
+	_, err = esClient.CreateIndex(
+		ctx,
+		esConfig.GetVisibilityIndex(),
+		map[string]any{
+			"settings": map[string]any{
+				"index": map[string]any{
+					"number_of_replicas": 0,
+				},
+			},
+		},
+	)
+	if err != nil {
+		return err
+	}
+	if err := waitForYellowStatus(esClient, esConfig.GetVisibilityIndex()); err != nil {
+		return err
+	}
+	logger.Info("Index created.", tag.ESIndex(esConfig.GetVisibilityIndex()))
+
+	logger.Info("Add custom search attributes for tests.")
+	_, err = esClient.PutMapping(ctx, esConfig.GetVisibilityIndex(), searchattribute.TestEsNameTypeMap().Custom())
+	if err != nil {
+		return err
+	}
+	if err := waitForYellowStatus(esClient, esConfig.GetVisibilityIndex()); err != nil {
+		return err
+	}
+	logger.Info("Index setup complete.", tag.ESIndex(esConfig.GetVisibilityIndex()))
+
+	return nil
+}
+
+func waitForYellowStatus(esClient esclient.IntegrationTestsClient, index string) error {
+	status, err := esClient.WaitForYellowStatus(context.Background(), index)
+	if err != nil {
+		return err
+	}
+	if status == "red" {
+		return fmt.Errorf("elasticsearch index status for %s is red", index)
+	}
+	return nil
+}
+
+func DeleteEsIndex(esConfig *esclient.Config, logger log.Logger) error {
+	esClient, err := esclient.NewFunctionalTestsClient(esConfig, logger)
+	if err != nil {
+		return err
+	}
+
+	logger.Info("Deleting index.", tag.ESIndex(esConfig.GetVisibilityIndex()))
+	_, err = esClient.DeleteIndex(context.Background(), esConfig.GetVisibilityIndex())
+	if err != nil {
+		return err
+	}
+	logger.Info("Index deleted.", tag.ESIndex(esConfig.GetVisibilityIndex()))
+	return nil
+}

--- a/common/persistence/persistence-tests/persistence_test_base.go
+++ b/common/persistence/persistence-tests/persistence_test_base.go
@@ -113,7 +113,16 @@ func NewTestClusterForCassandra(options *TestBaseOptions, logger log.Logger) *ca
 	if options.DBName == "" {
 		options.DBName = "test_" + GenerateRandomDBName(3)
 	}
-	testCluster := cassandra.NewTestCluster(options.DBName, options.DBUsername, options.DBPassword, options.DBHost, options.DBPort, options.SchemaDir, options.FaultInjection, logger)
+	testCluster := cassandra.NewTestCluster(
+		options.DBName,
+		options.DBUsername,
+		options.DBPassword,
+		options.DBHost,
+		options.DBPort,
+		options.SchemaDir,
+		options.FaultInjection,
+		logger,
+	)
 	return testCluster
 }
 
@@ -151,7 +160,42 @@ func NewTestBaseWithSQL(options *TestBaseOptions) *TestBase {
 			panic(fmt.Sprintf("unknown sql store driver: %v", options.SQLDBPluginName))
 		}
 	}
-	testCluster := sql.NewTestCluster(options.SQLDBPluginName, options.DBName, options.DBUsername, options.DBPassword, options.DBHost, options.DBPort, options.ConnectAttributes, options.SchemaDir, options.FaultInjection, logger)
+	testCluster := sql.NewTestCluster(
+		options.SQLDBPluginName,
+		options.DBName,
+		options.DBUsername,
+		options.DBPassword,
+		options.DBHost,
+		options.DBPort,
+		options.ConnectAttributes,
+		options.SchemaDir,
+		options.FaultInjection,
+		logger,
+	)
+	return NewTestBaseForCluster(testCluster, logger)
+}
+
+func NewTestBaseWithEs(options *TestBaseOptions) *TestBase {
+	logger := options.Logger
+	if logger == nil {
+		logger = log.NewTestLogger()
+	}
+
+	if options.DBHost == "" {
+		options.DBHost = environment.GetESAddress()
+	}
+	if options.DBPort == 0 {
+		options.DBPort = environment.GetESPort()
+	}
+
+	testCluster := newEsTestCluster(
+		options.DBHost,
+		options.DBPort,
+		options.DBUsername,
+		options.DBPassword,
+		options.DBName,
+		logger,
+	)
 	return NewTestBaseForCluster(testCluster, logger)
 }
 

--- a/common/persistence/persistence-tests/setup.go
+++ b/common/persistence/persistence-tests/setup.go
@@ -90,3 +90,13 @@ func GetSQLiteMemoryTestClusterOption() *TestBaseOptions {
 		ConnectAttributes: map[string]string{"mode": testSQLiteMode, "cache": testSQLiteCache},
 	}
 }
+
+func GetEsTestClusterOption() *TestBaseOptions {
+	return &TestBaseOptions{
+		DBName:     "temporal_visibility_v1_" + GenerateRandomDBName(3),
+		DBUsername: "",
+		DBPassword: "",
+		DBHost:     environment.GetESAddress(),
+		DBPort:     environment.GetESPort(),
+	}
+}

--- a/common/persistence/tests/elasticsearch_test.go
+++ b/common/persistence/tests/elasticsearch_test.go
@@ -1,0 +1,29 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	persistencetests "go.temporal.io/server/common/persistence/persistence-tests"
+)
+
+type ElasticsearchSuite struct {
+	suite.Suite
+	pluginName   string
+	connectAttrs map[string]string
+}
+
+func (p *ElasticsearchSuite) TestVisibilityPersistenceSuite() {
+	s := &VisibilityPersistenceSuite{
+		TestBase: persistencetests.NewTestBaseWithEs(
+			persistencetests.GetEsTestClusterOption(),
+		),
+	}
+	suite.Run(p.T(), s)
+}
+
+func TestElasticsearch(t *testing.T) {
+	t.Parallel()
+	s := &ElasticsearchSuite{}
+	suite.Run(t, s)
+}

--- a/common/persistence/tests/visibility_persistence_suite.go
+++ b/common/persistence/tests/visibility_persistence_suite.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -22,6 +23,7 @@ import (
 	persistencetests "go.temporal.io/server/common/persistence/persistence-tests"
 	"go.temporal.io/server/common/persistence/visibility"
 	"go.temporal.io/server/common/persistence/visibility/manager"
+	"go.temporal.io/server/common/persistence/visibility/store/elasticsearch"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/resolver"
 	"go.temporal.io/server/common/searchattribute"
@@ -67,7 +69,14 @@ func (s *VisibilityPersistenceSuite) SetupSuite() {
 		cfg,
 		resolver.NewNoopResolver(),
 		s.CustomVisibilityStoreFactory,
-		nil,
+		&elasticsearch.ProcessorConfig{
+			IndexerConcurrency:       dynamicconfig.GetIntPropertyFn(10),
+			ESProcessorNumOfWorkers:  dynamicconfig.GetIntPropertyFn(2),
+			ESProcessorBulkActions:   dynamicconfig.GetIntPropertyFn(10),
+			ESProcessorBulkSize:      dynamicconfig.GetIntPropertyFn(1 * 1024 * 1024), // 1MB
+			ESProcessorFlushInterval: dynamicconfig.GetDurationPropertyFn(time.Second),
+			ESProcessorAckTimeout:    dynamicconfig.GetDurationPropertyFn(30 * time.Second),
+		},
 		s.SearchAttributesProvider,
 		s.SearchAttributesMapperProvider,
 		s.NamespaceRegistry,
@@ -123,21 +132,25 @@ func (s *VisibilityPersistenceSuite) TestBasicVisibility() {
 	)
 
 	// ListOpenWorkflowExecutions
-	resp, err1 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    1,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
-			sadefs.StartTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.StartTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-		),
-	})
-	s.Nil(err1)
-	s.Equal(1, len(resp.Executions))
-	s.assertOpenExecutionEquals(startReq, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    1,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
+				sadefs.StartTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.StartTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertOpenExecutionEquals(t, startReq, resp.Executions[0])
+		},
+	)
 
 	closeReq := s.createClosedWorkflowRecord(
 		startReq,
@@ -146,37 +159,45 @@ func (s *VisibilityPersistenceSuite) TestBasicVisibility() {
 	)
 
 	// ListOpenWorkflowExecutions
-	resp, err3 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    1,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
-			sadefs.StartTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.StartTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-		),
-	})
-	s.Nil(err3)
-	s.Equal(0, len(resp.Executions))
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    1,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
+				sadefs.StartTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.StartTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Empty(t, resp.Executions)
+		},
+	)
 
 	// ListClosedWorkflowExecutions
-	resp, err4 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    1,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s != '%s'",
-			sadefs.CloseTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.CloseTime,
-			time.Now().Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-		),
-	})
-	s.Nil(err4)
-	s.Equal(1, len(resp.Executions))
-	s.assertClosedExecutionEquals(closeReq, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    1,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s != '%s'",
+				sadefs.CloseTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.CloseTime,
+				time.Now().Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertClosedExecutionEquals(t, closeReq, resp.Executions[0])
+		},
+	)
 }
 
 // TestBasicVisibilityTimeSkew test
@@ -194,21 +215,25 @@ func (s *VisibilityPersistenceSuite) TestBasicVisibilityTimeSkew() {
 	)
 
 	// ListOpenWorkflowExecutions
-	resp, err1 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    1,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
-			sadefs.StartTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.StartTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-		),
-	})
-	s.NoError(err1)
-	s.Equal(1, len(resp.Executions))
-	s.assertOpenExecutionEquals(openRecord, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    1,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
+				sadefs.StartTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.StartTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertOpenExecutionEquals(t, openRecord, resp.Executions[0])
+		},
+	)
 
 	closedRecord := s.createClosedWorkflowRecord(
 		openRecord,
@@ -217,37 +242,45 @@ func (s *VisibilityPersistenceSuite) TestBasicVisibilityTimeSkew() {
 	)
 
 	// ListOpenWorkflowExecutions
-	resp, err3 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    1,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
-			sadefs.StartTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.StartTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-		),
-	})
-	s.NoError(err3)
-	s.Equal(0, len(resp.Executions))
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    1,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
+				sadefs.StartTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.StartTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Empty(t, resp.Executions)
+		},
+	)
 
 	// ListClosedWorkflowExecutions
-	resp, err4 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    1,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s != '%s'",
-			sadefs.CloseTime,
-			startTime.Add(-10*time.Millisecond).Format(time.RFC3339Nano),
-			sadefs.CloseTime,
-			startTime.Add(-10*time.Millisecond).Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-		),
-	})
-	s.NoError(err4)
-	s.Equal(1, len(resp.Executions))
-	s.assertClosedExecutionEquals(closedRecord, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    1,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s != '%s'",
+				sadefs.CloseTime,
+				startTime.Add(-10*time.Millisecond).Format(time.RFC3339Nano),
+				sadefs.CloseTime,
+				startTime.Add(-10*time.Millisecond).Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertClosedExecutionEquals(t, closedRecord, resp.Executions[0])
+		},
+	)
 }
 
 func (s *VisibilityPersistenceSuite) TestBasicVisibilityShortWorkflow() {
@@ -269,42 +302,51 @@ func (s *VisibilityPersistenceSuite) TestBasicVisibilityShortWorkflow() {
 	)
 
 	// ListOpenWorkflowExecutions
-	resp, err3 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    1,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
-			sadefs.StartTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.StartTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-		),
-	})
-	s.NoError(err3)
-	s.Equal(0, len(resp.Executions))
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    1,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
+				sadefs.StartTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.StartTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Empty(t, resp.Executions)
+		},
+	)
 
 	// ListClosedWorkflowExecutions
-	resp, err4 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    1,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s != '%s'",
-			sadefs.CloseTime,
-			startTime.Add(10*time.Millisecond).Format(time.RFC3339Nano),
-			sadefs.CloseTime,
-			startTime.Add(10*time.Millisecond).Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-		),
-	})
-	s.NoError(err4)
-	s.Equal(1, len(resp.Executions))
-	s.assertClosedExecutionEquals(closedRecord, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    1,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s != '%s'",
+				sadefs.CloseTime,
+				startTime.Add(10*time.Millisecond).Format(time.RFC3339Nano),
+				sadefs.CloseTime,
+				startTime.Add(10*time.Millisecond).Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertClosedExecutionEquals(t, closedRecord, resp.Executions[0])
+		},
+	)
 }
 
 // TestVisibilityPagination test
 func (s *VisibilityPersistenceSuite) TestVisibilityPagination() {
 	testNamespaceUUID := namespace.ID(uuid.NewString())
+	var nextPageToken []byte
 
 	// Create 2 executions
 	startTime1 := time.Now().UTC()
@@ -328,44 +370,8 @@ func (s *VisibilityPersistenceSuite) TestVisibilityPagination() {
 	)
 
 	// Get the first one
-	resp, err2 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    1,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
-			sadefs.StartTime,
-			startTime1.Format(time.RFC3339Nano),
-			sadefs.StartTime,
-			startTime2.Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-		),
-	})
-	s.Nil(err2)
-	s.Equal(1, len(resp.Executions))
-	s.assertOpenExecutionEquals(openRecord2, resp.Executions[0])
-
-	// Use token to get the second one
-	resp, err3 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    1,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
-			sadefs.StartTime,
-			startTime1.Format(time.RFC3339Nano),
-			sadefs.StartTime,
-			startTime2.Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-		),
-		NextPageToken: resp.NextPageToken,
-	})
-	s.Nil(err3)
-	s.Equal(1, len(resp.Executions))
-	s.assertOpenExecutionEquals(openRecord1, resp.Executions[0])
-
-	// It is possible to not return non empty token which is going to return empty result
-	if len(resp.NextPageToken) != 0 {
-		// Now should get empty result by using token
-		resp, err4 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
 			NamespaceID: testNamespaceUUID,
 			PageSize:    1,
 			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
@@ -376,11 +382,142 @@ func (s *VisibilityPersistenceSuite) TestVisibilityPagination() {
 				sadefs.ExecutionStatus,
 				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
 			),
-			NextPageToken: resp.NextPageToken,
-		})
-		s.Nil(err4)
-		s.Equal(0, len(resp.Executions))
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertOpenExecutionEquals(t, openRecord2, resp.Executions[0])
+			nextPageToken = resp.NextPageToken
+		},
+	)
+
+	// Use token to get the second one
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    1,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
+				sadefs.StartTime,
+				startTime1.Format(time.RFC3339Nano),
+				sadefs.StartTime,
+				startTime2.Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			),
+			NextPageToken: nextPageToken,
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertOpenExecutionEquals(t, openRecord1, resp.Executions[0])
+			nextPageToken = resp.NextPageToken
+		},
+	)
+
+	// It is possible to not return non empty token which is going to return empty result
+	if len(nextPageToken) != 0 {
+		// Now should get empty result by using token
+		s.assertListWorkflowExecutions(
+			&manager.ListWorkflowExecutionsRequestV2{
+				NamespaceID: testNamespaceUUID,
+				PageSize:    1,
+				Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
+					sadefs.StartTime,
+					startTime1.Format(time.RFC3339Nano),
+					sadefs.StartTime,
+					startTime2.Format(time.RFC3339Nano),
+					sadefs.ExecutionStatus,
+					enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+				),
+				NextPageToken: nextPageToken,
+			},
+			func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+				require.NoError(t, err)
+				require.Empty(t, resp.Executions)
+			},
+		)
 	}
+}
+
+// TestPaginationEdgeCase verifies that the datatime filters works as expected
+// in the pagination filter.
+// Particularly, when a datetime is missing a component (eg: nanoseconds),
+// Elasticsearch fills it in unexpected ways.
+// Eg: if a workflow has CloseTime at 2023-04-05T06:07:08.100000000Z, a filter
+// like `CloseTime = '2023-04-05T06:07:08Z'` will match the workflow.
+// This can leads to unexpected behaviors during pagination.
+func (s *VisibilityPersistenceSuite) TestPaginationEdgeCase() {
+	testNamespaceUUID := namespace.ID(uuid.NewString())
+	startTime := time.Date(2023, 4, 5, 6, 7, 8, 0, time.UTC)
+	closeTime := startTime.Add(2 * time.Second)
+
+	// Generating workflows with oposite orders for CloseTime and StartTime.
+	// Eg: WF1 (CT1, ST1), WF2 (CT2, ST2), etc.
+	// We want ST1 < ST2 < ST3 < ... and CT1 > CT2 > CT3 > ...
+	// Furthermore, we want all of them to be within the same second and
+	// CTn must be an exact second, ie., no nanoseconds part.
+	// Since the step in time is 100ms, n must be less than 10.
+	n := 3
+	var startReqs []*manager.RecordWorkflowExecutionStartedRequest
+	for i := range n {
+		r := s.createOpenWorkflowRecord(
+			testNamespaceUUID,
+			fmt.Sprintf("visibility-datetime-filter-%d", i),
+			"visibility-datetime-filter",
+			startTime.Add(time.Duration(i)*100*time.Millisecond),
+			startTime.Add(time.Duration(i)*100*time.Millisecond),
+			"test-queue",
+		)
+		startReqs = append(startReqs, r)
+	}
+	for i := range startReqs {
+		r := s.createClosedWorkflowRecord(
+			startReqs[i],
+			closeTime.Add(time.Duration(n-i-1)*100*time.Millisecond),
+			enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+		)
+		fmt.Printf("FOO %d (%d, %d)\n", i, r.CloseTime.UTC().UnixNano(), r.StartTime.UTC().UnixNano())
+	}
+
+	s.assertCountWorkflowExecutions(
+		&manager.CountWorkflowExecutionsRequest{
+			NamespaceID: testNamespaceUUID,
+			Query:       "ExecutionStatus = 'Completed'",
+		},
+		func(t require.TestingT, resp *manager.CountWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Equal(t, int64(n), resp.Count)
+		},
+	)
+
+	pageSize := n
+	var nextPageToken []byte
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    pageSize,
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, pageSize)
+			require.NotEmpty(t, resp.NextPageToken)
+			nextPageToken = resp.NextPageToken
+		},
+	)
+
+	fmt.Printf("FOO page token: %s\n", nextPageToken)
+
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID:   testNamespaceUUID,
+			PageSize:      pageSize,
+			NextPageToken: nextPageToken,
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Empty(t, resp.Executions)
+		},
+	)
 }
 
 // TestFilteringByStartTime test
@@ -407,50 +544,76 @@ func (s *VisibilityPersistenceSuite) TestFilteringByStartTime() {
 	)
 
 	// List open workflows with start time filter
-	resp, err := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    2,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
-			sadefs.StartTime,
-			time.Now().Add(-time.Hour).Format(time.RFC3339Nano),
-			sadefs.StartTime,
-			time.Now().Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-		),
-	})
-	s.NoError(err)
-	s.Equal(1, len(resp.Executions))
-	s.assertOpenExecutionEquals(openRecord2, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    2,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
+				sadefs.StartTime,
+				time.Now().Add(-time.Hour).Format(time.RFC3339Nano),
+				sadefs.StartTime,
+				time.Now().Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertOpenExecutionEquals(t, openRecord2, resp.Executions[0])
+		},
+	)
 
 	// List with WorkflowType filter in query string
-	queryStr := fmt.Sprintf(`StartTime BETWEEN "%v" AND "%v"`, time.Now().Add(-time.Hour).Format(time.RFC3339Nano), time.Now().Format(time.RFC3339Nano))
-	resp, err = s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    2,
-		Query:       queryStr,
-	})
-	s.Nil(err)
-	s.Equal(1, len(resp.Executions))
-	s.assertOpenExecutionEquals(openRecord2, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    2,
+			Query: fmt.Sprintf(
+				`StartTime BETWEEN "%v" AND "%v"`,
+				time.Now().Add(-time.Hour).Format(time.RFC3339Nano),
+				time.Now().Format(time.RFC3339Nano),
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertOpenExecutionEquals(t, openRecord2, resp.Executions[0])
+		},
+	)
 
-	queryStr = fmt.Sprintf(`StartTime BETWEEN "%v" AND "%v"`, time.Now().Add(-3*time.Hour).Format(time.RFC3339Nano), time.Now().Format(time.RFC3339Nano))
-	resp, err = s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    2,
-		Query:       queryStr,
-	})
-	s.Nil(err)
-	s.Equal(2, len(resp.Executions))
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    2,
+			Query: fmt.Sprintf(
+				`StartTime BETWEEN "%v" AND "%v"`,
+				time.Now().Add(-3*time.Hour).Format(time.RFC3339Nano),
+				time.Now().Format(time.RFC3339Nano),
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 2)
+		},
+	)
 
-	resp, err = s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    2,
-		Query:       queryStr + ` AND WorkflowType = "visibility-workflow-1"`,
-	})
-	s.Nil(err)
-	s.Equal(1, len(resp.Executions))
-	s.assertOpenExecutionEquals(openRecord1, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    2,
+			Query: fmt.Sprintf(
+				`StartTime BETWEEN "%v" AND "%v" AND WorkflowType = "visibility-workflow-1"`,
+				time.Now().Add(-3*time.Hour).Format(time.RFC3339Nano),
+				time.Now().Format(time.RFC3339Nano),
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertOpenExecutionEquals(s.T(), openRecord1, resp.Executions[0])
+		},
+	)
 }
 
 // TestFilteringByType test
@@ -477,33 +640,41 @@ func (s *VisibilityPersistenceSuite) TestFilteringByType() {
 	)
 
 	// List open with filtering: ListOpenWorkflowExecutionsByType
-	resp, err2 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    2,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s' AND %s = '%s'",
-			sadefs.StartTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.StartTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-			sadefs.WorkflowType,
-			"visibility-workflow-1",
-		),
-	})
-	s.Nil(err2)
-	s.Equal(1, len(resp.Executions))
-	s.assertOpenExecutionEquals(openRecord1, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    2,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s' AND %s = '%s'",
+				sadefs.StartTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.StartTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+				sadefs.WorkflowType,
+				"visibility-workflow-1",
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertOpenExecutionEquals(t, openRecord1, resp.Executions[0])
+		},
+	)
 
 	// List with WorkflowType filter in query string
-	resp, err := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    2,
-		Query:       `WorkflowType = "visibility-workflow-1"`,
-	})
-	s.Nil(err)
-	s.Equal(1, len(resp.Executions))
-	s.assertOpenExecutionEquals(openRecord1, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    2,
+			Query:       `WorkflowType = "visibility-workflow-1"`,
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertOpenExecutionEquals(t, openRecord1, resp.Executions[0])
+		},
+	)
 
 	// Close both executions
 	s.createClosedWorkflowRecord(openRecord1, time.Now(), enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED)
@@ -514,33 +685,41 @@ func (s *VisibilityPersistenceSuite) TestFilteringByType() {
 	)
 
 	// List closed with filtering: ListClosedWorkflowExecutionsByType
-	resp, err5 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    2,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s != '%s' AND %s = '%s'",
-			sadefs.CloseTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.CloseTime,
-			time.Now().Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-			sadefs.WorkflowType,
-			"visibility-workflow-2",
-		),
-	})
-	s.Nil(err5)
-	s.Equal(1, len(resp.Executions))
-	s.assertClosedExecutionEquals(closedRecord2, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    2,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s != '%s' AND %s = '%s'",
+				sadefs.CloseTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.CloseTime,
+				time.Now().Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+				sadefs.WorkflowType,
+				"visibility-workflow-2",
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertClosedExecutionEquals(t, closedRecord2, resp.Executions[0])
+		},
+	)
 
 	// List with WorkflowType filter in query string
-	resp, err = s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    2,
-		Query:       `WorkflowType = "visibility-workflow-2"`,
-	})
-	s.Nil(err)
-	s.Equal(1, len(resp.Executions))
-	s.assertClosedExecutionEquals(closedRecord2, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    2,
+			Query:       `WorkflowType = "visibility-workflow-2"`,
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertClosedExecutionEquals(t, closedRecord2, resp.Executions[0])
+		},
+	)
 }
 
 // TestFilteringByWorkflowID test
@@ -567,33 +746,41 @@ func (s *VisibilityPersistenceSuite) TestFilteringByWorkflowID() {
 	)
 
 	// List open with filtering: ListOpenWorkflowExecutionsByWorkflowID
-	resp, err2 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    2,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s' AND %s = '%s'",
-			sadefs.StartTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.StartTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-			sadefs.WorkflowID,
-			"visibility-filtering-test1",
-		),
-	})
-	s.Nil(err2)
-	s.Equal(1, len(resp.Executions))
-	s.assertOpenExecutionEquals(openRecord1, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    2,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s' AND %s = '%s'",
+				sadefs.StartTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.StartTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+				sadefs.WorkflowID,
+				"visibility-filtering-test1",
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertOpenExecutionEquals(t, openRecord1, resp.Executions[0])
+		},
+	)
 
 	// List workflow with workflowID filter in query string
-	resp, err := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    2,
-		Query:       `WorkflowId = "visibility-filtering-test1"`,
-	})
-	s.Nil(err)
-	s.Equal(1, len(resp.Executions))
-	s.assertOpenExecutionEquals(openRecord1, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    2,
+			Query:       `WorkflowId = "visibility-filtering-test1"`,
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertOpenExecutionEquals(t, openRecord1, resp.Executions[0])
+		},
+	)
 
 	// Close both executions
 	s.createClosedWorkflowRecord(openRecord1, time.Now(), enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED)
@@ -604,33 +791,41 @@ func (s *VisibilityPersistenceSuite) TestFilteringByWorkflowID() {
 	)
 
 	// List closed with filtering: ListClosedWorkflowExecutionsByWorkflowID
-	resp, err5 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    2,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s != '%s' AND %s = '%s'",
-			sadefs.CloseTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.CloseTime,
-			time.Now().Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-			sadefs.WorkflowID,
-			"visibility-filtering-test2",
-		),
-	})
-	s.Nil(err5)
-	s.Equal(1, len(resp.Executions))
-	s.assertClosedExecutionEquals(closedRecord2, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    2,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s != '%s' AND %s = '%s'",
+				sadefs.CloseTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.CloseTime,
+				time.Now().Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+				sadefs.WorkflowID,
+				"visibility-filtering-test2",
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertClosedExecutionEquals(t, closedRecord2, resp.Executions[0])
+		},
+	)
 
 	// List workflow with workflowID filter in query string
-	resp, err = s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    2,
-		Query:       `WorkflowId = "visibility-filtering-test2"`,
-	})
-	s.Nil(err)
-	s.Equal(1, len(resp.Executions))
-	s.assertClosedExecutionEquals(closedRecord2, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    2,
+			Query:       `WorkflowId = "visibility-filtering-test2"`,
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertClosedExecutionEquals(t, closedRecord2, resp.Executions[0])
+		},
+	)
 }
 
 // TestFilteringByStatus test
@@ -668,30 +863,38 @@ func (s *VisibilityPersistenceSuite) TestFilteringByStatus() {
 	)
 
 	// List closed with filtering: ListClosedWorkflowExecutionsByStatus
-	resp, err4 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    2,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
-			sadefs.CloseTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.CloseTime,
-			time.Now().Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_FAILED,
-		),
-	})
-	s.Nil(err4)
-	s.Equal(1, len(resp.Executions))
-	s.assertClosedExecutionEquals(closeRecord2, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    2,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s = '%s'",
+				sadefs.CloseTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.CloseTime,
+				time.Now().Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_FAILED,
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertClosedExecutionEquals(t, closeRecord2, resp.Executions[0])
+		},
+	)
 
-	resp, err := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    5,
-		Query:       `ExecutionStatus = "Failed"`,
-	})
-	s.Nil(err)
-	s.Equal(1, len(resp.Executions))
-	s.assertClosedExecutionEquals(closeRecord2, resp.Executions[0])
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    5,
+			Query:       `ExecutionStatus = "Failed"`,
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, 1)
+			s.assertClosedExecutionEquals(t, closeRecord2, resp.Executions[0])
+		},
+	)
 }
 
 // TestDelete test
@@ -703,7 +906,7 @@ func (s *VisibilityPersistenceSuite) TestDeleteWorkflow() {
 	startTime := closeTime.Add(-5 * time.Second)
 	executionTime := closeTime.Add(-4 * time.Second)
 	var startRequests []*manager.RecordWorkflowExecutionStartedRequest
-	for i := 0; i < openRows; i++ {
+	for range openRows {
 		startReq := s.createOpenWorkflowRecord(
 			testNamespaceUUID,
 			uuid.NewString(),
@@ -715,7 +918,7 @@ func (s *VisibilityPersistenceSuite) TestDeleteWorkflow() {
 		startRequests = append(startRequests, startReq)
 	}
 
-	for i := 0; i < closedRows; i++ {
+	for i := range closedRows {
 		s.createClosedWorkflowRecord(
 			startRequests[i],
 			closeTime,
@@ -724,88 +927,109 @@ func (s *VisibilityPersistenceSuite) TestDeleteWorkflow() {
 	}
 
 	// ListClosedWorkflowExecutions
-	resp, err3 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    10,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s != '%s'",
-			sadefs.CloseTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.CloseTime,
-			closeTime.Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-		),
-	})
-	s.Nil(err3)
-	s.Equal(closedRows, len(resp.Executions))
+	var executions []*workflowpb.WorkflowExecutionInfo
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    10,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s != '%s'",
+				sadefs.CloseTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.CloseTime,
+				closeTime.Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, closedRows)
+			executions = resp.Executions
+		},
+	)
 
 	// Delete closed workflow
-	for _, row := range resp.Executions {
-		err4 := s.VisibilityMgr.DeleteWorkflowExecution(s.ctx, &manager.VisibilityDeleteWorkflowExecutionRequest{
-			NamespaceID: testNamespaceUUID,
-			WorkflowID:  row.GetExecution().GetWorkflowId(),
-			RunID:       row.GetExecution().GetRunId(),
-		})
-		s.Nil(err4)
+	for _, row := range executions {
+		s.deleteWorkflowRecord(
+			testNamespaceUUID,
+			row.GetExecution().GetWorkflowId(),
+			row.GetExecution().GetRunId(),
+		)
 	}
 
 	// ListClosedWorkflowExecutions
-	resp, err5 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		PageSize:    10,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s != '%s'",
-			sadefs.CloseTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.CloseTime,
-			closeTime.Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-		),
-	})
-	s.Nil(err5)
-	s.Equal(0, len(resp.Executions))
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			PageSize:    10,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s' AND %s != '%s'",
+				sadefs.CloseTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.CloseTime,
+				closeTime.Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			),
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Empty(t, resp.Executions)
+		},
+	)
 
 	// ListOpenWorkflowExecutions
-	resp, err6 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s'AND %s = '%s'",
-			sadefs.StartTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.StartTime,
-			closeTime.Format(time.RFC3339Nano),
-			sadefs.ExecutionStatus,
-			enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
-		),
-		PageSize: 10,
-	})
-	s.Nil(err6)
-	s.Equal(openRows-closedRows, len(resp.Executions))
-	// Delete open workflow
-	for _, row := range resp.Executions {
-		err7 := s.VisibilityMgr.DeleteWorkflowExecution(s.ctx, &manager.VisibilityDeleteWorkflowExecutionRequest{
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
 			NamespaceID: testNamespaceUUID,
-			WorkflowID:  row.GetExecution().GetWorkflowId(),
-			RunID:       row.GetExecution().GetRunId(),
-		})
-		s.Nil(err7)
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s'AND %s = '%s'",
+				sadefs.StartTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.StartTime,
+				closeTime.Format(time.RFC3339Nano),
+				sadefs.ExecutionStatus,
+				enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+			),
+			PageSize: 10,
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Len(t, resp.Executions, openRows-closedRows)
+			executions = resp.Executions
+		},
+	)
+
+	// Delete open workflow
+	for _, row := range executions {
+		s.deleteWorkflowRecord(
+			testNamespaceUUID,
+			row.GetExecution().GetWorkflowId(),
+			row.GetExecution().GetRunId(),
+		)
 	}
-	resp, err8 := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
-		NamespaceID: testNamespaceUUID,
-		Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s'",
-			sadefs.StartTime,
-			startTime.Format(time.RFC3339Nano),
-			sadefs.StartTime,
-			closeTime.Format(time.RFC3339Nano),
-		),
-		PageSize: 10,
-	})
-	s.Nil(err8)
-	s.Equal(0, len(resp.Executions))
+
+	s.assertListWorkflowExecutions(
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID: testNamespaceUUID,
+			Query: fmt.Sprintf("%s >= '%s' AND %s <= '%s'",
+				sadefs.StartTime,
+				startTime.Format(time.RFC3339Nano),
+				sadefs.StartTime,
+				closeTime.Format(time.RFC3339Nano),
+			),
+			PageSize: 10,
+		},
+		func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Empty(t, resp.Executions)
+		},
+	)
 }
 
 // TestUpsertWorkflowExecution test
 func (s *VisibilityPersistenceSuite) TestUpsertWorkflowExecution() {
+	testNamespaceUUID := namespace.ID(uuid.NewString())
 	temporalChangeVersionPayload, _ := payload.Encode([]string{"dummy"})
+	now := time.Now()
 	tests := []struct {
 		request  *manager.UpsertWorkflowExecutionRequest
 		expected error
@@ -813,13 +1037,15 @@ func (s *VisibilityPersistenceSuite) TestUpsertWorkflowExecution() {
 		{
 			request: &manager.UpsertWorkflowExecutionRequest{
 				VisibilityRequestBase: &manager.VisibilityRequestBase{
-					NamespaceID:      "",
-					Namespace:        "",
-					Execution:        &commonpb.WorkflowExecution{},
-					WorkflowTypeName: "",
-					StartTime:        time.Time{},
-					ExecutionTime:    time.Time{},
-					TaskID:           0,
+					NamespaceID: testNamespaceUUID,
+					Execution: &commonpb.WorkflowExecution{
+						WorkflowId: "upsert-workflow-1",
+						RunId:      uuid.NewString(),
+					},
+					WorkflowTypeName: "upsert-workflow",
+					StartTime:        now,
+					ExecutionTime:    now,
+					TaskID:           1,
 					Memo:             nil,
 					SearchAttributes: &commonpb.SearchAttributes{
 						IndexedFields: map[string]*commonpb.Payload{
@@ -834,13 +1060,15 @@ func (s *VisibilityPersistenceSuite) TestUpsertWorkflowExecution() {
 		{
 			request: &manager.UpsertWorkflowExecutionRequest{
 				VisibilityRequestBase: &manager.VisibilityRequestBase{
-					NamespaceID:      "",
-					Namespace:        "",
-					Execution:        &commonpb.WorkflowExecution{},
-					WorkflowTypeName: "",
-					StartTime:        time.Time{},
-					ExecutionTime:    time.Time{},
-					TaskID:           0,
+					NamespaceID: testNamespaceUUID,
+					Execution: &commonpb.WorkflowExecution{
+						WorkflowId: "upsert-workflow-2",
+						RunId:      uuid.NewString(),
+					},
+					WorkflowTypeName: "upsert-workflow",
+					StartTime:        now,
+					ExecutionTime:    now,
+					TaskID:           2,
 					Memo:             nil,
 					SearchAttributes: nil,
 					Status:           enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
@@ -865,7 +1093,7 @@ func (s *VisibilityPersistenceSuite) TestGetWorkflowExecution() {
 	startTime := closeTime.Add(-5 * time.Second)
 
 	var startRequests []*manager.RecordWorkflowExecutionStartedRequest
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		startRequests = append(
 			startRequests,
 			s.createOpenWorkflowRecord(
@@ -879,34 +1107,42 @@ func (s *VisibilityPersistenceSuite) TestGetWorkflowExecution() {
 		)
 	}
 	for _, req := range startRequests {
-		resp, err := s.VisibilityMgr.GetWorkflowExecution(
-			s.ctx,
+		s.assertGetWorkflowExecution(
 			&manager.GetWorkflowExecutionRequest{
 				NamespaceID: testNamespaceUUID,
+				WorkflowID:  req.Execution.WorkflowId,
 				RunID:       req.Execution.RunId,
 			},
+			func(t require.TestingT, resp *manager.GetWorkflowExecutionResponse, err error) {
+				require.NoErrorf(t, err, "execution %s not found", req.Execution.RunId)
+				s.assertOpenExecutionEquals(t, req, resp.Execution)
+			},
 		)
-		s.NoError(err)
-		s.assertOpenExecutionEquals(req, resp.Execution)
 	}
 
 	var closeRequests []*manager.RecordWorkflowExecutionClosedRequest
 	for _, startReq := range startRequests {
 		closeRequests = append(
 			closeRequests,
-			s.createClosedWorkflowRecord(startReq, closeTime, enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED),
+			s.createClosedWorkflowRecord(
+				startReq,
+				closeTime,
+				enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+			),
 		)
 	}
 	for _, req := range closeRequests {
-		resp, err := s.VisibilityMgr.GetWorkflowExecution(
-			s.ctx,
+		s.assertGetWorkflowExecution(
 			&manager.GetWorkflowExecutionRequest{
 				NamespaceID: testNamespaceUUID,
+				WorkflowID:  req.Execution.WorkflowId,
 				RunID:       req.Execution.RunId,
 			},
+			func(t require.TestingT, resp *manager.GetWorkflowExecutionResponse, err error) {
+				require.NoError(t, err)
+				s.assertClosedExecutionEquals(t, req, resp.Execution)
+			},
 		)
-		s.NoError(err)
-		s.assertClosedExecutionEquals(req, resp.Execution)
 	}
 }
 
@@ -917,7 +1153,7 @@ func (s *VisibilityPersistenceSuite) TestAdvancedVisibilityPagination() {
 	// Generate 5 workflow records, keep 2 open and 3 closed.
 	var startReqs []*manager.RecordWorkflowExecutionStartedRequest
 	var closeReqs []*manager.RecordWorkflowExecutionClosedRequest
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		startTime := time.Now()
 		startReq := s.createOpenWorkflowRecord(
 			testNamespaceUUID,
@@ -939,6 +1175,41 @@ func (s *VisibilityPersistenceSuite) TestAdvancedVisibilityPagination() {
 		}
 	}
 
+	// Wait until all workflows are persisted.
+	s.assertCountWorkflowExecutions(
+		&manager.CountWorkflowExecutionsRequest{
+			NamespaceID: testNamespaceUUID,
+			Query:       "GROUP BY ExecutionStatus",
+		},
+		func(t require.TestingT, resp *manager.CountWorkflowExecutionsResponse, err error) {
+			require.Equal(t, int64(5), resp.Count)
+			require.Len(t, resp.Groups, 2)
+			require.Subset(t, []int64{2, 3}, []int64{resp.Groups[0].Count, resp.Groups[1].Count})
+			var openGroup, closedGroup *workflowservice.CountWorkflowExecutionsResponse_AggregationGroup
+			if resp.Groups[0].Count == 2 {
+				openGroup = resp.Groups[0]
+				closedGroup = resp.Groups[1]
+			} else {
+				openGroup = resp.Groups[1]
+				closedGroup = resp.Groups[0]
+			}
+			require.Equal(t,
+				mustEncodeValue(t,
+					enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING.String(),
+					enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+				),
+				openGroup.GroupValues[0],
+			)
+			require.Equal(t,
+				mustEncodeValue(t,
+					enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED.String(),
+					enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+				),
+				closedGroup.GroupValues[0],
+			)
+		},
+	)
+
 	for pageSize := 1; pageSize <= 5; pageSize++ {
 		executions := make(map[string]*workflowpb.WorkflowExecutionInfo)
 		for _, e := range s.listWithPagination(testNamespaceUUID, 5) {
@@ -950,14 +1221,14 @@ func (s *VisibilityPersistenceSuite) TestAdvancedVisibilityPagination() {
 			id := r.Execution.GetWorkflowId()
 			e, ok := executions[id]
 			s.True(ok)
-			s.assertOpenExecutionEquals(r, e)
+			s.assertOpenExecutionEquals(s.T(), r, e)
 			delete(executions, id)
 		}
 		for _, r := range closeReqs {
 			id := r.Execution.GetWorkflowId()
 			e, ok := executions[id]
 			s.True(ok)
-			s.assertClosedExecutionEquals(r, e)
+			s.assertClosedExecutionEquals(s.T(), r, e)
 			delete(executions, id)
 		}
 		s.Empty(executions, "Unexpected executions returned from list method")
@@ -969,7 +1240,7 @@ func (s *VisibilityPersistenceSuite) TestCountWorkflowExecutions() {
 	closeTime := time.Now().UTC()
 	startTime := closeTime.Add(-5 * time.Second)
 
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		s.createOpenWorkflowRecord(
 			testNamespaceUUID,
 			"visibility-workflow-test",
@@ -980,16 +1251,17 @@ func (s *VisibilityPersistenceSuite) TestCountWorkflowExecutions() {
 		)
 	}
 
-	resp, err := s.VisibilityMgr.CountWorkflowExecutions(
-		s.ctx,
+	s.assertCountWorkflowExecutions(
 		&manager.CountWorkflowExecutionsRequest{
 			NamespaceID: testNamespaceUUID,
 			Query:       "",
 		},
+		func(t require.TestingT, resp *manager.CountWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Equal(t, int64(5), resp.Count)
+			require.Nil(t, resp.Groups)
+		},
 	)
-	s.NoError(err)
-	s.Equal(int64(5), resp.Count)
-	s.Nil(resp.Groups)
 }
 
 func (s *VisibilityPersistenceSuite) TestCountGroupByWorkflowExecutions() {
@@ -998,7 +1270,7 @@ func (s *VisibilityPersistenceSuite) TestCountGroupByWorkflowExecutions() {
 	startTime := closeTime.Add(-5 * time.Second)
 
 	var startRequests []*manager.RecordWorkflowExecutionStartedRequest
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		startRequests = append(
 			startRequests,
 			s.createOpenWorkflowRecord(
@@ -1012,30 +1284,33 @@ func (s *VisibilityPersistenceSuite) TestCountGroupByWorkflowExecutions() {
 		)
 	}
 
-	runningStatusPayload, _ := searchattribute.EncodeValue(
-		enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING.String(),
-		enumspb.INDEXED_VALUE_TYPE_KEYWORD,
-	)
-	resp, err := s.VisibilityMgr.CountWorkflowExecutions(
-		s.ctx,
+	s.assertCountWorkflowExecutions(
 		&manager.CountWorkflowExecutionsRequest{
 			NamespaceID: testNamespaceUUID,
 			Query:       "GROUP BY ExecutionStatus",
 		},
-	)
-	s.NoError(err)
-	s.Equal(int64(5), resp.Count)
-	s.Equal(
-		[]*workflowservice.CountWorkflowExecutionsResponse_AggregationGroup{
-			{
-				GroupValues: []*commonpb.Payload{runningStatusPayload},
-				Count:       int64(5),
-			},
+		func(t require.TestingT, resp *manager.CountWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Equal(t, int64(5), resp.Count)
+			require.Equal(
+				t,
+				[]*workflowservice.CountWorkflowExecutionsResponse_AggregationGroup{
+					{
+						GroupValues: []*commonpb.Payload{
+							mustEncodeValue(t,
+								enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING.String(),
+								enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+							),
+						},
+						Count: int64(5),
+					},
+				},
+				resp.Groups,
+			)
 		},
-		resp.Groups,
 	)
 
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		s.createClosedWorkflowRecord(
 			startRequests[i],
 			closeTime,
@@ -1043,25 +1318,29 @@ func (s *VisibilityPersistenceSuite) TestCountGroupByWorkflowExecutions() {
 		)
 	}
 
-	resp, err = s.VisibilityMgr.CountWorkflowExecutions(
-		s.ctx,
+	s.assertCountWorkflowExecutions(
 		&manager.CountWorkflowExecutionsRequest{
 			NamespaceID: testNamespaceUUID,
 			Query:       "GROUP BY ExecutionStatus",
 		},
+		func(t require.TestingT, resp *manager.CountWorkflowExecutionsResponse, err error) {
+			require.NoError(t, err)
+			require.Equal(t, int64(5), resp.Count)
+		},
 	)
-	s.NoError(err)
-	s.Equal(int64(5), resp.Count)
 }
 
-func (s *VisibilityPersistenceSuite) listWithPagination(namespaceID namespace.ID, pageSize int) []*workflowpb.WorkflowExecutionInfo {
+func (s *VisibilityPersistenceSuite) listWithPagination(
+	namespaceID namespace.ID,
+	pageSize int,
+) []*workflowpb.WorkflowExecutionInfo {
 	var executions []*workflowpb.WorkflowExecutionInfo
 	resp, err := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
 		NamespaceID: namespaceID,
 		PageSize:    pageSize,
 		Query:       "",
 	})
-	s.Nil(err)
+	s.NoError(err)
 	executions = append(executions, resp.Executions...)
 
 	for len(resp.NextPageToken) > 0 {
@@ -1071,7 +1350,7 @@ func (s *VisibilityPersistenceSuite) listWithPagination(namespaceID namespace.ID
 			Query:         "",
 			NextPageToken: resp.NextPageToken,
 		})
-		s.Nil(err)
+		s.NoError(err)
 		executions = append(executions, resp.Executions...)
 	}
 
@@ -1099,7 +1378,7 @@ func (s *VisibilityPersistenceSuite) createClosedWorkflowRecord(
 		HistoryLength:     5,
 	}
 	err := s.VisibilityMgr.RecordWorkflowExecutionClosed(s.ctx, closeReq)
-	s.Nil(err)
+	s.NoError(err)
 	return closeReq
 }
 
@@ -1129,29 +1408,103 @@ func (s *VisibilityPersistenceSuite) createOpenWorkflowRecord(
 		},
 	}
 	err := s.VisibilityMgr.RecordWorkflowExecutionStarted(s.ctx, startReq)
-	s.Nil(err)
+	s.NoError(err)
 	return startReq
 }
 
+func (s *VisibilityPersistenceSuite) deleteWorkflowRecord(
+	namespaceID namespace.ID,
+	workflowID string,
+	runID string,
+) {
+	s.taskID++
+	deleteReq := &manager.VisibilityDeleteWorkflowExecutionRequest{
+		NamespaceID: namespaceID,
+		WorkflowID:  workflowID,
+		RunID:       runID,
+		TaskID:      s.taskID,
+	}
+	err := s.VisibilityMgr.DeleteWorkflowExecution(s.ctx, deleteReq)
+	s.NoError(err)
+}
+
 func (s *VisibilityPersistenceSuite) assertClosedExecutionEquals(
-	req *manager.RecordWorkflowExecutionClosedRequest, resp *workflowpb.WorkflowExecutionInfo) {
-	s.Equal(req.Execution.RunId, resp.Execution.RunId)
-	s.Equal(req.Execution.WorkflowId, resp.Execution.WorkflowId)
-	s.Equal(req.WorkflowTypeName, resp.GetType().GetName())
-	s.Equal(persistence.UnixMilliseconds(req.StartTime), persistence.UnixMilliseconds(timestamp.TimeValue(resp.GetStartTime())))
-	s.Equal(persistence.UnixMilliseconds(req.CloseTime), persistence.UnixMilliseconds(timestamp.TimeValue(resp.GetCloseTime())))
-	s.Equal(req.Status, resp.GetStatus())
-	s.Equal(req.HistoryLength, resp.HistoryLength)
-	s.Equal(req.ExecutionDuration, resp.GetExecutionDuration().AsDuration())
+	t require.TestingT,
+	req *manager.RecordWorkflowExecutionClosedRequest,
+	resp *workflowpb.WorkflowExecutionInfo,
+) {
+	require.Equal(t, req.Execution.RunId, resp.Execution.RunId)
+	require.Equal(t, req.Execution.WorkflowId, resp.Execution.WorkflowId)
+	require.Equal(t, req.WorkflowTypeName, resp.GetType().GetName())
+	require.Equal(t, persistence.UnixMilliseconds(req.StartTime), persistence.UnixMilliseconds(timestamp.TimeValue(resp.GetStartTime())))
+	require.Equal(t, persistence.UnixMilliseconds(req.CloseTime), persistence.UnixMilliseconds(timestamp.TimeValue(resp.GetCloseTime())))
+	require.Equal(t, req.Status, resp.GetStatus())
+	require.Equal(t, req.HistoryLength, resp.HistoryLength)
+	require.Equal(t, req.ExecutionDuration, resp.GetExecutionDuration().AsDuration())
 }
 
 func (s *VisibilityPersistenceSuite) assertOpenExecutionEquals(
-	req *manager.RecordWorkflowExecutionStartedRequest, resp *workflowpb.WorkflowExecutionInfo) {
-	s.Equal(req.Execution.GetRunId(), resp.Execution.GetRunId())
-	s.Equal(req.Execution.WorkflowId, resp.Execution.WorkflowId)
-	s.Equal(req.WorkflowTypeName, resp.GetType().GetName())
-	s.Equal(persistence.UnixMilliseconds(req.StartTime), persistence.UnixMilliseconds(timestamp.TimeValue(resp.GetStartTime())))
-	s.Nil(resp.CloseTime)
-	s.Equal(resp.Status, enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING)
-	s.Zero(resp.HistoryLength)
+	t require.TestingT,
+	req *manager.RecordWorkflowExecutionStartedRequest,
+	resp *workflowpb.WorkflowExecutionInfo,
+) {
+	require.Equal(t, req.Execution.GetRunId(), resp.Execution.GetRunId())
+	require.Equal(t, req.Execution.WorkflowId, resp.Execution.WorkflowId)
+	require.Equal(t, req.WorkflowTypeName, resp.GetType().GetName())
+	require.Equal(t, persistence.UnixMilliseconds(req.StartTime), persistence.UnixMilliseconds(timestamp.TimeValue(resp.GetStartTime())))
+	require.Nil(t, resp.CloseTime)
+	require.Equal(t, enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, resp.Status)
+	require.Zero(t, resp.HistoryLength)
+}
+
+func (s *VisibilityPersistenceSuite) assertListWorkflowExecutions(
+	request *manager.ListWorkflowExecutionsRequestV2,
+	assertFn func(t require.TestingT, resp *manager.ListWorkflowExecutionsResponse, err error),
+) {
+	s.Require().EventuallyWithT(
+		func(t *assert.CollectT) {
+			resp, err := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, request)
+			assertFn(t, resp, err)
+		},
+		4*time.Second,
+		200*time.Millisecond,
+	)
+}
+
+func (s *VisibilityPersistenceSuite) assertCountWorkflowExecutions(
+	request *manager.CountWorkflowExecutionsRequest,
+	assertFn func(t require.TestingT, resp *manager.CountWorkflowExecutionsResponse, err error),
+) {
+	s.Require().EventuallyWithT(
+		func(t *assert.CollectT) {
+			resp, err := s.VisibilityMgr.CountWorkflowExecutions(s.ctx, request)
+			assertFn(t, resp, err)
+		},
+		4*time.Second,
+		200*time.Millisecond,
+	)
+}
+
+func (s *VisibilityPersistenceSuite) assertGetWorkflowExecution(
+	request *manager.GetWorkflowExecutionRequest,
+	assertFn func(t require.TestingT, resp *manager.GetWorkflowExecutionResponse, err error),
+) {
+	s.Require().EventuallyWithT(
+		func(t *assert.CollectT) {
+			resp, err := s.VisibilityMgr.GetWorkflowExecution(s.ctx, request)
+			assertFn(t, resp, err)
+		},
+		4*time.Second,
+		200*time.Millisecond,
+	)
+}
+
+func mustEncodeValue(
+	t require.TestingT,
+	val any,
+	tp enumspb.IndexedValueType,
+) *commonpb.Payload {
+	encoded, err := searchattribute.EncodeValue(val, tp)
+	require.NoError(t, err)
+	return encoded
 }

--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -37,6 +37,11 @@ const (
 	PersistenceName = "elasticsearch"
 
 	delimiter = "~"
+
+	// paginationDatetimeFormat is a copy from time.RFC3339Nano, but always writes
+	// the nanos component.
+	// Used only for formatting time.Time in the pagination filter.
+	paginationDatetimeFormat = "2006-01-02T15:04:05.000000000Z07:00"
 )
 
 type (
@@ -1395,12 +1400,13 @@ func buildPaginationQuery(
 //   - double: "Infinity" (desc) or "-Infinity" (asc)
 //   - keyword: nil
 //
-// Furthermore, for bool and datetime, they need to be converted to boolean or the RFC3339Nano
-// formats respectively.
+// Furthermore, for bool and datetime, they need to be converted to bool or string
+// types respectively.
 //
 //nolint:revive // cyclomatic complexity
 func parsePageTokenValue(
-	fieldName string, jsonValue any,
+	fieldName string,
+	jsonValue any,
 	tp enumspb.IndexedValueType,
 ) (any, error) {
 	switch tp {
@@ -1424,7 +1430,7 @@ func parsePageTokenValue(
 			return num != 0, nil
 		}
 		if tp == enumspb.INDEXED_VALUE_TYPE_DATETIME {
-			return time.Unix(0, num).UTC().Format(time.RFC3339Nano), nil
+			return time.Unix(0, num).UTC().Format(paginationDatetimeFormat), nil
 		}
 		return num, nil
 

--- a/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
@@ -1632,7 +1632,7 @@ func (s *ESVisibilitySuite) Test_buildPaginationQuery() {
 			searchAfter:  []any{json.Number(fmt.Sprintf("%d", startTime.UnixNano()))},
 			res: []elastic.Query{
 				elastic.NewBoolQuery().Filter(
-					elastic.NewRangeQuery(sadefs.StartTime).Lt(startTime.Format(time.RFC3339Nano)),
+					elastic.NewRangeQuery(sadefs.StartTime).Lt(startTime.Format(paginationDatetimeFormat)),
 				),
 			},
 			err: nil,
@@ -1652,7 +1652,7 @@ func (s *ESVisibilitySuite) Test_buildPaginationQuery() {
 				elastic.NewBoolQuery().
 					MustNot(elastic.NewExistsQuery(sadefs.CloseTime)).
 					Filter(
-						elastic.NewRangeQuery(sadefs.StartTime).Lt(startTime.Format(time.RFC3339Nano)),
+						elastic.NewRangeQuery(sadefs.StartTime).Lt(startTime.Format(paginationDatetimeFormat)),
 					),
 			},
 			err: nil,
@@ -1669,12 +1669,12 @@ func (s *ESVisibilitySuite) Test_buildPaginationQuery() {
 			},
 			res: []elastic.Query{
 				elastic.NewBoolQuery().Filter(
-					elastic.NewRangeQuery(sadefs.CloseTime).Lt(closeTime.Format(time.RFC3339Nano)),
+					elastic.NewRangeQuery(sadefs.CloseTime).Lt(closeTime.Format(paginationDatetimeFormat)),
 				),
 				elastic.NewBoolQuery().
 					Filter(
-						elastic.NewTermQuery(sadefs.CloseTime, closeTime.Format(time.RFC3339Nano)),
-						elastic.NewRangeQuery(sadefs.StartTime).Lt(startTime.Format(time.RFC3339Nano)),
+						elastic.NewTermQuery(sadefs.CloseTime, closeTime.Format(paginationDatetimeFormat)),
+						elastic.NewRangeQuery(sadefs.StartTime).Lt(startTime.Format(paginationDatetimeFormat)),
 					),
 			},
 			err: nil,
@@ -1693,17 +1693,17 @@ func (s *ESVisibilitySuite) Test_buildPaginationQuery() {
 			},
 			res: []elastic.Query{
 				elastic.NewBoolQuery().Filter(
-					elastic.NewRangeQuery(sadefs.CloseTime).Lt(closeTime.Format(time.RFC3339Nano)),
+					elastic.NewRangeQuery(sadefs.CloseTime).Lt(closeTime.Format(paginationDatetimeFormat)),
 				),
 				elastic.NewBoolQuery().
 					Filter(
-						elastic.NewTermQuery(sadefs.CloseTime, closeTime.Format(time.RFC3339Nano)),
-						elastic.NewRangeQuery(sadefs.StartTime).Lt(startTime.Format(time.RFC3339Nano)),
+						elastic.NewTermQuery(sadefs.CloseTime, closeTime.Format(paginationDatetimeFormat)),
+						elastic.NewRangeQuery(sadefs.StartTime).Lt(startTime.Format(paginationDatetimeFormat)),
 					),
 				elastic.NewBoolQuery().
 					Filter(
-						elastic.NewTermQuery(sadefs.CloseTime, closeTime.Format(time.RFC3339Nano)),
-						elastic.NewTermQuery(sadefs.StartTime, startTime.Format(time.RFC3339Nano)),
+						elastic.NewTermQuery(sadefs.CloseTime, closeTime.Format(paginationDatetimeFormat)),
+						elastic.NewTermQuery(sadefs.StartTime, startTime.Format(paginationDatetimeFormat)),
 						elastic.NewRangeQuery(sadefs.RunID).Gt("random-run-id"),
 					),
 			},
@@ -2335,4 +2335,61 @@ func (s *ESVisibilitySuite) TestValuesInterceptor_ChasmMapper() {
 	s.Error(err)
 	var converterErr *query.ConverterError
 	s.ErrorAs(err, &converterErr)
+}
+
+func TestPaginationDatetimeFormat(t *testing.T) {
+	testCases := []struct {
+		name string
+		in   time.Time
+		out  string
+	}{
+		{
+			name: "zero nanos",
+			in:   time.Date(2023, 4, 5, 6, 7, 8, 0, time.UTC),
+			out:  "2023-04-05T06:07:08.000000000Z",
+		},
+		{
+			name: "full nanos",
+			in:   time.Date(2023, 4, 5, 6, 7, 8, 123456789, time.UTC),
+			out:  "2023-04-05T06:07:08.123456789Z",
+		},
+		{
+			name: "trailing zeros in nanos",
+			in:   time.Date(2023, 4, 5, 6, 7, 8, 123000000, time.UTC),
+			out:  "2023-04-05T06:07:08.123000000Z",
+		},
+		{
+			name: "leading zeros in nanos",
+			in:   time.Date(2023, 4, 5, 6, 7, 8, 42, time.UTC),
+			out:  "2023-04-05T06:07:08.000000042Z",
+		},
+		{
+			name: "unix epoch",
+			in:   time.Unix(0, 0).UTC(),
+			out:  "1970-01-01T00:00:00.000000000Z",
+		},
+		{
+			name: "positive timezone offset",
+			in:   time.Date(2023, 4, 5, 6, 7, 8, 0, time.FixedZone("", 2*60*60+30*60)),
+			out:  "2023-04-05T06:07:08.000000000+02:30",
+		},
+		{
+			name: "negative timezone offset",
+			in:   time.Date(2023, 4, 5, 6, 7, 8, 123456789, time.FixedZone("", -5*60*60)),
+			out:  "2023-04-05T06:07:08.123456789-05:00",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := require.New(t)
+			out := tc.in.Format(paginationDatetimeFormat)
+			r.Equal(tc.out, out)
+			// The formatted value must remain a valid RFC3339 datetime, and parsing it back must
+			// return the original instant.
+			parsed, err := time.Parse(time.RFC3339Nano, out)
+			r.NoError(err)
+			r.True(tc.in.Equal(parsed), "expected %v, got %v", tc.in, parsed)
+		})
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/sony/gobreaker v1.0.0
 	github.com/stretchr/testify v1.11.1
 	github.com/temporalio/ringpop-go v0.0.0-20250130211428-b97329e994f7
-	github.com/temporalio/sqlparser v0.0.0-20231115171017-f4060bcfa6cb
+	github.com/temporalio/sqlparser v0.0.0-20260721183058-0466b6b405ac
 	github.com/temporalio/tchannel-go v1.22.1-0.20240528171429-1db37fdea938
 	github.com/uber-go/tally/v4 v4.1.17
 	github.com/urfave/cli v1.22.16

--- a/go.mod
+++ b/go.mod
@@ -43,9 +43,9 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/sony/gobreaker v1.0.0
 	github.com/stretchr/testify v1.11.1
-	github.com/temporalio/ringpop-go v0.0.0-20250130211428-b97329e994f7
+	github.com/temporalio/ringpop-go v0.1.0
 	github.com/temporalio/sqlparser v0.0.0-20260721183058-0466b6b405ac
-	github.com/temporalio/tchannel-go v1.22.1-0.20240528171429-1db37fdea938
+	github.com/temporalio/tchannel-go v1.22.1
 	github.com/uber-go/tally/v4 v4.1.17
 	github.com/urfave/cli v1.22.16
 	github.com/urfave/cli/v2 v2.27.5

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/sony/gobreaker v1.0.0
 	github.com/stretchr/testify v1.11.1
 	github.com/temporalio/ringpop-go v0.1.0
-	github.com/temporalio/sqlparser v0.0.0-20260721183058-0466b6b405ac
+	github.com/temporalio/sqlparser v0.1.0
 	github.com/temporalio/tchannel-go v1.22.1
 	github.com/uber-go/tally/v4 v4.1.17
 	github.com/urfave/cli v1.22.16

--- a/go.sum
+++ b/go.sum
@@ -312,8 +312,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/temporalio/ringpop-go v0.1.0 h1:VSyNcMOLYOnXwTPp2Yevhl5vqhMDU3M6iqpoL7qkrQI=
 github.com/temporalio/ringpop-go v0.1.0/go.mod h1:RE+CHmY+kOZQk47AQaVzwrGmxpflnLgTd6EOK0853j4=
-github.com/temporalio/sqlparser v0.0.0-20260721183058-0466b6b405ac h1:AFOFGU/hSzYNYfrMD6CNpnThorvFHC33jXqfrenkNKE=
-github.com/temporalio/sqlparser v0.0.0-20260721183058-0466b6b405ac/go.mod h1:143qKdh3G45IgV9p+gbAwp3ikRDI8mxsijFiXDfuxsw=
+github.com/temporalio/sqlparser v0.1.0 h1:jHbQyN3bfVLWGYPC/tLHpdjJxuL1YKOd1sf5OQPRM7o=
+github.com/temporalio/sqlparser v0.1.0/go.mod h1:143qKdh3G45IgV9p+gbAwp3ikRDI8mxsijFiXDfuxsw=
 github.com/temporalio/tchannel-go v1.22.1-0.20220818200552-1be8d8cffa5b/go.mod h1:c+V9Z/ZgkzAdyGvHrvC5AsXgN+M9Qwey04cBdKYzV7U=
 github.com/temporalio/tchannel-go v1.22.1 h1:H1hsQvAk0ExXgzGI3Qll6M0WjAlu2ysL2FtvZ/jdkU4=
 github.com/temporalio/tchannel-go v1.22.1/go.mod h1:ezRQRwu9KQXy8Wuuv1aaFFxoCNz5CeNbVOOkh3xctbY=

--- a/go.sum
+++ b/go.sum
@@ -310,13 +310,13 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/temporalio/ringpop-go v0.0.0-20250130211428-b97329e994f7 h1:lEebX/hZss+TSH3EBwhztnBavJVj7pWGJOH8UgKHS0w=
-github.com/temporalio/ringpop-go v0.0.0-20250130211428-b97329e994f7/go.mod h1:RE+CHmY+kOZQk47AQaVzwrGmxpflnLgTd6EOK0853j4=
+github.com/temporalio/ringpop-go v0.1.0 h1:VSyNcMOLYOnXwTPp2Yevhl5vqhMDU3M6iqpoL7qkrQI=
+github.com/temporalio/ringpop-go v0.1.0/go.mod h1:RE+CHmY+kOZQk47AQaVzwrGmxpflnLgTd6EOK0853j4=
 github.com/temporalio/sqlparser v0.0.0-20260721183058-0466b6b405ac h1:AFOFGU/hSzYNYfrMD6CNpnThorvFHC33jXqfrenkNKE=
 github.com/temporalio/sqlparser v0.0.0-20260721183058-0466b6b405ac/go.mod h1:143qKdh3G45IgV9p+gbAwp3ikRDI8mxsijFiXDfuxsw=
 github.com/temporalio/tchannel-go v1.22.1-0.20220818200552-1be8d8cffa5b/go.mod h1:c+V9Z/ZgkzAdyGvHrvC5AsXgN+M9Qwey04cBdKYzV7U=
-github.com/temporalio/tchannel-go v1.22.1-0.20240528171429-1db37fdea938 h1:sEJGhmDo+0FaPWM6f0v8Tjia0H5pR6/Baj6+kS78B+M=
-github.com/temporalio/tchannel-go v1.22.1-0.20240528171429-1db37fdea938/go.mod h1:ezRQRwu9KQXy8Wuuv1aaFFxoCNz5CeNbVOOkh3xctbY=
+github.com/temporalio/tchannel-go v1.22.1 h1:H1hsQvAk0ExXgzGI3Qll6M0WjAlu2ysL2FtvZ/jdkU4=
+github.com/temporalio/tchannel-go v1.22.1/go.mod h1:ezRQRwu9KQXy8Wuuv1aaFFxoCNz5CeNbVOOkh3xctbY=
 github.com/twmb/murmur3 v1.1.8 h1:8Yt9taO/WN3l08xErzjeschgZU2QSrwm1kclYq+0aRg=
 github.com/twmb/murmur3 v1.1.8/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 github.com/uber-common/bark v1.0.0/go.mod h1:g0ZuPcD7XiExKHynr93Q742G/sbrdVQkghrqLGOoFuY=

--- a/go.sum
+++ b/go.sum
@@ -312,8 +312,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/temporalio/ringpop-go v0.0.0-20250130211428-b97329e994f7 h1:lEebX/hZss+TSH3EBwhztnBavJVj7pWGJOH8UgKHS0w=
 github.com/temporalio/ringpop-go v0.0.0-20250130211428-b97329e994f7/go.mod h1:RE+CHmY+kOZQk47AQaVzwrGmxpflnLgTd6EOK0853j4=
-github.com/temporalio/sqlparser v0.0.0-20231115171017-f4060bcfa6cb h1:YzHH/U/dN7vMP+glybzcXRTczTrgfdRisNTzAj7La04=
-github.com/temporalio/sqlparser v0.0.0-20231115171017-f4060bcfa6cb/go.mod h1:143qKdh3G45IgV9p+gbAwp3ikRDI8mxsijFiXDfuxsw=
+github.com/temporalio/sqlparser v0.0.0-20260721183058-0466b6b405ac h1:AFOFGU/hSzYNYfrMD6CNpnThorvFHC33jXqfrenkNKE=
+github.com/temporalio/sqlparser v0.0.0-20260721183058-0466b6b405ac/go.mod h1:143qKdh3G45IgV9p+gbAwp3ikRDI8mxsijFiXDfuxsw=
 github.com/temporalio/tchannel-go v1.22.1-0.20220818200552-1be8d8cffa5b/go.mod h1:c+V9Z/ZgkzAdyGvHrvC5AsXgN+M9Qwey04cBdKYzV7U=
 github.com/temporalio/tchannel-go v1.22.1-0.20240528171429-1db37fdea938 h1:sEJGhmDo+0FaPWM6f0v8Tjia0H5pR6/Baj6+kS78B+M=
 github.com/temporalio/tchannel-go v1.22.1-0.20240528171429-1db37fdea938/go.mod h1:ezRQRwu9KQXy8Wuuv1aaFFxoCNz5CeNbVOOkh3xctbY=

--- a/service/history/api/getworkflowexecutionhistory/api.go
+++ b/service/history/api/getworkflowexecutionhistory/api.go
@@ -162,6 +162,19 @@ func Invoke(
 			continuationToken.FirstEventId = continuationToken.GetNextEventId()
 			continuationToken.NextEventId = nextEventID
 			continuationToken.IsWorkflowRunning = isWorkflowRunning
+		} else {
+			if err = api.ValidateBranchTokenForExecution(
+				ctx,
+				shardContext,
+				workflowConsistencyChecker,
+				eventNotifier,
+				namespaceName,
+				namespaceID,
+				execution,
+				continuationToken.BranchToken,
+			); err != nil {
+				return nil, err
+			}
 		}
 	} else {
 		continuationToken = &tokenspb.HistoryContinuation{}

--- a/service/history/api/getworkflowexecutionhistoryreverse/api.go
+++ b/service/history/api/getworkflowexecutionhistoryreverse/api.go
@@ -103,6 +103,23 @@ func Invoke(
 		}
 
 		execution.RunId = continuationToken.GetRunId()
+
+		var namespaceName namespace.Name
+		if entry, err := shardContext.GetNamespaceRegistry().GetNamespaceByID(namespaceID); err == nil {
+			namespaceName = entry.Name()
+		}
+		if err = api.ValidateBranchTokenForExecution(
+			ctx,
+			shardContext,
+			workflowConsistencyChecker,
+			eventNotifier,
+			namespaceName,
+			namespaceID,
+			execution,
+			continuationToken.BranchToken,
+		); err != nil {
+			return nil, err
+		}
 	}
 
 	// TODO below is a temporal solution to guard against invalid event batch

--- a/service/history/api/token.go
+++ b/service/history/api/token.go
@@ -1,10 +1,20 @@
 package api
 
 import (
+	"bytes"
+	"context"
+
+	commonpb "go.temporal.io/api/common/v1"
 	historyspb "go.temporal.io/server/api/history/v1"
 	"go.temporal.io/server/api/historyservice/v1"
 	tokenspb "go.temporal.io/server/api/token/v1"
+	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
+	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/service/history/consts"
+	"go.temporal.io/server/service/history/events"
+	historyi "go.temporal.io/server/service/history/interfaces"
 )
 
 // NOTE: DO NOT MODIFY UNLESS ALSO APPLIED TO ./service/frontend/token_deprecated.go
@@ -115,4 +125,119 @@ func ValidatePaginationToken(
 		return consts.ErrInvalidPaginationToken
 	}
 	return nil
+}
+
+const (
+	// branchTokenMismatchReasonNonCurrent is a branch this execution records but no longer reads from.
+	branchTokenMismatchReasonNonCurrent metrics.ReasonString = "non_current_branch"
+	branchTokenMismatchReasonForeign    metrics.ReasonString = "foreign_branch"
+)
+
+// maxLoggedBranchTokenLen bounds caller-supplied bytes reaching the log.
+const maxLoggedBranchTokenLen = 4096
+
+func branchTokenMismatchReason(
+	currentBranchToken []byte,
+	requestBranchToken []byte,
+	versionHistories *historyspb.VersionHistories,
+) metrics.ReasonString {
+	if bytes.Equal(requestBranchToken, currentBranchToken) {
+		return ""
+	}
+	for _, versionHistory := range versionHistories.GetHistories() {
+		if bytes.Equal(versionHistory.GetBranchToken(), requestBranchToken) {
+			return branchTokenMismatchReasonNonCurrent
+		}
+	}
+	return branchTokenMismatchReasonForeign
+}
+
+func reportBranchTokenMismatch(
+	shardContext historyi.ShardContext,
+	namespaceName string,
+	execution *commonpb.WorkflowExecution,
+	reason metrics.ReasonString,
+	currentBranchToken []byte,
+	requestBranchToken []byte,
+) {
+	if namespaceName == "" {
+		namespaceName = metrics.NamespaceUnknownTag().Value
+	}
+	metrics.PaginationTokenBranchMismatchCounter.With(shardContext.GetMetricsHandler()).Record(
+		1,
+		metrics.NamespaceTag(namespaceName),
+		metrics.ReasonTag(reason),
+	)
+	loggedRequestToken := requestBranchToken[:min(len(requestBranchToken), maxLoggedBranchTokenLen)]
+	shardContext.GetLogger().Warn("Pagination branch token is not the execution's current branch token",
+		tag.WorkflowNamespace(namespaceName),
+		tag.WorkflowID(execution.GetWorkflowId()),
+		tag.WorkflowRunID(execution.GetRunId()),
+		tag.NewStringTag("reason", string(reason)),
+		tag.WorkflowBranchToken(currentBranchToken),
+		tag.WorkflowRequestBranchToken(loggedRequestToken),
+	)
+}
+
+// ValidateBranchTokenForExecution rejects a paging branch token that is not the execution's current
+// one.
+func ValidateBranchTokenForExecution(
+	ctx context.Context,
+	shardContext historyi.ShardContext,
+	workflowConsistencyChecker WorkflowConsistencyChecker,
+	eventNotifier events.Notifier,
+	namespaceName namespace.Name,
+	namespaceID namespace.ID,
+	execution *commonpb.WorkflowExecution,
+	requestBranchToken []byte,
+) error {
+	config := shardContext.GetConfig()
+	if !config.EnablePaginationTokenBranchValidation() {
+		return nil
+	}
+	if len(requestBranchToken) == 0 {
+		return consts.ErrInvalidNextPageToken
+	}
+
+	response, err := GetOrPollWorkflowMutableState(
+		ctx,
+		shardContext,
+		&historyservice.GetMutableStateRequest{
+			NamespaceId: namespaceID.String(),
+			Execution:   execution,
+		},
+		workflowConsistencyChecker,
+		eventNotifier,
+	)
+	if err != nil {
+		return err
+	}
+
+	currentBranchToken := response.GetCurrentBranchToken()
+	mismatchReason := branchTokenMismatchReason(
+		currentBranchToken,
+		requestBranchToken,
+		response.GetVersionHistories(),
+	)
+	if mismatchReason == "" {
+		return nil
+	}
+
+	reportBranchTokenMismatch(
+		shardContext,
+		namespaceName.String(),
+		execution,
+		mismatchReason,
+		currentBranchToken,
+		requestBranchToken,
+	)
+	if config.EnablePaginationTokenBranchValidationShadowMode() {
+		return nil
+	}
+	return serviceerrors.NewCurrentBranchChanged(
+		currentBranchToken,
+		requestBranchToken,
+		nil,
+		nil,
+	)
 }

--- a/service/history/api/token_test.go
+++ b/service/history/api/token_test.go
@@ -1,0 +1,116 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	historyspb "go.temporal.io/server/api/history/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/primitives"
+	"go.temporal.io/server/service/history/configs"
+	"go.temporal.io/server/service/history/consts"
+	historyi "go.temporal.io/server/service/history/interfaces"
+	"go.uber.org/mock/gomock"
+)
+
+func newTestBranchToken(
+	t *testing.T,
+	treeID string,
+	branchID string,
+	ancestors []*persistencespb.HistoryBranchRange,
+) []byte {
+	t.Helper()
+	branchUtil := &persistence.HistoryBranchUtilImpl{}
+	token, err := branchUtil.NewHistoryBranch(
+		"namespace-id", "workflow-id", "run-id", treeID, &branchID, ancestors, 0, 0, 0,
+	)
+	require.NoError(t, err)
+	return token
+}
+
+func testVersionHistories(tokens ...[]byte) *historyspb.VersionHistories {
+	versionHistories := &historyspb.VersionHistories{}
+	for _, token := range tokens {
+		versionHistories.Histories = append(
+			versionHistories.Histories,
+			&historyspb.VersionHistory{BranchToken: token},
+		)
+	}
+	return versionHistories
+}
+
+func TestBranchTokenMismatchReason(t *testing.T) {
+	treeID := primitives.NewUUID().String()
+	branchID := primitives.NewUUID().String()
+	otherTreeID := primitives.NewUUID().String()
+	otherBranchID := primitives.NewUUID().String()
+
+	current := newTestBranchToken(t, treeID, branchID, nil)
+	nonCurrent := newTestBranchToken(t, otherTreeID, otherBranchID, nil)
+
+	t.Run("matches the current branch token", func(t *testing.T) {
+		got := branchTokenMismatchReason(current, current, testVersionHistories(current))
+		require.Empty(t, got)
+	})
+
+	t.Run("matches the current token when an identical token is recorded twice", func(t *testing.T) {
+		got := branchTokenMismatchReason(current, current, testVersionHistories(current, current))
+		require.Empty(t, got)
+	})
+
+	t.Run("matches opaque tokens the branch parser cannot read", func(t *testing.T) {
+		opaque := []byte{1, 2, 3}
+		got := branchTokenMismatchReason(opaque, opaque, testVersionHistories(opaque))
+		require.Empty(t, got)
+	})
+
+	t.Run("reports a non-current branch when the token names an older history", func(t *testing.T) {
+		histories := testVersionHistories(nonCurrent, current)
+		got := branchTokenMismatchReason(current, nonCurrent, histories)
+		require.Equal(t, branchTokenMismatchReasonNonCurrent, got)
+	})
+
+	t.Run("reports foreign for a different branch in the same tree", func(t *testing.T) {
+		request := newTestBranchToken(t, treeID, otherBranchID, nil)
+		got := branchTokenMismatchReason(current, request, testVersionHistories(current))
+		require.Equal(t, branchTokenMismatchReasonForeign, got)
+	})
+
+	t.Run("reports foreign for the current branch carrying injected ancestors", func(t *testing.T) {
+		request := newTestBranchToken(t, treeID, branchID, []*persistencespb.HistoryBranchRange{
+			{BranchId: otherBranchID, BeginNodeId: 1, EndNodeId: 1000},
+		})
+		got := branchTokenMismatchReason(current, request, testVersionHistories(current))
+		require.Equal(t, branchTokenMismatchReasonForeign, got)
+	})
+
+	t.Run("reports foreign when there are no version histories", func(t *testing.T) {
+		got := branchTokenMismatchReason(current, nonCurrent, nil)
+		require.Equal(t, branchTokenMismatchReasonForeign, got)
+	})
+}
+
+func TestValidateBranchTokenForExecution_EmptyRequestToken(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		validation bool
+		wantErr    error
+	}{
+		{name: "rejected while validating", validation: true, wantErr: consts.ErrInvalidNextPageToken},
+		{name: "served once validation is disabled", validation: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			shardContext := historyi.NewMockShardContext(gomock.NewController(t))
+			shardContext.EXPECT().GetConfig().Return(&configs.Config{
+				EnablePaginationTokenBranchValidation: dynamicconfig.GetBoolPropertyFn(tc.validation),
+			}).AnyTimes()
+
+			err := ValidateBranchTokenForExecution(
+				context.Background(), shardContext, nil, nil, "", "", nil, nil)
+			require.ErrorIs(t, err, tc.wantErr)
+		})
+	}
+}

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -381,6 +381,9 @@ type Config struct {
 	SendRawHistoryBetweenInternalServices dynamicconfig.BoolPropertyFn
 	SendRawWorkflowHistory                dynamicconfig.BoolPropertyFnWithNamespaceFilter
 
+	EnablePaginationTokenBranchValidation           dynamicconfig.BoolPropertyFn
+	EnablePaginationTokenBranchValidationShadowMode dynamicconfig.BoolPropertyFn
+
 	WorkflowIdReuseMinimalInterval           dynamicconfig.DurationPropertyFnWithNamespaceFilter
 	EnableWorkflowIdReuseStartTimeValidation dynamicconfig.BoolPropertyFnWithNamespaceFilter
 
@@ -747,8 +750,12 @@ func NewConfig(
 		EnableUpdateWithStartRetryOnClosedWorkflowAbort:               dynamicconfig.EnableUpdateWithStartRetryOnClosedWorkflowAbort.Get(dc),
 		EnableUpdateWithStartRetryableErrorOnClosedWorkflowAbort:      dynamicconfig.EnableUpdateWithStartRetryableErrorOnClosedWorkflowAbort.Get(dc),
 
-		SendRawHistoryBetweenInternalServices:    dynamicconfig.SendRawHistoryBetweenInternalServices.Get(dc),
-		SendRawWorkflowHistory:                   dynamicconfig.SendRawWorkflowHistory.Get(dc),
+		SendRawHistoryBetweenInternalServices: dynamicconfig.SendRawHistoryBetweenInternalServices.Get(dc),
+		SendRawWorkflowHistory:                dynamicconfig.SendRawWorkflowHistory.Get(dc),
+
+		EnablePaginationTokenBranchValidation:           dynamicconfig.EnablePaginationTokenBranchValidation.Get(dc),
+		EnablePaginationTokenBranchValidationShadowMode: dynamicconfig.EnablePaginationTokenBranchValidationShadowMode.Get(dc),
+
 		WorkflowIdReuseMinimalInterval:           dynamicconfig.WorkflowIdReuseMinimalInterval.Get(dc),
 		EnableWorkflowIdReuseStartTimeValidation: dynamicconfig.EnableWorkflowIdReuseStartTimeValidation.Get(dc),
 

--- a/service/history/history_engine_test.go
+++ b/service/history/history_engine_test.go
@@ -52,6 +52,7 @@ import (
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/rpc/interceptor"
 	"go.temporal.io/server/common/searchattribute"
+	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/common/tasktoken"
 	"go.temporal.io/server/common/testing/protorequire"
 	"go.temporal.io/server/service/history/api"
@@ -5792,6 +5793,33 @@ func (s *engineSuite) TestGetWorkflowExecutionHistory_RawHistoryWithTransientDec
 	}
 
 	s.mockNamespaceCache.EXPECT().GetNamespaceID(tests.Namespace).Return(tests.NamespaceID, nil).AnyTimes()
+	// The page token carries a branch token, so the read validates it against mutable state.
+	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.GetWorkflowExecutionResponse{
+		State: &persistencespb.WorkflowMutableState{
+			ExecutionState: &persistencespb.WorkflowExecutionState{
+				State:  enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING,
+				Status: enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+				RunId:  we.RunId,
+			},
+			NextEventId: 5,
+			ExecutionInfo: &persistencespb.WorkflowExecutionInfo{
+				NamespaceId: tests.NamespaceID.String(),
+				WorkflowId:  we.WorkflowId,
+				VersionHistories: &historyspb.VersionHistories{
+					CurrentVersionHistoryIndex: 0,
+					Histories: []*historyspb.VersionHistory{
+						{
+							BranchToken: branchToken,
+							Items: []*historyspb.VersionHistoryItem{
+								{EventId: 4, Version: 0},
+							},
+						},
+					},
+				},
+			},
+		},
+		MutableStateStats: persistence.MutableStateStatistics{},
+	}, nil).AnyTimes()
 	historyBlob1, err := s.mockShard.GetPayloadSerializer().SerializeEvents(
 		[]*historypb.HistoryEvent{
 			{
@@ -6774,4 +6802,209 @@ func addFailWorkflowEvent(
 		"",
 	)
 	return event
+}
+
+func (s *engineSuite) mockExecutionWithForeignBranchToken(
+	we *commonpb.WorkflowExecution,
+) (ownedToken []byte, foreignToken []byte) {
+	branchUtil := &persistence.HistoryBranchUtilImpl{}
+	treeID := uuid.NewString()
+	ownedBranchID := uuid.NewString()
+	foreignBranchID := uuid.NewString()
+
+	ownedBranchToken, err := branchUtil.NewHistoryBranch(
+		tests.NamespaceID.String(), we.WorkflowId, we.RunId, treeID, &ownedBranchID, nil, 0, 0, 0)
+	s.NoError(err)
+	foreignBranchToken, err := branchUtil.NewHistoryBranch(
+		tests.NamespaceID.String(), we.WorkflowId, we.RunId, treeID, &foreignBranchID, nil, 0, 0, 0)
+	s.NoError(err)
+
+	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.GetWorkflowExecutionResponse{
+		State: &persistencespb.WorkflowMutableState{
+			ExecutionState: &persistencespb.WorkflowExecutionState{
+				State:  enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING,
+				Status: enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
+				RunId:  we.RunId,
+			},
+			NextEventId: 5,
+			ExecutionInfo: &persistencespb.WorkflowExecutionInfo{
+				NamespaceId: tests.NamespaceID.String(),
+				WorkflowId:  we.WorkflowId,
+				VersionHistories: &historyspb.VersionHistories{
+					CurrentVersionHistoryIndex: 0,
+					Histories: []*historyspb.VersionHistory{
+						{
+							BranchToken: ownedBranchToken,
+							Items: []*historyspb.VersionHistoryItem{
+								{EventId: 4, Version: 0},
+							},
+						},
+					},
+				},
+			},
+		},
+		MutableStateStats: persistence.MutableStateStatistics{},
+	}, nil).AnyTimes()
+
+	return ownedBranchToken, foreignBranchToken
+}
+
+func (s *engineSuite) getHistoryRequestWithPageToken(
+	we *commonpb.WorkflowExecution,
+	continuation *tokenspb.HistoryContinuation,
+	waitNewEvent bool,
+) *historyservice.GetWorkflowExecutionHistoryRequest {
+	nextPageToken, err := api.SerializeHistoryToken(continuation)
+	s.NoError(err)
+	return &historyservice.GetWorkflowExecutionHistoryRequest{
+		NamespaceId: tests.NamespaceID.String(),
+		Request: &workflowservice.GetWorkflowExecutionHistoryRequest{
+			Execution:              we,
+			MaximumPageSize:        10,
+			NextPageToken:          nextPageToken,
+			WaitNewEvent:           waitNewEvent,
+			HistoryEventFilterType: enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT,
+			SkipArchival:           true,
+		},
+	}
+}
+
+// expectHistoryReadWithBranchToken allows the history read and pins the branch token it is issued with.
+func (s *engineSuite) expectHistoryReadWithBranchToken(branchToken []byte) {
+	s.mockSearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), false).
+		Return(searchattribute.TestNameTypeMap(), nil).AnyTimes()
+	s.mockVisibilityMgr.EXPECT().GetIndexName().Return(esIndexName).AnyTimes()
+	s.mockExecutionMgr.EXPECT().ReadHistoryBranch(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, request *persistence.ReadHistoryBranchRequest) (*persistence.ReadHistoryBranchResponse, error) {
+			s.Equal(branchToken, request.BranchToken)
+			return &persistence.ReadHistoryBranchResponse{HistoryEvents: []*historypb.HistoryEvent{}}, nil
+		},
+	).MinTimes(1)
+}
+
+func (s *engineSuite) TestGetWorkflowExecutionHistory_BranchTokenNotOwnedByExecution() {
+	we := commonpb.WorkflowExecution{WorkflowId: "wid-foreign-branch", RunId: uuid.NewString()}
+
+	engine, err := s.historyEngine.shardContext.GetEngine(context.Background())
+	s.NoError(err)
+
+	s.config.EnablePaginationTokenBranchValidationShadowMode = dynamicconfig.GetBoolPropertyFn(false)
+	_, foreignBranchToken := s.mockExecutionWithForeignBranchToken(&we)
+	req := s.getHistoryRequestWithPageToken(&we, &tokenspb.HistoryContinuation{
+		RunId:             we.GetRunId(),
+		FirstEventId:      common.FirstEventID,
+		NextEventId:       5,
+		PersistenceToken:  []byte("some random persistence token"),
+		BranchToken:       foreignBranchToken,
+		IsWorkflowRunning: true,
+	}, false)
+
+	// The history read must never be attempted, on either the decoded or the raw path.
+	s.mockExecutionMgr.EXPECT().ReadHistoryBranch(gomock.Any(), gomock.Any()).Times(0)
+	s.mockExecutionMgr.EXPECT().ReadRawHistoryBranch(gomock.Any(), gomock.Any()).Times(0)
+
+	for _, sendRawHistory := range []bool{false, true} {
+		s.config.SendRawWorkflowHistory = func(string) bool { return sendRawHistory }
+		_, err = engine.GetWorkflowExecutionHistory(context.Background(), req)
+		var branchErr *serviceerrors.CurrentBranchChanged
+		s.ErrorAs(err, &branchErr, "sendRawHistory=%v", sendRawHistory)
+	}
+}
+
+func (s *engineSuite) TestGetWorkflowExecutionHistory_ForeignBranchTokenServedWhenNotEnforcing() {
+	we := commonpb.WorkflowExecution{WorkflowId: "wid-foreign-branch-served", RunId: uuid.NewString()}
+
+	engine, err := s.historyEngine.shardContext.GetEngine(context.Background())
+	s.NoError(err)
+
+	s.config.SendRawWorkflowHistory = func(string) bool { return false }
+	_, foreignBranchToken := s.mockExecutionWithForeignBranchToken(&we)
+	// Not enforcing reads with the caller's token, exactly as before validation existed.
+	s.expectHistoryReadWithBranchToken(foreignBranchToken)
+
+	for _, tc := range []struct {
+		name       string
+		validation bool
+		shadow     bool
+	}{
+		{name: "shadow mode", validation: true, shadow: true},
+		{name: "validation disabled", validation: false, shadow: false},
+	} {
+		s.config.EnablePaginationTokenBranchValidation = dynamicconfig.GetBoolPropertyFn(tc.validation)
+		s.config.EnablePaginationTokenBranchValidationShadowMode = dynamicconfig.GetBoolPropertyFn(tc.shadow)
+		_, err = engine.GetWorkflowExecutionHistory(
+			context.Background(),
+			s.getHistoryRequestWithPageToken(&we, &tokenspb.HistoryContinuation{
+				RunId:             we.GetRunId(),
+				FirstEventId:      common.FirstEventID,
+				NextEventId:       5,
+				PersistenceToken:  []byte("some random persistence token"),
+				BranchToken:       foreignBranchToken,
+				IsWorkflowRunning: true,
+			}, false),
+		)
+		s.NoError(err, tc.name)
+	}
+}
+
+func (s *engineSuite) TestGetWorkflowExecutionHistory_LongPollDiscardsRequestBranchToken() {
+	we := commonpb.WorkflowExecution{WorkflowId: "wid-longpoll-overwrite", RunId: uuid.NewString()}
+
+	engine, err := s.historyEngine.shardContext.GetEngine(context.Background())
+	s.NoError(err)
+
+	s.config.EnablePaginationTokenBranchValidationShadowMode = dynamicconfig.GetBoolPropertyFn(false)
+	s.config.SendRawWorkflowHistory = func(string) bool { return false }
+	ownedBranchToken, foreignBranchToken := s.mockExecutionWithForeignBranchToken(&we)
+	s.expectHistoryReadWithBranchToken(ownedBranchToken)
+
+	// An empty persistence token and a next event ID behind mutable state select the long poll
+	// refresh, which replaces the caller's branch token instead of validating it.
+	req := s.getHistoryRequestWithPageToken(&we, &tokenspb.HistoryContinuation{
+		RunId:             we.GetRunId(),
+		FirstEventId:      common.FirstEventID,
+		NextEventId:       2,
+		PersistenceToken:  nil,
+		BranchToken:       foreignBranchToken,
+		IsWorkflowRunning: true,
+	}, true)
+
+	_, err = engine.GetWorkflowExecutionHistory(context.Background(), req)
+	s.NoError(err)
+}
+
+func (s *engineSuite) TestGetWorkflowExecutionHistoryReverse_BranchTokenNotOwnedByExecution() {
+	we := commonpb.WorkflowExecution{WorkflowId: "wid-foreign-branch-reverse", RunId: uuid.NewString()}
+
+	engine, err := s.historyEngine.shardContext.GetEngine(context.Background())
+	s.NoError(err)
+
+	s.config.EnablePaginationTokenBranchValidationShadowMode = dynamicconfig.GetBoolPropertyFn(false)
+	_, foreignBranchToken := s.mockExecutionWithForeignBranchToken(&we)
+
+	nextPageToken, err := api.SerializeHistoryToken(&tokenspb.HistoryContinuation{
+		RunId:            we.GetRunId(),
+		FirstEventId:     common.FirstEventID,
+		NextEventId:      5,
+		PersistenceToken: []byte("some random persistence token"),
+		BranchToken:      foreignBranchToken,
+	})
+	s.NoError(err)
+
+	// The history read must never be attempted.
+	s.mockExecutionMgr.EXPECT().ReadHistoryBranchReverse(gomock.Any(), gomock.Any()).Times(0)
+
+	_, err = engine.GetWorkflowExecutionHistoryReverse(
+		context.Background(),
+		&historyservice.GetWorkflowExecutionHistoryReverseRequest{
+			NamespaceId: tests.NamespaceID.String(),
+			Request: &workflowservice.GetWorkflowExecutionHistoryReverseRequest{
+				Execution:       &we,
+				MaximumPageSize: 10,
+				NextPageToken:   nextPageToken,
+			},
+		},
+	)
+	var branchErr *serviceerrors.CurrentBranchChanged
+	s.ErrorAs(err, &branchErr)
 }

--- a/tests/testcore/test_cluster.go
+++ b/tests/testcore/test_cluster.go
@@ -8,9 +8,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"path"
 	"testing"
-	"time"
 
 	"github.com/google/uuid"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -23,7 +21,6 @@ import (
 	"go.temporal.io/server/common/archiver"
 	"go.temporal.io/server/common/archiver/filestore"
 	"go.temporal.io/server/common/archiver/provider"
-	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -260,7 +257,7 @@ func newClusterWithPersistenceTestBaseFactory(t *testing.T, clusterConfig *TestC
 			Version: environment.GetESVersion(),
 		}
 
-		err := setupIndex(clusterConfig.ESConfig, logger)
+		err := persistencetests.SetupEsIndex(clusterConfig.ESConfig, logger)
 		if err != nil {
 			return nil, err
 		}
@@ -372,113 +369,6 @@ func newClusterWithPersistenceTestBaseFactory(t *testing.T, clusterConfig *TestC
 	return &TestCluster{testBase: testBase, archiverBase: archiverBase, host: cluster}, nil
 }
 
-func setupIndex(esConfig *esclient.Config, logger log.Logger) error {
-	ctx := context.Background()
-	var esClient esclient.IntegrationTestsClient
-	op := func() error {
-		var err error
-		esClient, err = esclient.NewFunctionalTestsClient(esConfig, logger)
-		if err != nil {
-			return err
-		}
-
-		return esClient.Ping(ctx)
-	}
-
-	err := backoff.ThrottleRetry(
-		op,
-		backoff.NewExponentialRetryPolicy(time.Second).WithExpirationInterval(time.Minute),
-		nil,
-	)
-	if err != nil {
-		logger.Fatal("Failed to connect to elasticsearch", tag.Error(err))
-	}
-
-	exists, err := esClient.IndexExists(ctx, esConfig.GetVisibilityIndex())
-	if err != nil {
-		return err
-	}
-	if exists {
-		logger.Info("Index already exists.", tag.ESIndex(esConfig.GetVisibilityIndex()))
-		err = deleteIndex(esConfig, logger)
-		if err != nil {
-			return err
-		}
-	}
-
-	indexTemplateFile := path.Join(testutils.GetRepoRootDirectory(), "schema/elasticsearch/visibility/index_template_v7.json")
-	logger.Info("Creating index template.", tag.NewStringTag("templatePath", indexTemplateFile))
-	template, err := os.ReadFile(indexTemplateFile)
-	if err != nil {
-		return err
-	}
-	// Template name doesn't matter.
-	// This operation is idempotent and won't return an error even if template already exists.
-	_, err = esClient.IndexPutTemplate(ctx, "temporal_visibility_v1_template", string(template))
-	if err != nil {
-		return err
-	}
-	logger.Info("Index template created.")
-
-	logger.Info("Creating index.", tag.ESIndex(esConfig.GetVisibilityIndex()))
-	_, err = esClient.CreateIndex(
-		ctx,
-		esConfig.GetVisibilityIndex(),
-		map[string]any{
-			"settings": map[string]any{
-				"index": map[string]any{
-					"number_of_replicas": 0,
-				},
-			},
-		},
-	)
-	if err != nil {
-		return err
-	}
-	if err := waitForYellowStatus(esClient, esConfig.GetVisibilityIndex()); err != nil {
-		return err
-	}
-	logger.Info("Index created.", tag.ESIndex(esConfig.GetVisibilityIndex()))
-
-	logger.Info("Add custom search attributes for tests.")
-	_, err = esClient.PutMapping(ctx, esConfig.GetVisibilityIndex(), searchattribute.TestEsNameTypeMap().Custom())
-	if err != nil {
-		return err
-	}
-	if err := waitForYellowStatus(esClient, esConfig.GetVisibilityIndex()); err != nil {
-		return err
-	}
-	logger.Info("Index setup complete.", tag.ESIndex(esConfig.GetVisibilityIndex()))
-
-	return nil
-}
-
-func waitForYellowStatus(esClient esclient.IntegrationTestsClient, index string) error {
-	status, err := esClient.WaitForYellowStatus(context.Background(), index)
-	if err != nil {
-		return err
-	}
-	if status == "red" {
-		return fmt.Errorf("Elasticsearch index status for %s is red", index)
-	}
-	return nil
-}
-
-func deleteIndex(esConfig *esclient.Config, logger log.Logger) error {
-	esClient, err := esclient.NewFunctionalTestsClient(esConfig, logger)
-	if err != nil {
-		return err
-	}
-
-	logger.Info("Deleting index.", tag.ESIndex(esConfig.GetVisibilityIndex()))
-	_, err = esClient.DeleteIndex(context.Background(), esConfig.GetVisibilityIndex())
-	if err != nil {
-		return err
-	}
-	logger.Info("Index deleted.", tag.ESIndex(esConfig.GetVisibilityIndex()))
-	return nil
-}
-
 func newPProfInitializerImpl(logger log.Logger, port int) *pprof.PProfInitializerImpl {
 	return &pprof.PProfInitializerImpl{
 		PProf: &config.PProf{
@@ -544,7 +434,7 @@ func (tc *TestCluster) TearDownCluster() error {
 	errs := tc.host.Stop()
 	tc.testBase.TearDownWorkflowStore()
 	if !UseSQLVisibility() && tc.host.esConfig != nil {
-		if err := deleteIndex(tc.host.esConfig, tc.host.logger); err != nil {
+		if err := persistencetests.DeleteEsIndex(tc.host.esConfig, tc.host.logger); err != nil {
 			errs = multierr.Combine(errs, err)
 		}
 	}


### PR DESCRIPTION
## What changed?
Cherry-picks the PRs labeled `release/1.30.7` onto `release/v1.30.x`, excluding https://github.com/temporalio/temporal/pull/11014, which will be cherry picked independently

List of PRs:
- https://github.com/temporalio/temporal/pull/11190 - Update sqlparser dependency
- https://github.com/temporalio/temporal/pull/11265 - Update ringpop-go and tchannel-go
- https://github.com/temporalio/temporal/pull/11409 - Update sqlparser to v0.1.0
- https://github.com/temporalio/temporal/pull/11564 - [Visibility][Elasticsearch] Change datetime format to always include nanos component
- https://github.com/temporalio/temporal/pull/11723 - Validate history pagination branch token against mutable state

Conflicts were in the dependency pins in `go.mod`/`go.sum`, in test and CI code, and in one production file:

- `service/history/configs/config.go` - `NewConfig` on `main` has a `SendRawHistoryBytesToMatchingService` entry that does not exist on this branch. Kept this branch's two `SendRaw*` entries and added only `EnablePaginationTokenBranchValidation` and `EnablePaginationTokenBranchValidationShadowMode`.

Two production edits were also needed where git reported no conflict:

- `common/persistence/visibility/store/elasticsearch/visibility_store.go` - #11564 carries an
  incidental refactor to `errors.AsType[*query.ConverterError]`, a Go 1.26 stdlib API. This
  branch's `go` directive is 1.25.11, so those two call sites are left as `errors.As`.
- `.github/workflows/run-tests.yml` - #11564 adds `elasticsearch` to a `CONTAINERS` env var that
  does not exist here.

## Why?
Security and reliability patch release for 1.30.7.

## How did you test it?
- [X] built
- [ ] run locally and tested manually
- [X] covered by existing tests
- [X] added new unit test(s)
- [ ] added new functional test(s)

## Potential risks
`EnablePaginationTokenBranchValidation` defaults to `true`, so #11723's rejection path is live as
soon as this ships.