### PR TITLE
Stop drained backlog manager goroutines

### DIFF
--- a/service/matching/backlog_manager.go
+++ b/service/matching/backlog_manager.go
@@ -58,6 +58,7 @@ type (
 	backlogManagerImpl struct {
 		pqMgr            physicalTaskQueueManager
 		tqCtx            context.Context
+		tqCtxCancel      context.CancelFunc
 		db               *taskQueueDB
 		taskWriter       *taskWriter
 		taskReader       *taskReader // reads tasks from db and async matches it with poller
@@ -87,9 +88,11 @@ func newBacklogManager(
 	matchingClient matchingservice.MatchingServiceClient,
 	metricsHandler metrics.Handler,
 ) *backlogManagerImpl {
+	tqCtx, tqCtxCancel := context.WithCancel(tqCtx)
 	bmg := &backlogManagerImpl{
 		pqMgr:            pqMgr,
 		tqCtx:            tqCtx,
+		tqCtxCancel:      tqCtxCancel,
 		matchingClient:   matchingClient,
 		metricsHandler:   metricsHandler,
 		logger:           logger,
@@ -102,7 +105,7 @@ func newBacklogManager(
 	bmg.taskWriter = newTaskWriter(bmg)
 	bmg.taskReader = newTaskReader(bmg)
 	bmg.taskAckManager = newAckManager(bmg.db, logger)
-	bmg.taskGC = newTaskGC(tqCtx, bmg.db, config)
+	bmg.taskGC = newTaskGC(bmg.tqCtx, bmg.db, config)
 
 	return bmg
 }
@@ -130,6 +133,8 @@ func (c *backlogManagerImpl) Start() {
 }
 
 func (c *backlogManagerImpl) Stop() {
+	defer c.tqCtxCancel()
+
 	// Maybe try to write one final update of ack level and GC some tasks.
 	// Skip the update if we never initialized (ackLevel will be -1 in that case).
 	// Also skip if we're stopping due to lost ownership (the update will fail in that case).

--- a/service/matching/backlog_manager_test.go
+++ b/service/matching/backlog_manager_test.go
@@ -42,6 +42,7 @@ type BacklogManagerTestSuite struct {
 	logger     *testlogger.TestLogger
 	blm        backlogManager
 	controller *gomock.Controller
+	tqCtx      context.Context
 	cancelCtx  context.CancelFunc
 	taskMgr    *testTaskManager
 	ptqMgr     *MockphysicalTaskQueueManager
@@ -98,13 +99,12 @@ func (s *BacklogManagerTestSuite) SetupTest() {
 	s.ptqMgr.EXPECT().GetFairnessWeightOverrides().AnyTimes().Return(fairnessWeightOverrides{ /* To avoid deadlock with gomock method */ })
 	s.ptqMgr.EXPECT().StartScaleManager(gomock.Any()).AnyTimes()
 
-	var ctx context.Context
-	ctx, s.cancelCtx = context.WithCancel(context.Background())
+	s.tqCtx, s.cancelCtx = context.WithCancel(context.Background())
 	s.T().Cleanup(s.cancelCtx)
 
 	if s.fairness {
 		s.blm = newFairBacklogManager(
-			ctx,
+			s.tqCtx,
 			s.ptqMgr,
 			tlCfg,
 			s.taskMgr,
@@ -117,7 +117,7 @@ func (s *BacklogManagerTestSuite) SetupTest() {
 		)
 	} else if s.newMatcher {
 		s.blm = newPriBacklogManager(
-			ctx,
+			s.tqCtx,
 			s.ptqMgr,
 			tlCfg,
 			s.taskMgr,
@@ -129,7 +129,7 @@ func (s *BacklogManagerTestSuite) SetupTest() {
 		)
 	} else {
 		s.blm = newBacklogManager(
-			ctx,
+			s.tqCtx,
 			s.ptqMgr,
 			tlCfg,
 			s.taskMgr,
@@ -148,6 +148,25 @@ func (s *BacklogManagerTestSuite) setupToCaptureTasks() {
 		s.capturedTasksSlice = append(s.capturedTasksSlice, t)
 		return nil
 	}).AnyTimes()
+}
+
+func (s *BacklogManagerTestSuite) TestStopCancelsBacklogManagerContext() {
+	var backlogCtx context.Context
+	switch blm := s.blm.(type) {
+	case *backlogManagerImpl:
+		backlogCtx = blm.tqCtx
+	case *priBacklogManagerImpl:
+		backlogCtx = blm.tqCtx
+	case *fairBacklogManagerImpl:
+		backlogCtx = blm.tqCtx
+	default:
+		s.FailNow("unknown backlog manager type")
+	}
+
+	s.Require().NoError(backlogCtx.Err())
+	s.blm.Stop()
+	s.Require().ErrorIs(backlogCtx.Err(), context.Canceled)
+	s.Require().NoError(s.tqCtx.Err())
 }
 
 func (s *BacklogManagerTestSuite) capturedTasksLen() int {

--- a/service/matching/fair_backlog_manager.go
+++ b/service/matching/fair_backlog_manager.go
@@ -26,12 +26,13 @@ import (
 
 type (
 	fairBacklogManagerImpl struct {
-		pqMgr      physicalTaskQueueManager
-		config     *taskQueueConfig
-		tqCtx      context.Context
-		isDraining bool
-		db         *taskQueueDB
-		taskWriter *fairTaskWriter
+		pqMgr       physicalTaskQueueManager
+		config      *taskQueueConfig
+		tqCtx       context.Context
+		tqCtxCancel context.CancelFunc
+		isDraining  bool
+		db          *taskQueueDB
+		taskWriter  *fairTaskWriter
 
 		subqueueLock        sync.Mutex
 		subqueues           []*fairTaskReader // subqueue index -> fairTaskReader
@@ -68,11 +69,13 @@ func newFairBacklogManager(
 	// For the purposes of taskQueueDB, call this just a TaskManager. It'll return errors if we
 	// use it incorectly. TODO(fairness): consider a cleaner way of doing this.
 	taskManager := persistence.TaskManager(fairTaskManager)
+	tqCtx, tqCtxCancel := context.WithCancel(tqCtx)
 
 	bmg := &fairBacklogManagerImpl{
 		pqMgr:               pqMgr,
 		config:              config,
 		tqCtx:               tqCtx,
+		tqCtxCancel:         tqCtxCancel,
 		isDraining:          isDraining,
 		db:                  newTaskQueueDB(config, taskManager, pqMgr.QueueKey(), logger, metricsHandler, isDraining),
 		subqueuesByPriority: make(map[priorityKey]subqueueIndex),
@@ -110,6 +113,8 @@ func (c *fairBacklogManagerImpl) Start() {
 }
 
 func (c *fairBacklogManagerImpl) Stop() {
+	defer c.tqCtxCancel()
+
 	// Maybe try to write one final update of ack level. Skip the update if we never
 	// initialized. Also skip if we're stopping due to lost ownership (the update will
 	// fail in that case). Ignore any errors. Don't bother with GC, the next reload will

--- a/service/matching/pri_backlog_manager.go
+++ b/service/matching/pri_backlog_manager.go
@@ -45,12 +45,13 @@ type (
 	// }
 
 	priBacklogManagerImpl struct {
-		pqMgr      physicalTaskQueueManager
-		config     *taskQueueConfig
-		tqCtx      context.Context
-		isDraining bool
-		db         *taskQueueDB
-		taskWriter *priTaskWriter
+		pqMgr       physicalTaskQueueManager
+		config      *taskQueueConfig
+		tqCtx       context.Context
+		tqCtxCancel context.CancelFunc
+		isDraining  bool
+		db          *taskQueueDB
+		taskWriter  *priTaskWriter
 
 		subqueueLock        sync.Mutex
 		subqueues           []*priTaskReader // subqueue index -> fairTaskReader
@@ -83,10 +84,12 @@ func newPriBacklogManager(
 	metricsHandler metrics.Handler,
 	isDraining bool,
 ) *priBacklogManagerImpl {
+	tqCtx, tqCtxCancel := context.WithCancel(tqCtx)
 	bmg := &priBacklogManagerImpl{
 		pqMgr:               pqMgr,
 		config:              config,
 		tqCtx:               tqCtx,
+		tqCtxCancel:         tqCtxCancel,
 		isDraining:          isDraining,
 		db:                  newTaskQueueDB(config, taskManager, pqMgr.QueueKey(), logger, metricsHandler, isDraining),
 		subqueuesByPriority: make(map[priorityKey]subqueueIndex),
@@ -123,6 +126,8 @@ func (c *priBacklogManagerImpl) Start() {
 }
 
 func (c *priBacklogManagerImpl) Stop() {
+	defer c.tqCtxCancel()
+
 	// Maybe try to write one final update of ack level. Skip the update if we never
 	// initialized. Also skip if we're stopping due to lost ownership (the update will
 	// fail in that case). Ignore any errors. Don't bother with GC, the next reload will


### PR DESCRIPTION
## What changed?

Give each backlog manager its own cancellable child context and cancel it when the backlog manager stops.

Cancellation happens after the final ack-level update and garbage-collection pass, preserving the existing shutdown ordering. Canceling a draining backlog manager therefore stops its writer, readers, timers, and retry work without canceling the parent physical task queue or its active backlog manager.

Add coverage for the classic, priority, and fairness backlog managers that verifies `Stop` cancels the manager context while leaving the physical task queue context active.

## Why?

When a priority/fairness migration is in progress, a physical task queue owns two backlog managers:

- the active manager writes and reads the selected persistence format;
- the draining manager reads outstanding tasks from the previous format until they have all been dispatched and acknowledged.

Once draining finishes, `FinishedDraining` removes the draining manager from the physical task queue, performs its final garbage collection, and calls `Stop`. Before this change, `Stop` only flushed the final ack state. The manager's background work used the physical task queue's context, which remains active after the draining manager is detached.

The periodic-sync goroutine that detects completion returns normally, but the detached manager's writer and priority subqueue readers remain blocked on the still-live physical task queue context. Fairness readers and retry work can also retain the manager while active. This keeps the manager and its associated state reachable until the entire physical task queue unloads.

Physical task queues normally unload after `MaxTaskQueueIdleTime`, but task additions, polls, and matching activity reset that timer. A busy queue may therefore remain loaded for the lifetime of the Matching process, turning a completed migration into long-lived goroutine and memory retention.

## Broader context

The lifecycle evolved in several steps:

- October 21, 2025: #8500 introduced dual-reading during migration between the priority and fairness persistence formats. It explicitly did not yet exit draining mode after the old backlog became empty.
- January 29, 2026: #9164 added drain completion. `FinishedDraining` began detaching the old manager and calling its existing `Stop` method, which had been designed for physical-queue shutdown where the shared context was canceled immediately afterward.
- March 24, 2026: #9595 enabled the new matcher and migration by default in OSS; its description notes that the path was already enabled by default in Cloud.
- July 24, 2026: #11133 removed the migration gate and made the path unconditional.

The intentional part of the old ordering is the final state flush before context cancellation: persistence operations use the manager context and would fail if it were canceled first. The unintended part is that drain completion is a component-level shutdown, not a physical-queue shutdown, so no cancellation followed the flush.

A child context restores that ownership boundary:

- stopping a backlog manager terminates only that manager's work;
- stopping the physical task queue still propagates through the parent context;
- repeated cancellation remains safe;
- early-return paths in `Stop`, including uninitialized managers and lost ownership, still cancel background work.


## Potential risks

The change makes `Stop` fully stop a backlog manager instead of relying on a later physical-queue cancellation. Final persistence and garbage collection still run before cancellation, and tests verify that the parent physical task queue context remains active. No task-routing or persistence-format behavior changes.
