### PR TITLE
Prevent batch workflows from sharing activity options

### DIFF
--- a/service/worker/batcher/workflow.go
+++ b/service/worker/batcher/workflow.go
@@ -120,20 +120,6 @@ type (
 	}
 )
 
-var (
-	batchActivityRetryPolicy = temporal.RetryPolicy{
-		InitialInterval:    10 * time.Second,
-		BackoffCoefficient: 1.7,
-		MaximumInterval:    5 * time.Minute,
-	}
-
-	batchActivityOptions = workflow.ActivityOptions{
-		ScheduleToStartTimeout: 5 * time.Minute,
-		StartToCloseTimeout:    infiniteDuration,
-		RetryPolicy:            &batchActivityRetryPolicy,
-	}
-)
-
 // BatchWorkflowProtobuf is the workflow that runs a batch job of resetting workflows.
 func BatchWorkflowProtobuf(ctx workflow.Context, batchParams *batchspb.BatchOperationInput) (HeartBeatDetails, error) {
 	if batchParams == nil {
@@ -141,8 +127,18 @@ func BatchWorkflowProtobuf(ctx workflow.Context, batchParams *batchspb.BatchOper
 	}
 
 	batchParams = setDefaultParams(batchParams)
-	batchActivityOptions.HeartbeatTimeout = batchParams.ActivityHeartbeatTimeout.AsDuration()
-	opt := workflow.WithActivityOptions(ctx, batchActivityOptions)
+	retryPolicy := temporal.RetryPolicy{
+		InitialInterval:    10 * time.Second,
+		BackoffCoefficient: 1.7,
+		MaximumInterval:    5 * time.Minute,
+	}
+	activityOptions := workflow.ActivityOptions{
+		ScheduleToStartTimeout: 5 * time.Minute,
+		StartToCloseTimeout:    infiniteDuration,
+		HeartbeatTimeout:       batchParams.ActivityHeartbeatTimeout.AsDuration(),
+		RetryPolicy:            &retryPolicy,
+	}
+	opt := workflow.WithActivityOptions(ctx, activityOptions)
 	var result HeartBeatDetails
 	var ac *activities
 	err := workflow.ExecuteActivity(opt, ac.BatchActivityWithProtobuf, batchParams).Get(ctx, &result)

--- a/service/worker/batcher/workflow_test.go
+++ b/service/worker/batcher/workflow_test.go
@@ -1,18 +1,24 @@
 package batcher
 
 import (
+	"context"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	batchpb "go.temporal.io/api/batch/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/testsuite"
 	batchspb "go.temporal.io/server/api/batch/v1"
 	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 type batcherSuite struct {
@@ -35,6 +41,49 @@ func (s *batcherSuite) SetupTest() {
 func (s *batcherSuite) TearDownTest() {
 	s.controller.Finish()
 	s.env.AssertExpectations(s.T())
+}
+
+func TestBatchWorkflowActivityOptionsAreIndependent(t *testing.T) {
+	const workflowCount = 32
+
+	expectedTimeouts := make([]time.Duration, workflowCount)
+	actualTimeouts := make([]time.Duration, workflowCount)
+	errs := make([]error, workflowCount)
+	var wg sync.WaitGroup
+	for i := range workflowCount {
+		expectedTimeout := time.Duration(i+10) * time.Second
+		var heartbeatTimeout *durationpb.Duration
+		if i == 0 {
+			expectedTimeout = defaultActivityHeartBeatTimeout
+		} else {
+			heartbeatTimeout = durationpb.New(expectedTimeout)
+		}
+		expectedTimeouts[i] = expectedTimeout
+
+		wg.Go(func() {
+			var workflowTestSuite testsuite.WorkflowTestSuite
+			env := workflowTestSuite.NewTestWorkflowEnvironment()
+			env.RegisterWorkflow(BatchWorkflowProtobuf)
+			var ac *activities
+			env.OnActivity(ac.BatchActivityWithProtobuf, mock.Anything, mock.Anything).
+				Return(func(ctx context.Context, _ *batchspb.BatchOperationInput) (HeartBeatDetails, error) {
+					actualTimeouts[i] = activity.GetInfo(ctx).HeartbeatTimeout
+					return HeartBeatDetails{}, nil
+				}).Once()
+			env.OnUpsertMemo(mock.Anything).Return(nil).Once()
+			env.ExecuteWorkflow(BatchWorkflowProtobuf, &batchspb.BatchOperationInput{
+				ActivityHeartbeatTimeout: heartbeatTimeout,
+			})
+			errs[i] = env.GetWorkflowError()
+			env.AssertExpectations(t)
+		})
+	}
+	wg.Wait()
+
+	for i := range workflowCount {
+		require.NoError(t, errs[i])
+		require.Equal(t, expectedTimeouts[i], actualTimeouts[i])
+	}
 }
 
 func (s *batcherSuite) TestBatchWorkflow_ValidParams_Query_Protobuf() {


### PR DESCRIPTION
## What changed?

- Construct the batch activity options and retry policy for each `BatchWorkflowProtobuf` invocation.
- Add a regression test that runs 32 independent SDK test environments concurrently and verifies each activity receives its requested heartbeat timeout, including the default timeout.

## Why?

`BatchWorkflowProtobuf` updated the package-level `batchActivityOptions.HeartbeatTimeout` before passing that shared struct to `workflow.WithActivityOptions`. Concurrent batch workflows could race and schedule an activity with another workflow's heartbeat timeout.

The regression test reproduced both the data race and an incorrect timeout before the fix. Keeping the options local removes the shared mutable state without serializing workflow execution or changing activity behavior.

## How did you test it?

- [ ] built
- [ ] run locally and tested manually
- [x] covered by existing tests
- [x] added new unit test(s)
- [ ] added new functional test(s)

```text
CGO_ENABLED=1 go test -tags test_dep -race -count=1 ./service/worker/batcher
CGO_ENABLED=1 go test -tags test_dep -race -count=1 -timeout=35m ./tests -run '^Test(WorkflowAPIBatch.*|Activity[Aa][Pp][Ii]Batch.*|AdminBatchRefreshWorkflowTasksTestSuite)$' -persistenceType=sql -persistenceDriver=sqlite
make fmt-imports
make lint-code-fast
```

## Potential risks

Low. The change preserves the existing activity timeouts, retry values, activity invocation, payload, memo update, and command ordering. It adds only per-workflow allocation of two small option structs.
