### PR TITLE
Preserve Nexus start-to-close timeout after deferred cancellation

### DIFF
--- a/service/history/hsm/nexusoperations/statemachine.go
+++ b/service/history/hsm/nexusoperations/statemachine.go
@@ -381,12 +381,14 @@ var TransitionStarted = hsm.NewTransition(
 			return hsm.TransitionOutput{}, err
 		}
 		if child != nil {
-			return hsm.TransitionOutput{}, hsm.MachineTransition(child, func(c Cancelation) (hsm.TransitionOutput, error) {
+			if err := hsm.MachineTransition(child, func(c Cancelation) (hsm.TransitionOutput, error) {
 				return TransitionCancelationScheduled.Apply(c, EventCancelationScheduled{
 					Time: event.Time,
 					Node: child,
 				})
-			})
+			}); err != nil {
+				return hsm.TransitionOutput{}, err
+			}
 		}
 
 		output, err := op.output()

--- a/service/history/hsm/nexusoperations/statemachine_test.go
+++ b/service/history/hsm/nexusoperations/statemachine_test.go
@@ -739,7 +739,9 @@ func TestCancelationValidTransitions(t *testing.T) {
 func TestCancelationBeforeStarted(t *testing.T) {
 	// Setup
 	backend := &hsmtest.NodeBackend{}
-	root := newOperationNode(t, backend, mustNewScheduledEvent(time.Now(), nil))
+	root := newOperationNode(t, backend, mustNewScheduledEvent(time.Now(), &historypb.NexusOperationScheduledEventAttributes{
+		StartToCloseTimeout: durationpb.New(time.Minute),
+	}))
 	require.NoError(t, hsm.MachineTransition(root, func(op nexusoperations.Operation) (hsm.TransitionOutput, error) {
 		return op.Cancel(root, time.Now(), 0)
 	}))
@@ -779,7 +781,8 @@ func TestCancelationBeforeStarted(t *testing.T) {
 
 	secondOp, ok := opLog[1].(hsm.TransitionOperation)
 	require.True(t, ok)
-	require.Empty(t, secondOp.Output.Tasks)
+	require.Len(t, secondOp.Output.Tasks, 1)
+	require.Equal(t, nexusoperations.TaskTypeStartToCloseTimeout, secondOp.Output.Tasks[0].Type())
 
 	node, err = root.Child([]hsm.Key{nexusoperations.CancelationMachineKey})
 	require.NoError(t, err)

--- a/tests/nexus_operation_deferred_cancellation_test.go
+++ b/tests/nexus_operation_deferred_cancellation_test.go
@@ -1,0 +1,169 @@
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"github.com/stretchr/testify/require"
+	commandpb "go.temporal.io/api/command/v1"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	historypb "go.temporal.io/api/history/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/client"
+	chasmnexus "go.temporal.io/server/chasm/lib/nexusoperation"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/nexus/nexustest"
+	"go.temporal.io/server/common/testing/await"
+	"go.temporal.io/server/tests/testcore"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+func TestNexusOperationStartToCloseTimeoutAfterDeferredCancellation(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+	env := newNexusTestEnv(t, true,
+		testcore.WithDynamicConfig(dynamicconfig.EnableChasm, false),
+		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMCallbacks, false),
+		testcore.WithDynamicConfig(dynamicconfig.EnableCHASMSignalBacklinks, false),
+		testcore.WithDynamicConfig(chasmnexus.EnableChasmWorkflowOperations, false),
+		testcore.WithDynamicConfig(chasmnexus.ChasmWorkflowOperationsRolloutPercent, 0),
+	)
+	taskQueue := testcore.RandomizeStr(t.Name())
+
+	startResponse := make(chan struct{})
+	cancelSent := make(chan struct{}, 1)
+	handler := nexustest.Handler{
+		OnStartOperation: func(ctx context.Context, service, operation string, input *nexus.LazyValue, options nexus.StartOperationOptions) (nexus.HandlerStartOperationResult[any], error) {
+			select {
+			case <-startResponse:
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+			return &nexus.HandlerStartOperationResultAsync{OperationToken: "operation-token"}, nil
+		},
+		OnCancelOperation: func(context.Context, string, string, string, nexus.CancelOperationOptions) error {
+			select {
+			case cancelSent <- struct{}{}:
+			default:
+			}
+			return nil
+		},
+	}
+	endpoint := env.createRandomExternalNexusServer(ctx, t, handler)
+
+	run, err := env.SdkClient().ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		TaskQueue:           taskQueue,
+		WorkflowTaskTimeout: 30 * time.Second,
+	}, "workflow")
+	require.NoError(t, err)
+	defer func() {
+		_ = env.SdkClient().TerminateWorkflow(testcore.NewContext(), run.GetID(), run.GetRunID(), "test cleanup")
+	}()
+
+	firstTask := pollDeferredCancellationWorkflowTask(ctx, t, env, taskQueue)
+	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+		Identity:  "test-worker",
+		TaskToken: firstTask.TaskToken,
+		Commands: []*commandpb.Command{
+			{
+				CommandType: enumspb.COMMAND_TYPE_SCHEDULE_NEXUS_OPERATION,
+				Attributes: &commandpb.Command_ScheduleNexusOperationCommandAttributes{
+					ScheduleNexusOperationCommandAttributes: &commandpb.ScheduleNexusOperationCommandAttributes{
+						Endpoint:            endpoint,
+						Service:             "service",
+						Operation:           "operation",
+						Input:               testcore.MustToPayload(t, "input"),
+						StartToCloseTimeout: durationpb.New(4 * time.Second),
+					},
+				},
+			},
+			{
+				CommandType: enumspb.COMMAND_TYPE_START_TIMER,
+				Attributes: &commandpb.Command_StartTimerCommandAttributes{
+					StartTimerCommandAttributes: &commandpb.StartTimerCommandAttributes{
+						TimerId:            "schedule-cancellation-task",
+						StartToFireTimeout: durationpb.New(10 * time.Millisecond),
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	secondTask := pollDeferredCancellationWorkflowTask(ctx, t, env, taskQueue)
+	scheduledEventID := findNexusEventID(secondTask.History.Events, enumspb.EVENT_TYPE_NEXUS_OPERATION_SCHEDULED)
+	require.Positive(t, scheduledEventID)
+	require.Zero(t, findNexusEventID(secondTask.History.Events, enumspb.EVENT_TYPE_NEXUS_OPERATION_STARTED))
+
+	_, err = env.FrontendClient().RespondWorkflowTaskCompleted(ctx, &workflowservice.RespondWorkflowTaskCompletedRequest{
+		Identity:  "test-worker",
+		TaskToken: secondTask.TaskToken,
+		Commands: []*commandpb.Command{
+			{
+				CommandType: enumspb.COMMAND_TYPE_REQUEST_CANCEL_NEXUS_OPERATION,
+				Attributes: &commandpb.Command_RequestCancelNexusOperationCommandAttributes{
+					RequestCancelNexusOperationCommandAttributes: &commandpb.RequestCancelNexusOperationCommandAttributes{
+						ScheduledEventId: scheduledEventID,
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	await.Require(ctx, t, func(t *await.T) {
+		desc, err := env.SdkClient().DescribeWorkflowExecution(ctx, run.GetID(), run.GetRunID())
+		require.NoError(t, err)
+		require.Len(t, desc.PendingNexusOperations, 1)
+		require.NotNil(t, desc.PendingNexusOperations[0].CancellationInfo)
+	}, 10*time.Second, 50*time.Millisecond)
+
+	close(startResponse)
+	select {
+	case <-cancelSent:
+	case <-time.After(10 * time.Second):
+		t.Fatal("cancel request was not sent after the operation started")
+	}
+
+	await.Require(ctx, t, func(t *await.T) {
+		history := env.GetHistory(env.Namespace().String(), &commonpb.WorkflowExecution{
+			WorkflowId: run.GetID(),
+			RunId:      run.GetRunID(),
+		})
+		timedOutEventID := findNexusEventID(history, enumspb.EVENT_TYPE_NEXUS_OPERATION_TIMED_OUT)
+		require.Positive(t, timedOutEventID)
+	}, 10*time.Second, 50*time.Millisecond)
+}
+
+func pollDeferredCancellationWorkflowTask(
+	ctx context.Context,
+	t *testing.T,
+	env *NexusTestEnv,
+	taskQueue string,
+) *workflowservice.PollWorkflowTaskQueueResponse {
+	t.Helper()
+	resp, err := env.FrontendClient().PollWorkflowTaskQueue(ctx, &workflowservice.PollWorkflowTaskQueueRequest{
+		Namespace: env.Namespace().String(),
+		TaskQueue: &taskqueuepb.TaskQueue{
+			Name: taskQueue,
+			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
+		},
+		Identity: "test-worker",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.TaskToken)
+	return resp
+}
+
+func findNexusEventID(events []*historypb.HistoryEvent, eventType enumspb.EventType) int64 {
+	for _, event := range events {
+		if event.GetEventType() == eventType {
+			return event.GetEventId()
+		}
+	}
+	return 0
+}


### PR DESCRIPTION
## What changed?

When a Nexus operation starts after cancellation was requested, schedule the deferred cancellation transition and then continue the parent operation transition so it also emits the configured start-to-close timeout task.

The state-machine regression test verifies that the transition emits the timeout task. The functional test blocks the Nexus start response, requests cancellation, then verifies both cancellation delivery and the eventual `NEXUS_OPERATION_TIMED_OUT` history event. It pins the legacy HSM implementation that contains this transition.

## Why?

When cancellation is requested while a Nexus start call is still in flight and that call later returns an asynchronous operation, Temporal can omit the configured start-to-close timeout and leave the operation pending past its deadline. `service/history/hsm/nexusoperations/statemachine_test.go` reproduces this transition order and observes that no start-to-close timeout task is emitted, leaving the operation without its configured deadline.

The started transition returned immediately after scheduling deferred cancellation, before it emitted the timeout task. Cancellation acknowledgement alone does not complete the operation.

## How did you test it?

- [x] built
- [x] run locally and tested manually
- [ ] covered by existing tests
- [x] added new unit test(s)
- [x] added new functional test(s)

Commands:

```text
go test -tags test_dep -p 4 ./service/history/hsm/nexusoperations -count=1
go test -tags test_dep -p 4 ./tests -run '^TestNexusOperationStartToCloseTimeoutAfterDeferredCancellation$' -count=3
make lint-code-fast
```

The state-machine regression assertion failed on the base revision with zero timeout tasks. It passes with this change, and the functional scenario passed three consecutive runs.

## Potential risks

This adds the normal start-to-close timer to the deferred-cancellation path. Existing task validation rejects the timer if the operation is no longer started when it fires.
